### PR TITLE
Feat: add visit label, connect to in house labs

### DIFF
--- a/apps/ehr/env/.env.local-template
+++ b/apps/ehr/env/.env.local-template
@@ -80,3 +80,4 @@ VITE_APP_COLLECT_IN_HOUSE_LAB_SPECIMEN=collect-in-house-lab-specimen
 VITE_APP_HANDLE_IN_HOUSE_LAB_RESULTS=handle-in-house-lab-results
 VITE_APP_DELETE_IN_HOUSE_LAB_ORDER=delete-in-house-lab-order
 VITE_APP_GET_LABEL_PDF_ZAMBDA_ID=get-label-pdf
+VITE_APP_GET_OR_CREATE_VISIT_LABEL_PDF_ZAMBDA_ID=get-or-create-visit-label-pdf

--- a/apps/ehr/src/api/api.ts
+++ b/apps/ehr/src/api/api.ts
@@ -144,7 +144,7 @@ export const getLabelPdf = async (oystehr: Oystehr, parameters: GetLabelPdfParam
 export const getOrCreateVisitLabel = async (oystehr: Oystehr, parameters: GetVisitLabelInput): Promise<LabelPdf[]> => {
   try {
     if (GET_OR_CREATE_VISIT_LABEL_PDF_ZAMBDA_ID == null) {
-      throw new Error('get-label-pdf evironment variable could not be loaded');
+      throw new Error('get-or-create-visit-label-pdf environment variable could not be loaded');
     }
 
     const response = await oystehr.zambda.execute({

--- a/apps/ehr/src/api/api.ts
+++ b/apps/ehr/src/api/api.ts
@@ -37,6 +37,7 @@ import {
   CreateInHouseLabOrderParameters,
   GetLabelPdfParameters,
   LabelPdf,
+  GetVisitLabelInput,
 } from 'utils';
 import {
   CancelAppointmentParameters,
@@ -92,6 +93,7 @@ const COLLECT_IN_HOUSE_LAB_SPECIMEN = import.meta.env.VITE_APP_COLLECT_IN_HOUSE_
 const HANDLE_IN_HOUSE_LAB_RESULTS = import.meta.env.VITE_APP_HANDLE_IN_HOUSE_LAB_RESULTS;
 const DELETE_IN_HOUSE_LAB_ORDER = import.meta.env.VITE_APP_DELETE_IN_HOUSE_LAB_ORDER;
 const GET_LABEL_PDF_ZAMBDA_ID = import.meta.env.VITE_APP_GET_LABEL_PDF_ZAMBDA_ID;
+const GET_OR_CREATE_VISIT_LABEL_PDF_ZAMBDA_ID = import.meta.env.VITE_APP_GET_OR_CREATE_VISIT_LABEL_PDF_ZAMBDA_ID;
 
 export const getUser = async (token: string): Promise<User> => {
   const oystehr = new Oystehr({
@@ -130,6 +132,23 @@ export const getLabelPdf = async (oystehr: Oystehr, parameters: GetLabelPdfParam
 
     const response = await oystehr.zambda.execute({
       id: GET_LABEL_PDF_ZAMBDA_ID,
+      ...parameters,
+    });
+    return chooseJson(response);
+  } catch (error: unknown) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export const getOrCreateVisitLabel = async (oystehr: Oystehr, parameters: GetVisitLabelInput): Promise<LabelPdf[]> => {
+  try {
+    if (GET_OR_CREATE_VISIT_LABEL_PDF_ZAMBDA_ID == null) {
+      throw new Error('get-label-pdf evironment variable could not be loaded');
+    }
+
+    const response = await oystehr.zambda.execute({
+      id: GET_OR_CREATE_VISIT_LABEL_PDF_ZAMBDA_ID,
       ...parameters,
     });
     return chooseJson(response);

--- a/apps/ehr/src/features/in-house-labs/components/details/CollectSampleView.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/CollectSampleView.tsx
@@ -12,7 +12,7 @@ import {
   IconButton,
   Collapse,
   useTheme,
-  // Stack,
+  Stack,
 } from '@mui/material';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
@@ -22,6 +22,7 @@ import { useAppointmentStore } from '../../../../telemed/state/appointment/appoi
 import { getSelectors } from '../../../../shared/store/getSelectors';
 import { getOrCreateVisitLabel } from 'src/api/api';
 import { useApiClients } from '../../../../hooks/useAppClients';
+import { LoadingButton } from '@mui/lab';
 
 interface CollectSampleViewProps {
   testDetails: LabTest;
@@ -36,9 +37,10 @@ export const CollectSampleView: React.FC<CollectSampleViewProps> = ({ testDetail
   const [collectionDate, setCollectionDate] = useState('');
   const [collectionTime, setCollectionTime] = useState('');
   const [notes, setNotes] = useState(testDetails.notes || '');
-  const [_error, setError] = useState('');
+  const [labelButtonLoading, setLabelButtonLoading] = useState(false);
+  const [error, setError] = useState('');
 
-  const _theme = useTheme();
+  const theme = useTheme();
   const { oystehrZambda } = useApiClients();
   const { encounter } = getSelectors(useAppointmentStore, ['encounter']);
 
@@ -61,17 +63,18 @@ export const CollectSampleView: React.FC<CollectSampleViewProps> = ({ testDetail
 
   const handleReprintLabel = async (): Promise<void> => {
     if (encounter.id && oystehrZambda) {
-      setError('TODO remove me');
+      setLabelButtonLoading(true);
       console.log('Fetching visit label for encounter ', encounter.id);
       const labelPdfs = await getOrCreateVisitLabel(oystehrZambda, { encounterId: encounter.id });
-      console.log('These are the labelPDFs plural returned', JSON.stringify(labelPdfs));
+
       if (labelPdfs.length !== 1) {
         setError('Expected 1 label pdf, received unexpected number');
         return;
       }
+
       const labelPdf = labelPdfs[0];
-      console.log('This is the labelPDF returned', JSON.stringify(labelPdf));
       window.open(labelPdf.presignedURL, '_blank');
+      setLabelButtonLoading(false);
     }
   };
 
@@ -215,21 +218,31 @@ export const CollectSampleView: React.FC<CollectSampleViewProps> = ({ testDetail
             <TextField fullWidth multiline rows={4} value={notes} onChange={(e) => setNotes(e.target.value)} />
           </Box>
 
-          <Box display="flex" justifyContent="space-between" mt={3}>
-            <Button variant="outlined" onClick={handleReprintLabel} sx={{ borderRadius: '50px', px: 4 }}>
-              Re-Print Label
-            </Button>
+          <Stack display="flex">
+            <Box display="flex" justifyContent="space-between" mt={3}>
+              <LoadingButton
+                loading={labelButtonLoading}
+                variant="outlined"
+                onClick={handleReprintLabel}
+                sx={{ borderRadius: '50px', px: 4 }}
+              >
+                Re-Print Label
+              </LoadingButton>
 
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleMarkAsCollected}
-              disabled={!sourceType || !collectedBy || !collectionDate || !collectionTime}
-              sx={{ borderRadius: '50px', px: 4 }}
-            >
-              Mark as Collected
-            </Button>
-          </Box>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleMarkAsCollected}
+                disabled={!sourceType || !collectedBy || !collectionDate || !collectionTime}
+                sx={{ borderRadius: '50px', px: 4 }}
+              >
+                Mark as Collected
+              </Button>
+            </Box>
+            <Box display="flex" justifyContent="space-between" mt={3}>
+              {!!error && <Typography sx={{ color: theme.palette.error.main }}>{error}</Typography>}
+            </Box>
+          </Stack>
         </Box>
       </Paper>
 

--- a/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx
+++ b/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx
@@ -22,7 +22,7 @@ import { getSelectors } from '../../../shared/store/getSelectors';
 import { DiagnosisDTO } from 'utils/lib/types/api/chart-data';
 import { PRACTITIONER_CODINGS, TestItem } from 'utils';
 import { useApiClients } from '../../../hooks/useAppClients';
-import { createInHouseLabOrder, getCreateInHouseLabOrderResources } from '../../../api/api';
+import { createInHouseLabOrder, getCreateInHouseLabOrderResources, getOrCreateVisitLabel } from '../../../api/api';
 import { useGetIcd10Search, useDebounce, ActionsList, DeleteIconButton } from '../../../telemed';
 import { enqueueSnackbar } from 'notistack';
 
@@ -137,10 +137,20 @@ export const InHouseLabOrderCreatePage: React.FC = () => {
 
         if (shouldPrintLabel) {
           // todo: print label
+          console.log('This is the encounterId', encounterId);
+          const labelPdfs = await getOrCreateVisitLabel(oystehrZambda, { encounterId });
+          console.log('These are the labelPDFs plural returned', JSON.stringify(labelPdfs));
+          if (labelPdfs.length !== 1) {
+            setError(['Expected 1 label pdf, received unexpected number']);
+          }
+          const labelPdf = labelPdfs[0];
+          console.log('This is the labelPDF returned', JSON.stringify(labelPdf));
+          window.open(labelPdf.presignedURL, '_blank');
         }
 
         navigate(`/in-person/${appointment?.id}/in-house-lab-orders`);
       } catch (e) {
+        console.error(e);
         setError(['There was an error creating this lab order']);
       } finally {
         setLoading(false);

--- a/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx
+++ b/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx
@@ -136,15 +136,13 @@ export const InHouseLabOrderCreatePage: React.FC = () => {
         });
 
         if (shouldPrintLabel) {
-          // todo: print label
-          console.log('This is the encounterId', encounterId);
           const labelPdfs = await getOrCreateVisitLabel(oystehrZambda, { encounterId });
-          console.log('These are the labelPDFs plural returned', JSON.stringify(labelPdfs));
+
           if (labelPdfs.length !== 1) {
             setError(['Expected 1 label pdf, received unexpected number']);
           }
+
           const labelPdf = labelPdfs[0];
-          console.log('This is the labelPDF returned', JSON.stringify(labelPdf));
           window.open(labelPdf.presignedURL, '_blank');
         }
 

--- a/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderDetailsPage.tsx
+++ b/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderDetailsPage.tsx
@@ -15,7 +15,7 @@ export const InHouseLabTestDetailsPage: React.FC = () => {
   const { oystehrZambda } = useApiClients();
 
   // eslint-disable-next-line @typescript-eslint/no-inferrable-types
-  const testId: string = 'perform-test-pending';
+  const testId: string = 'collect-sample';
 
   // Fetch the test details based on the current view/status
   useEffect(() => {

--- a/packages/utils/lib/types/common.ts
+++ b/packages/utils/lib/types/common.ts
@@ -6,13 +6,13 @@ import {
   Encounter,
   HealthcareService,
   Location,
+  LocationHoursOfOperation,
   Practitioner,
   PractitionerRole,
   QuestionnaireResponse,
   Task,
 } from 'fhir/r4b';
 import { TIMEZONES } from './constants';
-import { ScheduleExtension } from '../utils';
 
 export interface PatientBaseInfo {
   firstName?: string;
@@ -43,10 +43,11 @@ export interface AvailableLocationInformation {
   description: string | undefined;
   address: Address | undefined;
   telecom: ContactPoint[] | undefined;
-  timezone: Timezone | undefined;
+  hoursOfOperation: LocationHoursOfOperation[] | undefined;
+  closures: Closure[];
+  timezone: string | undefined;
   otherOffices: { display: string; url: string }[];
-  scheduleOwnerType: ScheduleType;
-  scheduleExtension?: ScheduleExtension;
+  scheduleType: ScheduleType;
 }
 
 // Closure start/end format: 'M/d/yyyy'
@@ -762,3 +763,6 @@ export interface CanonicalUrl {
 }
 
 export type Timezone = (typeof TIMEZONES)[number];
+export interface GetVisitLabelInput {
+  encounterId: string;
+}

--- a/packages/utils/lib/types/common.ts
+++ b/packages/utils/lib/types/common.ts
@@ -6,13 +6,13 @@ import {
   Encounter,
   HealthcareService,
   Location,
-  LocationHoursOfOperation,
   Practitioner,
   PractitionerRole,
   QuestionnaireResponse,
   Task,
 } from 'fhir/r4b';
 import { TIMEZONES } from './constants';
+import { ScheduleExtension } from '../utils';
 
 export interface PatientBaseInfo {
   firstName?: string;
@@ -43,11 +43,10 @@ export interface AvailableLocationInformation {
   description: string | undefined;
   address: Address | undefined;
   telecom: ContactPoint[] | undefined;
-  hoursOfOperation: LocationHoursOfOperation[] | undefined;
-  closures: Closure[];
-  timezone: string | undefined;
+  timezone: Timezone | undefined;
   otherOffices: { display: string; url: string }[];
-  scheduleType: ScheduleType;
+  scheduleOwnerType: ScheduleType;
+  scheduleExtension?: ScheduleExtension;
 }
 
 // Closure start/end format: 'M/d/yyyy'

--- a/packages/zambdas/ottehr-spec.json
+++ b/packages/zambdas/ottehr-spec.json
@@ -839,6 +839,14 @@
       "src": "src/ehr/get-label-pdf/index",
       "zip": ".dist/zips/get-label-pdf.zip"
     },
+    "GET-OR-CREATE-VISIT-LABEL-PDF": {
+      "name": "GET-OR-CREATE-VISIT-LABEL-PDF",
+      "type": "http_auth",
+      "runtime": "nodejs20.x",
+      "src": "src/ehr/get-or-create-visit-label-pdf/index",
+      "zip": ".dist/zips/get-or-create-visit-label-pdf.zip"
+    },
+
     "EHR-GET-SCHEDULE": {
       "name": "EHR-GET-SCHEDULE",
       "type": "http_auth",
@@ -959,10 +967,7 @@
         "patient": "patient-id",
         "title": "My Questions"
       },
-      "managedFields": [
-        "name",
-        "title"
-      ]
+      "managedFields": ["name", "title"]
     }
   },
   "apps": {
@@ -985,9 +990,7 @@
           "effect": "Allow"
         }
       ],
-      "roles": [
-        "#ref/EHR_SUPER_ADMIN"
-      ]
+      "roles": ["#ref/EHR_SUPER_ADMIN"]
     }
   },
   "roles": {

--- a/packages/zambdas/src/ehr/get-or-create-visit-label-pdf/index.ts
+++ b/packages/zambdas/src/ehr/get-or-create-visit-label-pdf/index.ts
@@ -126,8 +126,7 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
 
     throw new Error(`Got ${labelDocRefs.length} docRefs for Encounter/${encounterId}. Expected 0 or 1`);
   } catch (error: any) {
-    console.log(error);
-    console.log('get or create visit label pdf error:', JSON.stringify(error));
+    console.error('get or create visit label pdf error:', JSON.stringify(error));
     await topLevelCatch('admin-get-or-create-visit-label-pdf', error, input.secrets);
     let body = JSON.stringify({ message: 'Error fetching or creating visit label pdf' });
     if (isApiError(error)) {

--- a/packages/zambdas/src/ehr/get-or-create-visit-label-pdf/index.ts
+++ b/packages/zambdas/src/ehr/get-or-create-visit-label-pdf/index.ts
@@ -1,0 +1,138 @@
+import { APIGatewayProxyResult } from 'aws-lambda';
+import {
+  getPresignedURL,
+  isApiError,
+  APIError,
+  DYMO_30334_LABEL_CONFIG,
+  getPatientFirstName,
+  getPatientLastName,
+  getMiddleName,
+} from 'utils';
+import { checkOrCreateM2MClientToken, createOystehrClient, topLevelCatch } from '../../shared';
+import { ZambdaInput } from '../../shared';
+import { validateRequestParameters } from './validateRequestParameters';
+import { Appointment, DocumentReference, Encounter, Patient } from 'fhir/r4b';
+import { createVisitLabelPDF, VisitLabelConfig, VISIT_LABEL_DOC_REF_DOCTYPE } from '../../shared/pdf/visit-label-pdf';
+import { DateTime } from 'luxon';
+
+// Lifting up value to outside of the handler allows it to stay in memory across warm lambda invocations
+let m2mtoken: string;
+
+export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
+  try {
+    console.log(`Input: ${JSON.stringify(input)}`);
+    console.log('Validating input');
+    const { encounterId, secrets } = validateRequestParameters(input);
+
+    console.log('Getting token');
+    m2mtoken = await checkOrCreateM2MClientToken(m2mtoken, secrets);
+    console.log('token', m2mtoken);
+
+    const oystehr = createOystehrClient(m2mtoken, secrets);
+
+    const labelDocRefs = (
+      await oystehr.fhir.search<DocumentReference>({
+        resourceType: 'DocumentReference',
+        params: [
+          { name: 'encounter', value: `Encounter/${encounterId}` },
+          { name: 'status', value: 'current' },
+          { name: 'type', value: VISIT_LABEL_DOC_REF_DOCTYPE.code },
+        ],
+      })
+    ).unbundle();
+
+    if (!labelDocRefs.length) {
+      // we should create the pdf. Need patient & appointment info
+      const resources = (
+        await oystehr.fhir.search<Encounter | Patient | Appointment>({
+          resourceType: 'Encounter',
+          params: [
+            {
+              name: '_id',
+              value: encounterId!,
+            },
+            {
+              name: '_include',
+              value: 'Encounter:subject',
+            },
+            {
+              name: '_include',
+              value: 'Encounter:appointment',
+            },
+          ],
+        })
+      ).unbundle();
+
+      const patients: Patient[] = resources.filter(
+        (resource): resource is Patient => resource.resourceType === 'Patient'
+      );
+      const appointments: Appointment[] = resources.filter(
+        (resource): resource is Appointment => resource.resourceType === 'Appointment'
+      );
+
+      if (patients.length !== 1 || appointments.length !== 1) {
+        throw new Error(`Error fetching patient, encounter, or appointment for Encounter/${encounterId}`);
+      }
+
+      const patient = patients[0];
+
+      const labelConfig: VisitLabelConfig = {
+        labelConfig: DYMO_30334_LABEL_CONFIG,
+        content: {
+          patientId: patient.id!,
+          patientFirstName: getPatientFirstName(patient) ?? '',
+          patientMiddleName: getMiddleName(patient),
+          patientLastName: getPatientLastName(patient) ?? '',
+          patientDateOfBirth: patient.birthDate ? DateTime.fromISO(patient.birthDate) : undefined,
+          patientGender: patient.gender ?? '',
+          visitDate: appointments[0].start ? DateTime.fromISO(appointments[0].start) : undefined,
+        },
+      };
+
+      const { presignedURL, docRef: documentReference } = await createVisitLabelPDF(
+        labelConfig,
+        encounterId,
+        secrets,
+        m2mtoken,
+        oystehr
+      );
+
+      //  LabelPdf[] return type
+      return {
+        body: JSON.stringify([{ documentReference, presignedURL }]),
+        statusCode: 200,
+      };
+    } else if (labelDocRefs.length === 1) {
+      const labelDocRef = labelDocRefs[0];
+      const url = labelDocRef.content.find((content) => content.attachment.contentType === 'application/pdf')
+        ?.attachment.url;
+
+      if (!url) {
+        throw new Error(`No url found matching an application/pdf for DocumentReference/${labelDocRef.id}`);
+      }
+
+      return {
+        body: JSON.stringify({
+          documentReference: labelDocRef,
+          presignedURL: await getPresignedURL(url, m2mtoken),
+        }),
+        statusCode: 200,
+      };
+    }
+
+    throw new Error(`Got ${labelDocRefs.length} docRefs for Encounter/${encounterId}. Expected 0 or 1`);
+  } catch (error: any) {
+    console.log(error);
+    console.log('get or create visit label pdf error:', JSON.stringify(error));
+    await topLevelCatch('admin-get-or-create-visit-label-pdf', error, input.secrets);
+    let body = JSON.stringify({ message: 'Error fetching or creating visit label pdf' });
+    if (isApiError(error)) {
+      const { code, message } = error as APIError;
+      body = JSON.stringify({ message, code });
+    }
+    return {
+      statusCode: 500,
+      body,
+    };
+  }
+};

--- a/packages/zambdas/src/ehr/get-or-create-visit-label-pdf/index.ts
+++ b/packages/zambdas/src/ehr/get-or-create-visit-label-pdf/index.ts
@@ -43,6 +43,7 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
 
     if (!labelDocRefs.length) {
       // we should create the pdf. Need patient & appointment info
+      console.log(`No docrefs found for Encounter/${encounterId}. Making new label`);
       const resources = (
         await oystehr.fhir.search<Encounter | Patient | Appointment>({
           resourceType: 'Encounter',
@@ -104,6 +105,7 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
       };
     } else if (labelDocRefs.length === 1) {
       const labelDocRef = labelDocRefs[0];
+      console.log(`Found existing DocumentReference/${labelDocRef.id} for Encounter/${encounterId}`);
       const url = labelDocRef.content.find((content) => content.attachment.contentType === 'application/pdf')
         ?.attachment.url;
 
@@ -112,10 +114,12 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
       }
 
       return {
-        body: JSON.stringify({
-          documentReference: labelDocRef,
-          presignedURL: await getPresignedURL(url, m2mtoken),
-        }),
+        body: JSON.stringify([
+          {
+            documentReference: labelDocRef,
+            presignedURL: await getPresignedURL(url, m2mtoken),
+          },
+        ]),
         statusCode: 200,
       };
     }

--- a/packages/zambdas/src/ehr/get-or-create-visit-label-pdf/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/get-or-create-visit-label-pdf/validateRequestParameters.ts
@@ -1,0 +1,17 @@
+import { GetVisitLabelInput, MISSING_REQUEST_BODY, MISSING_REQUIRED_PARAMETERS } from 'utils';
+import { ZambdaInput } from '../../shared';
+
+export function validateRequestParameters(input: ZambdaInput): GetVisitLabelInput & Pick<ZambdaInput, 'secrets'> {
+  if (!input.body) {
+    throw MISSING_REQUEST_BODY;
+  }
+
+  const { encounterId } = JSON.parse(input.body) as GetVisitLabelInput;
+
+  if (!encounterId) throw MISSING_REQUIRED_PARAMETERS([encounterId]);
+
+  return {
+    encounterId,
+    secrets: input.secrets,
+  };
+}

--- a/packages/zambdas/src/shared/pdf/external-labs-label-pdf.ts
+++ b/packages/zambdas/src/shared/pdf/external-labs-label-pdf.ts
@@ -33,7 +33,7 @@ export interface ExternalLabsLabelConfig {
 
 const UPLOAD_BUCKET_NAME = 'visit-notes';
 
-const convertLabeConfigToPdfClientStyles = (labelConfig: LabelConfig): PdfClientStyles => {
+export const convertLabeConfigToPdfClientStyles = (labelConfig: LabelConfig): PdfClientStyles => {
   const inchesToPoints = (sizeInches: number): number => {
     // conversion factor is 1 point = 1/72 inches.
     // pdf-lib uses Points not pixels

--- a/packages/zambdas/src/shared/pdf/visit-label-pdf.ts
+++ b/packages/zambdas/src/shared/pdf/visit-label-pdf.ts
@@ -75,16 +75,25 @@ const createVisitLabelPdfBytes = async (data: VisitLabelConfig): Promise<Uint8Ar
   };
 
   const getAgeString = (dob: DateTime | undefined): string => {
-    if (!dob) return '';
+    if (!dob || dob.toUTC() > DateTime.utc()) return '';
 
     // get the date diff between now and the dob
-    // const ageInMonths = Math.round(dob.setZone('UTC').diffNow(['months']).as('months'));
-    const ageInMonths = Math.round(DateTime.utc().diff(dob.toUTC(), ['months']).as('months'));
-
-    if (ageInMonths <= 24) return `${ageInMonths} mo`;
-    else {
-      return `${Math.floor(ageInMonths / 12)} yo`;
+    // const ageInMonths = Math.round(DateTime.utc().diff(dob.toUTC(), ['months', 'weeks', 'days']).as('months'));
+    const { months, weeks, days } = DateTime.utc().diff(dob.toUTC(), ['months', 'weeks', 'days']).toObject();
+    if (!months && !weeks && days !== undefined) {
+      return `${days} d`;
     }
+
+    if (!months && weeks !== undefined) return `${weeks} wk`;
+
+    if (months !== undefined) {
+      if (months <= 24) return `${months} mo`;
+      else {
+        return `${Math.floor(months / 12)} yr`;
+      }
+    }
+
+    throw new Error(`Error processing age string for dob ${dob}`);
   };
 
   /**

--- a/packages/zambdas/src/shared/pdf/visit-label-pdf.ts
+++ b/packages/zambdas/src/shared/pdf/visit-label-pdf.ts
@@ -1,0 +1,208 @@
+import { DateTime } from 'luxon';
+import { createFilesDocumentReferences, Secrets, getPresignedURL, LabelConfig } from 'utils';
+import { PdfInfo, createPdfClient, Y_POS_GAP as pdfClientGapSubtraction } from './pdf-utils';
+import { TextStyle } from './types';
+import { makeZ3Url } from '../presigned-file-urls';
+import { createPresignedUrl, uploadObjectToZ3 } from '../z3Utils';
+import Oystehr from '@oystehr/sdk';
+import { DocumentReference } from 'fhir/r4b';
+import { randomUUID } from 'crypto';
+import { StandardFonts } from 'pdf-lib';
+import { convertLabeConfigToPdfClientStyles } from './external-labs-label-pdf';
+
+const VISIT_LABEL_PDF_BASE_NAME = 'VisitLabel';
+
+export const VISIT_LABEL_DOC_REF_DOCTYPE = {
+  system: 'http://ottehr.org/fhir/StructureDefinition/visit-label',
+  code: 'visit-label',
+  display: 'Visit Label',
+};
+
+const DATE_FORMAT = 'MM/dd/yyyy';
+
+interface VisitLabelContent {
+  patientLastName: string;
+  patientFirstName: string;
+  patientMiddleName?: string;
+  patientId: string;
+  patientDateOfBirth: DateTime | undefined;
+  patientGender: string;
+  visitDate: DateTime | undefined;
+}
+
+export interface VisitLabelConfig {
+  labelConfig: LabelConfig;
+  content: VisitLabelContent;
+}
+
+const UPLOAD_BUCKET_NAME = 'visit-notes';
+
+const createVisitLabelPdfBytes = async (data: VisitLabelConfig): Promise<Uint8Array> => {
+  const { labelConfig, content } = data;
+
+  const pdfClientStyles = convertLabeConfigToPdfClientStyles(labelConfig);
+
+  const pdfClient = await createPdfClient(pdfClientStyles);
+  // the pdf client initializes YPos to some non-zero number and it's causing huge gaps
+  pdfClient.setY(pdfClient.getY() + pdfClientGapSubtraction - 15);
+
+  const CourierBold = await pdfClient.embedStandardFont(StandardFonts.CourierBold);
+  const Courier = await pdfClient.embedStandardFont(StandardFonts.Courier);
+
+  const baseFontSize = 7;
+  const baseSpacing = 2;
+
+  const textStyles: Record<string, TextStyle> = {
+    fieldText: {
+      fontSize: baseFontSize,
+      spacing: baseSpacing,
+      font: Courier,
+      newLineAfter: false,
+    },
+    fieldHeader: {
+      fontSize: baseFontSize,
+      font: CourierBold,
+      spacing: baseSpacing,
+    },
+  };
+
+  const NEWLINE_Y_DROP =
+    pdfClient.getTextDimensions('Any text used to get height', textStyles.fieldHeader).height + baseSpacing;
+
+  const drawHeaderAndInlineText = (header: string, text: string): void => {
+    pdfClient.drawTextSequential(`${header}: `, textStyles.fieldHeader);
+    pdfClient.drawTextSequential(text, textStyles.fieldText);
+  };
+
+  const getAgeString = (dob: DateTime | undefined): string => {
+    if (!dob) return '';
+
+    // get the date diff between now and the dob
+    const ageInMonths = Math.round(dob.setZone('UTC').diffNow(['months']).as('months'));
+
+    if (ageInMonths <= 24) return `${ageInMonths} mo`;
+    else {
+      return `${Math.floor(ageInMonths / 12)} yo`;
+    }
+  };
+
+  /**
+   * Label format looks like:
+   *
+   * PID:
+   * patientLast, patientFirst, patientMiddle
+   * DOB: mm/dd/yyyy (#years old yo), gender
+   * Visit date: mm/dd/yyyy
+   */
+
+  const {
+    patientId,
+    patientFirstName,
+    patientMiddleName,
+    patientLastName,
+    patientDateOfBirth,
+    patientGender,
+    visitDate,
+  } = content;
+
+  drawHeaderAndInlineText('PID', patientId);
+  pdfClient.newLine(NEWLINE_Y_DROP);
+
+  pdfClient.drawTextSequential(
+    `${patientLastName}, ${patientFirstName}${patientMiddleName ? `, ${patientMiddleName}` : ''}`,
+    { ...textStyles.fieldHeader, fontSize: textStyles.fieldHeader.fontSize + 2 }
+  );
+  pdfClient.newLine(NEWLINE_Y_DROP);
+
+  const patientDOBString = patientDateOfBirth ? patientDateOfBirth.toFormat(DATE_FORMAT) : '';
+  const ageString = getAgeString(patientDateOfBirth);
+  const renderAgeString = ageString ? `(${ageString})` : '';
+  drawHeaderAndInlineText('DOB', `${patientDOBString} ${renderAgeString}, ${patientGender}`);
+  pdfClient.newLine(NEWLINE_Y_DROP);
+
+  drawHeaderAndInlineText('Visit date', visitDate ? visitDate.toFormat(DATE_FORMAT) : '');
+
+  return await pdfClient.save();
+};
+
+async function createVisitLabelPDFHelper(
+  input: VisitLabelConfig,
+  secrets: Secrets | null,
+  token: string
+): Promise<PdfInfo> {
+  console.log('Creating external labs label pdf bytes');
+
+  const pdfBytes = await createVisitLabelPdfBytes(input).catch((error) => {
+    throw new Error('failed creating visit label pdfBytes: ' + error.message);
+  });
+
+  console.log(`Created visit label pdf bytes`);
+
+  const fileName = `${VISIT_LABEL_PDF_BASE_NAME}-${
+    input.content.visitDate ? input.content.visitDate.toFormat(DATE_FORMAT) : ''
+  }.pdf`;
+
+  console.log(`Creating base file url for file ${fileName}`);
+
+  const baseFileUrl = makeZ3Url({
+    secrets,
+    fileName,
+    bucketName: UPLOAD_BUCKET_NAME,
+    patientID: input.content.patientId,
+  });
+
+  console.log('Uploading file to bucket, ', UPLOAD_BUCKET_NAME);
+
+  try {
+    const presignedUrl = await createPresignedUrl(token, baseFileUrl, 'upload');
+    await uploadObjectToZ3(pdfBytes, presignedUrl);
+  } catch (error: any) {
+    throw new Error(`failed uploading pdf ${fileName} to z3:  ${JSON.stringify(error.message)}`);
+  }
+
+  // for testing
+  // savePdfLocally(pdfBytes);
+
+  return { title: fileName, uploadURL: baseFileUrl };
+}
+
+export async function createVisitLabelPDF(
+  labelConfig: VisitLabelConfig,
+  encounterId: string,
+  secrets: Secrets | null,
+  token: string,
+  oystehr: Oystehr
+): Promise<{ docRef: DocumentReference; presignedURL: string }> {
+  const pdfInfo = await createVisitLabelPDFHelper(labelConfig, secrets, token);
+
+  console.log(`This is the made pdfInfo`, JSON.stringify(pdfInfo));
+
+  const { docRefs } = await createFilesDocumentReferences({
+    files: [{ url: pdfInfo.uploadURL, title: pdfInfo.title }],
+    type: { coding: [VISIT_LABEL_DOC_REF_DOCTYPE], text: 'Visit label' },
+    references: {
+      subject: {
+        reference: `Patient/${labelConfig.content.patientId}`,
+      },
+      context: {
+        encounter: [{ reference: `Encounter/${encounterId}` }],
+      },
+    },
+    docStatus: 'final',
+    dateCreated: DateTime.now().setZone('UTC').toISO() ?? '',
+    oystehr,
+    searchParams: [{ name: 'encounter', value: `Encounter/${encounterId}` }],
+    generateUUID: randomUUID,
+    listResources: [], // this for whatever reason needs to get added otherwise the function never adds the new docRef to the returned array
+  });
+
+  console.log(`These are the docRefs returned for the label: `, JSON.stringify(docRefs));
+
+  if (!docRefs.length) {
+    throw new Error('Unable to make docrefs for label');
+  }
+
+  const presignedURL = await getPresignedURL(pdfInfo.uploadURL, token);
+
+  return { docRef: docRefs[0], presignedURL };
+}

--- a/packages/zambdas/src/shared/pdf/visit-label-pdf.ts
+++ b/packages/zambdas/src/shared/pdf/visit-label-pdf.ts
@@ -78,7 +78,8 @@ const createVisitLabelPdfBytes = async (data: VisitLabelConfig): Promise<Uint8Ar
     if (!dob) return '';
 
     // get the date diff between now and the dob
-    const ageInMonths = Math.round(dob.setZone('UTC').diffNow(['months']).as('months'));
+    // const ageInMonths = Math.round(dob.setZone('UTC').diffNow(['months']).as('months'));
+    const ageInMonths = Math.round(DateTime.utc().diff(dob.toUTC(), ['months']).as('months'));
 
     if (ageInMonths <= 24) return `${ageInMonths} mo`;
     else {


### PR DESCRIPTION
#2152 

The visit label is general use and not specific to anything in house labs. However, it is used to label in house lab samples. Eventually, the getOrCreateVisitLabelPdf can easily be added to any other button in the UI that needs to pull up the visit label

Bug:
- [x] Age string is coming back as a negative number