### PR TITLE
[External Labs] update specimen dateTime saving logic 

### DIFF
--- a/apps/ehr/src/features/external-labs/components/OrderCollection.tsx
+++ b/apps/ehr/src/features/external-labs/components/OrderCollection.tsx
@@ -2,16 +2,8 @@ import React, { useState } from 'react';
 import { LoadingButton } from '@mui/lab';
 import { Box, Button, Stack, Typography, useTheme } from '@mui/material';
 import { AOECard } from './AOECard';
-// import { SampleCollectionInstructionsCard } from './SampleCollectionInstructionsCard';
 import { useForm, SubmitHandler, FormProvider } from 'react-hook-form';
-import {
-  DynamicAOEInput,
-  ExternalLabsStatus,
-  LabOrderDetailedPageDTO,
-  LabQuestionnaireResponse,
-  SpecimenDateChangedParameters,
-} from 'utils';
-// import useEvolveUser from '../../../hooks/useEvolveUser';
+import { DynamicAOEInput, ExternalLabsStatus, LabOrderDetailedPageDTO, LabQuestionnaireResponse } from 'utils';
 import { submitLabOrder } from '../../../api/api';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { OrderInformationCard } from './OrderInformationCard';
@@ -22,7 +14,6 @@ import { SampleCollectionInstructionsCard } from './SampleCollectionInstructions
 
 interface SampleCollectionProps {
   labOrder: LabOrderDetailedPageDTO;
-  saveSpecimenDate: (parameters: SpecimenDateChangedParameters) => Promise<void>;
   showActionButtons?: boolean;
   showOrderInfo?: boolean;
   isAOECollapsed?: boolean;
@@ -34,7 +25,6 @@ export async function openPdf(url: string): Promise<void> {
 
 export const OrderCollection: React.FC<SampleCollectionProps> = ({
   labOrder,
-  saveSpecimenDate,
   showActionButtons = true,
   showOrderInfo = true,
   isAOECollapsed = false,
@@ -52,15 +42,11 @@ export const OrderCollection: React.FC<SampleCollectionProps> = ({
   const labQuestionnaireResponses = questionnaireData?.questionnaireResponseItems;
   const [submitLoading, setSubmitLoading] = useState(false);
   const [error, setError] = useState<string[] | undefined>(undefined);
-  const [specimensLoadingState, setSpecimensLoadingState] = useState<{ [specimenId: string]: 'saving' | 'saved' }>({});
+  const [specimensData, setSpecimensData] = useState<{ [specimenId: string]: { date: string } }>({});
   const shouldShowSampleCollectionInstructions =
     !labOrder.isPSC &&
     (labOrder.orderStatus === ExternalLabsStatus.pending || labOrder.orderStatus === ExternalLabsStatus.sent);
   const showAOECard = aoe.length > 0;
-
-  const updateSpecimenLoadingState = (specimenId: string, state: 'saving' | 'saved'): void => {
-    setSpecimensLoadingState((prevState) => ({ ...prevState, [specimenId]: state }));
-  };
 
   const sampleCollectionSubmit: SubmitHandler<DynamicAOEInput> = (data) => {
     setSubmitLoading(true);
@@ -70,11 +56,13 @@ export const OrderCollection: React.FC<SampleCollectionProps> = ({
         setError(['Oystehr client is undefined']);
         return;
       }
+
       Object.keys(data).forEach((item) => {
         if (!data[item]) {
           delete data[item];
           return;
         }
+
         const question = aoe.find((question) => question.linkId === item);
 
         if (question && question.type === 'boolean') {
@@ -95,7 +83,8 @@ export const OrderCollection: React.FC<SampleCollectionProps> = ({
         const { orderPdfUrl, labelPdfUrl } = await submitLabOrder(oystehr, {
           serviceRequestID: labOrder.serviceRequestId,
           accountNumber: labOrder.accountNumber,
-          data: data,
+          data,
+          specimens: specimensData,
         });
 
         if (labelPdfUrl) await openPdf(labelPdfUrl);
@@ -121,8 +110,6 @@ export const OrderCollection: React.FC<SampleCollectionProps> = ({
     console.log(`data at submit: ${JSON.stringify(data)}`);
   };
 
-  const isSpecimenSaving = Object.values(specimensLoadingState).some((state) => state === 'saving');
-
   return (
     <FormProvider {...methods}>
       <form onSubmit={methods.handleSubmit(sampleCollectionSubmit)}>
@@ -142,8 +129,9 @@ export const OrderCollection: React.FC<SampleCollectionProps> = ({
                 sample={sample}
                 serviceRequestId={labOrder.serviceRequestId}
                 timezone={labOrder.encounterTimezone}
-                saveSpecimenDate={saveSpecimenDate}
-                updateSpecimenLoadingState={updateSpecimenLoadingState}
+                setSpecimenData={(specimenId: string, date: string) =>
+                  setSpecimensData((prev) => ({ ...prev, [specimenId]: { date } }))
+                }
                 printLabelVisible={orderStatus === 'sent'}
                 isDateEditable={orderStatus === 'pending'}
               />
@@ -170,9 +158,8 @@ export const OrderCollection: React.FC<SampleCollectionProps> = ({
                   variant="contained"
                   sx={{ borderRadius: '50px', textTransform: 'none', fontWeight: 600 }}
                   type="submit"
-                  disabled={isSpecimenSaving}
                 >
-                  {isSpecimenSaving ? 'Saving changes...' : 'Submit & Print order'}
+                  Submit & Print Order
                 </LoadingButton>
               </Stack>
             )}

--- a/apps/ehr/src/features/external-labs/components/details/DetailsWithResults.tsx
+++ b/apps/ehr/src/features/external-labs/components/details/DetailsWithResults.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LabOrderDetailedPageDTO, SpecimenDateChangedParameters, TaskReviewedParameters } from 'utils';
+import { LabOrderDetailedPageDTO, TaskReviewedParameters } from 'utils';
 import { CSSPageTitle } from '../../../../telemed/components/PageTitle';
 import { ResultItem } from './ResultItem';
 import { Button, Typography } from '@mui/material';
@@ -9,9 +9,8 @@ import { OrderCollection } from '../OrderCollection';
 export const DetailsWithResults: React.FC<{
   labOrder: LabOrderDetailedPageDTO;
   markTaskAsReviewed: (parameters: TaskReviewedParameters) => Promise<void>;
-  saveSpecimenDate: (parameters: SpecimenDateChangedParameters) => Promise<void>;
   loading: boolean;
-}> = ({ labOrder, markTaskAsReviewed, saveSpecimenDate, loading }) => {
+}> = ({ labOrder, markTaskAsReviewed, loading }) => {
   const navigate = useNavigate();
 
   const handleBack = (): void => {
@@ -41,13 +40,7 @@ export const DetailsWithResults: React.FC<{
         />
       ))}
 
-      <OrderCollection
-        showActionButtons={false}
-        showOrderInfo={false}
-        isAOECollapsed={true}
-        labOrder={labOrder}
-        saveSpecimenDate={saveSpecimenDate}
-      />
+      <OrderCollection showActionButtons={false} showOrderInfo={false} isAOECollapsed={true} labOrder={labOrder} />
 
       <Button
         variant="outlined"

--- a/apps/ehr/src/features/external-labs/components/details/DetailsWithoutResults.tsx
+++ b/apps/ehr/src/features/external-labs/components/details/DetailsWithoutResults.tsx
@@ -2,13 +2,12 @@ import React from 'react';
 import { Typography, Stack, Grid } from '@mui/material';
 import { OrderCollection } from '../OrderCollection';
 import { CSSPageTitle } from '../../../../telemed/components/PageTitle';
-import { LabOrderDetailedPageDTO, SpecimenDateChangedParameters } from 'utils';
+import { LabOrderDetailedPageDTO } from 'utils';
 import { LabsOrderStatusChip } from '../ExternalLabsStatusChip';
 
 export const DetailsWithoutResults: React.FC<{
   labOrder: LabOrderDetailedPageDTO;
-  saveSpecimenDate: (params: SpecimenDateChangedParameters) => Promise<void>;
-}> = ({ labOrder, saveSpecimenDate }) => {
+}> = ({ labOrder }) => {
   return (
     <Stack spacing={2} sx={{ width: '100%' }}>
       <CSSPageTitle>{labOrder.testItem}</CSSPageTitle>
@@ -39,11 +38,7 @@ export const DetailsWithoutResults: React.FC<{
             taskStatus={taskStatus}
           />
         )} */}
-      <OrderCollection
-        labOrder={labOrder}
-        showOrderInfo={labOrder.orderStatus === 'sent'}
-        saveSpecimenDate={saveSpecimenDate}
-      />
+      <OrderCollection labOrder={labOrder} showOrderInfo={labOrder.orderStatus === 'sent'} />
     </Stack>
   );
 };

--- a/apps/ehr/src/features/external-labs/pages/CreateExternalLabOrder.tsx
+++ b/apps/ehr/src/features/external-labs/pages/CreateExternalLabOrder.tsx
@@ -36,6 +36,7 @@ import { enqueueSnackbar } from 'notistack';
 import { LabBreadcrumbs } from '../components/labs-orders/LabBreadcrumbs';
 import { OystehrSdkError } from '@oystehr/sdk/dist/cjs/errors';
 import DetailPageContainer from 'src/features/common/DetailPageContainer';
+
 interface CreateExternalLabOrdersProps {
   appointmentID?: string;
 }

--- a/apps/ehr/src/features/external-labs/pages/OrderDetails.tsx
+++ b/apps/ehr/src/features/external-labs/pages/OrderDetails.tsx
@@ -11,7 +11,7 @@ export const OrderDetailsPage: React.FC = () => {
   const urlParams = useParams();
   const serviceRequestId = urlParams.serviceRequestID as string;
 
-  const { labOrders, loading, markTaskAsReviewed, saveSpecimenDate } = usePatientLabOrders({
+  const { labOrders, loading, markTaskAsReviewed } = usePatientLabOrders({
     searchBy: { field: 'serviceRequestId', value: serviceRequestId },
   });
 
@@ -35,7 +35,7 @@ export const OrderDetailsPage: React.FC = () => {
     return (
       <DetailPageContainer>
         <LabBreadcrumbs sectionName={pageName}>
-          <DetailsWithoutResults labOrder={labOrder} saveSpecimenDate={saveSpecimenDate} />
+          <DetailsWithoutResults labOrder={labOrder} />
         </LabBreadcrumbs>
       </DetailPageContainer>
     );
@@ -44,12 +44,7 @@ export const OrderDetailsPage: React.FC = () => {
   return (
     <DetailPageContainer>
       <LabBreadcrumbs sectionName={pageName}>
-        <DetailsWithResults
-          labOrder={labOrder}
-          markTaskAsReviewed={markTaskAsReviewed}
-          saveSpecimenDate={saveSpecimenDate}
-          loading={loading}
-        />
+        <DetailsWithResults labOrder={labOrder} markTaskAsReviewed={markTaskAsReviewed} loading={loading} />
       </LabBreadcrumbs>
     </DetailPageContainer>
   );

--- a/packages/utils/lib/types/data/labs/labs.types.ts
+++ b/packages/utils/lib/types/data/labs/labs.types.ts
@@ -171,6 +171,11 @@ export type SubmitLabOrderInput = {
   serviceRequestID: string;
   accountNumber: string;
   data: DynamicAOEInput;
+  specimens: {
+    [specimenId: string]: {
+      date: string;
+    };
+  };
 };
 
 export type SubmitLabOrderDTO = {

--- a/packages/zambdas/src/ehr/submit-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/submit-lab-order/index.ts
@@ -37,7 +37,13 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
   try {
     console.log(`Input: ${JSON.stringify(input)}`);
     console.log('Validating input');
-    const { serviceRequestID, accountNumber, data, secrets } = validateRequestParameters(input);
+    const {
+      serviceRequestID,
+      accountNumber,
+      data,
+      secrets,
+      specimens: specimensFromSubmit,
+    } = validateRequestParameters(input);
 
     console.log('Getting token');
     m2mtoken = await checkOrCreateM2MClientToken(m2mtoken, secrets);
@@ -57,7 +63,7 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
       appointment,
       encounter,
       organization: labOrganization,
-      specimens,
+      specimens: specimenResourses,
     } = await getLabOrderResources(oystehr, 'external', serviceRequestID);
 
     const locationID = serviceRequest.locationReference?.[0].reference?.replace('Location/', '');
@@ -147,58 +153,52 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
 
     const now = DateTime.now();
     let timezone = undefined;
+
     if (location) {
       timezone = getTimezone(location);
     }
+
     const sampleCollectionDates: DateTime[] = [];
 
     const specimenPatchOperations: BatchInputPatchRequest<FhirResource>[] =
-      specimens.length > 0
-        ? specimens.reduce<BatchInputPatchRequest<FhirResource>[]>((acc, specimen) => {
+      specimenResourses.length > 0
+        ? specimenResourses.reduce<BatchInputPatchRequest<FhirResource>[]>((acc, specimen) => {
             if (!specimen.id) {
               return acc;
             }
 
-            /**
-             * Editable samples are presented on the submit page and on pages with subsequent statuses. To unify the
-             * functionality of the samples - when editing data in date fields, they are saved immediately. Therefore,
-             * if the user has selected a date, we keep the selected one. And if they haven't selected a date, then
-             * upon submission we should set the current date.
-             */
-            const specimenDateTime = specimen.collection?.collectedDateTime;
-            console.log('specimenDateTime', specimenDateTime);
-
+            // There is an option to edit the date through the update-lab-order-resources zambda as well.
+            const specimenFromSubmitDate = DateTime.fromISO(specimensFromSubmit[specimen.id].date);
+            const specimeCollection = specimen.collection;
+            const collectedDateTime = specimeCollection?.collectedDateTime;
+            const collector = specimeCollection?.collector;
             const specimenCollector = { reference: currentUser?.profile };
-
             const requests: Operation[] = [];
 
-            if (!specimenDateTime) {
-              sampleCollectionDates.push(now);
-              if (specimen.collection) {
-                requests.push(
-                  {
-                    path: '/collection/collectedDateTime',
-                    op: 'add',
-                    value: now,
-                  },
-                  {
-                    path: '/collection/collector',
-                    op: 'add',
-                    value: specimenCollector,
-                  }
-                );
-              } else {
-                requests.push({
-                  path: '/collection',
-                  op: 'add',
-                  value: {
-                    collectedDateTime: now,
-                    collector: specimenCollector,
-                  },
-                });
-              }
+            sampleCollectionDates.push(specimenFromSubmitDate);
+
+            if (specimeCollection) {
+              requests.push(
+                {
+                  path: '/collection/collectedDateTime',
+                  op: collectedDateTime ? 'replace' : 'add',
+                  value: specimenFromSubmitDate,
+                },
+                {
+                  path: '/collection/collector',
+                  op: collector ? 'replace' : 'add',
+                  value: specimenCollector,
+                }
+              );
             } else {
-              sampleCollectionDates.push(DateTime.fromISO(specimenDateTime));
+              requests.push({
+                path: '/collection',
+                op: 'add',
+                value: {
+                  collectedDateTime: specimenFromSubmitDate,
+                  collector: specimenCollector,
+                },
+              });
             }
 
             if (requests.length) {

--- a/packages/zambdas/src/ehr/submit-lab-order/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/submit-lab-order/validateRequestParameters.ts
@@ -6,12 +6,17 @@ export function validateRequestParameters(input: ZambdaInput): SubmitLabOrderInp
     throw MISSING_REQUEST_BODY;
   }
 
-  const { serviceRequestID, accountNumber, data } = JSON.parse(input.body);
+  const { serviceRequestID, accountNumber, data, specimens } = JSON.parse(input.body) as SubmitLabOrderInput;
 
   const missingResources = [];
   if (!serviceRequestID) missingResources.push('serviceRequestID');
   if (!accountNumber) missingResources.push('accountNumber');
   if (!data) missingResources.push('data');
+
+  if (!Object.values(specimens).every((specimen) => typeof specimen.date === 'string')) {
+    missingResources.push('specimens');
+  }
+
   if (missingResources.length) {
     throw MISSING_REQUIRED_PARAMETERS(missingResources);
   }
@@ -21,5 +26,6 @@ export function validateRequestParameters(input: ZambdaInput): SubmitLabOrderInp
     accountNumber,
     data,
     secrets: input.secrets,
+    specimens,
   };
 }


### PR DESCRIPTION
- Save actual specimen dateTime from UI
- Save specimen dateTime inside submit-lab-order zambda without async update-resources calls
- We still have ability to update specimen dateTime by update-lab-resource zambda

Reference: #2165