### PR TITLE
add fax number to organization telecom

### DIFF
--- a/packages/zambdas/ottehr-spec.json
+++ b/packages/zambdas/ottehr-spec.json
@@ -1061,7 +1061,13 @@
     "OTTEHR_ORGANIZATION": {
       "resourceType": "Organization",
       "active": true,
-      "name": "Example Organization"
+      "name": "Example Organization",
+      "telecom": [
+        {
+          "system": "phone",
+          "value": "#{var/fax-number}"
+        }
+      ]
     },
     "AUTOLAB_ORGANIZATION": {
       "resourceType": "Organization",


### PR DESCRIPTION
instead of having to manually add the fax id to the organization resource on onboarding, we can set it in the secrets and have the spec handle it

- [x] lints and builds
- [x] e2e tests pass