### PR TITLE
Update Coverage.payor when insurance provider is changed during paperwork

### DIFF
--- a/packages/intake/zambdas/src/subscriptions/questionnaire-response/sub-intake-harvest/helpers.ts
+++ b/packages/intake/zambdas/src/subscriptions/questionnaire-response/sub-intake-harvest/helpers.ts
@@ -1214,7 +1214,8 @@ export interface PatientMasterRecordResources {
 
 export function createMasterRecordPatchOperations(
   questionnaireResponse: QuestionnaireResponse,
-  resources: PatientMasterRecordResources
+  resources: PatientMasterRecordResources,
+  insurancePlanResources: InsurancePlan[]
 ): MasterRecordPatchOperations {
   const flattenedPaperwork = flattenIntakeQuestionnaireItems(
     questionnaireResponse.item as IntakeQuestionnaireItem[]
@@ -1253,14 +1254,13 @@ export function createMasterRecordPatchOperations(
     if (!fullPath) return;
 
     const { resourceType, path } = extractResourceTypeAndPath(fullPath);
-    let operation: Operation | undefined;
 
     switch (resourceType) {
       case 'Patient': {
         // Handle telecom fields
         const contactTelecomConfig = contactTelecomConfigs[item.linkId];
         if (contactTelecomConfig) {
-          operation = createPatchOperationForTelecom(
+          const operation = createPatchOperationForTelecom(
             value as string | boolean,
             contactTelecomConfig,
             resources.patient,
@@ -1275,6 +1275,7 @@ export function createMasterRecordPatchOperations(
           const url = path.replace('/extension/', '');
           const currentValue = getCurrentValue(resources.patient, path);
           if (value !== currentValue) {
+            let operation: Operation | undefined;
             if (value === '') {
               if (currentValue !== undefined && currentValue !== null) {
                 operation = getPatchOperationToRemoveExtension(resources.patient, { url });
@@ -1313,20 +1314,18 @@ export function createMasterRecordPatchOperations(
             const cleanArray = currentArray.filter(
               (item, index) => item !== undefined || index < currentArray.length - 1
             );
-
-            if (cleanArray.length > 0) {
-              operation = {
-                op: effectiveArrayValue === undefined ? 'add' : 'replace',
-                path: arrayPath,
-                value: cleanArray,
-              };
-            } else {
-              operation = {
-                op: 'remove',
-                path: arrayPath,
-              };
-            }
-            if (operation) tempOperations.patient.push(operation);
+            const operation: Operation =
+              cleanArray.length > 0
+                ? {
+                    op: effectiveArrayValue === undefined ? 'add' : 'replace',
+                    path: arrayPath,
+                    value: cleanArray,
+                  }
+                : {
+                    op: 'remove',
+                    path: arrayPath,
+                  };
+            tempOperations.patient.push(operation);
           }
           return;
         }
@@ -1337,7 +1336,7 @@ export function createMasterRecordPatchOperations(
           const url = DATE_OF_BIRTH_URL;
           const currentValue = getCurrentValue(resources.patient, path);
           if (value !== currentValue) {
-            operation = {
+            tempOperations.patient.push({
               op: 'add',
               path: '/contact/0/extension',
               value: [
@@ -1346,8 +1345,7 @@ export function createMasterRecordPatchOperations(
                   valueString: value,
                 },
               ],
-            };
-            if (operation) tempOperations.patient.push(operation);
+            });
           }
           return;
         }
@@ -1356,7 +1354,7 @@ export function createMasterRecordPatchOperations(
           const url = PRACTICE_NAME_URL;
           const currentValue = getCurrentValue(resources.patient, path);
           if (value !== currentValue) {
-            operation = {
+            tempOperations.patient.push({
               op: 'add',
               path: '/contained/0/extension',
               value: [
@@ -1365,8 +1363,7 @@ export function createMasterRecordPatchOperations(
                   valueString: value,
                 },
               ],
-            };
-            if (operation) tempOperations.patient.push(operation);
+            });
           }
           return;
         }
@@ -1374,9 +1371,9 @@ export function createMasterRecordPatchOperations(
         // Handle regular fields
         const currentValue = getCurrentValue(resources.patient, path);
         if (value !== currentValue) {
-          operation = createBasicPatchOperation(value, path, currentValue);
+          const operation = createBasicPatchOperation(value, path, currentValue);
+          if (operation) tempOperations.patient.push(operation);
         }
-        if (operation) tempOperations.patient.push(operation);
         break;
       }
 
@@ -1385,19 +1382,28 @@ export function createMasterRecordPatchOperations(
 
         if (coverage) {
           const currentValue = getCurrentValue(coverage, path);
+          const operations: (Operation | undefined)[] = [];
 
           if (baseFieldId === 'insurance-carrier') {
             if ((value as Reference).display !== currentValue) {
-              operation = createBasicPatchOperation((value as Reference).display!, path, currentValue);
+              operations.push(createBasicPatchOperation((value as Reference).display!, path, currentValue));
+            }
+            const insurancePlanId = (value as Reference).reference?.split('/')?.[1];
+            const payor = insurancePlanResources.find((insurancePlan) => insurancePlan.id === insurancePlanId)?.ownedBy
+              ?.reference;
+            if (payor != null) {
+              operations.push(createBasicPatchOperation(payor, '/payor/0/reference', coverage.payor?.[0].reference));
             }
           } else if (value !== currentValue) {
-            operation = createBasicPatchOperation(value, path, currentValue);
+            operations.push(createBasicPatchOperation(value, path, currentValue));
           }
 
-          if (operation) {
-            tempOperations.coverage[coverage.id!] = tempOperations.coverage[coverage.id!] || [];
-            tempOperations.coverage[coverage.id!].push(operation);
-          }
+          operations.forEach((operation) => {
+            if (operation) {
+              tempOperations.coverage[coverage.id!] = tempOperations.coverage[coverage.id!] || [];
+              tempOperations.coverage[coverage.id!].push(operation);
+            }
+          });
         }
         break;
       }
@@ -1408,12 +1414,11 @@ export function createMasterRecordPatchOperations(
         if (relatedPerson) {
           const currentValue = getCurrentValue(relatedPerson, path);
           if (value !== currentValue) {
-            operation = createBasicPatchOperation(value, path, currentValue);
-          }
-
-          if (operation) {
-            tempOperations.relatedPerson[relatedPerson.id!] = tempOperations.relatedPerson[relatedPerson.id!] || [];
-            tempOperations.relatedPerson[relatedPerson.id!].push(operation);
+            const operation = createBasicPatchOperation(value, path, currentValue);
+            if (operation) {
+              tempOperations.relatedPerson[relatedPerson.id!] = tempOperations.relatedPerson[relatedPerson.id!] || [];
+              tempOperations.relatedPerson[relatedPerson.id!].push(operation);
+            }
           }
         }
         break;

--- a/packages/intake/zambdas/src/subscriptions/questionnaire-response/sub-intake-harvest/index.ts
+++ b/packages/intake/zambdas/src/subscriptions/questionnaire-response/sub-intake-harvest/index.ts
@@ -138,9 +138,10 @@ export const index = wrapHandler(async (input: ZambdaInput): Promise<APIGatewayP
       relatedPersons: relatedPersonResources,
     };
     console.log('Patient Master Record resources: ', JSON.stringify(patientMasterRecordResources, null, 2));
+    console.log('Insurance information resources: ', JSON.stringify(insuranceInformationResources, null, 2));
 
     console.log('creating patch operations');
-    const patientPatchOps = createMasterRecordPatchOperations(qr, patientMasterRecordResources);
+    const patientPatchOps = createMasterRecordPatchOperations(qr, patientMasterRecordResources, insurancePlanResources);
 
     console.log('All Patient patch operations being attempted: ', JSON.stringify(patientPatchOps, null, 2));
 


### PR DESCRIPTION
Fix for https://github.com/masslight/ottehr/issues/1037.
`Coverage.payor` needs to be updated when `insurance-carrier` is present in `QuestionnaireResponse`.
Did a small refactoring by deleting a shared `operation` variable as it's usage is very confusing.