### PR TITLE
Remove Warning's on App Startup

### DIFF
--- a/packages/telemed-ehr/app/index.html
+++ b/packages/telemed-ehr/app/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="./public/favicon.ico" />
+    <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Web site created using create-react-app" />
     <link rel="apple-touch-icon" href="./public/logo192.png" />
-    <link rel="manifest" href="./public/manifest.json" />
+    <link rel="manifest" href="/manifest.json" />
     <title>Ottehr EHR</title>
   </head>
   <body>


### PR DESCRIPTION
Previously on app startup, the application was showing the following warnings:
```
packages/telemed-ehr/app start:local: files in the public directory are served at the root path.
packages/telemed-ehr/app start:local: Instead of /public/favicon.ico, use /favicon.ico.
packages/telemed-ehr/app start:local: files in the public directory are served at the root path.
packages/telemed-ehr/app start:local: Instead of /public/manifest.json, use /manifest.json.
```

This pull request serves the files from the root directory and removes both warnings.