### PR TITLE
Issue 735. EHR. Patient information. Docs. Uploaded insurance should be displayed in "Insurance Cards" instead of "Consent Forms" section

### DIFF
--- a/packages/utils/lib/fhir/constants.ts
+++ b/packages/utils/lib/fhir/constants.ts
@@ -264,7 +264,7 @@ export const FOLDERS_CONFIG: ListConfig[] = [
   {
     title: 'consent-forms',
     display: 'Consent Forms',
-    documentTypeCode: [CONSENT_CODE, INSURANCE_CARD_CODE],
+    documentTypeCode: CONSENT_CODE,
   },
   {
     title: 'insurance-cards',


### PR DESCRIPTION
#735 