### PR TITLE
Issue 821: Remove weight percentiles

### DIFF
--- a/apps/ehr/src/features/css-module/components/Header.tsx
+++ b/apps/ehr/src/features/css-module/components/Header.tsx
@@ -67,7 +67,6 @@ export const Header = (): JSX.Element => {
   const language = format(processedData?.preferredLanguage, 'Lang');
   const dob = format(processedData?.DOB, 'DOB', true);
   const allergies = format(chartData?.allergies?.map((allergy) => allergy.name)?.join(', '), 'Allergy', true, 'none');
-  const weight = format(processedData?.weight, 'Weight', true);
   const reasonForVisit = format(appointment?.description, 'Reason for Visit');
   const userId = format(patient?.id);
   const [_status, setStatus] = useState<VisitStatusLabel | undefined>(undefined);
@@ -113,8 +112,7 @@ export const Header = (): JSX.Element => {
                   sx={{ fontWeight: chartData?.allergies?.length ? 700 : 400, maxWidth: '250px' }}
                 >
                   {allergies}
-                </PatientMetadata>{' '}
-                |<PatientMetadata>{weight}</PatientMetadata>
+                </PatientMetadata>
               </PatientInfoWrapper>
               <PatientInfoWrapper>
                 <PatientMetadata>{pronouns}</PatientMetadata> | <PatientMetadata>{gender}</PatientMetadata> |

--- a/apps/ehr/src/features/css-module/components/vitals/weights/VitalWeightHistoryElement.tsx
+++ b/apps/ehr/src/features/css-module/components/vitals/weights/VitalWeightHistoryElement.tsx
@@ -1,6 +1,5 @@
 import React, { JSX, useState } from 'react';
 import { useTheme, Box, Typography, IconButton } from '@mui/material';
-import ErrorIcon from '@mui/icons-material/Error';
 import { DeleteOutlined as DeleteIcon } from '@mui/icons-material';
 import { VitalWeightHistoryEntry } from './VitalWeightHistoryEntry';
 import { VitalsObservationDTO } from 'utils';
@@ -26,7 +25,6 @@ export const VitalWeightHistoryElement: React.FC<VitalWeightHistoryElementProps>
   };
 
   const hasAuthor = !!historyEntry.author && historyEntry.author?.length > 0;
-  const lineColor = historyEntry.isPercentileWarning ? theme.palette.error.main : theme.palette.text.primary;
 
   return (
     <>
@@ -38,18 +36,10 @@ export const VitalWeightHistoryElement: React.FC<VitalWeightHistoryElementProps>
             </Typography>
           )}
           {historyEntry.recordDateTime} {hasAuthor && 'by'} {historyEntry.author} - &nbsp;
-          <Typography component="span" sx={{ fontWeight: 'bold', color: lineColor }}>
+          <Typography component="span" sx={{ fontWeight: 'bold' }}>
             {historyEntry.weightKg} kg &nbsp;
           </Typography>
