### PR TITLE
Final view improvements

### DIFF
--- a/apps/ehr/src/features/in-house-labs/components/details/ResultEntryRadioButton.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/ResultEntryRadioButton.tsx
@@ -4,7 +4,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 
 interface ResultEntryRadioButtonProps {
   testItemComponent: CodeableConceptComponent;
-  disabled?: boolean;
+  disabled?: boolean; // equates to the final view
 }
 
 const ABNORMAL_FONT_COLOR = '#F44336';
@@ -85,6 +85,48 @@ export const ResultEntryRadioButton: React.FC<ResultEntryRadioButtonProps> = ({ 
     }
   };
 
+  const finalViewNullOptionCheckboxStyling = (curValue: string): SxProps<Theme> => {
+    const isFinalView = !!disabled;
+    if (isFinalView) {
+      const isChecked = curValue === nullCode;
+      if (isChecked) {
+        return {
+          color: 'primary.main',
+          '&.Mui-disabled': {
+            color: 'primary.main',
+            '& .MuiSvgIcon-root': {
+              fill: 'primary.main',
+            },
+          },
+        };
+      } else {
+        return {};
+      }
+    }
+    return {};
+  };
+
+  const finalViewNullOptionCheckboxLabelStyling = (curValue: string): SxProps<Theme> => {
+    const isFinalView = !!disabled;
+    if (isFinalView) {
+      const isChecked = curValue === nullCode;
+      if (isChecked) {
+        return {
+          color: 'text.primary',
+          '& .MuiFormControlLabel-label': {
+            color: 'text.primary',
+          },
+          '&.Mui-disabled .MuiFormControlLabel-label': {
+            color: 'text.primary',
+          },
+        };
+      } else {
+        return {};
+      }
+    }
+    return {};
+  };
+
   return (
     <Controller
       name={testItemComponent.observationDefinitionId}
@@ -125,10 +167,11 @@ export const ResultEntryRadioButton: React.FC<ResultEntryRadioButtonProps> = ({ 
                     disabled={!!disabled}
                     checked={field.value === nullCode}
                     onChange={() => field.onChange(field.value === nullCode ? '' : nullCode)}
+                    sx={disabled ? finalViewNullOptionCheckboxStyling(field.value) : {}}
                   />
                 }
                 label={testItemComponent.nullOption.text}
-                sx={{ color: 'text.secondary' }}
+                sx={disabled ? finalViewNullOptionCheckboxLabelStyling(field.value) : {}}
               />
             </Box>
           )}

--- a/apps/ehr/src/features/in-house-labs/components/details/ResultEntryRadioButton.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/ResultEntryRadioButton.tsx
@@ -1,6 +1,8 @@
 import { Typography, Grid, FormControlLabel, Radio, RadioGroup, Checkbox, Box, SxProps, Theme } from '@mui/material';
 import { CodeableConceptComponent } from 'utils';
 import { Controller, useFormContext } from 'react-hook-form';
