### PR TITLE
Temporarily hard coding type and container quantity on specimen

### DIFF
--- a/packages/utils/lib/types/data/labs/labs.constants.ts
+++ b/packages/utils/lib/types/data/labs/labs.constants.ts
@@ -54,6 +54,8 @@ export const ADDED_VIA_LAB_ORDER_SYSTEM = 'http://ottehr.org/fhir/StructureDefin
 export const RELATED_SPECIMEN_DEFINITION_SYSTEM =
   'http://ottehr.org/fhir/StructureDefinition/related-specimen-definition';
 
+export const SPECIMEN_TYPE_CODING_SYSTEM = 'http://terminology.hl7.org/ValueSet/v2-0487';
+
 export const LAB_RESTULT_PDF_BASE_NAME = 'ExternalLabsResultsForm';
 
 // These are oystehr dependent

--- a/packages/zambdas/src/ehr/create-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/create-lab-order/index.ts
@@ -10,6 +10,7 @@ import {
   PROVENANCE_ACTIVITY_CODING_ENTITY,
   SPECIMEN_CODING_CONFIG,
   RELATED_SPECIMEN_DEFINITION_SYSTEM,
+  SPECIMEN_TYPE_CODING_SYSTEM,
 } from 'utils';
 import { validateRequestParameters } from './validateRequestParameters';
 import {
@@ -408,6 +409,16 @@ const formatSpecimenResources = (
       subject: {
         type: 'Patient',
         reference: `Patient/${patientID}`,
+      },
+      // temp hard coding to eliminate submission errors and allow for testing the sepciment ui
+      type: {
+        coding: [
+          {
+            system: SPECIMEN_TYPE_CODING_SYSTEM,
+            code: 'SER', // this will come from the orderable item (?)
+            display: 'Serum', // tbd where will we get this but it is needed for the lab submission
+          },
+        ],
       },
     };
     specimenConfigs.push(specimenConfig);


### PR DESCRIPTION
We need to add a field to capture number of containers used for collection (we have a ticket to do this in the next iteration). For now we will just hard code it to 1 so there are no errors submitting the order to oystehr. 

We are still figuring out how to deal with the issue of not have a type - for now, hard coding this value at creation. This is just to facilitate testing.