### PR TITLE
Fix lab screen gutters 

### DIFF
--- a/apps/ehr/src/features/common/DetailPageContainer.tsx
+++ b/apps/ehr/src/features/common/DetailPageContainer.tsx
@@ -6,7 +6,11 @@ interface DetailPageContainerProps {
 }
 export default function DetailPageContainer({ children }: DetailPageContainerProps): ReactElement {
   return (
-    <Stack id="detail-page-container" spacing={2} sx={{ p: 0, maxWidth: '680px !important', mx: 'auto' }}>
+    <Stack
+      id="detail-page-container"
+      spacing={2}
+      sx={{ p: 0, maxWidth: '680px !important', mx: 'auto', width: '100%' }}
+    >
       {children}
     </Stack>
   );

--- a/apps/ehr/src/features/common/ListViewContainer.tsx
+++ b/apps/ehr/src/features/common/ListViewContainer.tsx
@@ -6,7 +6,7 @@ interface ListViewContainerProps {
 }
 export default function ListViewContainer({ children }: ListViewContainerProps): ReactElement {
   return (
-    <Box id="list-view-container" sx={{ p: 0, maxWidth: '1536px !important', mx: 'auto' }}>
+    <Box id="list-view-container" sx={{ p: 0, maxWidth: '1536px !important', mx: 'auto', width: '100%' }}>
       {children}
     </Box>
   );


### PR DESCRIPTION
Looks like changes in this commit https://github.com/masslight/ottehr/commit/fa8be55#diff-bfe2fbe9c3dd2856a6889275dbfed1fb1069248fa4de7a0e59e47c77b8abe37b to CSS layout caused the gutters for the labs screens to render incorrectly.