### PR TITLE
feat(navigation): Add bottom navigation for the Provider mode

### DIFF
--- a/apps/ehr/src/features/css-module/context/NavigationContext.tsx
+++ b/apps/ehr/src/features/css-module/context/NavigationContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, ReactNode, useState, useCallback, useEffect, useRef } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation, useMatch } from 'react-router-dom';
 import { sidebarMenuIcons } from '../components/Sidebar';
 import { CSSModal } from '../components/CSSModal';
 import { ROUTER_PATH, routesCSS } from '../routing/routesCSS';
@@ -34,7 +34,7 @@ interface NavigationContextType {
   isNavigationHidden: boolean;
   interactionMode: InteractionMode;
   setInteractionMode: (mode: InteractionMode) => void;
-  availableRoutes: string[];
+  availableRoutes: RouteCSS[];
   isFirstPage: boolean;
   isLastPage: boolean;
   isNavigationDisabled: boolean;
@@ -65,14 +65,6 @@ export const NavigationProvider: React.FC<{ children: ReactNode }> = ({ children
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const [_disabledNavigationState, _setDisabledNavigationState] = useState<Record<string, boolean>>({});
-
-  useEffect(() => {
-    if (interactionMode === 'intake') {
-      setIsNavigationHidden(false);
-    } else {
-      setIsNavigationHidden(true);
-    }
-  }, [interactionMode]);
 
   setNavigationDisable = (newState: Record<string, boolean>): void => {
     let shouldUpdate = false;
@@ -109,9 +101,12 @@ export const NavigationProvider: React.FC<{ children: ReactNode }> = ({ children
     _setDisabledNavigationState({});
   };
 
-  const availableRoutes = Object.values(routesCSS)
-    .filter((route) => route.modes.includes(interactionMode))
-    .map((route) => route.path);
+  const availableRoutes = Object.values(routesCSS).filter((route) => route.modes.includes(interactionMode));
+  const availableRoutesForBottomNavigation = availableRoutes.filter((route) => !route.isSkippedInNavigation);
+
+  const availableRoutesPathsForBottomNavigation = availableRoutesForBottomNavigation.map(
+    (route) => route.sidebarPath || route.path
+  );
 
   const setInteractionMode = (mode: InteractionMode): void => {
     const basePath = location.pathname.match(/.*?(in-person)\/[^/]*/)?.[0];
@@ -132,62 +127,88 @@ export const NavigationProvider: React.FC<{ children: ReactNode }> = ({ children
     navigate(newPath);
   };
 
-  const currentRouteIndex = availableRoutes.indexOf((location.pathname.split('/').pop() || '') as ROUTER_PATH);
-  const currentRoute = availableRoutes[currentRouteIndex];
+  const match = useMatch('/in-person/:id/*');
+  const splat = match?.params['*'];
+  const currentRouteIndex = availableRoutesPathsForBottomNavigation.indexOf(splat || '');
+  const currentRoute = availableRoutesPathsForBottomNavigation[currentRouteIndex];
+  const isFirstPage = currentRouteIndex === 0;
+  const isLastPage = currentRouteIndex === availableRoutesPathsForBottomNavigation.length - 1;
+  const nextRoutePath = !isLastPage ? availableRoutesPathsForBottomNavigation?.[currentRouteIndex + 1] : null;
+  const previousRoutePath = !isFirstPage ? availableRoutesPathsForBottomNavigation?.[currentRouteIndex - 1] : null;
+
+  // Hide bottom navigation for pages that shouldn't be accessed through the bottom navigation
+  // These pages will have currentRouteIndex === -1 because they are not in the availableRoutesPathsForBottomNavigation array
+  // Examples: order details, order edit pages
+  const isPageWithHiddenBottomNavigation = currentRouteIndex === -1;
+
+  useEffect(() => {
+    setIsNavigationHidden(isPageWithHiddenBottomNavigation);
+  }, [isPageWithHiddenBottomNavigation]);
 
   const goToNext = useCallback(() => {
-    if (currentRouteIndex < availableRoutes.length - 1) {
-      const validators = Object.values(nextPageValidatorsRef.current);
-      for (let i = 0; i < validators.length; i++) {
-        const validationResult = validators[i]();
-        if (validationResult) {
-          setModalContent(validationResult);
-          setIsModalOpen(true);
-          return;
-        }
-      }
-      navigate(availableRoutes[currentRouteIndex + 1]);
+    if (!nextRoutePath) {
+      return;
     }
-  }, [availableRoutes, currentRouteIndex, navigate]);
+
+    const validators = Object.values(nextPageValidatorsRef.current);
+
+    for (let i = 0; i < validators.length; i++) {
+      const validationResult = validators[i]();
+
+      if (validationResult) {
+        setModalContent(validationResult);
+        setIsModalOpen(true);
+        return;
+      }
+    }
+
+    navigate(nextRoutePath);
+  }, [nextRoutePath, navigate]);
 
   const goToPrevious = useCallback(() => {
-    if (currentRouteIndex > 0) {
-      const validators = Object.values(previousPageValidatorsRef.current);
-      for (let i = 0; i < validators.length; i++) {
-        const validationResult = validators[i]();
-        if (validationResult) {
-          setModalContent(validationResult);
-          setIsModalOpen(true);
-          return;
-        }
-      }
-      navigate(availableRoutes[currentRouteIndex - 1]);
+    if (!previousRoutePath) {
+      return;
     }
-  }, [availableRoutes, currentRouteIndex, navigate]);
 
-  const isFirstPage = currentRouteIndex === 0;
-  const isLastPage = currentRouteIndex === availableRoutes.length - 1;
+    const validators = Object.values(previousPageValidatorsRef.current);
+
+    for (let i = 0; i < validators.length; i++) {
+      const validationResult = validators[i]();
+      if (validationResult) {
+        setModalContent(validationResult);
+        setIsModalOpen(true);
+        return;
+      }
+    }
+
+    navigate(previousRoutePath);
+  }, [previousRoutePath, navigate]);
 
   const { chartData, isChartDataLoading } = getSelectors(useAppointmentStore, ['chartData', 'isChartDataLoading']);
 
   const nextButtonText = (() => {
     if (isChartDataLoading) return ' ';
-    switch (currentRoute) {
-      case 'allergies':
-        return chartData?.allergies?.length ? 'Allergies Confirmed' : 'Confirmed No Known Allergies';
-      case 'medications':
-        return chartData?.medications?.length ? 'Medications Confirmed' : 'Confirmed No Medications';
-      case 'medical-conditions':
-        return chartData?.conditions?.length ? 'Medical Conditions Confirmed' : 'Confirmed No Medical Conditions';
-      case 'surgical-history':
-        return chartData?.procedures?.length ? 'Surgical History Confirmed' : 'Confirmed No Surgical History';
-      case 'hospitalization':
-        return `${
-          chartData?.episodeOfCare?.length ? 'Hospitalization Confirmed' : 'Confirmed No Hospitalization'
-        } AND Complete Intake`;
-      default:
-        return isLastPage ? 'Complete' : 'Next';
+
+    if (interactionMode === 'intake') {
+      switch (currentRoute) {
+        case 'allergies':
+          return chartData?.allergies?.length ? 'Allergies Confirmed' : 'Confirmed No Known Allergies';
+        case 'medications':
+          return chartData?.medications?.length ? 'Medications Confirmed' : 'Confirmed No Medications';
+        case 'medical-conditions':
+          return chartData?.conditions?.length ? 'Medical Conditions Confirmed' : 'Confirmed No Medical Conditions';
+        case 'surgical-history':
+          return chartData?.procedures?.length ? 'Surgical History Confirmed' : 'Confirmed No Surgical History';
+        case 'hospitalization':
+          return `${
+            chartData?.episodeOfCare?.length ? 'Hospitalization Confirmed' : 'Confirmed No Hospitalization'
+          } AND Complete Intake`;
+        default:
+          return isLastPage ? 'Complete' : 'Next';
+      }
     }
+
+    return 'Next';
   })();
 
   return (

--- a/apps/ehr/src/features/css-module/layout/BottomNavigation.tsx
+++ b/apps/ehr/src/features/css-module/layout/BottomNavigation.tsx
@@ -37,16 +37,16 @@ export const BottomNavigation = (): JSX.Element => {
   const handleNextPage = async (): Promise<void> => {
     try {
       setNextButtonLoading(true);
-      if (isLastPage) {
+      if (isLastPage && interactionMode === 'intake') {
         await handleUpdatePractitioner();
-        setNextButtonLoading(false);
       }
       goToNext();
-      setNextButtonLoading(false);
       await refetch();
     } catch (error: any) {
       console.log(error.message);
       enqueueSnackbar('An error occurred trying to complete intake. Please try again.', { variant: 'error' });
+    } finally {
+      setNextButtonLoading(false);
     }
   };
 
@@ -92,7 +92,7 @@ export const BottomNavigation = (): JSX.Element => {
           Back
         </Button>
         <LoadingButton
-          disabled={isNavigationDisabled || isEncounterUpdatePending}
+          disabled={isNavigationDisabled || isEncounterUpdatePending || (isLastPage && interactionMode === 'provider')}
           loading={nextButtonLoading}
           endIcon={<ArrowForwardIcon sx={{ width: '32px', height: '32px' }} />}
           onClick={handleNextPage}

--- a/apps/ehr/src/features/css-module/routing/CSSRouting.tsx
+++ b/apps/ehr/src/features/css-module/routing/CSSRouting.tsx
@@ -5,17 +5,11 @@ import { useCSSPermissions } from '../hooks/useCSSPermissions';
 import { FeatureFlagsProvider } from '../context/featureFlags';
 import { CSSLoader } from '../components/CSSLoader';
 import { NavigationProvider, useNavigationContext } from '../context/NavigationContext';
-import { routesCSS } from './routesCSS';
-
-const allRoutes = Object.values(routesCSS);
-const providerRoutes = allRoutes.filter((route) => route.modes.includes('provider'));
-const intakeRoutes = allRoutes.filter((route) => route.modes.includes('intake'));
-// const readonlyRoutes = allRoutes.filter((route) => route.modes.includes('readonly'));
 
 const CSSRouting: React.FC = () => {
   const permissions = useCSSPermissions();
   const navigate = useNavigate();
-  const { interactionMode } = useNavigationContext();
+  const { availableRoutes } = useNavigationContext();
   if (permissions.isPending) {
     return <CSSLoader />;
   }
@@ -24,8 +18,6 @@ const CSSRouting: React.FC = () => {
     navigate('/visits');
     return null;
   }
-
-  const availableRoutes = interactionMode === 'provider' ? providerRoutes : intakeRoutes;
 
   return (
     <FeatureFlagsProvider flagsToSet={{ css: true }}>


### PR DESCRIPTION
https://github.com/masslight/ottehr/issues/911

Add bottom navigation for the Provider mode

- Improve route navigation logic in NavigationContext
- Add support for skipping routes in bottom navigation
- Refactor bottom navigation button behavior for different interaction modes
- Update routing to dynamically handle available routes based on interaction mode