### PR TITLE
Issue 1311. EHR. Patient record. Patient information. Insurance Information section. "Policy holder address is the same as patient's address" checkbox doesn't work

### DIFF
--- a/apps/ehr/src/components/patient/InsuranceContainer.tsx
+++ b/apps/ehr/src/components/patient/InsuranceContainer.tsx
@@ -108,7 +108,7 @@ export const InsuranceContainer: FC<InsuranceContainerProps> = ({ ordinal, remov
             required: REQUIRED_FIELD_ERROR_MESSAGE,
             validate: (value, ctxt) => {
               // todo: this validation concept would be good to lift into the paperwork validation engine
-              const otherGroupKey = InsurancePriorityOptions.find((key) => key !== FormFields.insuranceCarrier.key);
+              const otherGroupKey = InsurancePriorityOptions.find((key) => key !== FormFields.insurancePriority.key);
               let otherGroupValue: 'Primary' | 'Secondary' | undefined;
               if (otherGroupKey) {
                 otherGroupValue = ctxt[otherGroupKey];


### PR DESCRIPTION
#1311 
Checkbox 'Policy holder address is the same as patient's address' already worked, fixed validation rule that blocks saving the insurance.