### PR TITLE
Fix config

### DIFF
--- a/config/ottehr-spec.json
+++ b/config/ottehr-spec.json
@@ -1064,7 +1064,7 @@
       "zip": ".dist/zips/failing-endpoint.zip"
     },
     "CREATE-DISCHARGE_SUMMARY": {
-      "name": "CREATE-DISCHARGE-SUMMARY",
+      "name": "create-discharge-summary",
       "type": "http_auth",
       "runtime": "nodejs20.x",
       "src": "src/ehr/create-discharge-summary/index",
@@ -5468,7 +5468,8 @@
             "Z3:#{var/PROJECT_ID}-receipts/*",
             "Z3:#{var/PROJECT_ID}-school-work-notes/*",
             "Z3:#{var/PROJECT_ID}-privacy-policy/*",
-            "Z3:#{var/PROJECT_ID}-exported-questionnaires/*"
+            "Z3:#{var/PROJECT_ID}-exported-questionnaires/*",
+            "Z3:#{var/PROJECT_ID}-discharge-summaries/*"
           ],
           "action": ["Z3:PutObject", "Z3:GetObject"],
           "effect": "Allow"
@@ -6003,7 +6004,10 @@
       "name": "#{var/PROJECT_ID}-receipts"
     },
     "PAPERWORK": {
-      "name": "#{var/PROJECT_ID}-paperwork"
+      "name": "#{var/PROJECT_ID}-exported-questionnaires"
+    },
+    "DISCHARGE_SUMMARIES": {
+      "name": "#{var/PROJECT_ID}-discharge-summaries"
     }
   },
   "labRoutes": {

--- a/scripts/ottehr-setup.ts
+++ b/scripts/ottehr-setup.ts
@@ -92,6 +92,7 @@ async function createM2M(
               `Z3:${projectId}-school-work-notes/*`,
               `Z3:${projectId}-privacy-policy/*`,
               `Z3:${projectId}-exported-questionnaires/*`,
+              `Z3:${projectId}-discharge-summaries/*`,
             ],
             action: ['Z3:PutObject', 'Z3:GetObject'],
             effect: 'Allow',
@@ -128,7 +129,7 @@ async function runCLI(): Promise<void> {
   let userInput: { accessToken: string; projectId: string; providerEmail: string };
   try {
     userInput = await getUserInput();
-  } catch (err) {
+  } catch {
     console.error('Setup canceled');
     process.exit(1);
   }


### PR DESCRIPTION
Resolves issues with the zambdas `create-discharge-summary` and `paperwork-to-pdf`, as well as potentially other related ones in the `discharge-summaries` and `exported-questionnaires` buckets