### PR TITLE
fix: operate in state button changes in patient side

### DIFF
--- a/apps/intake/src/pages/StartVirtualVisit.tsx
+++ b/apps/intake/src/pages/StartVirtualVisit.tsx
@@ -128,13 +128,14 @@ const StartVirtualVisit = (): JSX.Element => {
         const currentWorkingHours = currentWorkingHoursText(serverState);
         return {
           state: stateCode,
-          available: serverState?.locationInformation?.scheduleExtension
-            ? isLocationOpen(
-                serverState.locationInformation.scheduleExtension,
-                serverState.locationInformation.timezone ?? TIMEZONES[0],
-                DateTime.now().setZone(serverState.locationInformation.timezone ?? '')
-              )
-            : false,
+          available:
+            serverState?.available && serverState?.locationInformation?.scheduleExtension
+              ? isLocationOpen(
+                  serverState.locationInformation.scheduleExtension,
+                  serverState.locationInformation.timezone ?? TIMEZONES[0],
+                  DateTime.now().setZone(serverState.locationInformation.timezone ?? '')
+                )
+              : false,
           workingHours: (Boolean(serverState?.available) && currentWorkingHours) || null,
           fullName: stateCodeToFullName[stateCode] || stateCode,
           scheduleId: serverState?.schedule.id || '',


### PR DESCRIPTION
Before we weren't checking the availability of the location/state:
<img width="976" height="621" alt="Screenshot 2025-07-14 at 14 14 02" src="https://github.com/user-attachments/assets/2d052d06-c2a1-4d7f-a2c0-523b35b7e93e" />
<img width="717" height="577" alt="Screenshot 2025-07-14 at 14 13 34" src="https://github.com/user-attachments/assets/0e734214-65de-4b0a-a41b-fd091b97b5ad" />

After the change:
<img width="628" height="553" alt="Screenshot 2025-07-14 at 15 12 03" src="https://github.com/user-attachments/assets/d7c2c9fe-c933-4082-a230-20e0bcc7c3b9" />


