### PR TITLE
EHR. Patients search. Always query appointments and locations for "Last Visit" column

### DIFF
--- a/apps/ehr/src/components/PatientsSearch/utils/buildSearchQuery.ts
+++ b/apps/ehr/src/components/PatientsSearch/utils/buildSearchQuery.ts
@@ -6,9 +6,9 @@ export const buildSearchQuery = (filter: Partial<SearchOptionsFilters>): string 
 
   if (filter.location && filter.location !== 'All') {
     params.push(`_has:Appointment:patient:actor:Location.name:contains=${encodeURIComponent(filter.location)}`);
-    params.push('_revinclude=Appointment:patient');
-    params.push('_include:iterate=Appointment:actor:Location');
   }
+  params.push('_revinclude=Appointment:patient');
+  params.push('_include:iterate=Appointment:actor:Location');
 
   if (filter.phone) {
     const digits = filter.phone.replace(/\D/g, '');


### PR DESCRIPTION
Fix for https://github.com/masslight/ottehr/issues/976

Appointemnts and corresponding Locations need to be queried every time despite `location` filter in order to correctly populate  "Last Visit" column.