### PR TITLE
Procedures. Don't show 'Dx' and 'CPT' labels on Progress note if they were not filled on Procedures screen

### DIFF
--- a/apps/ehr/src/telemed/features/appointment/ReviewTab/components/ProceduresContainer.tsx
+++ b/apps/ehr/src/telemed/features/appointment/ReviewTab/components/ProceduresContainer.tsx
@@ -34,13 +34,13 @@ export const ProceduresContainer: FC = () => {
             <Typography sx={{ color: '#0F347C', fontWeight: '500' }}>{procedure.procedureType}</Typography>
             {renderProperty(
               'CPT',
-              procedure.cptCodes != null
+              procedure.cptCodes != null && procedure.cptCodes.length > 0
                 ? procedure.cptCodes.map((cptCode) => cptCode.code + ' ' + cptCode.display).join('; ')
                 : undefined
             )}
             {renderProperty(
               'Dx',
-              procedure.diagnoses != null
+              procedure.diagnoses != null && procedure.diagnoses.length > 0
                 ? procedure.diagnoses.map((diagnosis) => diagnosis.code + ' ' + diagnosis.display).join('; ')
                 : undefined
             )}

--- a/packages/zambdas/src/shared/pdf/visit-note-pdf.ts
+++ b/packages/zambdas/src/shared/pdf/visit-note-pdf.ts
@@ -566,8 +566,16 @@ async function createVisitNotePdfBytes(data: VisitNoteData, isInPersonAppointmen
     drawBlockHeader('Procedures');
     data.procedures.forEach((procedure) => {
       drawBlockHeader(procedure.procedureType ?? '', textStyles.blockSubHeader);
-      regularText(procedure.cptCodes != null ? 'CPT: ' + procedure.cptCodes.join('; ') : undefined);
-      regularText(procedure.diagnoses != null ? 'Dx: ' + procedure.diagnoses.join('; ') : undefined);
+      regularText(
+        procedure.cptCodes != null && procedure.cptCodes.length > 0
+          ? 'CPT: ' + procedure.cptCodes.join('; ')
+          : undefined
+      );
+      regularText(
+        procedure.diagnoses != null && procedure.diagnoses.length > 0
+          ? 'Dx: ' + procedure.diagnoses.join('; ')
+          : undefined
+      );
 
       regularText(
         procedure.procedureDateTime != null


### PR DESCRIPTION
Fix for https://github.com/masslight/ottehr/issues/2484