### PR TITLE
fix(payment): throw if 3ds at payment time for now

### DIFF
--- a/packages/zambdas/src/ehr/patient-payments/post/index.ts
+++ b/packages/zambdas/src/ehr/patient-payments/post/index.ts
@@ -140,6 +140,10 @@ const performEffect = async (
     };
     const paymentIntent = await stripeClient.paymentIntents.create(paymentIntentInput);
 
+    if (paymentIntent.status !== 'succeeded') {
+      throw new Error(`The card payment was not successful. Try a different card`);
+    }
+
     paymentNoticeInput.stripePaymentIntentId = paymentIntent.id;
 
     console.log('Payment Intent created:', JSON.stringify(paymentIntent, null, 2));


### PR DESCRIPTION
You can test this with the stripe 3ds test cards from here https://docs.stripe.com/testing?testing-method=card-numbers