+import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
+import RadioButtonCheckedIcon from '@mui/icons-material/RadioButtonChecked';
 
 interface ResultEntryRadioButtonProps {
   testItemComponent: CodeableConceptComponent;
@@ -164,6 +166,8 @@ export const ResultEntryRadioButton: React.FC<ResultEntryRadioButtonProps> = ({ 
               <FormControlLabel
                 control={
                   <Checkbox
+                    icon={<RadioButtonUncheckedIcon />}
+                    checkedIcon={<RadioButtonCheckedIcon />}
                     disabled={!!disabled}
                     checked={field.value === nullCode}
                     onChange={() => field.onChange(field.value === nullCode ? '' : nullCode)}

--- a/apps/ehr/src/features/in-house-labs/components/details/ResultEntrySelect.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/ResultEntrySelect.tsx
@@ -1,4 +1,4 @@
-import { Select, InputLabel, FormControl, MenuItem } from '@mui/material';
+import { Select, FormControl, MenuItem } from '@mui/material';
 import { TestItemComponent } from 'utils';
 import { useFormContext, Controller } from 'react-hook-form';
 
@@ -61,20 +61,6 @@ export const ResultEntrySelect: React.FC<ResultEntrySelectProps> = ({
       }}
       size="small"
     >
-      <InputLabel
-        id="result-entry-labe"
-        sx={{
-          color: isAbnormal ? 'error.dark' : '',
-          '&.Mui-focused': {
-            color: isAbnormal ? 'error.dark' : '',
-          },
-          '&.Mui-disabled': {
-            color: isAbnormal ? 'error.dark' : '',
-          },
-        }}
-      >
-        Select
-      </InputLabel>
       <Controller
         name={testItemComponent.observationDefinitionId}
         control={control}
@@ -83,9 +69,7 @@ export const ResultEntrySelect: React.FC<ResultEntrySelectProps> = ({
           <Select
             disabled={!!disabled}
             fullWidth
-            labelId="result-entry-label"
             id="result-entry-select"
-            label="Select"
             {...field}
             onChange={(e) => {
               field.onChange(e);

--- a/apps/ehr/src/features/in-house-labs/components/details/ResultEntrySelect.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/ResultEntrySelect.tsx
@@ -55,8 +55,8 @@ export const ResultEntrySelect: React.FC<ResultEntrySelectProps> = ({
         },
 
         '& .MuiSelect-select.Mui-disabled': {
-          color: isAbnormal ? 'error.dark' : '',
-          WebkitTextFillColor: isAbnormal ? '#C62828' : '',
+          color: isAbnormal ? 'error.dark' : '#000000e0',
+          WebkitTextFillColor: isAbnormal ? '#C62828' : '#000000e0',
         },
       }}
       size="small"

--- a/apps/ehr/src/features/in-house-labs/components/details/ResultEntrySelect.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/ResultEntrySelect.tsx
@@ -6,7 +6,7 @@ interface ResultEntrySelectProps {
   testItemComponent: TestItemComponent;
   isAbnormal: boolean;
   setIsAbnormal: (bool: boolean) => void;
-  disabled?: boolean;
+  disabled?: boolean; // equates to the final view
 }
 
 export const ResultEntrySelect: React.FC<ResultEntrySelectProps> = ({

--- a/apps/ehr/src/features/in-house-labs/components/details/ResultsEntryNumericInput.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/ResultsEntryNumericInput.tsx
@@ -51,12 +51,9 @@ export const ResultEntryNumericInput: React.FC<ResultEntryNumericInputProps> = (
           error={isAbnormal}
           sx={{
             width: '80%',
-            '& .MuiInputBase-root': {
-              color: isAbnormal ? 'error.dark' : 'text.primary',
-            },
             '& .Mui-disabled': {
               color: isAbnormal ? 'error.dark' : '',
-              WebkitTextFillColor: isAbnormal ? '#C62828' : '',
+              WebkitTextFillColor: isAbnormal ? '#C62828' : '#000000e0',
             },
             '& .MuiOutlinedInput-root': {
               '&.Mui-disabled': {

--- a/apps/ehr/src/features/in-house-labs/components/details/ResultsEntryNumericInput.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/ResultsEntryNumericInput.tsx
@@ -7,7 +7,7 @@ interface ResultEntryNumericInputProps {
   testItemComponent: TestItemComponent;
   isAbnormal: boolean;
   setIsAbnormal: (bool: boolean) => void;
-  disabled?: boolean;
+  disabled?: boolean; // equates to the final view
 }
 
 export const ResultEntryNumericInput: React.FC<ResultEntryNumericInputProps> = ({

--- a/apps/ehr/src/features/in-house-labs/components/details/ResultsEntryTable.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/ResultsEntryTable.tsx
@@ -41,8 +41,12 @@ export const ResultEntryTable: React.FC<ResultEntryTableProps> = ({ testItemComp
           </TableRow>
         </TableHead>
         <TableBody>
-          {testItemComponents.map((component) => (
-            <ResultEntryTableRow component={component} disabled={disabled} />
+          {testItemComponents.map((component, index) => (
+            <ResultEntryTableRow
+              component={component}
+              disabled={disabled}
+              isLastRow={index === testItemComponents.length - 1}
+            />
           ))}
         </TableBody>
       </Table>

--- a/apps/ehr/src/features/in-house-labs/components/details/ResultsEntryTable.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/ResultsEntryTable.tsx
@@ -4,7 +4,7 @@ import { ResultEntryTableRow } from './ResultsEntryTableRow';
 
 interface ResultEntryTableProps {
   testItemComponents: TestItemComponent[];
-  disabled?: boolean;
+  disabled?: boolean; // equates to the final view
 }
 
 const HEADER_ROW_STYLING = { borderBottom: 'none', padding: '0 8px 6px 0' };

--- a/apps/ehr/src/features/in-house-labs/components/details/ResultsEntryTableRow.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/ResultsEntryTableRow.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect } from 'react';
 
 interface ResultEntryTableRowProps {
   component: TestItemComponent;
-  disabled?: boolean;
+  disabled?: boolean; // equates to the final view
 }
 
 const ROW_STYLING = { paddingLeft: 0 };

--- a/apps/ehr/src/features/in-house-labs/components/details/ResultsEntryTableRow.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/ResultsEntryTableRow.tsx
@@ -1,4 +1,4 @@
-import { Typography, TableCell, TableRow } from '@mui/material';
+import { Typography, TableCell, TableRow, SxProps, Theme } from '@mui/material';
 import { TestItemComponent, OBSERVATION_CODES, quantityRangeFormat } from 'utils';
 import { ResultEntrySelect } from './ResultEntrySelect';
 import { ResultEntryNumericInput } from './ResultsEntryNumericInput';
@@ -6,12 +6,13 @@ import { useState, useEffect } from 'react';
 
 interface ResultEntryTableRowProps {
   component: TestItemComponent;
+  isLastRow: boolean;
   disabled?: boolean; // equates to the final view
 }
 
 const ROW_STYLING = { paddingLeft: 0 };
 
-export const ResultEntryTableRow: React.FC<ResultEntryTableRowProps> = ({ component, disabled }) => {
+export const ResultEntryTableRow: React.FC<ResultEntryTableRowProps> = ({ component, disabled, isLastRow }) => {
   const [isAbnormal, setIsAbnormal] = useState<boolean>(false);
 
   useEffect(() => {
@@ -30,7 +31,6 @@ export const ResultEntryTableRow: React.FC<ResultEntryTableRowProps> = ({ compon
     units = component.unit;
     referenceRange = quantityRangeFormat(component);
   }
-
   if (component.dataType === 'CodeableConcept') {
     units = component.unit ?? '';
     referenceRange =
@@ -40,7 +40,6 @@ export const ResultEntryTableRow: React.FC<ResultEntryTableRowProps> = ({ compon
         })
         .join(', ') ?? '';
   }
-
   if (component.displayType === 'Numeric') {
     valueElement = (
       <ResultEntryNumericInput
@@ -62,18 +61,22 @@ export const ResultEntryTableRow: React.FC<ResultEntryTableRowProps> = ({ compon
     );
   }
 
+  const rowStyling: SxProps<Theme> = isLastRow
+    ? { ...ROW_STYLING, borderBottom: 'none', paddingBottom: 0 }
+    : ROW_STYLING;
+
   return (
     <TableRow key={`row-${component.observationDefinitionId}`}>
-      <TableCell sx={ROW_STYLING}>
+      <TableCell sx={rowStyling}>
         <Typography variant="body1" sx={{ color: `${isAbnormal ? 'error.dark' : ''}` }}>
           {component.componentName}
         </Typography>
       </TableCell>
-      <TableCell sx={ROW_STYLING}>{valueElement}</TableCell>
-      <TableCell sx={ROW_STYLING}>
+      <TableCell sx={rowStyling}>{valueElement}</TableCell>
+      <TableCell sx={rowStyling}>
         <Typography variant="body1">{units}</Typography>
       </TableCell>
-      <TableCell sx={ROW_STYLING}>
+      <TableCell sx={rowStyling}>
         <Typography variant="body1">{referenceRange}</Typography>
       </TableCell>
     </TableRow>


### PR DESCRIPTION
Updates per QA comments here https://github.com/masslight/ottehr/issues/2159

- [ ] Rename "Positive" to "Detected", "Negative" to "Not detected".
- [ ] Need to talk to Athena about: In Glucose Finger Stick the name for the value should be just "Glucose". "Glucose Finger Stick" is a name of the test, but measured parameter is "Glucose".
- [x] In "final" status all values should be as colorful as in the "collected" status. Currently normal values has "disabled" styling. - that abnormal red "50" looks same in "final" and in "entry" screens (good). But normal "80" looks black in "entry" screen but light-grey in "final" screen. Can it be as black as in the "entry" screen? Because light blue looks like less meaningful. 
- [x] In Urinalysis selectors hide upper "Select" labels in input fields (when the value is being entered).
- [x] In "final" status show “Indeterminate” option as colorful as in the "collected" status, just not editable. Currently it has "disabled" styling and hardly noticeable.
- [x] Hide grey divider line under the last row.