### PR TITLE
feat: Add support for local TLS

### DIFF
--- a/apps/ehr/vite.config.ts
+++ b/apps/ehr/vite.config.ts
@@ -12,7 +12,7 @@ export default ({ mode }) => {
   const tlsCertExists = existsSync(path.join(process.cwd(), envDir, 'cert.pem'));
   const tlsKeyExists = existsSync(path.join(process.cwd(), envDir, 'key.pem'));
   if (tlsCertExists && tlsKeyExists) {
-    console.log(`Found TLS certificate and key, serving in ${mode} over HTTPS`)
+    console.log(`Found TLS certificate and key, serving in ${mode} over HTTPS`);
   } else if (tlsCertExists && !tlsKeyExists) {
     console.error(`Found TLS certificate but private key is missing, serving in ${mode} over HTTP`);
   } else if (!tlsCertExists && tlsKeyExists) {
@@ -27,10 +27,13 @@ export default ({ mode }) => {
       open: !process.env.VITE_NO_OPEN,
       host: '0.0.0.0',
       port: env.PORT ? parseInt(env.PORT) : undefined,
-      https: tlsCertExists && tlsKeyExists ? {
-        cert: './env/cert.pem',
-        key: './env/key.pem',
-      } : undefined,
+      https:
+        tlsCertExists && tlsKeyExists
+          ? {
+              cert: './env/cert.pem',
+              key: './env/key.pem',
+            }
+          : undefined,
     },
     build: {
       outDir: './build',

--- a/apps/ehr/vite.config.ts
+++ b/apps/ehr/vite.config.ts
@@ -4,10 +4,20 @@ import viteTsconfigPaths from 'vite-tsconfig-paths';
 import browserslistToEsbuild from 'browserslist-to-esbuild';
 import svgr from 'vite-plugin-svgr';
 import * as path from 'path';
+import { existsSync } from 'fs';
 
 export default ({ mode }) => {
   const envDir = './env';
   const env = loadEnv(mode, path.join(process.cwd(), envDir), '');
+  const tlsCertExists = existsSync(path.join(process.cwd(), envDir, 'cert.pem'));
+  const tlsKeyExists = existsSync(path.join(process.cwd(), envDir, 'key.pem'));
+  if (tlsCertExists && tlsKeyExists) {
+    console.log(`Found TLS certificate and key, serving in ${mode} over HTTPS`)
+  } else if (tlsCertExists && !tlsKeyExists) {
+    console.error(`Found TLS certificate but private key is missing, serving in ${mode} over HTTP`);
+  } else if (!tlsCertExists && tlsKeyExists) {
+    console.error(`Found TLS private key but certificate is missing, serving in ${mode} over HTTP`);
+  }
 
   return defineConfig({
     envDir: envDir,
@@ -17,6 +27,10 @@ export default ({ mode }) => {
       open: !process.env.VITE_NO_OPEN,
       host: '0.0.0.0',
       port: env.PORT ? parseInt(env.PORT) : undefined,
+      https: tlsCertExists && tlsKeyExists ? {
+        cert: './env/cert.pem',
+        key: './env/key.pem',
+      } : undefined,
     },
     build: {
       outDir: './build',

--- a/apps/intake/vite.config.ts
+++ b/apps/intake/vite.config.ts
@@ -38,7 +38,7 @@ export default (env) => {
   const tlsCertExists = existsSync(path.join(process.cwd(), envDir, 'cert.pem'));
   const tlsKeyExists = existsSync(path.join(process.cwd(), envDir, 'key.pem'));
   if (tlsCertExists && tlsKeyExists) {
-    console.log(`Found TLS certificate and key, serving in ${mode} over HTTPS`)
+    console.log(`Found TLS certificate and key, serving in ${mode} over HTTPS`);
   } else if (tlsCertExists && !tlsKeyExists) {
     console.error(`Found TLS certificate but private key is missing, serving in ${mode} over HTTP`);
   } else if (!tlsCertExists && tlsKeyExists) {
@@ -55,10 +55,13 @@ export default (env) => {
       server: {
         open: !process.env.VITE_NO_OPEN,
         host: '0.0.0.0',
-        https: tlsCertExists && tlsKeyExists ? {
-          cert: './env/cert.pem',
-          key: './env/key.pem',
-        } : undefined,
+        https:
+          tlsCertExists && tlsKeyExists
+            ? {
+                cert: './env/cert.pem',
+                key: './env/key.pem',
+              }
+            : undefined,
       },
     })
   );

--- a/apps/intake/vite.config.ts
+++ b/apps/intake/vite.config.ts
@@ -1,4 +1,5 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin';
+import { existsSync } from 'fs';
 import path from 'path';
 import { PluginOption, defineConfig, loadEnv, mergeConfig } from 'vite';
 import IstanbulPlugin from 'vite-plugin-istanbul';
@@ -34,6 +35,16 @@ export default (env) => {
     );
   }
 
+  const tlsCertExists = existsSync(path.join(process.cwd(), envDir, 'cert.pem'));
+  const tlsKeyExists = existsSync(path.join(process.cwd(), envDir, 'key.pem'));
+  if (tlsCertExists && tlsKeyExists) {
+    console.log(`Found TLS certificate and key, serving in ${mode} over HTTPS`)
+  } else if (tlsCertExists && !tlsKeyExists) {
+    console.error(`Found TLS certificate but private key is missing, serving in ${mode} over HTTP`);
+  } else if (!tlsCertExists && tlsKeyExists) {
+    console.error(`Found TLS private key but certificate is missing, serving in ${mode} over HTTP`);
+  }
+
   return mergeConfig(
     config({ mode }),
     defineConfig({
@@ -44,6 +55,10 @@ export default (env) => {
       server: {
         open: !process.env.VITE_NO_OPEN,
         host: '0.0.0.0',
+        https: tlsCertExists && tlsKeyExists ? {
+          cert: './env/cert.pem',
+          key: './env/key.pem',
+        } : undefined,
       },
     })
   );

--- a/packages/ehr/zambdas/scripts/detect-tls.js
+++ b/packages/ehr/zambdas/scripts/detect-tls.js
@@ -1,0 +1,2 @@
+const { existsSync } = require('fs');
+module.exports.tlsPath = existsSync('./.env/cert.pem') && existsSync('./.env/key.pem') ? './.env' : undefined;

--- a/packages/ehr/zambdas/scripts/setup.ts
+++ b/packages/ehr/zambdas/scripts/setup.ts
@@ -1,7 +1,7 @@
 import Oystehr from '@oystehr/sdk';
 import { exec } from 'child_process';
 import { FhirResource, Organization } from 'fhir/r4b';
-import fs, { existsSync } from 'fs';
+import fs from 'fs';
 import path from 'path';
 import { ScheduleStrategyCoding, TIMEZONE_EXTENSION_URL } from 'utils';
 import { inviteUser } from './invite-user';
@@ -12,7 +12,12 @@ async function createApplication(oystehr: Oystehr, applicationName: string): Pro
     name: applicationName,
     description: 'EHR application with email authentication',
     loginRedirectUri: 'https://ehr-local.ottehr.com/dashboard',
-    allowedCallbackUrls: ['http://localhost:4002', 'http://localhost:4002/dashboard', 'https://localhost:4002', 'https://localhost:4002/dashboard'],
+    allowedCallbackUrls: [
+      'http://localhost:4002',
+      'http://localhost:4002/dashboard',
+      'https://localhost:4002',
+      'https://localhost:4002/dashboard',
+    ],
     allowedLogoutUrls: ['http://localhost:4002', 'https://localhost:4002'],
     allowedWebOriginsUrls: ['http://localhost:4002', 'https://localhost:4002'],
     allowedCORSOriginsUrls: ['http://localhost:4002', 'https://localhost:4002'],

--- a/packages/ehr/zambdas/scripts/setup.ts
+++ b/packages/ehr/zambdas/scripts/setup.ts
@@ -1,7 +1,7 @@
 import Oystehr from '@oystehr/sdk';
 import { exec } from 'child_process';
 import { FhirResource, Organization } from 'fhir/r4b';
-import fs from 'fs';
+import fs, { existsSync } from 'fs';
 import path from 'path';
 import { ScheduleStrategyCoding, TIMEZONE_EXTENSION_URL } from 'utils';
 import { inviteUser } from './invite-user';
@@ -12,10 +12,10 @@ async function createApplication(oystehr: Oystehr, applicationName: string): Pro
     name: applicationName,
     description: 'EHR application with email authentication',
     loginRedirectUri: 'https://ehr-local.ottehr.com/dashboard',
-    allowedCallbackUrls: ['http://localhost:4002', 'http://localhost:4002/dashboard'],
-    allowedLogoutUrls: ['http://localhost:4002'],
-    allowedWebOriginsUrls: ['http://localhost:4002'],
-    allowedCORSOriginsUrls: ['http://localhost:4002'],
+    allowedCallbackUrls: ['http://localhost:4002', 'http://localhost:4002/dashboard', 'https://localhost:4002', 'https://localhost:4002/dashboard'],
+    allowedLogoutUrls: ['http://localhost:4002', 'https://localhost:4002'],
+    allowedWebOriginsUrls: ['http://localhost:4002', 'https://localhost:4002'],
+    allowedCORSOriginsUrls: ['http://localhost:4002', 'https://localhost:4002'],
     shouldSendInviteEmail: true,
   });
   return [application.id, application.clientId];
@@ -61,6 +61,11 @@ function createZambdaEnvFile(
 
   const envData = { ...templateData, ...overrideData };
 
+  // Handle TLS certificate
+  if (fs.existsSync(path.join(envFolderPath, 'cert.pem')) && fs.existsSync(path.join(envFolderPath, 'key.pem'))) {
+    envData.WEBSITE_URL = 'https://localhost';
+  }
+
   if (!fs.existsSync(envFolderPath)) {
     fs.mkdirSync(envFolderPath, { recursive: true });
   }
@@ -69,17 +74,23 @@ function createZambdaEnvFile(
 }
 
 function createFrontEndEnvFile(clientId: string, environment: string, projectId: string): string {
-  const envTemplatePath = 'apps/ehr/env/.env.local-template';
-  const envPath = `apps/ehr/env/.env.${environment}`;
+  const envFolderPath = 'apps/ehr/env';
+  const envTemplatePath = path.join(envFolderPath, '.env.local-template');
+  const envPath = path.join(envFolderPath, `.env.${environment}`);
 
   // Read the template file
   const templateData = fs.readFileSync(envTemplatePath, 'utf8');
 
   // Replace the placeholders with the actual values
-  const updatedData = templateData
+  let updatedData = templateData
     .replace('VITE_APP_OYSTEHR_APPLICATION_CLIENT_ID=', `VITE_APP_OYSTEHR_APPLICATION_CLIENT_ID=${clientId}`)
     .replace('VITE_APP_ENV=', `VITE_APP_ENV=${environment}`)
     .replace('VITE_APP_PROJECT_ID=', `VITE_APP_PROJECT_ID=${projectId}`);
+
+  // Handle TLS certificate
+  if (fs.existsSync(path.join(envFolderPath, 'cert.pem')) && fs.existsSync(path.join(envFolderPath, 'key.pem'))) {
+    updatedData = updatedData.replace('http://localhost', 'https://localhost');
+  }
 
   // Write the updated data to the new file
   fs.writeFileSync(envPath, updatedData);

--- a/packages/ehr/zambdas/serverless.yml
+++ b/packages/ehr/zambdas/serverless.yml
@@ -17,6 +17,7 @@ custom:
     host: 0.0.0.0
     httpPort: 4000
     lambdaPort: 4001
+    httpsProtocol: ${file(./scripts/detect-tls.js):tlsPath, null}
   esbuild:
     minify: false
     sourcemap: linked

--- a/packages/intake/zambdas/scripts/detect-tls.js
+++ b/packages/intake/zambdas/scripts/detect-tls.js
@@ -1,0 +1,2 @@
+const { existsSync } = require('fs');
+module.exports.tlsPath = existsSync('./.env/cert.pem') && existsSync('./.env/key.pem') ? './.env' : undefined;

--- a/packages/intake/zambdas/scripts/setup-intake.ts
+++ b/packages/intake/zambdas/scripts/setup-intake.ts
@@ -187,10 +187,13 @@ async function createApplication(oystehr: Oystehr, applicationName: string): Pro
         'http://localhost:3002',
         'http://localhost:3002/patients',
         'http://localhost:3002/redirect',
+        'https://localhost:3002',
+        'https://localhost:3002/patients',
+        'https://localhost:3002/redirect',
       ],
-      allowedLogoutUrls: ['http://localhost:3002'],
-      allowedWebOriginsUrls: ['http://localhost:3002'],
-      allowedCORSOriginsUrls: ['http://localhost:3002'],
+      allowedLogoutUrls: ['http://localhost:3002', 'https://localhost:3002'],
+      allowedWebOriginsUrls: ['http://localhost:3002', 'https://localhost:3002'],
+      allowedCORSOriginsUrls: ['http://localhost:3002', 'https://localhost:3002'],
       loginWithEmailEnabled: true,
       passwordlessSMS: true,
       mfaEnabled: false,
@@ -235,6 +238,11 @@ function createZambdaEnvFile(
 
   const envData = { ...templateData, ...overrideData };
 
+  // Handle TLS certificate
+  if (fs.existsSync(path.join(envFolderPath, 'cert.pem')) && fs.existsSync(path.join(envFolderPath, 'key.pem'))) {
+    envData.WEBSITE_URL = 'https://localhost';
+  }
+
   if (!fs.existsSync(envFolderPath)) {
     fs.mkdirSync(envFolderPath, { recursive: true });
   }
@@ -243,18 +251,23 @@ function createZambdaEnvFile(
 }
 
 function createAppEnvFile(clientId: string, environment: string, projectId: string): string {
-  const envTemplatePath = 'apps/intake/env/.env.local-template';
-  const envPath = `apps/intake/env/.env.${environment}`;
+  const envFolderPath = 'apps/intake/env';
+  const envTemplatePath = path.join(envFolderPath, '.env.local-template');
+  const envPath = path.join(envFolderPath, `.env.${environment}`);
 
   // Read the template file
   const templateData = fs.readFileSync(envTemplatePath, 'utf8');
-
   // Replace the placeholders with the actual values
   let updatedData = templateData
     .replace('VITE_APP_CLIENT_ID=', `VITE_APP_CLIENT_ID=${clientId}`)
     .replace('VITE_APP_PROJECT_ID=', `VITE_APP_PROJECT_ID=${projectId}`);
   if (environment !== 'local') {
     updatedData = updatedData.replace('VITE_APP_IS_LOCAL=true', 'VITE_APP_IS_LOCAL=false');
+  }
+
+  // Handle TLS certificate
+  if (fs.existsSync(path.join(envFolderPath, 'cert.pem')) && fs.existsSync(path.join(envFolderPath, 'key.pem'))) {
+    updatedData = updatedData.replace('http://localhost', 'https://localhost');
   }
 
   // Write the updated data to the new file

--- a/packages/intake/zambdas/serverless.yml
+++ b/packages/intake/zambdas/serverless.yml
@@ -17,6 +17,7 @@ custom:
     host: 0.0.0.0
     httpPort: 3000
     lambdaPort: 3001
+    httpsProtocol: ${file(./scripts/detect-tls.js):tlsPath, null}
   esbuild:
     sourcemap: true
 


### PR DESCRIPTION
This change supports developers working on a "remote development mode" setup, where they stand up Ottehr for testing or development in local "development mode" (`npm run apps:start`) on a remote server. The auth0 provider requires it be served over HTTPS when not on `localhost`, so these setups won't run without local TLS support.

#285 