### PR TITLE
971 missing section e2e tests

### DIFF
--- a/apps/ehr/tests/e2e/specs/telemed/assessmentTab.spec.ts
+++ b/apps/ehr/tests/e2e/specs/telemed/assessmentTab.spec.ts
@@ -60,9 +60,12 @@ test('Remove MDM and check missing required fields on review and sign page', asy
   await page.getByTestId(dataTestIds.telemedEhrFlow.appointmentVisitTabs(TelemedAppointmentVisitTabs.sign)).click();
   await telemedProgressNotePage.expectLoaded();
   await telemedProgressNotePage.verifyReviewAndSignButtonDisabled();
-  await expect(page.getByTestId(dataTestIds.progressNotePage.missingCard)).toBeVisible();
-  await expect(page.getByTestId(dataTestIds.progressNotePage.emCodeLink)).toBeVisible();
-  await expect(page.getByTestId(dataTestIds.progressNotePage.medicalDecisionLink)).toBeVisible();
+  await test.step('Verify missing card is visible and has all required missing fields', async () => {
+    await expect(page.getByTestId(dataTestIds.progressNotePage.missingCard)).toBeVisible();
+    await expect(page.getByTestId(dataTestIds.progressNotePage.emCodeLink)).toBeVisible();
+    await expect(page.getByTestId(dataTestIds.progressNotePage.medicalDecisionLink)).toBeVisible();
+    await expect(page.getByTestId(dataTestIds.progressNotePage.primaryDiagnosisLink)).toBeVisible();
+  });
   await page.getByTestId(dataTestIds.progressNotePage.primaryDiagnosisLink).click();
   await telemedAssessmentPage.expectDiagnosisDropdown();
   await telemedAssessmentPage.expectEmCodeDropdown();
@@ -247,5 +250,8 @@ test('Add E&M code', async () => {
     await page.getByTestId(dataTestIds.telemedEhrFlow.appointmentVisitTabs(TelemedAppointmentVisitTabs.sign)).click();
     await telemedProgressNotePage.expectLoaded();
     await expect(page.getByText(E_M_CODE)).toBeVisible();
+  });
+  await test.step('Verify missing card is not visible', async () => {
+    await expect(page.getByTestId(dataTestIds.progressNotePage.missingCard)).not.toBeVisible();
   });
 });


### PR DESCRIPTION
#971 was already partially covered in assessmentPage tests. 
It checks for missing card here and all required field links: https://vscode.dev/github/masslight/ottehr/blob/971/missing-section-tests/apps/ehr/tests/e2e/specs/telemed/assessmentTab.spec.ts#L63
A couple lines after, it clicks on the missing field link and it goes to Assessment page.
Here I added check that it's not visible if everything is filled in: https://vscode.dev/github/masslight/ottehr/blob/971/missing-section-tests/apps/ehr/tests/e2e/specs/telemed/assessmentTab.spec.ts#L254