### PR TITLE
Patient logs. Chart data logging into AuditEvents

### DIFF
--- a/apps/ehr/test/e2e/specs/ehr.spec.ts
+++ b/apps/ehr/test/e2e/specs/ehr.spec.ts
@@ -2,6 +2,7 @@ import { expect, Page, test } from '@playwright/test';
 import { dataTestIds } from '../../../src/constants/data-test-ids';
 import { ResourceHandler } from '../../e2e-utils/resource-handler';
 import { ENV_LOCATION_NAME } from '../../e2e-utils/resource/constants';
+import { RoleType } from 'utils';
 
 // We may create new instances for the tests with mutable operations, and keep parralel tests isolated
 const resourceHandler = new ResourceHandler();
@@ -80,6 +81,7 @@ test('Happy path: set up filters and navigate to visit page', async ({ page }) =
 
 test('CSS intake patient page is available', async ({ page }) => {
   await page.goto(`in-person/intake/${resourceHandler.appointment.id}/patient-info`);
+  console.log('role', RoleType.Provider);
   await awaitCSSHeaderInit(page);
 });
 

--- a/packages/ehr/zambdas/scripts/deploy-zambdas.ts
+++ b/packages/ehr/zambdas/scripts/deploy-zambdas.ts
@@ -143,6 +143,9 @@ const ZAMBDAS: { [name: string]: DeployZambda } = {
   'CREATE-UPLOAD-DOCUMENT-URL': {
     type: 'http_auth',
   },
+  'GET-CHART-DATA-VERSIONED': {
+    type: 'http_auth',
+  },
 };
 
 const updateZambdas = async (config: any, env: string): Promise<void> => {

--- a/packages/ehr/zambdas/scripts/package-for-release.sh
+++ b/packages/ehr/zambdas/scripts/package-for-release.sh
@@ -12,7 +12,7 @@ SLS_DIR=$(realpath $SCRIPTS_DIR/../.serverless)
 DIST_DIR=$(realpath $SCRIPTS_DIR/../.dist)
 
 # Zip
-ZIP_ORDER=("version" "deactivate-user" "save-followup-encounter" "get-appointments" "get-telemed-appointments" "change-telemed-appointment-status" "assign-practitioner" "unassign-practitioner" "get-conversation" "get-employees" "update-user" "get-user" "init-telemed-session" "save-chart-data" "get-chart-data" "delete-chart-data" "save-patient-instruction" "get-patient-instructions" "delete-patient-instruction" "notifications-updater" "sync-user" "icd-search" "communication-subscription" "process-erx-resources" "telemed-appointment-subscription" "get-claims" "get-patient-profile-photo-url" "create-update-medication-order" "get-medication-orders" "create-upload-document-url" "sign-appointment")
+ZIP_ORDER=("version" "deactivate-user" "save-followup-encounter" "get-appointments" "get-telemed-appointments" "change-telemed-appointment-status" "assign-practitioner" "unassign-practitioner" "get-conversation" "get-employees" "update-user" "get-user" "init-telemed-session" "save-chart-data" "get-chart-data" "delete-chart-data" "save-patient-instruction" "get-patient-instructions" "delete-patient-instruction" "notifications-updater" "sync-user" "icd-search" "communication-subscription" "process-erx-resources" "telemed-appointment-subscription" "get-claims" "get-patient-profile-photo-url" "create-update-medication-order" "get-medication-orders" "create-upload-document-url" "sign-appointment" "get-chart-data-versioned")
 
 for ZAMBDA in ${ZIP_ORDER[@]}; do
   # Set up temp directory for the zip

--- a/packages/ehr/zambdas/serverless.yml
+++ b/packages/ehr/zambdas/serverless.yml
@@ -273,6 +273,22 @@ functions:
       PROJECT_API: ${file(./.env/${self:provider.stage}.json):PROJECT_API}
       ENVIRONMENT: ${file(./.env/${self:provider.stage}.json):ENVIRONMENT}
 
+  get-chart-data-versioned:
+    handler: src/get-chart-data-versioned/index.index
+    events:
+      - http:
+          path: zambda/get-chart-data-versioned/execute
+          method: POST
+    timeout: 25
+    environment:
+      AUTH0_ENDPOINT: ${file(./.env/${self:provider.stage}.json):AUTH0_ENDPOINT}
+      URGENT_CARE_AUTH0_CLIENT: ${file(./.env/${self:provider.stage}.json):AUTH0_CLIENT}
+      URGENT_CARE_AUTH0_SECRET: ${file(./.env/${self:provider.stage}.json):AUTH0_SECRET}
+      AUTH0_AUDIENCE: ${file(./.env/${self:provider.stage}.json):AUTH0_AUDIENCE}
+      FHIR_API: ${file(./.env/${self:provider.stage}.json):FHIR_API}
+      PROJECT_API: ${file(./.env/${self:provider.stage}.json):PROJECT_API}
+      ENVIRONMENT: ${file(./.env/${self:provider.stage}.json):ENVIRONMENT}
+
   delete-chart-data:
     handler: src/delete-chart-data/index.index
     events:

--- a/packages/ehr/zambdas/src/get-chart-data-versioned/index.ts
+++ b/packages/ehr/zambdas/src/get-chart-data-versioned/index.ts
@@ -1,0 +1,96 @@
+// Lifting up value to outside of the handler allows it to stay in memory across warm lambda invocations
+import { ZambdaInput } from '../types';
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { checkOrCreateM2MClientToken, createOystehrClient } from '../shared/helpers';
+import { validateRequestParameters } from './validateRequestParameters';
+import { AuditEvent, FhirResource } from 'fhir/r4b';
+import { getResourcesFromBatchInlineRequests, GetVersionedChartDataResponse } from 'utils';
+import Oystehr from '@oystehr/sdk';
+import { convertChartResourcesToResponse } from '../get-chart-data/helpers';
+import { getPersonIdFromAuditEvent, parseAuditEventEntity } from 'utils/lib/helpers/resources';
+
+let m2mtoken: string;
+
+export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
+  try {
+    console.log(`Input: ${JSON.stringify(input)}`);
+    console.log('Validating input');
+    const { chartDataAuditEventId, secrets } = validateRequestParameters(input);
+    m2mtoken = await checkOrCreateM2MClientToken(m2mtoken, secrets);
+    const oystehr = createOystehrClient(m2mtoken, secrets);
+
+    const output = await performEffect(oystehr, chartDataAuditEventId);
+
+    return {
+      body: JSON.stringify(output),
+      statusCode: 200,
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      body: JSON.stringify({ message: 'Error saving encounter data...' }),
+      statusCode: 500,
+    };
+  }
+};
+
+async function performEffect(oystehr: Oystehr, auditEventId: string): Promise<GetVersionedChartDataResponse> {
+  const auditEvent = (await oystehr.fhir.get({ resourceType: 'AuditEvent', id: auditEventId })) as AuditEvent;
+  console.log(`AuditEvent with id: ${auditEvent.id} successfully fetched`);
+
+  const requests = parseAuditEventIntoResourceInlineRequests(auditEvent);
+  console.log(
+    `AuditEvent was parsed into resources requests: previousSet: ${requests.previousSet.length} requests, newSet: ${requests.newSet.length} requests.`
+  );
+
+  const [previousResourcesSet, newResourcesSet] = await Promise.all([
+    getResourcesFromBatchInlineRequests(oystehr, requests.previousSet),
+    getResourcesFromBatchInlineRequests(oystehr, requests.newSet),
+  ]);
+  console.log(
+    `Resources for chart data received: previousSetRes: ${previousResourcesSet.length} resources, newSetRes: ${newResourcesSet.length} resources.`
+  );
+
+  const auditEventPatientId = getPersonIdFromAuditEvent(auditEvent, 'Patient');
+  const encounterId = previousResourcesSet.find((res) => res.resourceType === 'Encounter')?.id;
+  console.log(`Patient id: ${auditEventPatientId}, Encounter id: ${encounterId}`);
+  if (auditEventPatientId && encounterId) {
+    const previousChartData = convertChartResourcesToResponse(
+      previousResourcesSet as FhirResource[],
+      auditEventPatientId,
+      encounterId
+    ).chartData;
+    const newChartData = convertChartResourcesToResponse(
+      newResourcesSet as FhirResource[],
+      auditEventPatientId,
+      encounterId
+    ).chartData;
+    console.log('Chart parsed.');
+    return {
+      previousChartData,
+      newChartData,
+    };
+  } else throw new Error('Patient id or encounter id was not found for this auditEvent.');
+}
+
+function parseAuditEventIntoResourceInlineRequests(auditEvent: AuditEvent): {
+  previousSet: string[];
+  newSet: string[];
+} {
+  const entities = auditEvent.entity;
+  const resultOldRequests: string[] = [];
+  const resultNewRequests: string[] = [];
+  entities?.forEach((entity) => {
+    const parsedEntity = parseAuditEventEntity(entity);
+    const entityResourceReference = parsedEntity.resourceReference.reference;
+
+    resultOldRequests.push(`/${entityResourceReference}/_history/${parsedEntity.previousVersionId}`);
+    if (parsedEntity.newVersionId)
+      resultNewRequests.push(`/${entityResourceReference}/_history/${parsedEntity.newVersionId}`);
+    else resultNewRequests.push(`/${entityResourceReference}/_history/${parsedEntity.previousVersionId}`);
+  });
+  return {
+    previousSet: resultOldRequests,
+    newSet: resultNewRequests,
+  };
+}

--- a/packages/ehr/zambdas/src/get-chart-data-versioned/validateRequestParameters.ts
+++ b/packages/ehr/zambdas/src/get-chart-data-versioned/validateRequestParameters.ts
@@ -1,0 +1,21 @@
+import { ZambdaInput } from '../types';
+import { GetVersionedChartDataRequest } from 'utils';
+
+export function validateRequestParameters(
+  input: ZambdaInput
+): GetVersionedChartDataRequest & Pick<ZambdaInput, 'secrets'> {
+  if (!input.body) {
+    throw new Error('No request body provided');
+  }
+
+  const { chartDataAuditEventId } = JSON.parse(input.body);
+
+  if (chartDataAuditEventId === undefined) {
+    throw new Error('Field "chartDataAuditEventId" should be provided in zambda input');
+  }
+
+  return {
+    chartDataAuditEventId,
+    secrets: input.secrets,
+  };
+}

--- a/packages/ehr/zambdas/src/get-chart-data/index.ts
+++ b/packages/ehr/zambdas/src/get-chart-data/index.ts
@@ -6,7 +6,7 @@ import { getPatientEncounter } from '../shared';
 import { checkOrCreateM2MClientToken, createOystehrClient } from '../shared/helpers';
 import { ZambdaInput } from '../types';
 import {
-  convertSearchResultsToResponse,
+  convertChartResourcesToResponse,
   createFindResourceRequest,
   createFindResourceRequestById,
   createFindResourceRequestByPatientField,
@@ -178,8 +178,9 @@ export async function getChartData(
   // console.debug('result JSON\n\n==============\n\n', JSON.stringify(result));
 
   console.timeLog('check', 'after fetch, before converting chart data to response');
-  const chartDataResult = convertSearchResultsToResponse(
-    result,
+  const resources = result.unbundle();
+  const chartDataResult = convertChartResourcesToResponse(
+    resources,
     patient.id!,
     encounterId,
     requestedFields ? (Object.keys(requestedFields) as (keyof ChartDataFields)[]) : undefined

--- a/packages/ehr/zambdas/src/save-chart-data/index.ts
+++ b/packages/ehr/zambdas/src/save-chart-data/index.ts
@@ -64,12 +64,15 @@ import { PdfDocumentReferencePublishedStatuses } from '../shared/pdf/pdf-utils';
 import { createSchoolWorkNotePDF } from '../shared/pdf/school-work-note-pdf';
 import { ZambdaInput } from '../types';
 import {
+  createVersionEntitiesForChartResources,
+  createAuditEvent,
   filterServiceRequestsFromFhir,
   followUpToPerformerMap,
   getEncounterAndRelatedResources,
   validateBundleAndExtractSavedChartData,
 } from './helpers';
 import { validateRequestParameters } from './validateRequestParameters';
+import { getChartData } from '../get-chart-data';
 
 // Lifting up value to outside of the handler allows it to stay in memory across warm lambda invocations
 let m2mtoken: string;
@@ -130,15 +133,10 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
     console.timeLog('time', 'before fetching resources');
     // get encounter and resources
     console.log(`Getting encounter ${encounterId}`);
-    // ----- !!!DON'T DELETE!!! this is in #2129 scope -----
-    // const [allResources, currentPractitioner, chartDataBeforeUpdate] = await Promise.all([
-    //   getEncounterAndRelatedResources(oystehr, encounterId),
-    //   getUserPractitioner(oystehr, oystehrCurrentUser),
-    //   getChartData(oystehr, encounterId),
-    // ]);
-    const [allResources, currentPractitioner] = await Promise.all([
+    const [allResources, currentPractitioner, chartDataBeforeUpdate] = await Promise.all([
       getEncounterAndRelatedResources(oystehr, encounterId),
       getUserPractitioner(oystehr, oystehrCurrentUser),
+      getChartData(oystehr, encounterId),
     ]);
 
     const encounter = allResources.filter((resource) => resource.resourceType === 'Encounter')[0] as Encounter;
@@ -468,15 +466,21 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
     );
     console.timeLog('time', 'after sorting resources');
 
-    // ----- !!!DON'T DELETE!!! this is in #2129 scope -----
-    // console.timeLog('time', 'before creating auditEvent');
-    // const auditEvent = createAuditEvent(chartDataBeforeUpdate.chartResources, output.chartResources);
-    // await oystehr.fhir.create(auditEvent);
-    // console.timeLog('time', 'after creating auditEvent');
+    // todo: find organization id
+    console.timeLog('time', 'before creating auditEvent');
+    chartDataBeforeUpdate.chartResources.push(encounter); // we do this to be sure we'll have encounter in our set 100%
+    const resVersionsEntities = createVersionEntitiesForChartResources(
+      chartDataBeforeUpdate.chartResources,
+      output.chartResources
+    );
+    const auditEvent = createAuditEvent(currentPractitioner.id!, patient.id, resVersionsEntities);
+    console.log('Audit event: ' + JSON.stringify(auditEvent));
+    await oystehr.fhir.create(auditEvent);
+    console.timeLog('time', 'after creating auditEvent');
 
     console.timeEnd('time');
     return {
-      body: JSON.stringify(output),
+      body: JSON.stringify(output.chartResources),
       statusCode: 200,
     };
   } catch (error) {
@@ -487,73 +491,6 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
     };
   }
 };
-
-// ----- !!!DON'T DELETE!!! this is in #2129 scope -----
-// function createAuditEvent(chartResourcesBeforeUpdate: Resource[], chartResourcesAfterUpdate: Resource[]): AuditEvent {
-//   // todo finish up this function to create proper AuditEvent and maybe discuss AE format with guys later
-//   const resourcesEntities: AuditEventEntity[] = [];
-//
-//   // todo add previous resources and new one into entries
-//   chartResourcesBeforeUpdate.forEach((res) => {
-//     const resReference = createReference(res);
-//     if (resReference.reference && res.meta?.versionId) {
-//       createAuditEventEntity(createReference(res), 'entityName', res.meta.versionId);
-//     }
-//   });
-//   return {
-//     resourceType: 'AuditEvent',
-//     type: {
-//       code: '110101',
-//       system: 'http://dicom.nema.org/resources/ontology/DCM',
-//       display: 'Audit Log Used\t',
-//     },
-//     agent: [
-//       {
-//         who: {
-//           reference: 'Practitioner/96587574-637b-4346-91d9-27abc655365f',
-//         },
-//         requestor: true,
-//       },
-//     ],
-//     recorded: DateTime.now().toISO() ?? '',
-//     source: {
-//       observer: {
-//         reference: 'Organization/165bb2f4-a972-4d29-b092-dac9d0bc43cf',
-//       },
-//     },
-//     entity: resourcesEntities,
-//   };
-// }
-//
-// function createAuditEventEntity(
-//   resourceReference: Reference,
-//   name: string,
-//   previousVersionId: string,
-//   newVersionId?: string
-// ): AuditEventEntity {
-//   const entity = {
-//     what: resourceReference,
-//     name,
-//     detail: [
-//       {
-//         type: 'previousVersionId',
-//         valueString: previousVersionId,
-//       },
-//       // do we wanna keep this request json?? because idk how to create such thing in save-chart-data
-//       {
-//         type: 'requestJson',
-//         valueString: '{"name": [{"given": ["Jonathan"], "family": "Doe"}]}',
-//       },
-//     ],
-//   };
-//   if (newVersionId) {
-//     entity.detail.push({
-//       type: 'newVersionId',
-//       valueString: newVersionId,
-//     });
-//   }
-//   return entity;
-// }
 
 async function getUserPractitioner(oystehr: Oystehr, oystehrCurrentUser: Oystehr): Promise<Practitioner> {
   try {

--- a/packages/ehr/zambdas/src/shared/chart-data/chart-data-helpers.ts
+++ b/packages/ehr/zambdas/src/shared/chart-data/chart-data-helpers.ts
@@ -1132,15 +1132,22 @@ export function mapResourceToChartDataResponse(
   };
 }
 
-export function handleCustomDTOExtractions(data: ChartDataFields, resources: FhirResource[]): ChartDataFields {
+export function handleCustomDTOExtractions(
+  data: ChartDataFields,
+  resources: FhirResource[]
+): { chartData: ChartDataFields; chartResources?: Resource[] } {
   const encounterResource = resources.find((res) => res.resourceType === 'Encounter') as Encounter;
-  if (!encounterResource) return data;
+  // if (!encounterResource) throw new Error('Encounter is required to extract chart resources');
+  if (!encounterResource) return { chartData: data };
+  let chartResources: Resource[] = [];
+  chartResources.push(encounterResource);
 
   // 1. Getting DispositionDTO
   const serviceRequests: ServiceRequest[] = resources.filter(
     (res) => res.resourceType === 'ServiceRequest'
   ) as ServiceRequest[];
   data.disposition = makeDispositionDTOFromFhirResources(encounterResource, serviceRequests);
+  if (data.disposition) chartResources = chartResources.concat(serviceRequests);
 
   // 2. Getting DiagnosisDTO
   encounterResource.diagnosis?.forEach((encounterDiagnosis) => {
@@ -1174,7 +1181,7 @@ export function handleCustomDTOExtractions(data: ChartDataFields, resources: Fhi
     data.addendumNote = { text: addendumNote.valueString };
   }
 
-  return data;
+  return { chartData: data, chartResources };
 }
 
 export const createDispositionServiceRequest = ({

--- a/packages/utils/lib/helpers/resources/audit-event.helpers.ts
+++ b/packages/utils/lib/helpers/resources/audit-event.helpers.ts
@@ -1,0 +1,76 @@
+import { AuditEvent, AuditEventEntity, Patient, Practitioner, Reference } from 'fhir/r4b';
+
+/**
+ * This creates entity that reflects previous and new state of resource
+ * or just one state of it as log.
+ * @param name custom name for current versioned log.
+ * @param previousVersionId resource version id from meta before update.
+ * @param newVersionId resource version id from meta after update.
+ * */
+export interface VersionEntity {
+  resourceReference: Reference;
+  name?: string;
+  previousVersionId?: string;
+  newVersionId?: string;
+  requestJson?: string;
+}
+
+export const AUDIT_EVENT_ENTITY_PREVIOUS_VERSION_ID_TYPE = 'previousVersionId';
+export const AUDIT_EVENT_ENTITY_VERSION_ID_TYPE = 'versionId';
+export const AUDIT_EVENT_ENTITY_REQUEST_JSON_TYPE = 'requestJson';
+
+export function createAuditEventEntity(input: VersionEntity): AuditEventEntity {
+  const { resourceReference, name, previousVersionId, newVersionId, requestJson } = input;
+  const entity: AuditEventEntity = {
+    what: resourceReference,
+    name,
+  };
+  if (previousVersionId) {
+    if (!entity.detail?.length) entity.detail = [];
+    entity.detail.push({
+      type: AUDIT_EVENT_ENTITY_PREVIOUS_VERSION_ID_TYPE,
+      valueString: previousVersionId,
+    });
+  }
+  if (newVersionId) {
+    if (!entity.detail?.length) entity.detail = [];
+    entity.detail.push({
+      type: AUDIT_EVENT_ENTITY_VERSION_ID_TYPE,
+      valueString: newVersionId,
+    });
+  }
+  if (requestJson) {
+    if (!entity.detail?.length) entity.detail = [];
+    entity.detail.push({
+      type: AUDIT_EVENT_ENTITY_REQUEST_JSON_TYPE,
+      valueString: requestJson,
+    });
+  }
+  return entity;
+}
+
+export function parseAuditEventEntity(entity: AuditEventEntity): VersionEntity {
+  const resourceReference = entity.what;
+  if (!resourceReference) throw new Error('This AE entity does not contain resource reference in .what field');
+  const previousVersionId = entity.detail?.find((detail) => detail.type === AUDIT_EVENT_ENTITY_PREVIOUS_VERSION_ID_TYPE)
+    ?.valueString;
+  const newVersionId = entity.detail?.find((detail) => detail.type === AUDIT_EVENT_ENTITY_VERSION_ID_TYPE)?.valueString;
+  const requestJson = entity.detail?.find((detail) => detail.type === AUDIT_EVENT_ENTITY_REQUEST_JSON_TYPE)
+    ?.valueString;
+  return {
+    resourceReference,
+    name: entity.name,
+    previousVersionId,
+    newVersionId,
+    requestJson,
+  };
+}
+
+export function getPersonIdFromAuditEvent(
+  auditEvent: AuditEvent,
+  personType: Patient['resourceType'] | Practitioner['resourceType']
+): string | undefined {
+  return auditEvent.agent
+    .find((agent) => agent.who?.reference?.includes(personType))
+    ?.who?.reference?.replace(`${personType}/`, '');
+}

--- a/packages/utils/lib/helpers/resources/index.ts
+++ b/packages/utils/lib/helpers/resources/index.ts
@@ -1,0 +1,1 @@
+export * from './audit-event.helpers';

--- a/packages/utils/lib/types/api/audit-event.constants.ts
+++ b/packages/utils/lib/types/api/audit-event.constants.ts
@@ -1,0 +1,3 @@
+export const CHART_DATA_PATIENT_LOGS_AUDIT_EVENT_SYSTEM = 'patient-logs';
+
+export const CHART_DATA_PATIENT_LOGS_AUDIT_EVENT_CODE = 'chart-data-logs';

--- a/packages/utils/lib/types/api/chart-data/get-chart-data.types.ts
+++ b/packages/utils/lib/types/api/chart-data/get-chart-data.types.ts
@@ -14,3 +14,12 @@ export interface GetChartDataResponse extends ChartDataFields {
 }
 
 export type ChartDataRequestedFields = Partial<Record<keyof GetChartDataResponse, SearchParams>>;
+
+export interface GetVersionedChartDataRequest {
+  chartDataAuditEventId: string;
+}
+
+export interface GetVersionedChartDataResponse {
+  previousChartData: GetChartDataResponse;
+  newChartData: GetChartDataResponse;
+}


### PR DESCRIPTION
Added logic to create AuditEvents at the end of save-chart-data, it contains references to all chart-data resources with previous and updated version ids. Also i've added new endpoint get-chart-data-versioned. For this endpoint AuditEvent id is input, it parses resources contained in AE into two sets and creates two chart data jsons for previous version and new one.