### PR TITLE
fix(deploy): Set up resources before secrets, fail on error

### DIFF
--- a/scripts/deploy/aws/bin/update-config.ts
+++ b/scripts/deploy/aws/bin/update-config.ts
@@ -22,7 +22,6 @@ void (async () => {
     if (patientPortalDistribution && ehrDistribution) {
       const patientPortalUrl = `https://${patientPortalDistribution.DomainName}`;
       const ehrUrl = `https://${ehrDistribution.DomainName}`;
-      console.log('colin', patientPortalUrl, ehrUrl);
       const oystehr = new Oystehr({
         accessToken,
         projectId,

--- a/scripts/deploy/aws/deploy.sh
+++ b/scripts/deploy/aws/deploy.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -eo pipefail
+
 project_id=$(grep '"project_id"' "$(dirname "$0")/../deploy-config.json" | sed 's/.*: "\(.*\)".*/\1/')
 access_token=$(grep '"access_token"' "$(dirname "$0")/../deploy-config.json" | sed 's/.*: "\(.*\)".*/\1/')
 provider_email=$(grep '"provider_email"' "$(dirname "$0")/../deploy-config.json" | sed 's/.*: "\(.*\)".*/\1/')
@@ -20,8 +24,8 @@ fi
 
 pushd packages/zambdas
 ENV=$environment npm run deploy-zambdas $environment
-ENV=$environment npm run setup-secrets $environment
 ENV=$environment npm run setup-deployed-resources $environment
+ENV=$environment npm run setup-secrets $environment
 popd
 
 pushd apps/intake

--- a/scripts/deploy/gcp/deploy.sh
+++ b/scripts/deploy/gcp/deploy.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -eo pipefail
+
 project_id=$(grep '"project_id"' "$(dirname "$0")/../deploy-config.json" | sed 's/.*: "\(.*\)".*/\1/')
 access_token=$(grep '"access_token"' "$(dirname "$0")/../deploy-config.json" | sed 's/.*: "\(.*\)".*/\1/')
 provider_email=$(grep '"provider_email"' "$(dirname "$0")/../deploy-config.json" | sed 's/.*: "\(.*\)".*/\1/')
@@ -27,8 +31,8 @@ popd
 
 pushd packages/zambdas
 ENV=$environment npm run deploy-zambdas $environment
-ENV=$environment npm run setup-secrets $environment
 ENV=$environment npm run setup-deployed-resources $environment
+ENV=$environment npm run setup-secrets $environment
 popd
 
 pushd apps/intake

--- a/scripts/deploy/package-lock.json
+++ b/scripts/deploy/package-lock.json
@@ -1191,9 +1191,10 @@
       }
     },
     "node_modules/@oystehr/sdk": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@oystehr/sdk/-/sdk-3.0.7.tgz",
-      "integrity": "sha512-XwX+KACqIPagwOZC9RLq8GkclWCg1iyY0JBV7MOky6LjD+zNXf7KqvRwKwiHvyD2p+o3ZQ9mYASSDLT2UvqtEQ==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@oystehr/sdk/-/sdk-3.0.16.tgz",
+      "integrity": "sha512-i8nlAsZxYV4b4YumMEbw6d7QvsX7HM93lg4Tyn5xJ5n239ZLT8krOBQkrfzxCmquv+C1pAIizdT9c/jHvhNOnA==",
+      "license": "MIT",
       "dependencies": {
         "@types/fhir": "0.0.41",
         "@types/node": "20.17.6",


### PR DESCRIPTION
Having these out of order was causing an error when setting up secrets. The error was not easily visible as part of deploy execution without `set -e`.