### PR TITLE
Rename "id" parameter to "instructionId" for "delete-patient-instruction" and "save-patient-instruction" zambdas

### DIFF
--- a/apps/ehr/src/telemed/features/appointment/PlanTab/components/PatientInstructionsTemplatesDialog.tsx
+++ b/apps/ehr/src/telemed/features/appointment/PlanTab/components/PatientInstructionsTemplatesDialog.tsx
@@ -38,7 +38,7 @@ export const PatientInstructionsTemplatesDialog: FC<MyTemplatesDialogProps> = (p
 
   const onDelete = (id: string): void => {
     mutate(
-      { id },
+      { instructionId: id },
       {
         onSuccess: () => {
           void queryClient.invalidateQueries({ queryKey: ['telemed-get-patient-instructions'] });

--- a/apps/ehr/src/telemed/state/appointment/appointment.queries.ts
+++ b/apps/ehr/src/telemed/state/appointment/appointment.queries.ts
@@ -674,7 +674,7 @@ export const useDeletePatientInstruction = () => {
   const apiClient = useZapEHRAPIClient();
 
   return useMutation({
-    mutationFn: (instruction: { id: string }) => {
+    mutationFn: (instruction: { instructionId: string }) => {
       if (apiClient) {
         return apiClient.deletePatientInstruction(instruction);
       }

--- a/packages/ehr/zambdas/src/delete-patient-instruction/index.ts
+++ b/packages/ehr/zambdas/src/delete-patient-instruction/index.ts
@@ -10,18 +10,18 @@ let m2mtoken: string;
 export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   try {
     console.log(`Input: ${JSON.stringify(input)}`);
-    const { id, secrets, userToken } = validateRequestParameters(input);
+    const { instructionId, secrets, userToken } = validateRequestParameters(input);
     m2mtoken = await checkOrCreateM2MClientToken(m2mtoken, secrets);
     const oystehr = createOystehrClient(m2mtoken, secrets);
     const oystehrCurrentUser = createOystehrClient(userToken, secrets);
-    const isProviderInstruction = await checkIfBelongsToCurrentProvider(oystehrCurrentUser, id);
+    const isProviderInstruction = await checkIfBelongsToCurrentProvider(oystehrCurrentUser, instructionId);
     if (!isProviderInstruction)
       throw new Error('Instruction deletion failed. Instruction does not belongs to provider');
-    await deleteCommunication(oystehr, id);
+    await deleteCommunication(oystehr, instructionId);
 
     return {
       body: JSON.stringify({
-        message: `Successfully deleted patient instruction: ${id}`,
+        message: `Successfully deleted patient instruction: ${instructionId}`,
       }),
       statusCode: 200,
     };

--- a/packages/ehr/zambdas/src/delete-patient-instruction/validateRequestParameters.ts
+++ b/packages/ehr/zambdas/src/delete-patient-instruction/validateRequestParameters.ts
@@ -14,8 +14,8 @@ export function validateRequestParameters(
     throw new Error('AuthToken is not provided in headers');
   }
 
-  if (data.id === undefined) {
-    throw new Error('These fields are required: "type"');
+  if (data.instructionId === undefined) {
+    throw new Error('These fields are required: "instructionId"');
   }
 
   const userToken = input.headers.Authorization.replace('Bearer ', '');

--- a/packages/ehr/zambdas/src/save-patient-instruction/index.ts
+++ b/packages/ehr/zambdas/src/save-patient-instruction/index.ts
@@ -11,16 +11,16 @@ let m2mtoken: string;
 export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   try {
     console.log(`Input: ${JSON.stringify(input)}`);
-    const { id, text, secrets, userToken } = validateRequestParameters(input);
+    const { instructionId, text, secrets, userToken } = validateRequestParameters(input);
     m2mtoken = await checkOrCreateM2MClientToken(m2mtoken, secrets);
     const oystehr = createOystehrClient(m2mtoken, secrets);
     const oystehrCurrentUser = createOystehrClient(userToken, secrets);
     const myUserProfile = (await oystehrCurrentUser.user.me()).profile;
     let communication: Communication;
 
-    if (id) {
-      await checkIfProvidersInstruction(id, myUserProfile, oystehr);
-      communication = await updateCommunicationResource(id, text, oystehr);
+    if (instructionId) {
+      await checkIfProvidersInstruction(instructionId, myUserProfile, oystehr);
+      communication = await updateCommunicationResource(instructionId, text, oystehr);
     } else {
       communication = await createCommunicationResource(text, myUserProfile, oystehr);
     }

--- a/packages/utils/lib/types/api/patient-instructions/patient-instructions.types.ts
+++ b/packages/utils/lib/types/api/patient-instructions/patient-instructions.types.ts
@@ -11,10 +11,10 @@ export interface GetPatientInstructionsInput {
 }
 
 export interface SavePatientInstructionInput {
-  id?: string;
+  instructionId?: string;
   text: string;
 }
 
 export interface DeletePatientInstructionInput {
-  id: string;
+  instructionId: string;
 }


### PR DESCRIPTION
When a zambda has `id` as a parameter it's impossible to execute it correctly as the `id` parameter clashes with zambda's `id` when executed using OystEHR's SDK `oystehr.zambda.execute` function.
Fix for https://github.com/masslight/ottehr/issues/956.