### PR TITLE
Make a single scrollbar to be on a page

### DIFF
--- a/apps/ehr/src/features/css-module/layout/CSSLayout.tsx
+++ b/apps/ehr/src/features/css-module/layout/CSSLayout.tsx
@@ -11,7 +11,7 @@ import { BottomNavigation } from './BottomNavigation';
 const layoutStyle: React.CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
-  height: '100vh',
+  minHeight: '100vh',
 };
 
 const mainBlocksStyle: React.CSSProperties = {


### PR DESCRIPTION
Currently the progress note page has three scroll bars:
![image](https://github.com/user-attachments/assets/86d54e07-b582-4ed2-ba80-1810a686c4ea)

This PR removes redundant scrollbars:
![image](https://github.com/user-attachments/assets/7df7f8e1-67f5-444b-92c0-09172936e45a)
