### PR TITLE
Fix ERX history

### DIFF
--- a/apps/ehr/src/telemed/features/appointment/PlanTab/ERxContainer.tsx
+++ b/apps/ehr/src/telemed/features/appointment/PlanTab/ERxContainer.tsx
@@ -15,7 +15,7 @@ import { Stack } from '@mui/system';
 import { Practitioner } from 'fhir/r4b';
 import { enqueueSnackbar } from 'notistack';
 import { FC, useState } from 'react';
-import { ERX_MEDICATION_TAG, formatDateToMDYWithTime, RoleType } from 'utils';
+import { ERX_MEDICATION_META_TAG_CODE, formatDateToMDYWithTime, RoleType } from 'utils';
 import { RoundedButton } from '../../../../components/RoundedButton';
 import { useChartData } from '../../../../features/css-module/hooks/useChartData';
 import { useApiClients } from '../../../../hooks/useAppClients';
@@ -129,7 +129,7 @@ export const ERxContainer: FC<ERxContainerProps> = ({ showHeader = true }) => {
     requestedFields: {
       prescribedMedications: {
         _include: 'MedicationRequest:requester',
-        _tag: ERX_MEDICATION_TAG.code,
+        _tag: ERX_MEDICATION_META_TAG_CODE,
       },
     },
     refetchInterval: 10000,

--- a/apps/ehr/src/telemed/features/appointment/PlanTab/ERxContainer.tsx
+++ b/apps/ehr/src/telemed/features/appointment/PlanTab/ERxContainer.tsx
@@ -15,7 +15,7 @@ import { Stack } from '@mui/system';
 import { Practitioner } from 'fhir/r4b';
 import { enqueueSnackbar } from 'notistack';
 import { FC, useState } from 'react';
-import { formatDateToMDYWithTime, RoleType } from 'utils';
+import { ERX_MEDICATION_TAG, formatDateToMDYWithTime, RoleType } from 'utils';
 import { RoundedButton } from '../../../../components/RoundedButton';
 import { useChartData } from '../../../../features/css-module/hooks/useChartData';
 import { useApiClients } from '../../../../hooks/useAppClients';
@@ -129,6 +129,7 @@ export const ERxContainer: FC<ERxContainerProps> = ({ showHeader = true }) => {
     requestedFields: {
       prescribedMedications: {
         _include: 'MedicationRequest:requester',
+        _tag: ERX_MEDICATION_TAG.code,
       },
     },
     refetchInterval: 10000,

--- a/packages/utils/lib/fhir/constants.ts
+++ b/packages/utils/lib/fhir/constants.ts
@@ -242,6 +242,11 @@ export const FHIR_APPOINTMENT_INTAKE_HARVESTING_COMPLETED_TAG = {
   code: 'SUB_INTAKE_HARVEST_TASK_COMPLETE',
 };
 
+export const ERX_MEDICATION_TAG = {
+  code: 'erx-medication',
+  system: `${PRIVATE_EXTENSION_BASE_URL}/erx-medication`,
+};
+
 export const FHIR_APPOINTMENT_TYPE_MAP: Record<string, AppointmentType> = {
   walkin: 'walk-in',
   prebook: 'pre-booked',

--- a/packages/utils/lib/fhir/constants.ts
+++ b/packages/utils/lib/fhir/constants.ts
@@ -242,10 +242,7 @@ export const FHIR_APPOINTMENT_INTAKE_HARVESTING_COMPLETED_TAG = {
   code: 'SUB_INTAKE_HARVEST_TASK_COMPLETE',
 };
 
-export const ERX_MEDICATION_TAG = {
-  code: 'erx-medication',
-  system: `${PRIVATE_EXTENSION_BASE_URL}/erx-medication`,
-};
+export const ERX_MEDICATION_META_TAG_CODE = 'erx-medication';
 
 export const FHIR_APPOINTMENT_TYPE_MAP: Record<string, AppointmentType> = {
   walkin: 'walk-in',

--- a/packages/zambdas/src/subscriptions/medication-request/process-erx-resources/index.ts
+++ b/packages/zambdas/src/subscriptions/medication-request/process-erx-resources/index.ts
@@ -1,8 +1,14 @@
 import { BatchInputRequest } from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Encounter, MedicationRequest } from 'fhir/r4b';
-import { ERX_MEDICATION_TAG, getPatchBinary, getSecret, isTruthy, Secrets, SecretsKeys } from 'utils';
-import { checkOrCreateM2MClientToken, createOystehrClient, topLevelCatch, ZambdaInput } from '../../../shared';
+import { ERX_MEDICATION_META_TAG_CODE, getPatchBinary, getSecret, isTruthy, Secrets, SecretsKeys } from 'utils';
+import {
+  checkOrCreateM2MClientToken,
+  createOystehrClient,
+  fillMeta,
+  topLevelCatch,
+  ZambdaInput,
+} from '../../../shared';
 
 export function validateRequestParameters(input: ZambdaInput): { secrets: Secrets | null } {
   return {
@@ -106,9 +112,7 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
                 {
                   op: 'add',
                   path: '/meta',
-                  value: {
-                    tag: [ERX_MEDICATION_TAG],
-                  },
+                  value: fillMeta(ERX_MEDICATION_META_TAG_CODE, ERX_MEDICATION_META_TAG_CODE),
                 },
               ],
             })

--- a/packages/zambdas/src/subscriptions/medication-request/process-erx-resources/index.ts
+++ b/packages/zambdas/src/subscriptions/medication-request/process-erx-resources/index.ts
@@ -1,7 +1,7 @@
 import { BatchInputRequest } from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Encounter, MedicationRequest } from 'fhir/r4b';
-import { getPatchBinary, getSecret, isTruthy, Secrets, SecretsKeys } from 'utils';
+import { ERX_MEDICATION_TAG, getPatchBinary, getSecret, isTruthy, Secrets, SecretsKeys } from 'utils';
 import { checkOrCreateM2MClientToken, createOystehrClient, topLevelCatch, ZambdaInput } from '../../../shared';
 
 export function validateRequestParameters(input: ZambdaInput): { secrets: Secrets | null } {
@@ -102,6 +102,13 @@ export const index = async (input: ZambdaInput): Promise<APIGatewayProxyResult> 
                   op: 'add',
                   path: '/encounter',
                   value: { reference: `Encounter/${encounter.id}` },
+                },
+                {
+                  op: 'add',
+                  path: '/meta',
+                  value: {
+                    tag: [ERX_MEDICATION_TAG],
+                  },
                 },
               ],
             })


### PR DESCRIPTION
This commit fixes https://github.com/masslight/ottehr/issues/3074

Currently there's no way to test the implementation since the erx functionality is blocked by the non-working request to https://erx-api.zapehr.com/v3/patient/... Here's the discussion of this issue https://masslight.slack.com/archives/C06JW8P5CD8/p1752064652257499

I would appreciate an early code review