### PR TITLE
Make menu items always clickable in visit chart

### DIFF
--- a/apps/ehr/src/features/css-module/components/Sidebar.tsx
+++ b/apps/ehr/src/features/css-module/components/Sidebar.tsx
@@ -338,7 +338,6 @@ export const Sidebar = (): JSX.Element => {
           return (
             <StyledButton
               isactive={location.pathname.includes(comparedPath).toString()}
-              disabled={location.pathname.includes(comparedPath)}
               key={item.text}
               onClick={() => {
                 requestAnimationFrame(() => {


### PR DESCRIPTION
Fix for https://github.com/masslight/ottehr/issues/2317.