### PR TITLE
Feat: add e-req line to order form

### DIFF
--- a/packages/zambdas/src/ehr/submit-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/submit-lab-order/index.ts
@@ -469,6 +469,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
           name: code.text || ORDER_ITEM_UNKNOWN,
         })),
         orderPriority: serviceRequest.priority || ORDER_ITEM_UNKNOWN,
+        isManualOrder: manualOrder,
       },
       patient.id,
       secrets,

--- a/packages/zambdas/src/shared/pdf/external-labs-order-form-pdf.ts
+++ b/packages/zambdas/src/shared/pdf/external-labs-order-form-pdf.ts
@@ -65,8 +65,12 @@ async function createExternalLabsOrderFormPdfBytes(data: LabsData): Promise<Uint
   // Draw header
   pdfClient.drawText(`${data.labOrganizationName}: Order Form`, textStyles.headerRight); // the original was 18 font
   pdfClient.newLine(STANDARD_NEW_LINE);
-  pdfClient.drawText('E-REQ', { ...textStyles.textBoldRight, fontSize: textStyles.headerRight.fontSize - 2 });
-  pdfClient.newLine(STANDARD_NEW_LINE);
+
+  // print 'e-req' if submitting electronically
+  if (!data.isManualOrder) {
+    pdfClient.drawText('E-REQ', { ...textStyles.textBoldRight, fontSize: textStyles.headerRight.fontSize - 2 });
+    pdfClient.newLine(STANDARD_NEW_LINE);
+  }
   pdfClient.drawSeparatedLine(BLACK_LINE_STYLE);
 
   // Location Details (left column)

--- a/packages/zambdas/src/shared/pdf/external-labs-order-form-pdf.ts
+++ b/packages/zambdas/src/shared/pdf/external-labs-order-form-pdf.ts
@@ -65,6 +65,8 @@ async function createExternalLabsOrderFormPdfBytes(data: LabsData): Promise<Uint
   // Draw header
   pdfClient.drawText(`${data.labOrganizationName}: Order Form`, textStyles.headerRight); // the original was 18 font
   pdfClient.newLine(STANDARD_NEW_LINE);
+  pdfClient.drawText('E-REQ', { ...textStyles.textBoldRight, fontSize: textStyles.headerRight.fontSize - 2 });
+  pdfClient.newLine(STANDARD_NEW_LINE);
   pdfClient.drawSeparatedLine(BLACK_LINE_STYLE);
 
   // Location Details (left column)

--- a/packages/zambdas/src/shared/pdf/types.ts
+++ b/packages/zambdas/src/shared/pdf/types.ts
@@ -162,6 +162,7 @@ export interface LabsData {
   orderName?: string | undefined;
   orderAssessments: { code: string; name: string }[];
   orderPriority: string;
+  isManualOrder: boolean;
 }
 
 export interface ExternalLabResult {
@@ -202,6 +203,7 @@ export interface LabResultsData
     | 'sampleCollectionDate'
     | 'billClass'
     | 'accountNumber'
+    | 'isManualOrder'
   > {
   testName: string;
   resultStatus: string;


### PR DESCRIPTION
#3326 

Order submitted electronically w/ E-REQ line
<img width="820" height="783" alt="Screenshot 2025-07-22 at 12 48 24 AM" src="https://github.com/user-attachments/assets/48a54cb7-47a4-47bd-aaba-526deab4eeee" />


Order submitted manually
<img width="848" height="832" alt="Screenshot 2025-07-22 at 12 48 19 AM" src="https://github.com/user-attachments/assets/fedfc54e-fdcb-4ca5-b5b8-eed724e5f4d8" />
