### PR TITLE
Feat: enable zambda subs to run on create&update (not XOR)

### DIFF
--- a/packages/zambdas/ottehr-spec.json
+++ b/packages/zambdas/ottehr-spec.json
@@ -400,8 +400,7 @@
       "zip": ".dist/zips/handle-lab-result.zip",
       "subscription": {
         "criteria": "DiagnosticReport?category=OSL",
-        "reason": "Received new preliminary or final lab result",
-        "event": "create"
+        "reason": "Received new preliminary or final lab result"
       }
     },
     "PAPERWORK-TO-PDF": {

--- a/packages/zambdas/src/scripts/deploy-zambdas.ts
+++ b/packages/zambdas/src/scripts/deploy-zambdas.ts
@@ -5,7 +5,6 @@ import { SubscriptionZambdaDetails } from 'utils';
 import ottehrSpec from '../../ottehr-spec.json';
 import { getAuth0Token } from '../shared';
 
-
 interface DeployZambda {
   type: 'http_open' | 'http_auth' | 'subscription' | 'cron';
   subscriptionDetails?: SubscriptionZambdaDetails[];
@@ -27,7 +26,7 @@ Object.entries(ottehrSpec.zambdas).forEach(([_key, spec]) => {
 
   const zambdaDefinition: DeployZambda = {
     type: spec.type,
-  }
+  };
 
   if (spec.type === 'subscription') {
     if (anySpec.subscription === undefined) {
@@ -38,9 +37,6 @@ Object.entries(ottehrSpec.zambdas).forEach(([_key, spec]) => {
     }
     if (anySpec.subscription.reason === undefined) {
       throw new Error('Subscription zambda must have the subscription.reason property');
-    }
-    if (anySpec.subscription.event === undefined) {
-      throw new Error('Subscription zambda must have the subscription.event property');
     }
 
     zambdaDefinition.subscriptionDetails = [anySpec.subscription];
@@ -54,10 +50,13 @@ Object.entries(ottehrSpec.zambdas).forEach(([_key, spec]) => {
 
     zambdaDefinition.schedule = {
       expression: anySpec.schedule.expression,
-    }
+    };
   }
 
-  if (process.env.environment !== 'demo' && (spec.name === 'SEND-MESSAGE-CRON' || spec.name === 'NOTIFICATIONS-UPDATER')) {
+  if (
+    process.env.environment !== 'demo' &&
+    (spec.name === 'SEND-MESSAGE-CRON' || spec.name === 'NOTIFICATIONS-UPDATER')
+  ) {
     console.log('TODO Skipping zambda because we only want it in the demo env', spec.name);
     return;
   }


### PR DESCRIPTION
#2006 
Previous deploy zambda script failed validation if an event was not passed into the ottehr spec for subscription zambda, but "no event" is the equivalent of saying the sub should run on both create and update (and matches the convention in the public docs). This tiny change enables that. 

Tested on dev with the handle-lab-result zambda (which should indeed run on both create and update). Confirmed that no extension for create or update was written to the Subscription. 