### PR TITLE
[EHR] fix crash on patient info page if no appointment was opened

### DIFF
--- a/apps/ehr/src/components/patient/Header.tsx
+++ b/apps/ehr/src/components/patient/Header.tsx
@@ -20,7 +20,7 @@ export const Header: FC<HeaderProps> = ({ handleDiscard, id }) => {
 
   // todo: product has said that on screens with no specific encounter, use the latest encounter for the label
   // which seems ok for now but might change later
-  const latestAppointmentEncounter = appointments?.[0].encounter;
+  const latestAppointmentEncounter = appointments?.[0]?.encounter;
 
   return (
     <Box


### PR DESCRIPTION
add optional chaining to safely access latest appointment encounter