### PR TITLE
Fix: add reviewed time to corrected pdf, fix history

### DIFF
--- a/apps/ehr/src/features/external-labs/components/OrderHistoryCard.tsx
+++ b/apps/ehr/src/features/external-labs/components/OrderHistoryCard.tsx
@@ -32,7 +32,8 @@ export const OrderHistoryCard: React.FC<OrderHistoryProps> = ({ isCollapsed = fa
       >
         <Table>
           {orderHistory.map((row) => {
-            const isReviewOrReceiveAction = row.action === 'reviewed' || row.action === 'received';
+            const isReviewOrReceiveAction =
+              row.action === 'reviewed' || row.action === 'received' || row.action === 'corrected';
             return (
               <TableRow key={`${row.action}-${row.performer}-${row.date}`}>
                 <TableCell>

--- a/packages/zambdas/src/ehr/get-lab-orders/helpers.ts
+++ b/packages/zambdas/src/ehr/get-lab-orders/helpers.ts
@@ -755,10 +755,6 @@ export const fetchFinalAndPrelimAndCorrectedTasks = async (
           name: 'based-on',
           value: resultsIds.join(','),
         },
-        // {
-        //   name: 'status:not',
-        //   value: 'cancelled',
-        // },
       ],
     })
   ).unbundle();
@@ -792,6 +788,8 @@ export const fetchFinalAndPrelimAndCorrectedTasks = async (
 
   tasksResponse.forEach((task) => {
     // easy case, we take all non-cancelled. identical to previous behavior
+    // Note: this will only show the latest correction for a given result (so if there were multiple corrections sent,
+    // you'd only see the latest one until it was reviewed)
     if (task.status !== 'cancelled') {
       tasksToReturn.push(task);
       return;

--- a/packages/zambdas/src/shared/pdf/labs-results-form-pdf.ts
+++ b/packages/zambdas/src/shared/pdf/labs-results-form-pdf.ts
@@ -69,8 +69,6 @@ export async function createLabResultPDF(
     observations,
   } = await getLabOrderResources(oystehr, labType, serviceRequestID);
 
-  console.log(`>>> in labs-results-form-pdf, this is the task returned by getLabOrderResources`, JSON.stringify(task));
-
   const locationID = serviceRequest.locationReference?.[0].reference?.replace('Location/', '');
 
   if (!appointment.id) {
@@ -151,7 +149,7 @@ export async function createLabResultPDF(
   );
 
   const latestReviewTask = reviewTasksFinalOrCorrected?.sort((a, b) => compareDates(a.authoredOn, b.authoredOn))[0];
-  console.log(`>>> in labs-results-form-pdf, this is the latestReviewTask`, JSON.stringify(latestReviewTask));
+
   let provenanceReviewTask = undefined;
 
   if (latestReviewTask) {


### PR DESCRIPTION
#2291 and #2129 -- fix undefined time in reviewed corrected result pdf
#2292 -- ensure received row in history doesn't disappear when corrected result arrives before the final result was reviewed
