### PR TITLE
Refactor chart data to use "surgicalHistory" for representing Surgical history data

### DIFF
--- a/apps/ehr/src/features/css-module/context/NavigationContext.tsx
+++ b/apps/ehr/src/features/css-module/context/NavigationContext.tsx
@@ -235,7 +235,7 @@ export const NavigationProvider: React.FC<{ children: ReactNode }> = ({ children
         case 'medical-conditions':
           return chartData?.conditions?.length ? 'Medical Conditions Confirmed' : 'Confirmed No Medical Conditions';
         case 'surgical-history':
-          return chartData?.procedures?.length ? 'Surgical History Confirmed' : 'Confirmed No Surgical History';
+          return chartData?.surgicalHistory?.length ? 'Surgical History Confirmed' : 'Confirmed No Surgical History';
         case 'hospitalization':
           return `${
             chartData?.episodeOfCare?.length ? 'Hospitalization Confirmed' : 'Confirmed No Hospitalization'

--- a/apps/ehr/src/telemed/features/appointment/MedicalHistoryTab/SurgicalHistory/ProceduresForm.tsx
+++ b/apps/ehr/src/telemed/features/appointment/MedicalHistoryTab/SurgicalHistory/ProceduresForm.tsx
@@ -56,7 +56,7 @@ export const ProceduresForm: FC = () => {
 
   const { control, reset } = methods;
 
-  const { isLoading, onSubmit, onRemove, values: procedures } = useChartDataArrayValue('procedures', reset, {});
+  const { isLoading, onSubmit, onRemove, values: procedures } = useChartDataArrayValue('surgicalHistory', reset, {});
 
   const handleSelectOption = (data: CPTCodeDTO | null): void => {
     if (data) {

--- a/apps/ehr/src/telemed/features/appointment/MedicalHistoryTab/SurgicalHistory/ProceduresNoteField.tsx
+++ b/apps/ehr/src/telemed/features/appointment/MedicalHistoryTab/SurgicalHistory/ProceduresNoteField.tsx
@@ -10,12 +10,12 @@ export const ProceduresNoteField: FC = () => {
   const { chartData } = getSelectors(useAppointmentStore, ['chartData']);
   const methods = useForm({
     defaultValues: {
-      text: chartData?.proceduresNote?.text || '',
+      text: chartData?.surgicalHistoryNote?.text || '',
     },
   });
 
   const { control } = methods;
-  const { onValueChange } = useDebounceNotesField('proceduresNote');
+  const { onValueChange } = useDebounceNotesField('surgicalHistoryNote');
 
   return (
     <Controller

--- a/apps/ehr/src/telemed/features/appointment/MedicalHistoryTab/SurgicalHistory/SurgicalHistoryProviderColumn.tsx
+++ b/apps/ehr/src/telemed/features/appointment/MedicalHistoryTab/SurgicalHistory/SurgicalHistoryProviderColumn.tsx
@@ -12,7 +12,7 @@ import { dataTestIds } from '../../../../../constants/data-test-ids';
 export const SurgicalHistoryProviderColumn: FC = () => {
   const { isChartDataLoading, chartData } = getSelectors(useAppointmentStore, ['isChartDataLoading', 'chartData']);
 
-  const procedures = chartData?.procedures || [];
+  const procedures = chartData?.surgicalHistory || [];
 
   const cssColumnFeatureFlag = useFeatureFlags();
 

--- a/apps/ehr/src/telemed/features/appointment/ReviewTab/components/SurgicalHistoryContainer.tsx
+++ b/apps/ehr/src/telemed/features/appointment/ReviewTab/components/SurgicalHistoryContainer.tsx
@@ -8,8 +8,8 @@ export const SurgicalHistoryContainer: FC = () => {
   const { chartData } = getSelectors(useAppointmentStore, ['chartData']);
   const theme = useTheme();
 
-  const procedures = chartData?.procedures;
-  const proceduresNote = chartData?.proceduresNote?.text;
+  const procedures = chartData?.surgicalHistory;
+  const surgicalHistoryNote = chartData?.surgicalHistoryNote?.text;
 
   return (
     <Box
@@ -28,7 +28,7 @@ export const SurgicalHistoryContainer: FC = () => {
       ) : (
         <Typography color={theme.palette.text.secondary}>No surgical history</Typography>
       )}
-      <Typography>{proceduresNote}</Typography>
+      <Typography>{surgicalHistoryNote}</Typography>
     </Box>
   );
 };

--- a/apps/ehr/src/telemed/hooks/useChartDataArrayValue.ts
+++ b/apps/ehr/src/telemed/hooks/useChartDataArrayValue.ts
@@ -7,7 +7,7 @@ import { useAppointmentStore, useDeleteChartData, useSaveChartData } from '../st
 
 type ChartDataArrayValueType = Pick<
   GetChartDataResponse,
-  'episodeOfCare' | 'allergies' | 'medications' | 'conditions' | 'procedures'
+  'episodeOfCare' | 'allergies' | 'medications' | 'conditions' | 'surgicalHistory'
 >;
 
 type ElementType<T extends ReadonlyArray<unknown>> = T extends ReadonlyArray<infer ElementType> ? ElementType : never;
@@ -17,7 +17,7 @@ const mapValueToLabel: Record<keyof ChartDataArrayValueType, string> = {
   allergies: 'known allergies',
   medications: 'current medications',
   conditions: 'medical conditions',
-  procedures: 'surgical history',
+  surgicalHistory: 'surgical history',
 };
 
 export const useChartDataArrayValue = <

--- a/apps/ehr/src/telemed/hooks/useDebounceNotesField.ts
+++ b/apps/ehr/src/telemed/hooks/useDebounceNotesField.ts
@@ -6,13 +6,13 @@ import { enqueueSnackbar } from 'notistack';
 
 type ChartDataTextValueType = Pick<
   ChartDataFields,
-  'chiefComplaint' | 'ros' | 'proceduresNote' | 'medicalDecision' | 'addendumNote'
+  'chiefComplaint' | 'ros' | 'surgicalHistoryNote' | 'medicalDecision' | 'addendumNote'
 >;
 
 enum nameToTypeEnum {
   'chiefComplaint' = 'text',
   'ros' = 'text',
-  'proceduresNote' = 'text',
+  'surgicalHistoryNote' = 'text',
   'medicalDecision' = 'text',
   'addendumNote' = 'text',
 }
@@ -20,7 +20,7 @@ enum nameToTypeEnum {
 const mapValueToLabel: Record<keyof ChartDataTextValueType, string> = {
   chiefComplaint: 'HPI note',
   ros: 'ROS note',
-  proceduresNote: 'Surgical history note',
+  surgicalHistoryNote: 'Surgical history note',
   medicalDecision: 'Medical Decision Making note',
   addendumNote: 'Addendum note',
 };

--- a/packages/utils/lib/types/api/chart-data/chart-data.types.ts
+++ b/packages/utils/lib/types/api/chart-data/chart-data.types.ts
@@ -45,8 +45,8 @@ export interface ChartDataFields {
   medications?: MedicationDTO[];
   prescribedMedications?: PrescribedMedicationDTO[];
   allergies?: AllergyDTO[];
-  procedures?: CPTCodeDTO[];
-  proceduresNote?: FreeTextNoteDTO;
+  surgicalHistory?: CPTCodeDTO[];
+  surgicalHistoryNote?: FreeTextNoteDTO;
   observations?: ObservationDTO[];
   examObservations?: ExamObservationDTO[];
   medicalDecision?: ClinicalImpressionDTO;

--- a/packages/zambdas/src/ehr/delete-chart-data/index.ts
+++ b/packages/zambdas/src/ehr/delete-chart-data/index.ts
@@ -66,8 +66,8 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
       conditions,
       medications,
       allergies,
-      proceduresNote,
-      procedures,
+      surgicalHistoryNote,
+      surgicalHistory,
       observations,
       episodeOfCare,
       secrets,
@@ -125,12 +125,12 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
       deleteOrUpdateRequests.push(deleteResourceRequest('AllergyIntolerance', element.resourceId!));
     });
 
-    if (proceduresNote) {
-      deleteOrUpdateRequests.push(deleteResourceRequest('Procedure', proceduresNote.resourceId!));
+    if (surgicalHistoryNote) {
+      deleteOrUpdateRequests.push(deleteResourceRequest('Procedure', surgicalHistoryNote.resourceId!));
     }
 
     // 6. delete Procedures
-    procedures?.forEach((element: CPTCodeDTO) => {
+    surgicalHistory?.forEach((element: CPTCodeDTO) => {
       deleteOrUpdateRequests.push(deleteResourceRequest('Procedure', element.resourceId!));
     });
 

--- a/packages/zambdas/src/ehr/get-chart-data/helpers.ts
+++ b/packages/zambdas/src/ehr/get-chart-data/helpers.ts
@@ -191,7 +191,7 @@ export async function convertSearchResultsToResponse(
           conditions: [],
           medications: [],
           allergies: [],
-          procedures: [],
+          surgicalHistory: [],
           examObservations: [],
           cptCodes: [],
           instructions: [],

--- a/packages/zambdas/src/ehr/get-chart-data/index.ts
+++ b/packages/zambdas/src/ehr/get-chart-data/index.ts
@@ -97,7 +97,7 @@ export async function getChartData(
   addRequestIfNeeded({ field: 'medications', resourceType: 'MedicationStatement', defaultSearchBy: 'patient' });
 
   // search by patient by default
-  addRequestIfNeeded({ field: 'procedures', resourceType: 'Procedure', defaultSearchBy: 'patient' });
+  addRequestIfNeeded({ field: 'surgicalHistory', resourceType: 'Procedure', defaultSearchBy: 'patient' });
 
   // edge case for Procedures just for getting cpt codes..
   // todo: delete this and just use procedures with special tag in frontend (todo: need to pass tag here through search params most likely)

--- a/packages/zambdas/src/ehr/save-chart-data/helpers.ts
+++ b/packages/zambdas/src/ehr/save-chart-data/helpers.ts
@@ -16,7 +16,7 @@ export const validateBundleAndExtractSavedChartData = (
 ): ChartDataWithResources => {
   let chartDataResponse: GetChartDataResponse = {
     patientId,
-    procedures: [],
+    surgicalHistory: [],
     medications: [],
     conditions: [],
     allergies: [],

--- a/packages/zambdas/src/ehr/save-chart-data/index.ts
+++ b/packages/zambdas/src/ehr/save-chart-data/index.ts
@@ -71,8 +71,8 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
       conditions,
       medications,
       allergies,
-      proceduresNote,
-      procedures,
+      surgicalHistoryNote,
+      surgicalHistory,
       episodeOfCare,
       observations,
       secrets,
@@ -178,17 +178,17 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
       );
     });
 
-    procedures?.forEach((procedure) => {
+    surgicalHistory?.forEach((procedure) => {
       saveOrUpdateRequests.push(
         saveOrUpdateResourceRequest(makeProcedureResource(encounterId, patient.id!, procedure, 'surgical-history'))
       );
     });
 
-    if (proceduresNote) {
+    if (surgicalHistoryNote) {
       // convert Procedure to Procedure (FHIR) and preserve FHIR resource IDs
       saveOrUpdateRequests.push(
         saveOrUpdateResourceRequest(
-          makeProcedureResource(encounterId, patient.id!, proceduresNote, 'surgical-history-note')
+          makeProcedureResource(encounterId, patient.id!, surgicalHistoryNote, 'surgical-history-note')
         )
       );
     }

--- a/packages/zambdas/src/shared/chart-data/index.ts
+++ b/packages/zambdas/src/shared/chart-data/index.ts
@@ -1058,13 +1058,13 @@ const mapResourceToChartDataFields = (
     chartDataResourceHasMetaTagByCode(resource, 'surgical-history')
   ) {
     const cptDto = makeCPTCodeDTO(resource);
-    if (cptDto) data.procedures?.push(cptDto);
+    if (cptDto) data.surgicalHistory?.push(cptDto);
     resourceMapped = true;
   } else if (
     resource?.resourceType === 'Procedure' &&
     chartDataResourceHasMetaTagByCode(resource, 'surgical-history-note')
   ) {
-    data.proceduresNote = makeFreeTextNoteDTO(resource);
+    data.surgicalHistoryNote = makeFreeTextNoteDTO(resource);
     resourceMapped = true;
   } else if (
     resource?.resourceType === 'Observation' &&

--- a/packages/zambdas/src/shared/pdf/visit-details-pdf/visit-note-pdf-creation.ts
+++ b/packages/zambdas/src/shared/pdf/visit-details-pdf/visit-note-pdf-creation.ts
@@ -116,7 +116,7 @@ function composeDataForPdf(
   const medicalConditions = mapMedicalConditions(chartData);
 
   // --- Surgical history ---
-  const surgicalHistory = chartData.procedures ? mapResourceByNameField(chartData.procedures) : []; // surgical history
+  const surgicalHistory = chartData.surgicalHistory ? mapResourceByNameField(chartData.surgicalHistory) : []; // surgical history
 
   // --- Addition questions ---
   const additionalQuestions = Object.values(AdditionalBooleanQuestionsFieldsNames).reduce(


### PR DESCRIPTION
Refactor chart data to use "surgicalHistory" and "surgicalHistoryNote" for representing Surgical history related data instead of "procedure" and "procedureNote" to avoid clash with the new "Procedures" feature.