### PR TITLE
Fix: update lab order creation priority

### DIFF
--- a/packages/zambdas/src/ehr/create-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/create-lab-order/index.ts
@@ -117,7 +117,7 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
         },
       ],
       authoredOn: DateTime.now().toISO() || undefined,
-      priority: 'routine',
+      priority: 'stat',
       code: serviceRequestCode,
       reasonCode: serviceRequestReasonCode,
       instantiatesCanonical: [`#${activityDefinitionToContain.id}`],


### PR DESCRIPTION
Changed from `routine` to `stat` per @IraLeontseva's comment on #1249 