### PR TITLE
Fix: Make sub-harvest-intake zambda criteria more specific

### DIFF
--- a/packages/zambdas/ottehr-spec.json
+++ b/packages/zambdas/ottehr-spec.json
@@ -786,7 +786,7 @@
       "src": "src/subscriptions/questionnaire-response/sub-intake-harvest/index",
       "zip": ".dist/zips/sub-intake-harvest.zip",
       "subscription": {
-        "criteria": "QuestionnaireResponse?status=completed,amended",
+        "criteria": "QuestionnaireResponse?status=completed,amended&questionnaire=https://ottehr.com/FHIR/Questionnaire/intake-paperwork-inperson,https://ottehr.com/FHIR/Questionnaire/intake-paperwork-virtual",
         "reason": "paperwork harvest",
         "event": "update"
       }


### PR DESCRIPTION
This was impacting labs workflows when we would submit our QuestionnaireResponse. This change makes the criteria for this harvest zambda more specific to only trigger on harvest specific QRs

Tested on dev