### PR TITLE
EHR. Docs. Privacy Policy and Paperwork folders do not allow to upload docs

### DIFF
--- a/apps/ehr/src/pages/PatientDocumentsExplorerPage.tsx
+++ b/apps/ehr/src/pages/PatientDocumentsExplorerPage.tsx
@@ -176,6 +176,8 @@ const PatientDocumentsExplorerPage: FC = () => {
         fileName: fileName,
         fileFolderId: folderId,
       });
+
+      event.target.value = '';
     },
     [documentActions, selectedFolder?.id]
   );
@@ -327,7 +329,7 @@ const PatientDocumentsExplorerPage: FC = () => {
                   >
                     Upload New Doc
                     <FileAttachmentHiddenInput
-                      onChange={(e) => handleDocumentUploadInputChange(e)}
+                      onChange={handleDocumentUploadInputChange}
                       type="file"
                       capture="environment"
                     />

--- a/apps/ehr/tests/e2e-utils/seed-data/seed-ehr-appointment-data.json
+++ b/apps/ehr/tests/e2e-utils/seed-data/seed-ehr-appointment-data.json
@@ -789,7 +789,7 @@
         "resourceType": "List",
         "status": "current",
         "mode": "working",
-        "title": "photo-ids",
+        "title": "photo-id-cards",
         "code": {
           "coding": [
             {
@@ -813,7 +813,7 @@
                 }
               ]
             },
-            "value": "photo-ids"
+            "value": "photo-id-cards"
           }
         ]
       }

--- a/packages/utils/lib/fhir/constants.ts
+++ b/packages/utils/lib/fhir/constants.ts
@@ -352,7 +352,7 @@ export const FOLDERS_CONFIG: ListConfig[] = [
     documentTypeCode: INSURANCE_CARD_CODE,
   },
   {
-    title: 'photo-ids',
+    title: 'photo-id-cards',
     display: 'Photo ID',
     documentTypeCode: PHOTO_ID_CARD_CODE,
   },

--- a/packages/zambdas/src/scripts/setup-document-explorer.ts
+++ b/packages/zambdas/src/scripts/setup-document-explorer.ts
@@ -64,8 +64,8 @@ const checkAndUpdateListResources = async (config: any, oystehr?: Oystehr): Prom
       }
     }
 
-    console.log('TESTING: Stopping after first batch');
-    break;
+    // console.log('TESTING: Stopping after first batch');
+    // break;
 
     offset += BATCH_SIZE;
   }


### PR DESCRIPTION
#1942

 - updated folder title photo IDs to match allowed to client bucket
 - allowed re-uploading the same file to avoid user confusion when no visible action occurs