### PR TITLE
[E2E] Add cache receiver workflow for cross-branch user.json sharing

### DIFF
--- a/.github/workflows/cache-user-json-to-main.yml
+++ b/.github/workflows/cache-user-json-to-main.yml
@@ -1,0 +1,48 @@
+name: User.json Cache Receiver
+on:
+  repository_dispatch:
+    types: [cache-user-json-to-main]
+
+jobs:
+  save-cache-to-main:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Decrypt and save user.json
+        run: |
+          if [ -z "${{ secrets.DEPLOY_OTTEHR_KEY }}" ]; then
+            echo "ERROR: DEPLOY_OTTEHR_KEY secret is empty or missing"
+            exit 1
+          fi
+          
+          echo '${{ github.event.client_payload.encrypted_content }}' > user.json.enc
+          
+          if openssl enc -aes-256-cbc -d -a \
+              -pass pass:"${{ secrets.DEPLOY_OTTEHR_KEY }}" \
+              -in user.json.enc \
+              -out user.json; then
+            echo "File decrypted successfully"
+            echo "File size: $(wc -c < user.json)"
+          else
+            echo "ERROR: Failed to decrypt user.json"
+            exit 1
+          fi
+          
+          rm -f user.json.enc
+
+      - name: Save to main branch cache
+        uses: actions/cache/save@v4
+        with:
+          path: user.json
+          key: ${{ github.event.client_payload.cache_key }}
+
+      - name: Report success
+        run: |
+          echo "Successfully cached user.json to main branch"
+          echo "Cache key: ${{ github.event.client_payload.cache_key }}"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -f user.json
+          echo "Cleanup completed"


### PR DESCRIPTION
## What & Why
Receiver workflow that creates shared cache accessible by all feature branches.

## How it works
1. Listen for dispatch events from feature branches
2. Decrypt `user.json` and save to main branch cache
3. Feature branches access via `restore-keys`

## Why in main branch?
- `repository_dispatch` only works in default branch (GitHub limitation)
- Cache created in feature scope only accessible by that branch or main branch
- Cache created in main scope is accessible by all branches

## Security
AES-256 decryption, cleanup

sender PR: https://github.com/masslight/ottehr/pull/2887

ref: https://github.com/masslight/ottehr/issues/2893