### PR TITLE
[In-House Labs] tracking board improvements

### DIFF
--- a/apps/ehr/src/components/AppointmentTableRow.tsx
+++ b/apps/ehr/src/components/AppointmentTableRow.tsx
@@ -64,6 +64,7 @@ import GoToButton from './GoToButton';
 import { progressNoteIcon, startIntakeIcon } from '@theme/icons';
 import { InHouseLabsAppointmentTooltip } from 'src/features/in-house-labs/components/tracking-board/InHouseLabsAppointmentTooltip';
 import { sidebarMenuIcons } from 'src/features/css-module/components/Sidebar';
+import { getInHouseLabsUrl } from 'src/features/css-module/routing/helpers';
 
 interface AppointmentTableProps {
   appointment: InPersonAppointmentInformation;
@@ -826,22 +827,29 @@ export default function AppointmentTableRow({
           </GenericToolTip>
 
           {!!inHouseLabOrders?.length && (
-            <GenericToolTip title={<InHouseLabsAppointmentTooltip items={inHouseLabOrders} />} customWidth="none">
-              <Box
-                sx={{
-                  display: 'flex',
-                  gap: 0,
-                  color: '#0F347C',
-                  backgroundColor: '#2169F514',
-                  borderRadius: '50%',
-                  width: '28px',
-                  height: '28px',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                {sidebarMenuIcons['In-house Labs']}
-              </Box>
+            <GenericToolTip
+              title={<InHouseLabsAppointmentTooltip appointmentId={appointment.id} items={inHouseLabOrders} />}
+              customWidth="none"
+              placement="top"
+              leaveDelay={300}
+            >
+              <Link to={getInHouseLabsUrl(appointment.id)} style={{ textDecoration: 'none' }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    gap: 0,
+                    color: '#0F347C',
+                    backgroundColor: '#2169F514',
+                    borderRadius: '50%',
+                    width: '28px',
+                    height: '28px',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  {sidebarMenuIcons['In-house Labs']}
+                </Box>
+              </Link>
             </GenericToolTip>
           )}
         </div>

--- a/apps/ehr/src/features/in-house-labs/components/tracking-board/InHouseLabsAppointmentTooltip.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/tracking-board/InHouseLabsAppointmentTooltip.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { sidebarMenuIcons } from 'src/features/css-module/components/Sidebar';
+import { getInHouseLabOrderDetailsUrl } from 'src/features/css-module/routing/helpers';
 import { InHouseOrderListPageItemDTO } from 'utils';
-import { getStatusColor, InHouseLabsStatusChip } from '../InHouseLabsStatusChip';
+import { InHouseLabsStatusChip } from '../InHouseLabsStatusChip';
 
-export const InHouseLabsAppointmentTooltip: React.FC<{ items: InHouseOrderListPageItemDTO[] }> = ({ items }) => {
+export const InHouseLabsAppointmentTooltip: React.FC<{
+  items: InHouseOrderListPageItemDTO[];
+  appointmentId: string;
+}> = ({ items, appointmentId }) => {
   if (!items || items.length === 0) {
     return null;
   }
@@ -63,7 +68,7 @@ export const InHouseLabsAppointmentTooltip: React.FC<{ items: InHouseOrderListPa
 
       {items.map((item, index) => {
         return (
-          <div
+          <Link
             key={item.serviceRequestId}
             style={{
               display: 'flex',
@@ -72,7 +77,9 @@ export const InHouseLabsAppointmentTooltip: React.FC<{ items: InHouseOrderListPa
               paddingTop: '12px',
               paddingBottom: '12px',
               borderBottom: index < items.length - 1 ? '1px solid #E5E7EB' : 'none',
+              textDecoration: 'none',
             }}
+            to={getInHouseLabOrderDetailsUrl(appointmentId, item.serviceRequestId)}
           >
             <div
               style={{
@@ -96,16 +103,18 @@ export const InHouseLabsAppointmentTooltip: React.FC<{ items: InHouseOrderListPa
             >
               <InHouseLabsStatusChip status={item.status} />
 
-              <div
+              {/* 
+                // TODO: the dots will be needed later after the tasks will be implemented
+                <div
                 style={{
                   width: '12px',
                   height: '12px',
                   borderRadius: '50%',
                   backgroundColor: getStatusColor(item.status).backgroundColor,
                 }}
-              />
+              /> */}
             </div>
-          </div>
+          </Link>
         );
       })}
     </div>


### PR DESCRIPTION
In-house Tooltip fixes from (#2151) and improvements:

- Added leave delay functionality to allow easy navigation to the tooltip
- Implemented click functionality on tooltip rows that redirects to the order page
- Added click functionality on the in-house icon that leads to the table
- Removed dots from the tooltip display