### PR TITLE
Labs/fixes

### DIFF
--- a/apps/ehr/src/features/external-labs/components/details/FinalCardView.tsx
+++ b/apps/ehr/src/features/external-labs/components/details/FinalCardView.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Divider, Switch, Typography } from '@mui/material';
+import { Box, Button, Divider } from '@mui/material';
 import BiotechOutlinedIcon from '@mui/icons-material/BiotechOutlined';
 import { FC } from 'react';
 import { ExternalLabsStatus } from 'utils';
@@ -34,14 +34,14 @@ export const FinalCardView: FC<FinalCardViewProps> = ({ resultPdfUrl, labStatus,
 
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: 2 }}>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          <Switch
+          {/* <Switch
             disabled={true} // todo: will be released in the future
             checked={false} // todo: will be released in the future
             onChange={() => null} // todo: will be released in the future
             color="primary"
             sx={{ mr: 1 }}
           />
-          <Typography variant="body2">Show Results on the Patient Portal</Typography>
+          <Typography variant="body2">Show Results on the Patient Portal</Typography> */}
         </Box>
 
         {labStatus === ExternalLabsStatus.received ? (

--- a/apps/ehr/src/features/external-labs/components/labs-orders/LabOrderLoading.tsx
+++ b/apps/ehr/src/features/external-labs/components/labs-orders/LabOrderLoading.tsx
@@ -10,7 +10,7 @@ export const LabOrderLoading: React.FC = () => {
         top: 'calc(50% + 60px)',
         left: '50%',
         transform: 'translate(-50%, -50%)',
-        backgroundColor: 'rgba(255, 255, 255, 0.7)',
+        backgroundColor: 'transparent',
         zIndex: 10,
         display: 'flex',
         alignItems: 'center',

--- a/apps/ehr/src/features/external-labs/components/labs-orders/LabsTableRow.tsx
+++ b/apps/ehr/src/features/external-labs/components/labs-orders/LabsTableRow.tsx
@@ -51,18 +51,20 @@ export const LabsTableRow = ({
         return labOrderData.orderingPhysician || '';
       case 'dx': {
         const firstDx = labOrderData.diagnosesDTO[0]?.display || '';
-        const fullDxText = labOrderData.diagnosesDTO.map((dx) => dx.display).join('; ');
+        const firstDxCode = labOrderData.diagnosesDTO[0]?.code || '';
+        const firstDxText = `${firstDxCode} ${firstDx}`;
+        const fullDxText = labOrderData.diagnosesDTO.map((dx) => `${dx.code} ${dx.display}`).join('; ');
         const dxCount = labOrderData.diagnosesDTO.length;
         if (dxCount > 1) {
           return (
             <Tooltip title={fullDxText} arrow placement="top">
               <Typography variant="body2">
-                {firstDx}; <span style={{ color: theme.palette.text.secondary }}>+ {dxCount - 1} more</span>
+                {firstDxText}; <span style={{ color: theme.palette.text.secondary }}>+ {dxCount - 1} more</span>
               </Typography>
             </Tooltip>
           );
         }
-        return <Typography variant="body2">{firstDx}</Typography>;
+        return <Typography variant="body2">{firstDxText}</Typography>;
       }
       case 'resultsReceived':
         return <DateTimeDisplay dateTimeString={labOrderData.lastResultReceivedDate} />;

--- a/apps/ehr/src/features/external-labs/pages/ExternalLabOrdersListPage.tsx
+++ b/apps/ehr/src/features/external-labs/pages/ExternalLabOrdersListPage.tsx
@@ -7,7 +7,7 @@ import { ButtonRounded } from '../../css-module/components/RoundedButton';
 import { LabsTable, LabsTableColumn } from '../components/labs-orders/LabsTable';
 import { AUTO_REDIRECTED_PARAM } from 'utils/lib/types/data/labs/labs.constants';
 
-const externalLabsColumns: LabsTableColumn[] = ['testType', 'orderAdded', 'provider', 'dx', 'status', 'actions'];
+const externalLabsColumns: LabsTableColumn[] = ['testType', 'orderAdded', 'provider', 'dx', 'status', 'psc', 'actions'];
 
 export const ExternalLabOrdersListPage: React.FC = () => {
   const navigate = useNavigate();


### PR DESCRIPTION
https://github.com/masslight/ottehr/issues/1227:
- [fixed] Dx should include Dx name AND Dx code. Currently only name is displayed.
- [fixed] Add PSC column to the Labs table in the Patient Chart. For MVP: all orders will show PSC marker.

https://github.com/masslight/ottehr/issues/2056:
- [testing resource issue, fixed] History has a duplicate of "received (ordered)" line. Should remove it.
- [testing resource issue, fixed] Don't display "who" (Admin Demo) value in "received (ordered)" line. Put nothing or "-" there.
- [fixed] Hide "Patient Portal" toggle for MVP.