-          <Typography component="span" sx={{ color: lineColor }}>
-            / {historyEntry.weightLbs} lbs&nbsp;
-          </Typography>
-          <Typography component="span" sx={{ color: lineColor }}>
-            / {historyEntry.percentile} percentile
-          </Typography>
-          {historyEntry.isPercentileWarning && (
-            <ErrorIcon fontSize="small" sx={{ ml: '4px', verticalAlign: 'middle', color: lineColor }} />
-          )}
+          <Typography component="span">/ {historyEntry.weightLbs} lbs&nbsp;</Typography>
         </Typography>
 
         {historyEntry.isDeletable && (

--- a/apps/ehr/src/features/css-module/components/vitals/weights/VitalWeightHistoryEntry.ts
+++ b/apps/ehr/src/features/css-module/components/vitals/weights/VitalWeightHistoryEntry.ts
@@ -4,6 +4,4 @@ import { VitalHistoryEntry } from '../types';
 export type VitalWeightHistoryEntry = {
   weightKg: number;
   weightLbs: number;
-  percentile: number;
-  isPercentileWarning: boolean;
 } & VitalHistoryEntry<VitalsWeightObservationDTO>;

--- a/apps/ehr/src/features/css-module/components/vitals/weights/VitalsWeightsCard.tsx
+++ b/apps/ehr/src/features/css-module/components/vitals/weights/VitalsWeightsCard.tsx
@@ -1,20 +1,17 @@
-import ErrorIcon from '@mui/icons-material/Error';
-import { Box, CircularProgress, Grid, InputAdornment, TextField, Typography, useTheme } from '@mui/material';
+import { Box, CircularProgress, Grid, TextField, Typography } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
 import React, { JSX, useCallback, useMemo, useState } from 'react';
-import { VitalFieldNames, VitalsWeightObservationDTO, textToWeightNumber, kgToLb, weightPercentile } from 'utils';
+import { VitalFieldNames, VitalsWeightObservationDTO, textToWeightNumber, kgToLb } from 'utils';
 import { RoundedButton } from '../../../../../components/RoundedButton';
-import { AccordionCard, DoubleColumnContainer } from '../../../../../telemed/components';
+import { AccordionCard, DoubleColumnContainer } from '../../../../../telemed';
 import VitalsHistoryContainer from '../components/VitalsHistoryContainer';
 import { VitalsTextInputFiled } from '../components/VitalsTextInputFiled';
 import { useVitalsCardState } from '../hooks/useVitalsCardState';
-import { composeWeightVitalsHistoryEntries, PERCENTILE_THRESHOLD } from './helpers';
+import { composeWeightVitalsHistoryEntries } from './helpers';
 import VitalWeightHistoryElement from './VitalWeightHistoryElement';
 import { VitalWeightHistoryEntry } from './VitalWeightHistoryEntry';
 
 const VitalsWeightsCard: React.FC = (): JSX.Element => {
-  const appTheme = useTheme();
-
   const {
     isLoadingVitalsByEncounter,
     handleSaveVital,
@@ -43,12 +40,6 @@ const VitalsWeightsCard: React.FC = (): JSX.Element => {
     return kgToLb(weightKg);
   }, [weightValueText]);
 
-  const enteredWeightPercentile: number | undefined = useMemo(() => {
-    const weightKg = textToWeightNumber(weightValueText);
-    if (!weightKg) return;
-    return weightPercentile(weightKg);
-  }, [weightValueText]);
-
   const handleSaveWeightObservation = async (weightValueText: string): Promise<void> => {
     const weightValueNumber = textToWeightNumber(weightValueText);
     if (!weightValueNumber) return;
@@ -66,9 +57,6 @@ const VitalsWeightsCard: React.FC = (): JSX.Element => {
       setSavingCardData(false);
     }
   };
-
-  const isPercentileWarning = enteredWeightPercentile && enteredWeightPercentile > PERCENTILE_THRESHOLD;
-  const percentileColor = isPercentileWarning ? appTheme.palette.error.main : appTheme.palette.text.primary;
 
   return (
     <Box sx={{ mt: 3 }}>
@@ -94,7 +82,7 @@ const VitalsWeightsCard: React.FC = (): JSX.Element => {
               }}
             >
               {/* Weight Input Field column */}
-              <Grid item xs={12} sm={8} md={8} lg={8} order={{ xs: 1, sm: 1, md: 1 }}>
+              <Grid item xs={12} sm={6} md={6} lg={6} order={{ xs: 1, sm: 1, md: 1 }}>
                 <Box
                   sx={{
                     display: 'flex',
@@ -122,33 +110,6 @@ const VitalsWeightsCard: React.FC = (): JSX.Element => {
                     disabled
                     InputLabelProps={{ shrink: true }}
                     value={enteredWeightInLb ?? ''}
-                  />
-                  <Typography fontSize={25} sx={{ ml: 1 }}>
-                    /
-                  </Typography>
-
-                  <TextField
-                    fullWidth
-                    size="small"
-                    label="Percentile"
-                    disabled
-                    sx={{
-                      '& .MuiInputBase-input.Mui-disabled': {
-                        color: 'red', // Desired color for disabled text
-                        fontWeight: 700,
-                      },
-                      '& fieldset': { border: 'none' },
-                      maxWidth: '110px',
-                    }}
-                    InputProps={{
-                      startAdornment: (
-                        <InputAdornment position="start" sx={{ marginLeft: 1 }}>
-                          {isPercentileWarning && <ErrorIcon fontSize="small" sx={{ color: percentileColor, ml: 0 }} />}
-                        </InputAdornment>
-                      ),
-                    }}
-                    InputLabelProps={{ shrink: true }}
-                    value={enteredWeightPercentile ?? ''}
                   />
                 </Box>
               </Grid>

--- a/apps/ehr/src/features/css-module/components/vitals/weights/helpers.ts
+++ b/apps/ehr/src/features/css-module/components/vitals/weights/helpers.ts
@@ -1,17 +1,6 @@
-import {
-  isWeightVitalObservation,
-  VitalsObservationDTO,
-  VitalsWeightObservationDTO,
-  kgToLb,
-  weightPercentile,
-} from 'utils';
+import { isWeightVitalObservation, VitalsObservationDTO, VitalsWeightObservationDTO, kgToLb } from 'utils';
 import { VitalWeightHistoryEntry } from './VitalWeightHistoryEntry';
 import { composeVitalsHistoryEntries } from '../utils';
-
-export const PERCENTILE_THRESHOLD = 3;
-const checkIsPercentileWarning = (weightKg: number): boolean => {
-  return weightPercentile(weightKg) > PERCENTILE_THRESHOLD;
-};
 
 export const composeWeightVitalsHistoryEntries = (
   encounterId: string,
@@ -29,8 +18,6 @@ export const composeWeightVitalsHistoryEntries = (
       return {
         weightKg: observation.value,
         weightLbs: kgToLb(observation.value),
-        percentile: weightPercentile(observation.value),
-        isPercentileWarning: checkIsPercentileWarning(observation.value),
       };
     }
   );

--- a/apps/ehr/src/telemed/features/appointment/AppointmentSidePanel.tsx
+++ b/apps/ehr/src/telemed/features/appointment/AppointmentSidePanel.tsx
@@ -113,21 +113,6 @@ export const AppointmentSidePanel: FC = () => {
     return null;
   }
 
-  const weight = patient.extension?.find(
-    (extension) => extension.url === 'https://fhir.zapehr.com/r4/StructureDefinitions/weight'
-  )?.valueString;
-  const weightLastUpdated = patient.extension?.find(
-    (extension) => extension.url === 'https://fhir.zapehr.com/r4/StructureDefinitions/weight-last-updated'
-  )?.valueString;
-
-  const weightString =
-    weight &&
-    weightLastUpdated &&
-    `${Math.round(+weight * 0.45359237 * 100) / 100} kg (updated ${DateTime.fromFormat(
-      weightLastUpdated,
-      'yyyy-MM-dd'
-    ).toFormat('MM/dd/yyyy')})`;
-
   function isSpanish(language: string): boolean {
     return language.toLowerCase() === 'Spanish'.toLowerCase();
   }
@@ -204,8 +189,6 @@ export const AppointmentSidePanel: FC = () => {
             DOB: {DateTime.fromFormat(patient.birthDate!, 'yyyy-MM-dd').toFormat('MM/dd/yyyy')}, Age:{' '}
             {calculatePatientAge(patient.birthDate!)}
           </Typography>
-
-          {weightString && <Typography variant="body2">Wt: {weightString}</Typography>}
 
           <Typography variant="body2" fontWeight={700}>
             Allergies:{' '}

--- a/packages/utils/lib/helpers/visit-note/map-vitals-to-display.helper.ts
+++ b/packages/utils/lib/helpers/visit-note/map-vitals-to-display.helper.ts
@@ -18,7 +18,6 @@ import {
   parseVisionExtraOptions,
   parseVisionValue,
   VitalsVisitNoteData,
-  weightPercentile,
 } from '../vitals';
 
 export const mapVitalsToDisplay = (vitalsObservations?: VitalsObservationDTO[]): VitalsVisitNoteData | undefined =>
@@ -53,11 +52,11 @@ export const mapVitalsToDisplay = (vitalsObservations?: VitalsObservationDTO[]):
         break;
       case VitalFieldNames.VitalWeight:
         parsed = observation as VitalsWeightObservationDTO;
-        text = `${parsed.value} cm / ${heightInCmToInch(parsed.value)} inch`;
+        text = `${parsed.value} kg / ${heightInCmToInch(parsed.value)} lbs`;
         break;
       case VitalFieldNames.VitalHeight:
         parsed = observation as VitalsHeightObservationDTO;
-        text = `${parsed.value} kg / ${kgToLb(parsed.value)} lbs / ${weightPercentile(parsed.value)} percentile`;
+        text = `${parsed.value} cm / ${kgToLb(parsed.value)} inch`;
         break;
       case VitalFieldNames.VitalVision:
         parsed = observation as VitalsVisionObservationDTO;

--- a/packages/utils/lib/helpers/vitals/vitals-weight.helper.ts
+++ b/packages/utils/lib/helpers/vitals/vitals-weight.helper.ts
@@ -9,16 +9,3 @@ export const textToWeightNumber = (text: string): number | undefined => {
 export const kgToLb = (kg: number): number => roundVitalWeightValue(2.2 * kg);
 
 const roundVitalWeightValue = (weight: number): number => roundNumberToDecimalPlaces(weight, 1);
-
-export const weightPercentile = (kg: number): number => {
-  if (kg < 45) {
-    return 4;
-  }
-  if (kg > 90) {
-    return 4;
-  }
-
-  const firstDigit = kg.toString()[0];
-  const dummyPercentile = parseInt(firstDigit, 10) % 4;
-  return Math.max(dummyPercentile, 1);
-};


### PR DESCRIPTION
Link to issue #821 

Removed weight percentiles out of everywhere, removed weight from Telemed sidebar and in-person header

![2025-01-27_16-56-37](https://github.com/user-attachments/assets/120d1835-750e-4e8a-a049-54b8da674c04)
![2025-01-27_16-36-19](https://github.com/user-attachments/assets/83f0be55-48d4-40f6-9faf-c1fdc0f990be)
![2025-01-27_16-35-58](https://github.com/user-attachments/assets/760c0cca-fd6b-4f61-a55e-9d49f92492f8)
![2025-01-27_16-35-35](https://github.com/user-attachments/assets/8e0b178e-c7ff-4001-adc4-b1527466ab7a)
![2025-01-27_16-35-16](https://github.com/user-attachments/assets/4bbe31c5-8305-44b2-9dc6-d62325949fcf)
