### PR TITLE
[External Labs] navigation to redirect to external lab orders URL after marking task as reviewed

### DIFF
--- a/apps/ehr/src/features/css-module/routing/helpers.ts
+++ b/apps/ehr/src/features/css-module/routing/helpers.ts
@@ -18,6 +18,10 @@ export const getAssessmentUrl = (appointmentId: string): string => {
   return `/in-person/${appointmentId}/assessment`;
 };
 
+export const getExternalLabOrdersUrl = (appointmentId: string): string => {
+  return `/in-person/${appointmentId}/external-lab-orders/`;
+};
+
 export const getExternalLabOrderEditUrl = (appointmentId: string, orderId: string): string => {
   return `/in-person/${appointmentId}/external-lab-orders/${orderId}/order-details`;
 };

--- a/apps/ehr/src/features/external-labs/components/details/DetailsWithResults.tsx
+++ b/apps/ehr/src/features/external-labs/components/details/DetailsWithResults.tsx
@@ -8,7 +8,7 @@ import { OrderCollection } from '../OrderCollection';
 
 export const DetailsWithResults: React.FC<{
   labOrder: LabOrderDetailedPageDTO;
-  markTaskAsReviewed: (parameters: TaskReviewedParameters) => Promise<void>;
+  markTaskAsReviewed: (parameters: TaskReviewedParameters & { appointmentId: string }) => Promise<void>;
   saveSpecimenDate: (parameters: SpecimenDateChangedParameters) => Promise<void>;
   loading: boolean;
 }> = ({ labOrder, markTaskAsReviewed, saveSpecimenDate, loading }) => {
@@ -33,6 +33,7 @@ export const DetailsWithResults: React.FC<{
               taskId: result.taskId,
               serviceRequestId: labOrder.serviceRequestId,
               diagnosticReportId: result.diagnosticReportId,
+              appointmentId: labOrder.appointmentId,
             })
           }
           resultDetails={result}

--- a/apps/ehr/src/features/external-labs/components/labs-orders/usePatientLabOrders.ts
+++ b/apps/ehr/src/features/external-labs/components/labs-orders/usePatientLabOrders.ts
@@ -14,6 +14,8 @@ import { useApiClients } from '../../../../hooks/useAppClients';
 import { getExternalLabOrders, deleteLabOrder, updateLabOrderResources } from '../../../../api/api';
 import { DateTime } from 'luxon';
 import { useDeleteCommonLabOrderDialog } from '../../../common/useDeleteCommonLabOrderDialog';
+import { getExternalLabOrdersUrl } from 'src/features/css-module/routing/helpers';
+import { useNavigate } from 'react-router-dom';
 
 interface UsePatientLabOrdersResult<SearchBy extends LabOrdersSearchBy> {
   labOrders: LabOrderDTO<SearchBy>[];
@@ -39,7 +41,7 @@ interface UsePatientLabOrdersResult<SearchBy extends LabOrdersSearchBy> {
     testItemName: string;
   }) => void;
   DeleteOrderDialog: ReactElement | null;
-  markTaskAsReviewed: (parameters: TaskReviewedParameters) => Promise<void>;
+  markTaskAsReviewed: (parameters: TaskReviewedParameters & { appointmentId: string }) => Promise<void>;
   saveSpecimenDate: (parameters: SpecimenDateChangedParameters) => Promise<void>;
 }
 
@@ -49,6 +51,7 @@ export const usePatientLabOrders = <SearchBy extends LabOrdersSearchBy>(
   _searchBy: SearchBy
 ): UsePatientLabOrdersResult<SearchBy> => {
   const { oystehrZambda } = useApiClients();
+  const navigate = useNavigate();
   const [labOrders, setLabOrders] = useState<LabOrderDTO<SearchBy>[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -208,7 +211,12 @@ export const usePatientLabOrders = <SearchBy extends LabOrdersSearchBy>(
   });
 
   const markTaskAsReviewed = useCallback(
-    async ({ taskId, serviceRequestId, diagnosticReportId }: TaskReviewedParameters): Promise<void> => {
+    async ({
+      taskId,
+      serviceRequestId,
+      diagnosticReportId,
+      appointmentId,
+    }: TaskReviewedParameters & { appointmentId: string }): Promise<void> => {
       if (!oystehrZambda) {
         console.error('oystehrZambda is not defined');
         return;
@@ -218,8 +226,9 @@ export const usePatientLabOrders = <SearchBy extends LabOrdersSearchBy>(
 
       await updateLabOrderResources(oystehrZambda, { taskId, serviceRequestId, diagnosticReportId, event: 'reviewed' });
       setSearchParams({ pageNumber: 1 });
+      navigate(getExternalLabOrdersUrl(appointmentId));
     },
-    [oystehrZambda, setSearchParams]
+    [oystehrZambda, setSearchParams, navigate]
   );
 
   const saveSpecimenDate = useCallback(


### PR DESCRIPTION
Changes

- Added helper function to generate URLs for external lab orders
- Updated markTaskAsReviewed function to include appointmentId parameter across relevant components
- Modified navigation to redirect to external lab orders URL after marking task as reviewed

Ref: EHR. Labs. Click on "Mark as Reviewed" should automatically redirect user to the Labs table #2501