### PR TITLE
add VitalsTextFreeInputField and update vision observation handling

### DIFF
--- a/apps/ehr/src/features/css-module/components/vitals/components/VitalsTextInputFiled.tsx
+++ b/apps/ehr/src/features/css-module/components/vitals/components/VitalsTextInputFiled.tsx
@@ -31,3 +31,31 @@ export const VitalsTextInputFiled = styled((props: TextFieldProps & { extraSx?: 
     {...props}
   />
 ))(() => ({}));
+
+export const VitalsTextFreeInputField = styled(
+  (props: TextFieldProps & { extraSx?: SxProps; isInputError: boolean }) => (
+    <TextField
+      variant="outlined"
+      fullWidth
+      autoComplete="off"
+      size="small"
+      error={props.isInputError}
+      helperText={props.isInputError ? 'Invalid value' : ''}
+      FormHelperTextProps={{
+        sx: { backgroundColor: '#F7F8F9', mx: 0, fontWeight: 500, fontSize: '14px' },
+      }}
+      sx={{
+        backgroundColor: 'white',
+        '& .MuiOutlinedInput-root': {
+          height: '100%',
+        },
+        '& .MuiInputLabel-root': {
+          color: 'text.secondary',
+        },
+        ...props.extraSx,
+      }}
+      type="text"
+      {...props}
+    />
+  )
+)(() => ({}));

--- a/apps/ehr/src/features/css-module/components/vitals/vision/VitalsVisionCard.tsx
+++ b/apps/ehr/src/features/css-module/components/vitals/vision/VitalsVisionCard.tsx
@@ -3,7 +3,6 @@ import { enqueueSnackbar } from 'notistack';
 import React, { JSX, useCallback, useMemo, useState } from 'react';
 import {
   getVisionExtraOptionsFormattedString,
-  textToNumericValue,
   VitalFieldNames,
   VitalsVisionObservationDTO,
   VitalsVisionOption,
@@ -11,7 +10,7 @@ import {
 import { RoundedButton } from '../../../../../components/RoundedButton';
 import { AccordionCard, DoubleColumnContainer } from '../../../../../telemed/components';
 import VitalsHistoryContainer from '../components/VitalsHistoryContainer';
-import { VitalsTextInputFiled } from '../components/VitalsTextInputFiled';
+import { VitalsTextFreeInputField } from '../components/VitalsTextInputFiled';
 import { useVitalsCardState } from '../hooks/useVitalsCardState';
 import { composeVisionVitalsHistoryEntries } from './helpers';
 import { VitalVisionHistoryEntry } from './VitalVisionEntry';
@@ -60,10 +59,8 @@ const VitalsVisionCard: React.FC = (): JSX.Element => {
   }, [latestHistoryEntry]);
 
   const handleSaveVisionObservation = async (leftEyeVisionText: string, rightEeyVisionText: string): Promise<void> => {
-    const lefEyeValueNum = textToNumericValue(leftEyeVisionText);
-    if (!lefEyeValueNum) return;
-    const rightEyeValueNum = textToNumericValue(rightEeyVisionText);
-    if (!rightEyeValueNum) return;
+    if (!leftEyeVisionText) return;
+    if (!rightEeyVisionText) return;
 
     const extraOptions: VitalsVisionOption[] = [];
     if (isChildTooYoungOptionSelected) {
@@ -78,10 +75,11 @@ const VitalsVisionCard: React.FC = (): JSX.Element => {
 
     try {
       setSavingCardData(true);
+
       const vitalObs: VitalsVisionObservationDTO = {
         field: VitalFieldNames.VitalVision,
-        leftEyeVisionValue: lefEyeValueNum,
-        rightEyeVisionValue: rightEyeValueNum,
+        leftEyeVisionText: leftEyeVisionText,
+        rightEyeVisionText: rightEeyVisionText,
         extraVisionOptions: extraOptions,
       };
       await handleSaveVital(vitalObs);
@@ -176,7 +174,7 @@ const VitalsVisionCard: React.FC = (): JSX.Element => {
                     ml: 0,
                   }}
                 >
-                  <VitalsTextInputFiled
+                  <VitalsTextFreeInputField
                     label="Left eye"
                     value={leftEyeSelection}
                     disabled={isSavingCardData}
@@ -195,7 +193,7 @@ const VitalsVisionCard: React.FC = (): JSX.Element => {
                     ml: 1,
                   }}
                 >
-                  <VitalsTextInputFiled
+                  <VitalsTextFreeInputField
                     label="Right eye"
                     value={rightEyeSelection}
                     disabled={isSavingCardData}
@@ -222,7 +220,7 @@ const VitalsVisionCard: React.FC = (): JSX.Element => {
                     ml: 1,
                   }}
                 >
-                  <VitalsTextInputFiled
+                  <VitalsTextFreeInputField
                     label="Both eyes"
                     value={bothEyesSelection}
                     disabled={isSavingCardData}

--- a/apps/ehr/src/features/css-module/components/vitals/vision/helpers.ts
+++ b/apps/ehr/src/features/css-module/components/vitals/vision/helpers.ts
@@ -21,8 +21,8 @@ export const composeVisionVitalsHistoryEntries = (
     isVisionVitalObservation,
     (observation) => {
       return {
-        leftEyeVision: observation.leftEyeVisionValue?.toString(),
-        rightEyeVision: observation.rightEyeVisionValue?.toString(),
+        leftEyeVision: observation.leftEyeVisionText,
+        rightEyeVision: observation.rightEyeVisionText,
         extraOptions: parseVisionExtraOptions(observation.extraVisionOptions),
       };
     }

--- a/packages/utils/lib/fhir/vitals.ts
+++ b/packages/utils/lib/fhir/vitals.ts
@@ -336,8 +336,7 @@ export const extractOxySaturationObservationMethod = (
 export const getVisionObservationComponents = (visionDTO: VitalsVisionObservationDTO): ObservationComponent[] => {
   let result: ObservationComponent[] = [];
 
-  const leftEyeVision = visionDTO.leftEyeVisionValue;
-  if (leftEyeVision) {
+  if (visionDTO.leftEyeVisionText) {
     const leftEye: CodeableConcept = {
       coding: [
         {
@@ -349,14 +348,13 @@ export const getVisionObservationComponents = (visionDTO: VitalsVisionObservatio
     };
     const leftEyeVisionComponent: ObservationComponent = {
       code: leftEye,
-      valueQuantity: { value: leftEyeVision, system: 'http://unitsofmeasure.org' },
+      valueString: visionDTO.leftEyeVisionText,
     };
 
     result.push(leftEyeVisionComponent);
   }
 
-  const rightEyeVision = visionDTO.rightEyeVisionValue;
-  if (rightEyeVision) {
+  if (visionDTO.rightEyeVisionText) {
     const rightEyeCode: CodeableConcept = {
       coding: [
         {
@@ -368,7 +366,7 @@ export const getVisionObservationComponents = (visionDTO: VitalsVisionObservatio
     };
     const rightEyeVisionComponent: ObservationComponent = {
       code: rightEyeCode,
-      valueQuantity: { value: rightEyeVision, system: 'http://unitsofmeasure.org' },
+      valueString: visionDTO.rightEyeVisionText,
     };
 
     result.push(rightEyeVisionComponent);
@@ -421,19 +419,21 @@ export const getVisionObservationComponents = (visionDTO: VitalsVisionObservatio
 export const extractVisionValues = (
   components: ObservationComponent[]
 ): {
-  leftEyeVisValue?: number;
-  rightEyeVisValue?: number;
+  leftEyeVisText?: string;
+  rightEyeVisText?: string;
   visionOptions?: VitalsVisionOption[];
 } => {
   const leftEyeComponent = components.find((cmp) => {
     return cmp.code?.coding?.find((coding) => coding?.code === VITAL_LEFT_EYE_SNOMED_CODE);
   });
-  const leftEyeVisionValue = leftEyeComponent?.valueQuantity?.value;
+
+  const leftEyeVisionText = leftEyeComponent?.valueString || leftEyeComponent?.valueQuantity?.value?.toString();
 
   const rightEyeComponent = components.find((cmp) => {
     return cmp.code?.coding?.find((coding) => coding?.code === VITAL_RIGHT_EYE_SNOMED_CODE);
   });
-  const rightEyeVisionValue = rightEyeComponent?.valueQuantity?.value;
+
+  const rightEyeVisionText = rightEyeComponent?.valueString || rightEyeComponent?.valueQuantity?.value?.toString();
 
   const getVisionExtraOptionValue = (option: VitalsVisionOption): boolean | undefined => {
     let optionCode = '';
@@ -455,8 +455,8 @@ export const extractVisionValues = (
   const storedExtraVisionOptions = allExtraVisionOptions.filter((option) => getVisionExtraOptionValue(option) === true);
 
   return {
-    leftEyeVisValue: leftEyeVisionValue,
-    rightEyeVisValue: rightEyeVisionValue,
+    leftEyeVisText: leftEyeVisionText,
+    rightEyeVisText: rightEyeVisionText,
     visionOptions: storedExtraVisionOptions,
   };
 };
@@ -724,8 +724,8 @@ export function makeVitalsObservationDTO(observation: Observation): VitalsObserv
     const result: VitalsVisionObservationDTO = {
       ...baseProps,
       field: VitalFieldNames.VitalVision,
-      leftEyeVisionValue: visionValues.leftEyeVisValue ?? 0,
-      rightEyeVisionValue: visionValues.rightEyeVisValue ?? 0,
+      leftEyeVisionText: visionValues.leftEyeVisText ?? '',
+      rightEyeVisionText: visionValues.rightEyeVisText ?? '',
       extraVisionOptions: visionValues.visionOptions,
     };
     return result;

--- a/packages/utils/lib/helpers/visit-note/map-vitals-to-display.helper.ts
+++ b/packages/utils/lib/helpers/visit-note/map-vitals-to-display.helper.ts
@@ -59,7 +59,7 @@ export const mapVitalsToDisplay = (vitalsObservations?: VitalsObservationDTO[]):
         break;
       case VitalFieldNames.VitalVision:
         parsed = observation as VitalsVisionObservationDTO;
-        text = `Left eye: ${parsed.leftEyeVisionValue}; Right eye: ${parsed.rightEyeVisionValue};${
+        text = `Left eye: ${parsed.leftEyeVisionText}; Right eye: ${parsed.rightEyeVisionText};${
           parsed.extraVisionOptions && parsed.extraVisionOptions.length > 0
             ? ` ${getVisionExtraOptionsFormattedString(parseVisionExtraOptions(parsed.extraVisionOptions))}`
             : ''

--- a/packages/utils/lib/types/api/chart-data/chart-data.types.ts
+++ b/packages/utils/lib/types/api/chart-data/chart-data.types.ts
@@ -205,8 +205,8 @@ export type VitalsVisionOption = 'child_too_young' | 'with_glasses' | 'without_g
 export interface VitalsVisionObservationDTO extends VitalsBaseObservationDTO {
   field: Extract<VitalFieldNames, 'vital-vision'>;
   value?: never;
-  leftEyeVisionValue: number;
-  rightEyeVisionValue: number;
+  leftEyeVisionText: string;
+  rightEyeVisionText: string;
   extraVisionOptions?: VitalsVisionOption[];
 }
 


### PR DESCRIPTION
Ref: https://github.com/masslight/ottehr/issues/2913

# Add free text support to vision vitals input fields
- Added VitalsTextFreeInputField component for text input (replaces numeric-only inputs)
- Extended VitalsVisionObservationDTO with leftEyeVisionText and rightEyeVisionText fields
- Updated FHIR functions to store vision data as valueString instead of valueQuantity
- Added backward compatibility to read legacy numeric values and convert them to text
- All vision input fields (left eye, right eye, both eyes) now accept free text input