### PR TITLE
fix pre-commit hooks commits all files not just staged ones

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,1 @@
+git stash pop

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,5 @@
+git stash --staged
+git stash --include-untracked
+git stash pop "stash@{1}"
 npm run lint:fix
 git add .


### PR DESCRIPTION
#1804

my approach was:

1. stash staged changes only
2. stash everything else
3. pop staged-only stash
4. lint and stage everything as before because linting might fix and stage files
5. commit
6. pop non-staged files stash