### PR TITLE
enable multiline for notes readonly view

### DIFF
--- a/apps/ehr/src/features/in-house-labs/components/details/InHouseLabsNotesCard.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/InHouseLabsNotesCard.tsx
@@ -60,6 +60,8 @@ export const InHouseLabsNotesCard: React.FC<InHouseLabsNotesCardProps> = ({
         value={notes}
         onChange={(e) => handleNotesUpdate?.(e.target.value)}
         variant="outlined"
+        multiline
+        maxRows={4}
         sx={{ ...sxStyling }}
       />
     </Box>

--- a/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx
+++ b/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx
@@ -564,7 +564,7 @@ export const InHouseLabOrderCreatePage: React.FC = () => {
                     notesLabel={'Notes (optional)'}
                     readOnly={false}
                     additionalBoxSxProps={{ mb: 3 }}
-                    additionalTextFieldProps={{ multiline: true, rows: 4 }}
+                    additionalTextFieldProps={{ rows: 4 }}
                     handleNotesUpdate={(newNote: string) => setNotes(newNote)}
                   />
                 </Grid>


### PR DESCRIPTION
Resolves: 
> If the notes span multiple lines, the field on 'Sample Collection' screen should be increased to fit the content for better readability. Please see how it works now on the video below ❌

per https://github.com/masslight/ottehr/issues/2551#issuecomment-2966401835