### PR TITLE
Update external lab order history table 

### DIFF
--- a/apps/ehr/src/features/external-labs/components/details/DetailsWithoutResults.tsx
+++ b/apps/ehr/src/features/external-labs/components/details/DetailsWithoutResults.tsx
@@ -25,10 +25,10 @@ export const DetailsWithoutResults: React.FC<{
         </Typography>
         <Grid container justifyContent="end" spacing={2}>
           <Grid item>
-            <LabsOrderStatusChip status={labOrder.orderStatus} />
+            <Typography variant="body1">{labOrder.isPSC ? 'PSC' : ''}</Typography>
           </Grid>
           <Grid item>
-            <Typography variant="body1">{labOrder.orderSource}</Typography>
+            <LabsOrderStatusChip status={labOrder.orderStatus} />
           </Grid>
         </Grid>
       </Stack>

--- a/packages/utils/lib/types/data/labs/labs.constants.ts
+++ b/packages/utils/lib/types/data/labs/labs.constants.ts
@@ -51,6 +51,9 @@ export const LAB_ACCOUNT_NUMBER_SYSTEM = 'https://identifiers.fhir.oystehr.com/l
 
 export const ADDED_VIA_LAB_ORDER_SYSTEM = 'http://ottehr.org/fhir/StructureDefinition/added-via-lab-order';
 
+export const RELATED_SPECIMEN_DEFINITION_SYSTEM =
+  'http://ottehr.org/fhir/StructureDefinition/related-specimen-definition';
+
 export const LAB_RESTULT_PDF_BASE_NAME = 'ExternalLabsResultsForm';
 
 // These are oystehr dependent

--- a/packages/utils/lib/types/data/labs/labs.types.ts
+++ b/packages/utils/lib/types/data/labs/labs.types.ts
@@ -119,7 +119,6 @@ export type LabOrderDetailedPageDTO = LabOrderListPageDTO & {
   accountNumber: string; // identifier.system === LAB_ACCOUNT_NUMBER_SYSTEM (organization identifier) [added if list requested by ServiceRequest id]
   history: LabOrderHistoryRow[];
   resultsDetails: LabOrderResultDetails[];
-  orderSource: string; // order source (SR.orderDetail code.display)
   questionnaire: QuestionnaireData[];
   samples: sampleDTO[];
 };

--- a/packages/zambdas/src/ehr/create-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/create-lab-order/index.ts
@@ -9,6 +9,7 @@ import {
   PRACTITIONER_CODINGS,
   PROVENANCE_ACTIVITY_CODING_ENTITY,
   SPECIMEN_CODING_CONFIG,
+  RELATED_SPECIMEN_DEFINITION_SYSTEM,
 } from 'utils';
 import { validateRequestParameters } from './validateRequestParameters';
 import {
@@ -360,9 +361,10 @@ const formatSpecimenResources = (
       ],
       text: specimen.collectionInstructions,
     };
+    const specimenDefinitionId = `specimenDefinitionId${idx}`;
     const specimenDefitionConfig: SpecimenDefinition = {
       resourceType: 'SpecimenDefinition',
-      id: `specimenDefinitionId${idx}`,
+      id: specimenDefinitionId,
       typeTested: [
         {
           preference: 'preferred',
@@ -397,6 +399,12 @@ const formatSpecimenResources = (
       collection: {
         method: collectionInstructionsCoding,
       },
+      extension: [
+        {
+          url: RELATED_SPECIMEN_DEFINITION_SYSTEM,
+          valueString: specimenDefinitionId,
+        },
+      ],
       subject: {
         type: 'Patient',
         reference: `Patient/${patientID}`,

--- a/packages/zambdas/src/ehr/submit-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/submit-lab-order/index.ts
@@ -155,24 +155,45 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
         return acc;
       }
 
-      acc.push(
-        getPatchBinary({
-          resourceType: 'Specimen',
-          resourceId: specimen.id,
-          patchOperations: [
-            {
-              path: '/collection/collectedDateTime',
-              op: 'add',
-              value: now, // todo this needs to come from the frontend
-            },
-            {
-              path: '/collection/collector',
-              op: 'add',
-              value: { reference: currentUser?.profile },
-            },
-          ],
-        })
-      );
+      const specimenCollector = { reference: currentUser?.profile };
+
+      if (specimen.collection) {
+        acc.push(
+          getPatchBinary({
+            resourceType: 'Specimen',
+            resourceId: specimen.id,
+            patchOperations: [
+              {
+                path: '/collection/collectedDateTime',
+                op: 'add',
+                value: now, // todo this needs to come from the frontend
+              },
+              {
+                path: '/collection/collector',
+                op: 'add',
+                value: specimenCollector,
+              },
+            ],
+          })
+        );
+      } else {
+        acc.push(
+          getPatchBinary({
+            resourceType: 'Specimen',
+            resourceId: specimen.id,
+            patchOperations: [
+              {
+                path: '/collection',
+                op: 'add',
+                value: {
+                  collectedDateTime: now, // todo this needs to come from the frontend
+                  collector: specimenCollector,
+                },
+              },
+            ],
+          })
+        );
+      }
 
       return acc;
     }, []);

--- a/packages/zambdas/src/ehr/submit-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/submit-lab-order/index.ts
@@ -135,6 +135,51 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
       }
     }
 
+    const now = DateTime.now();
+
+    const specimenPatchOperations = specimens.reduce<BatchInputPatchRequest<FhirResource>[]>((acc, specimen) => {
+      if (!specimen.id) {
+        return acc;
+      }
+
+      const specimenDateTime = specimen.collection?.collectedDateTime;
+      console.log('specimenDateTime', specimenDateTime);
+
+      if (specimenDateTime) {
+        /**
+         * Editable samples are presented on the submit page and on pages with subsequent statuses. To unify the
+         * functionality of the samples - when editing data in date fields, they are saved immediately. Therefore,
+         * if the user has selected a date, we keep the selected one. And if they haven't selected a date, then
+         * upon submission we should set the current date.
+         */
+        return acc;
+      }
+
+      acc.push(
+        getPatchBinary({
+          resourceType: 'Specimen',
+          resourceId: specimen.id,
+          patchOperations: [
+            {
+              path: '/collection/collectedDateTime',
+              op: 'add',
+              value: now, // todo this needs to come from the frontend
+            },
+            {
+              path: '/collection/collector',
+              op: 'add',
+              value: { reference: currentUser?.profile },
+            },
+          ],
+        })
+      );
+
+      return acc;
+    }, []);
+
+    // Specimen.collection.collected is required at time of order so we must make this patch before submitting to oystehr
+    const preSumbissionWriteRequests = [...specimenPatchOperations];
+
     // not every order will have an AOE
     let questionsAndAnswers: AOEDisplayForOrderForm[] = [];
     if (questionnaireResponse !== undefined && questionnaireResponse.id) {
@@ -143,25 +188,30 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
 
       questionsAndAnswers = questionsAndAnswersForFormDisplay;
 
+      preSumbissionWriteRequests.push(
+        getPatchBinary({
+          resourceType: 'QuestionnaireResponse',
+          resourceId: questionnaireResponse.id,
+          patchOperations: [
+            {
+              op: 'add',
+              path: '/item',
+              value: questionnaireResponseItems,
+            },
+            {
+              op: 'replace',
+              path: '/status',
+              value: 'completed',
+            },
+          ],
+        })
+      );
+    }
+
+    if (preSumbissionWriteRequests.length > 0) {
+      console.log('writing updates that must occur before sending order to oysther');
       await oystehr?.fhir.transaction({
-        requests: [
-          getPatchBinary({
-            resourceType: 'QuestionnaireResponse',
-            resourceId: questionnaireResponse.id,
-            patchOperations: [
-              {
-                op: 'add',
-                path: '/item',
-                value: questionnaireResponseItems,
-              },
-              {
-                op: 'replace',
-                path: '/status',
-                value: 'completed',
-              },
-            ],
-          }),
-        ],
+        requests: preSumbissionWriteRequests,
       });
     }
 
@@ -183,7 +233,6 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
     }
 
     // submitted successful, so do the fhir provenance writes and update SR
