### PR TITLE
tweak(local): Bind to 0.0.0.0 for all services

### DIFF
--- a/apps/ehr/vite.config.ts
+++ b/apps/ehr/vite.config.ts
@@ -15,6 +15,7 @@ export default ({ mode }) => {
     plugins: [react(), viteTsconfigPaths(), svgr()],
     server: {
       open: !process.env.VITE_NO_OPEN,
+      host: '0.0.0.0',
       port: env.PORT ? parseInt(env.PORT) : undefined,
     },
     build: {

--- a/apps/intake/vite.config.ts
+++ b/apps/intake/vite.config.ts
@@ -43,6 +43,7 @@ export default (env) => {
       plugins,
       server: {
         open: !process.env.VITE_NO_OPEN,
+        host: '0.0.0.0',
       },
     })
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ottehr",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ottehr",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "workspaces": [
         "packages/**/*",
         "apps/*"
@@ -41849,7 +41849,7 @@
     },
     "packages/ehr/zambdas": {
       "name": "ehr-zambdas",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.272.0",
         "@oystehr/sdk": "3.0.7",
@@ -41926,7 +41926,7 @@
     },
     "packages/intake/zambdas": {
       "name": "intake-zambdas",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "diacritics": "^1.3.0",
         "esbuild": "^0.20.2",

--- a/packages/intake/zambdas/serverless.yml
+++ b/packages/intake/zambdas/serverless.yml
@@ -1,6 +1,6 @@
 service: zambdas
 
-frameworkVersion: '3'
+frameworkVersion: "3"
 
 package:
   individually: true
@@ -14,6 +14,7 @@ custom:
   defaultStage: local
   serverless-offline:
     reloadHandler: true
+    host: 0.0.0.0
     httpPort: 3000
     lambdaPort: 3001
   esbuild:


### PR DESCRIPTION
This allows `http://127.0.0.1:[3|4]002` urls to resolve. #880 isn't totally solved by this PR though, because auth0 also requires the Login URI to be served using TLS. I'll address that in a second PR.