### PR TITLE
fix bug, show section if note added

### DIFF
--- a/apps/ehr/src/features/css-module/components/progress-note/ProgressNoteDetails.tsx
+++ b/apps/ehr/src/features/css-module/components/progress-note/ProgressNoteDetails.tsx
@@ -64,7 +64,8 @@ export const ProgressNoteDetails: FC = () => {
 
   const showChiefComplaint = !!(chiefComplaint && chiefComplaint.length > 0);
   const showReviewOfSystems = !!(ros && ros.length > 0);
-  const showAdditionalQuestions = !!(observations && observations.length > 0);
+  const showAdditionalQuestions =
+    !!(observations && observations.length > 0) || !!(screeningNotes && screeningNotes.length > 0);
   const showAllergies = !!(allergies && allergies.length > 0);
   const showMedications = !!(medications && medications.length > 0);
   const showMedicalConditions = !!(conditions && conditions.length > 0);
@@ -79,7 +80,8 @@ export const ProgressNoteDetails: FC = () => {
   const showPrescribedMedications = !!(prescriptions && prescriptions.length > 0);
   const { showPatientInstructions } = usePatientInstructionsVisibility();
   const showEpisodeOfCare = !!(episodeOfCare && episodeOfCare.length > 0);
-  const showVitalsObservations = !!(vitalsObservations && vitalsObservations.length > 0);
+  const showVitalsObservations =
+    !!(vitalsObservations && vitalsObservations.length > 0) || !!(vitalsNotes && vitalsNotes.length > 0);
 
   const sections = [
     showChiefComplaint && <ChiefComplaintContainer />,

--- a/apps/ehr/src/features/css-module/components/progress-note/ProgressNoteDetails.tsx
+++ b/apps/ehr/src/features/css-module/components/progress-note/ProgressNoteDetails.tsx
@@ -21,7 +21,7 @@ import { ExamReadOnlyBlock } from '../examination/ExamReadOnly';
 import { getSelectors } from '../../../../shared/store/getSelectors';
 import { useChartData } from '../../hooks/useChartData';
 import { HospitalizationContainer } from './HospitalizationContainer';
-import { NOTE_TYPE, progressNoteChartDataRequestedFields } from 'utils';
+import { NOTE_TYPE, getProgressNoteChartDataRequestedFields } from 'utils';
 import { PatientVitalsContainer } from './PatientVitalsContainer';
 
 export const ProgressNoteDetails: FC = () => {
@@ -33,7 +33,7 @@ export const ProgressNoteDetails: FC = () => {
 
   const { chartData: additionalChartData } = useChartData({
     encounterId: encounter.id || '',
-    requestedFields: progressNoteChartDataRequestedFields,
+    requestedFields: getProgressNoteChartDataRequestedFields(),
     onSuccess: (data) => {
       setPartialChartData({
         episodeOfCare: data?.episodeOfCare,

--- a/packages/utils/lib/helpers/visit-note/create-vitals-search-config.helper.ts
+++ b/packages/utils/lib/helpers/visit-note/create-vitals-search-config.helper.ts
@@ -8,7 +8,6 @@ import {
 
 export interface VitalsSearchConfig {
   fieldName: Extract<keyof ChartDataFields, 'vitalsObservations'>;
-  vitalFiledName: VitalFieldNames;
   searchParams: SearchParams;
 }
 
@@ -18,7 +17,6 @@ export const createVitalsSearchConfig = (
 ): VitalsSearchConfig => {
   return {
     fieldName: 'vitalsObservations',
-    vitalFiledName: vitalFieldName,
     searchParams: {
       _search_by: searchBy,
       _include: 'Observation:performer',

--- a/packages/utils/lib/helpers/visit-note/progress-note-chart-data-requested-fields.helper.ts
+++ b/packages/utils/lib/helpers/visit-note/progress-note-chart-data-requested-fields.helper.ts
@@ -15,11 +15,7 @@ export const progressNoteChartDataRequestedFields: ChartDataRequestedFields = {
     _sort: '-_lastUpdated',
     _count: 100,
     _tag: Object.values(VitalFieldNames)
-      .map(
-        (name) =>
-          (createVitalsSearchConfig(name, 'encounter').searchParams as { _tag: { type: string; value: string } })._tag
-            .value
-      )
+      .map((name) => (createVitalsSearchConfig(name, 'encounter').searchParams as { _tag: string })._tag)
       .join(','),
   },
 };

--- a/packages/utils/lib/helpers/visit-note/progress-note-chart-data-requested-fields.helper.ts
+++ b/packages/utils/lib/helpers/visit-note/progress-note-chart-data-requested-fields.helper.ts
@@ -2,7 +2,7 @@ import { PRIVATE_EXTENSION_BASE_URL } from '../../fhir';
 import { ChartDataRequestedFields, CSS_NOTE_ID, NOTE_TYPE, VitalFieldNames } from '../../types';
 import { createVitalsSearchConfig } from './create-vitals-search-config.helper';
 
-export const progressNoteChartDataRequestedFields: ChartDataRequestedFields = {
+export const getProgressNoteChartDataRequestedFields = (): ChartDataRequestedFields => ({
   episodeOfCare: {},
   prescribedMedications: {},
   notes: {
@@ -18,7 +18,7 @@ export const progressNoteChartDataRequestedFields: ChartDataRequestedFields = {
       .map((name) => (createVitalsSearchConfig(name, 'encounter').searchParams as { _tag: string })._tag)
       .join(','),
   },
-};
+});
 
 export const telemedProgressNoteChartDataRequestedFields: ChartDataRequestedFields = {
   prescribedMedications: {},

--- a/packages/zambdas/src/ehr/sign-appointment/index.ts
+++ b/packages/zambdas/src/ehr/sign-appointment/index.ts
@@ -11,7 +11,7 @@ import {
   visitStatusToFhirAppointmentStatusMap,
   visitStatusToFhirEncounterStatusMap,
   getCriticalUpdateTagOp,
-  progressNoteChartDataRequestedFields,
+  getProgressNoteChartDataRequestedFields,
   OTTEHR_MODULE,
   telemedProgressNoteChartDataRequestedFields,
 } from 'utils';
@@ -92,7 +92,7 @@ export const performEffect = async (
   const additionalChartDataPromise = getChartData(
     oystehr,
     visitResources.encounter.id!,
-    isInPersonAppointment ? progressNoteChartDataRequestedFields : telemedProgressNoteChartDataRequestedFields
+    isInPersonAppointment ? getProgressNoteChartDataRequestedFields() : telemedProgressNoteChartDataRequestedFields
   );
 
   const [chartData, additionalChartData] = (await Promise.all([chartDataPromise, additionalChartDataPromise])).map(


### PR DESCRIPTION
#1713

- [x] lints
- [x] builds
- [x] e2e tests pass (2 tests are flaky)

fixed bug. also display section if notes added even if no observations shown, otherwise why add the note? e.g. "No vitals taken"