### PR TITLE
fix update apt using old start time

### DIFF
--- a/packages/zambdas/src/patient/appointment/prebook-update-appointment/index.ts
+++ b/packages/zambdas/src/patient/appointment/prebook-update-appointment/index.ts
@@ -216,7 +216,7 @@ export const index = wrapHandler(async (input: ZambdaInput): Promise<APIGatewayP
           getPatientContactEmail(fhirPatient), // todo use the right email
           getPatientFirstName(fhirPatient),
           `RelatedPerson/${relatedPerson.id}`,
-          originalDate.setZone(timezone).toFormat(DATETIME_FULL_NO_YEAR),
+          DateTime.fromISO(startTime).setZone(timezone).toFormat(DATETIME_FULL_NO_YEAR),
           secrets,
           scheduleOwner,
           appointmentID,


### PR DESCRIPTION
#1239

- [x] lints
- [x] builds
- [x] e2e tests pass

---

there are 2 pending bugs:

1. modifying an apt sends the old start time in the confirmation email and message (this pr)
2. i believe sometimes the subscription is run before the appointment is created, so the fhir search fails and the confirmation email and message is never sent because the subscription fails. oystehr has fixed this and will be in the v1.22 release.