-    const now = DateTime.now();
     const fhirUrl = `urn:uuid:${uuid()}`;
 
     const provenanceFhir: Provenance = {
@@ -205,43 +254,8 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
       },
     };
 
-    const specimenPatchOperations = specimens.reduce<BatchInputPatchRequest<FhirResource>[]>((acc, specimen) => {
-      if (!specimen.id) {
-        return acc;
-      }
-
-      const specimenDateTime = specimen.collection?.collectedDateTime;
-
-      if (specimenDateTime) {
-        /**
-         * Editable samples are presented on the submit page and on pages with subsequent statuses. To unify the
-         * functionality of the samples - when editing data in date fields, they are saved immediately. Therefore,
-         * if the user has selected a date, we keep the selected one. And if they haven't selected a date, then
-         * upon submission we should set the current date.
-         */
-        return acc;
-      }
-
-      acc.push(
-        getPatchBinary({
-          resourceType: 'Specimen',
-          resourceId: specimen.id,
-          patchOperations: [
-            {
-              path: '/collection/collectedDateTime',
-              op: 'add',
-              value: now.toISO(),
-            },
-          ],
-        })
-      );
-
-      return acc;
-    }, []);
-
     await oystehr?.fhir.transaction({
       requests: [
-        ...specimenPatchOperations,
         getPatchBinary({
           resourceType: 'ServiceRequest',
           resourceId: serviceRequest.id || 'unknown',


### PR DESCRIPTION
- https://github.com/masslight/ottehr/issues/2079
- patches specimen with collected by / datetime before submitting to oystehr
- adds an extension to specimen to link it back to the correct specimen definition
- removes orderSource from LabOrderDetailedPageDTO (wasn't being used)
