### PR TITLE
Temp fix: add accountNumber to Org, update submit lab flow

### DIFF
--- a/apps/ehr/src/features/external-labs/components/OrderCollection.tsx
+++ b/apps/ehr/src/features/external-labs/components/OrderCollection.tsx
@@ -28,6 +28,7 @@ interface SampleCollectionProps {
   specimen: any;
   serviceRequestID: string;
   serviceRequest: OrderDetails;
+  accountNumber: string;
   _onCollectionSubmit: () => void;
   oystehr: Oystehr | undefined;
 }
@@ -42,6 +43,7 @@ export const OrderCollection: React.FC<SampleCollectionProps> = ({
   specimen: _2,
   serviceRequestID,
   serviceRequest,
+  accountNumber,
   _onCollectionSubmit,
   oystehr,
 }) => {
@@ -92,6 +94,7 @@ export const OrderCollection: React.FC<SampleCollectionProps> = ({
       try {
         const request: any = await submitLabOrder(oystehr, {
           serviceRequestID: serviceRequestID,
+          accountNumber: accountNumber,
           data: data,
         });
         const token = await getAccessTokenSilently();

--- a/apps/ehr/src/features/external-labs/components/details/DetailsWithoutResults.tsx
+++ b/apps/ehr/src/features/external-labs/components/details/DetailsWithoutResults.tsx
@@ -120,6 +120,7 @@ export const DetailsWithoutResults: React.FC = () => {
               specimen={specimen}
               serviceRequestID={serviceRequestID}
               serviceRequest={serviceRequest}
+              accountNumber={serviceRequest.accountNumber}
               _onCollectionSubmit={handleSampleCollectionTaskChange}
               oystehr={oystehrZambda}
             />

--- a/apps/ehr/src/features/external-labs/components/details/Questionarie.tsx
+++ b/apps/ehr/src/features/external-labs/components/details/Questionarie.tsx
@@ -26,7 +26,7 @@ export const Questionarie: React.FC = () => {
   const initialAoe: QuestionnaireItem[] = [];
   const [aoe, setAoe] = useState(initialAoe);
   const [isLoading, setIsLoading] = useState(true);
-  const [taskStatus, setTaskStatus] = useState('pending' as StatusString);
+  const [_taskStatus, setTaskStatus] = useState('pending' as StatusString);
 
   const handleSampleCollectionTaskChange = useCallback(() => setTaskStatus('collected'), [setTaskStatus]);
 
@@ -79,6 +79,7 @@ export const Questionarie: React.FC = () => {
       specimen={specimen}
       serviceRequestID={serviceRequestID}
       serviceRequest={serviceRequest}
+      accountNumber={serviceRequest.accountNumber}
       _onCollectionSubmit={handleSampleCollectionTaskChange}
       oystehr={oystehrZambda}
     />

--- a/packages/utils/lib/types/api/lab.ts
+++ b/packages/utils/lib/types/api/lab.ts
@@ -6,6 +6,7 @@ export interface GetLabOrderDetailsInput {
 
 export interface SubmitLabOrderInput {
   serviceRequestID: string;
+  accountNumber: string;
   data: any;
 }
 
@@ -17,6 +18,7 @@ export interface OrderDetails {
   orderingPhysician: string;
   orderDateTime: string;
   labName: string;
+  accountNumber: string;
   sampleCollectionDateTime: string;
   labQuestions: Questionnaire;
 }

--- a/packages/utils/lib/types/data/labs/labs.constants.ts
+++ b/packages/utils/lib/types/data/labs/labs.constants.ts
@@ -17,6 +17,8 @@ export const LAB_ORDER_TASK = {
 
 export const LAB_ORG_TYPE_CODING = { system: 'http://snomed.info/sct', code: '261904005', display: 'Laboratory' };
 
+export const LAB_ACCOUNT_NUMBER_SYSTEM = 'https://identifiers.fhir.oystehr.com/lab-account-number';
+
 export const ADDED_VIA_LAB_ORDER_SYSTEM = 'http://ottehr.org/fhir/StructureDefinition/added-via-lab-order';
 
 // These are oystehr dependent

--- a/packages/zambdas/src/ehr/get-create-lab-order-resources/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/get-create-lab-order-resources/validateRequestParameters.ts
@@ -1,5 +1,5 @@
-import { ZambdaInput } from 'zambda-utils';
 import { GetCreateLabOrderResources } from 'utils';
+import { ZambdaInput } from '../../shared';
 
 export function validateRequestParameters(input: ZambdaInput): GetCreateLabOrderResources & { secrets: any } {
   if (!input.body) {

--- a/packages/zambdas/src/ehr/get-lab-order-details/index.ts
+++ b/packages/zambdas/src/ehr/get-lab-order-details/index.ts
@@ -46,8 +46,7 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
     });
     const questionnaire: Questionnaire = await questionnaireRequest.json();
 
-    const accountNumber = org.identifier?.filter((identifier) => identifier.system === LAB_ACCOUNT_NUMBER_SYSTEM)?.[0]
-      .value;
+    const accountNumber = org.identifier?.find((identifier) => identifier.system === LAB_ACCOUNT_NUMBER_SYSTEM)?.value;
 
     if (!accountNumber) {
       throw new Error('accountNumber not found on ServiceRequest.performer Organization resource');

--- a/packages/zambdas/src/ehr/get-lab-order-details/index.ts
+++ b/packages/zambdas/src/ehr/get-lab-order-details/index.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { OrderDetails } from 'utils';
+import { LAB_ACCOUNT_NUMBER_SYSTEM, OrderDetails } from 'utils';
 import { checkOrCreateM2MClientToken, createOystehrClient } from '../../shared';
 import { ZambdaInput } from '../../shared';
 import { validateRequestParameters } from './validateRequestParameters';
@@ -22,10 +22,13 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
 
     const oystehr = createOystehrClient(m2mtoken, secrets);
 
-    const { serviceRequest, practitioner, questionnaireResponse, task } = await getLabOrderResources(
-      oystehr,
-      serviceRequestID
-    );
+    const {
+      serviceRequest,
+      practitioner,
+      questionnaireResponse,
+      task,
+      organization: org,
+    } = await getLabOrderResources(oystehr, serviceRequestID);
 
     if (!task.authoredOn) {
       throw new Error('task.authoredOn is undefined');
@@ -43,6 +46,13 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
     });
     const questionnaire: Questionnaire = await questionnaireRequest.json();
 
+    const accountNumber = org.identifier?.filter((identifier) => identifier.system === LAB_ACCOUNT_NUMBER_SYSTEM)?.[0]
+      .value;
+
+    if (!accountNumber) {
+      throw new Error('accountNumber not found on ServiceRequest.performer Organization resource');
+    }
+
     const orderDetails: OrderDetails = {
       diagnosis: serviceRequest?.reasonCode?.map((reasonCode) => reasonCode.text).join('; ') || 'Missing diagnosis',
       patientName: 'Patient Name',
@@ -53,6 +63,7 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
         : 'Missing Provider name',
       orderDateTime: task.authoredOn,
       labName: (serviceRequest?.contained?.[0] as ActivityDefinition).publisher || 'Missing Publisher name',
+      accountNumber: accountNumber,
       sampleCollectionDateTime: DateTime.now().toString(),
       labQuestions: questionnaire,
     };

--- a/packages/zambdas/src/ehr/shared/labs.ts
+++ b/packages/zambdas/src/ehr/shared/labs.ts
@@ -52,22 +52,22 @@ export async function getLabOrderResources(oystehr: Oystehr, serviceRequestID: s
     })
   )?.unbundle();
   const serviceRequestsTemp: ServiceRequest[] | undefined = serviceRequestTemp?.filter(
-    (resourceTemp) => resourceTemp.resourceType === 'ServiceRequest'
+    (resourceTemp): resourceTemp is ServiceRequest => resourceTemp.resourceType === 'ServiceRequest'
   );
   const patientsTemp: Patient[] | undefined = serviceRequestTemp?.filter(
-    (resourceTemp) => resourceTemp.resourceType === 'Patient'
+    (resourceTemp): resourceTemp is Patient => resourceTemp.resourceType === 'Patient'
   );
   const practitionersTemp: Practitioner[] | undefined = serviceRequestTemp?.filter(
-    (resourceTemp) => resourceTemp.resourceType === 'Practitioner'
+    (resourceTemp): resourceTemp is Practitioner => resourceTemp.resourceType === 'Practitioner'
   );
   const questionnaireResponsesTemp: QuestionnaireResponse[] | undefined = serviceRequestTemp?.filter(
-    (resourceTemp) => resourceTemp.resourceType === 'QuestionnaireResponse'
+    (resourceTemp): resourceTemp is QuestionnaireResponse => resourceTemp.resourceType === 'QuestionnaireResponse'
   );
   const tasksTemp: Task[] | undefined = serviceRequestTemp?.filter(
-    (resourceTemp) => resourceTemp.resourceType === 'Task'
+    (resourceTemp): resourceTemp is Task => resourceTemp.resourceType === 'Task'
   );
   const orgsTemp: Organization[] | undefined = serviceRequestTemp?.filter(
-    (resourceTemp) => resourceTemp.resourceType === 'Organization'
+    (resourceTemp): resourceTemp is Organization => resourceTemp.resourceType === 'Organization'
   );
 
   if (serviceRequestsTemp?.length !== 1) {

--- a/packages/zambdas/src/ehr/submit-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/submit-lab-order/index.ts
@@ -79,13 +79,13 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
       )?.unbundle();
 
       const coveragesRequestsTemp: Coverage[] | undefined = insuranceRequestTemp?.filter(
-        (resourceTemp) => resourceTemp.resourceType === 'Coverage'
+        (resourceTemp): resourceTemp is Coverage => resourceTemp.resourceType === 'Coverage'
       );
       const organizationsRequestsTemp: Organization[] | undefined = insuranceRequestTemp?.filter(
-        (resourceTemp) => resourceTemp.resourceType === 'Organization'
+        (resourceTemp): resourceTemp is Organization => resourceTemp.resourceType === 'Organization'
       );
       const patientsRequestsTemp: Patient[] | undefined = insuranceRequestTemp?.filter(
-        (resourceTemp) => resourceTemp.resourceType === 'Patient'
+        (resourceTemp): resourceTemp is Patient => resourceTemp.resourceType === 'Patient'
       );
       if (coveragesRequestsTemp?.length !== 1) {
         throw new Error('coverage is not found');

--- a/packages/zambdas/src/ehr/submit-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/submit-lab-order/index.ts
@@ -26,7 +26,7 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
   try {
     console.log(`Input: ${JSON.stringify(input)}`);
     console.log('Validating input');
-    const { serviceRequestID, data, secrets } = validateRequestParameters(input);
+    const { serviceRequestID, accountNumber, data, secrets } = validateRequestParameters(input);
 
     console.log('Getting token');
     m2mtoken = await checkOrCreateM2MClientToken(m2mtoken, secrets);
@@ -281,7 +281,7 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
       },
       body: JSON.stringify({
         serviceRequest: `ServiceRequest/${serviceRequest.id}`,
-        accountNumber: 'teset',
+        accountNumber: accountNumber,
       }),
     });
     if (!submitLabRequest.ok) {

--- a/packages/zambdas/src/ehr/submit-lab-order/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/submit-lab-order/validateRequestParameters.ts
@@ -6,14 +6,15 @@ export function validateRequestParameters(input: ZambdaInput): SubmitLabOrderInp
     throw new Error('No request body provided');
   }
 
-  const { serviceRequestID, data } = JSON.parse(input.body);
+  const { serviceRequestID, accountNumber, data } = JSON.parse(input.body);
 
-  if (serviceRequestID === undefined || data === undefined) {
-    throw new Error('These fields are required: "serviceRequestID", "data');
+  if (serviceRequestID === undefined || accountNumber === undefined || data === undefined) {
+    throw new Error('These fields are required: "serviceRequestID", "accountNumber", "data"');
   }
 
   return {
     serviceRequestID,
+    accountNumber,
     data,
     secrets: input.secrets,
   };

--- a/packages/zambdas/src/shared/pdf/types.ts
+++ b/packages/zambdas/src/shared/pdf/types.ts
@@ -145,6 +145,7 @@ export interface LabResultsData extends ExternalLabsData {
   reportDate: string;
   specimenSource: string;
   Dx: string;
+  labType: string;
   specimenDescription: string;
   specimenValue: string;
   specimenReferenceRange: string;

--- a/packages/zambdas/src/subscriptions/questionnaire-response/sub-intake-harvest/index.ts
+++ b/packages/zambdas/src/subscriptions/questionnaire-response/sub-intake-harvest/index.ts
@@ -166,8 +166,8 @@ export const performEffect = async (input: QRSubscriptionInput, oystehr: Oystehr
   }
   if (accountBundle && checkBundleOutcomeOk(accountBundle)) {
     try {
-      const bundleResources = flattenBundleResources(accountBundle);
-      const accountResource = bundleResources.find((res) => res.resourceType === 'Account') as Account;
+      const bundleResources = flattenBundleResources<FhirResource>(accountBundle);
+      const accountResource = bundleResources.find((res): res is Account => res.resourceType === 'Account');
       if (accountResource) {
         const guarantorReference = getActiveAccountGuarantorReference(accountResource);
         if (guarantorReference) {


### PR DESCRIPTION
We needed a solution asap to be able to test on staging, otherwise there was no good way for the FE to get the accountNumber which is necessary to submit the lab.