### PR TITLE
fix(dx): Update husky, per-project hook config

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,0 @@
-{
-  "(packages|apps)/**/*.(tsx|ts|js|jsx)": ["eslint --fix", "prettier . --write"]
-}

--- a/apps/ehr/.lintstagedrc.json
+++ b/apps/ehr/.lintstagedrc.json
@@ -1,0 +1,6 @@
+{
+  "*.(tsx|ts|js|jsx)": [
+    "eslint --fix",
+    "prettier --write"
+  ]
+}

--- a/apps/intake/.lintstagedrc.json
+++ b/apps/intake/.lintstagedrc.json
@@ -1,0 +1,6 @@
+{
+  "*.(tsx|ts|js|jsx)": [
+    "eslint --fix",
+    "prettier --write"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "happy-dom": "^16.8.1",
-        "husky": "^8.0.0",
+        "husky": "^9.0.11",
         "jest": "^29.6.2",
         "lint-staged": "^15.0.2",
         "parquetjs": "^0.11.2",
@@ -29881,14 +29881,16 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "ehr:lint": "turbo lint --filter=ehr-ui... --filter=ehr-zambdas...",
     "ehr:start:ui": "turbo start --filter=ehr-ui",
     "apps:start": "turbo start --filter=intake-ui --filter=intake-zambdas --filter=ehr-ui --filter=ehr-zambdas",
-    "test": "turbo test"
+    "test": "turbo test",
+    "prepare": "husky"
   },
   "workspaces": [
     "packages/**/*",
@@ -117,7 +118,7 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "happy-dom": "^16.8.1",
-    "husky": "^8.0.0",
+    "husky": "^9.0.11",
     "jest": "^29.6.2",
     "lint-staged": "^15.0.2",
     "parquetjs": "^0.11.2",

--- a/packages/ehr/zambdas/.lintstagedrc.json
+++ b/packages/ehr/zambdas/.lintstagedrc.json
@@ -1,0 +1,6 @@
+{
+  "*.(tsx|ts|js|jsx)": [
+    "eslint --fix",
+    "prettier --write"
+  ]
+}

--- a/packages/intake/zambdas/.lintstagedrc.json
+++ b/packages/intake/zambdas/.lintstagedrc.json
@@ -1,0 +1,6 @@
+{
+  "*.(tsx|ts|js|jsx)": [
+    "eslint --fix",
+    "prettier --write"
+  ]
+}

--- a/scripts/.lintstagedrc.json
+++ b/scripts/.lintstagedrc.json
@@ -1,0 +1,6 @@
+{
+  "*.(tsx|ts|js|jsx)": [
+    "eslint --fix",
+    "prettier --write"
+  ]
+}


### PR DESCRIPTION
A single top-level config file wasn't working, and lint-staged [recommends](https://github.com/lint-staged/lint-staged?tab=readme-ov-file#how-to-use-lint-staged-in-a-multi-package-monorepo) per-package config for monorepos. Also updates `husky` to a new version with a simplified interface.