### PR TITLE
[E2E] prevent duplication logins

### DIFF
--- a/.github/workflows/e2e-intake.yml
+++ b/.github/workflows/e2e-intake.yml
@@ -163,6 +163,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-
 
+      - name: Try restore user.json cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.USER_JSON_PATH }}
+          key: ${{ env.USER_JSON_CACHE_KEY }}
+          restore-keys: ${{ env.USER_JSON_CACHE_RESTORE_KEYS }}              
+
       - name: Check out secrets repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Reverting to the approach where we retrieve user.json cache from the login step to avoid duplicate logins. The trade-off is that we won't refresh cache that's about to expire. Not critical, so I'll consider a better solution later.