### PR TITLE
wait 3s if user edits own provider before reloading

### DIFF
--- a/apps/ehr/src/components/EmployeeInformation/index.tsx
+++ b/apps/ehr/src/components/EmployeeInformation/index.tsx
@@ -166,6 +166,8 @@ export default function EmployeeInformationForm({
         variant: 'success',
       });
       if (evolveUser?.id === user.id) {
+        // wait 3 seconds for the snackbar to be seen before reloading
+        await new Promise((resolve) => setTimeout(resolve, 3000));
         window.location.reload();
       }
     } catch (error) {


### PR DESCRIPTION
#546

- [x] lints
- [x] builds
- [x] e2e tests pass

---

the snackbar was there but we reload too quickly if a provider edits their own page, so i added a wait time