### PR TITLE
Show exported questionnaire PDFs in patient docs explorer 

### DIFF
--- a/packages/utils/lib/fhir/constants.ts
+++ b/packages/utils/lib/fhir/constants.ts
@@ -1,6 +1,7 @@
 import {
   AppointmentType,
   CONSENT_CODE,
+  EXPORTED_QUESTIONNAIRE_CODE,
   INSURANCE_CARD_CODE,
   PATIENT_PHOTO_CODE,
   PHOTO_ID_CARD_CODE,
@@ -298,6 +299,11 @@ export const FOLDERS_CONFIG: ListConfig[] = [
     title: 'receipts',
     display: 'Receipts',
     documentTypeCode: RECEIPT_CODE,
+  },
+  {
+    title: 'exported-questionnaires',
+    display: 'Exported questionnaires',
+    documentTypeCode: EXPORTED_QUESTIONNAIRE_CODE,
   },
 ];
 

--- a/packages/utils/lib/fhir/constants.ts
+++ b/packages/utils/lib/fhir/constants.ts
@@ -302,7 +302,7 @@ export const FOLDERS_CONFIG: ListConfig[] = [
   },
   {
     title: 'exported-questionnaires',
-    display: 'Exported questionnaires',
+    display: 'Paperwork',
     documentTypeCode: EXPORTED_QUESTIONNAIRE_CODE,
   },
 ];

--- a/packages/utils/lib/types/data/paperwork/paperwork.constants.ts
+++ b/packages/utils/lib/types/data/paperwork/paperwork.constants.ts
@@ -24,6 +24,7 @@ export const PATIENT_PHOTO_CODE = '72170-4';
 export const PHOTO_ID_CARD_CODE = '55188-7';
 export const SCHOOL_WORK_NOTE_CODE = '47420-5';
 export const RECEIPT_CODE = '34105-7';
+export const EXPORTED_QUESTIONNAIRE_CODE = '74465-6';
 export const SCHOOL_WORK_NOTE_TEMPLATE_CODE = 'school-work-note-template';
 
 export const CONSENT_CODE = '59284-0';


### PR DESCRIPTION
Implementation of https://github.com/masslight/ottehr/issues/1318
Exported questionnaire responses PDF are shown in "Patient docs" under "Exported questionnaires".
![image](https://github.com/user-attachments/assets/02968ddb-7803-4328-8b07-249915333ae1)
![image](https://github.com/user-attachments/assets/2e65219c-14f2-496d-8b95-cc39eac69cd9)
