### PR TITLE
fix `lotNumber` and `expDate` required for not administered button sometimes

### DIFF
--- a/apps/ehr/src/features/css-module/components/medication-administration/medication-editable-card/MedicationCardField.tsx
+++ b/apps/ehr/src/features/css-module/components/medication-administration/medication-editable-card/MedicationCardField.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DateTime } from 'luxon';
@@ -102,6 +103,38 @@ export const MedicationCardField: React.FC<MedicationCardFieldProps> = ({
             },
           }}
           format="yyyy-MM-dd HH:mm a"
+        />
+      </LocalizationProvider>
+    );
+  }
+
+  if (field === 'expDate') {
+    const dateTimeValue = value ? DateTime.fromISO(value as string) : null;
+
+    return (
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <DatePicker
+          data-testid={dataTestIds.orderMedicationPage.inputField(field)}
+          label={label}
+          value={dateTimeValue}
+          onChange={(newValue) => {
+            if (!newValue) return;
+            const isoString = newValue.toISO();
+            if (isoString) {
+              handleChange(isoString);
+            }
+          }}
+          disabled={!isEditable}
+          slotProps={{
+            textField: {
+              fullWidth: true,
+              variant: 'outlined',
+              required: required,
+              error: showError && required && !value,
+              helperText: showError && required && !value ? REQUIRED_FIELD_ERROR_MESSAGE : '',
+            },
+          }}
+          format="yyyy-MM-dd"
         />
       </LocalizationProvider>
     );
@@ -287,7 +320,7 @@ export const MedicationCardField: React.FC<MedicationCardFieldProps> = ({
       {...(type === 'number' ? { inputProps: { min: 0 } } : {})}
       multiline={isInstruction}
       rows={isInstruction ? 3 : undefined}
-      InputLabelProps={type === 'datetime' || type === 'month' || isInstruction ? { shrink: true } : undefined}
+      InputLabelProps={type === 'datetime' || isInstruction ? { shrink: true } : undefined}
       required={required}
       error={showError && required && !value}
       helperText={showError && required && !value ? REQUIRED_FIELD_ERROR_MESSAGE : ''}

--- a/apps/ehr/src/features/css-module/components/medication-administration/medication-editable-card/MedicationCardView.tsx
+++ b/apps/ehr/src/features/css-module/components/medication-administration/medication-editable-card/MedicationCardView.tsx
@@ -20,7 +20,7 @@ import { getInHouseMedicationMARUrl } from '../../../routing/helpers';
 import { CSSLoader } from '../../CSSLoader';
 import { ButtonRounded } from '../../RoundedButton';
 import { MedicationStatusChip } from '../statuses/MedicationStatusChip';
-import { getFieldLabel, MedicationFieldType, MedicationOrderType } from './fieldsConfig';
+import { getFieldLabel, MedicationFieldType, MedicationOrderType, XsVariants } from './fieldsConfig';
 import { MedicationCardField } from './MedicationCardField';
 import { InHouseMedicationFieldType } from './utils';
 
@@ -37,7 +37,7 @@ type MedicationCardViewProps = {
     Record<
       keyof MedicationData,
       {
-        xs: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+        xs: XsVariants;
         isRequired: boolean;
       }
     >

--- a/apps/ehr/src/features/css-module/components/medication-administration/medication-editable-card/fieldsConfig.ts
+++ b/apps/ehr/src/features/css-module/components/medication-administration/medication-editable-card/fieldsConfig.ts
@@ -8,6 +8,8 @@ export type MedicationFieldType =
   | 'manufacturer'
   | 'route'
   | 'providerId'
+  // TODO: uncomment when the "anatomical locations" feature is completed
+  // | 'location'
   | 'effectiveDateTime'
   | 'instructions'
   | 'lotNumber'
@@ -15,7 +17,7 @@ export type MedicationFieldType =
 
 export type MedicationFormType = 'order-new' | 'order-edit' | 'dispense' | 'dispense-not-administered';
 
-type XsVariants = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type XsVariants = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 export const fieldsConfigForOrder: Record<
   Exclude<MedicationFieldType, 'effectiveDateTime' | 'lotNumber' | 'expDate'>,

--- a/apps/ehr/src/features/css-module/components/medication-administration/medication-editable-card/utils.tsx
+++ b/apps/ehr/src/features/css-module/components/medication-administration/medication-editable-card/utils.tsx
@@ -28,11 +28,11 @@ export const medicationOrderFieldsWithOptions: Partial<keyof ExtendedMedicationD
 
 export type MedicationOrderFieldWithOptionsType = (typeof medicationOrderFieldsWithOptions)[number];
 
-export type InHouseMedicationFieldType = 'text' | 'number' | 'select' | 'datetime' | 'month' | 'autocomplete';
+export type InHouseMedicationFieldType = 'text' | 'number' | 'select' | 'datetime' | 'date' | 'autocomplete';
 
 export const getFieldType = (field: keyof MedicationData): InHouseMedicationFieldType => {
   if (field === 'dose') return 'number';
-  if (field === 'expDate') return 'month';
+  if (field === 'expDate') return 'date';
   if (field === 'effectiveDateTime') return 'datetime';
   if (field === 'medicationId') return 'autocomplete';
   if (field === 'route') return 'autocomplete'; // Make route searchable

--- a/packages/zambdas/src/ehr/create-update-medication-order/helpers.ts
+++ b/packages/zambdas/src/ehr/create-update-medication-order/helpers.ts
@@ -6,6 +6,7 @@ import {
   getResourcesFromBatchInlineRequests,
   INVENTORY_MEDICATION_TYPE_CODE,
   MedicationData,
+  MedicationOrderStatuses,
   OrderPackage,
   removePrefix,
   searchMedicationLocation,
@@ -21,7 +22,8 @@ export function getPerformerId(medicationAdministration: MedicationAdministratio
 
 export function createMedicationCopy(
   inventoryMedication: Medication,
-  orderData: { lotNumber?: string; expDate?: string; manufacturer?: string }
+  orderData: { lotNumber?: string; expDate?: string; manufacturer?: string },
+  newStatus?: string
 ): Medication {
   const resourceCopy = { ...inventoryMedication };
   delete resourceCopy.id;
@@ -30,7 +32,7 @@ export function createMedicationCopy(
   const typeIdentifierArrId =
     resourceCopy.identifier?.findIndex((idn) => idn.value === INVENTORY_MEDICATION_TYPE_CODE) ?? -1;
   if (typeIdentifierArrId >= 0) resourceCopy.identifier?.splice(typeIdentifierArrId, 1);
-  if (orderData.lotNumber || orderData.expDate) {
+  if (newStatus !== MedicationOrderStatuses['administered-not'] && (orderData.lotNumber || orderData.expDate)) {
     resourceCopy.batch = {
       lotNumber: orderData.lotNumber,
       expirationDate: orderData.expDate,

--- a/packages/zambdas/src/ehr/create-update-medication-order/index.ts
+++ b/packages/zambdas/src/ehr/create-update-medication-order/index.ts
@@ -137,7 +137,7 @@ async function updateOrder(
   } else if (existingMedicationCopy) {
     console.log('Updating existing copy for order');
     // during copy process we also update lotNumber, expDate etc.
-    newMedicationCopy = createMedicationCopy(existingMedicationCopy, orderData);
+    newMedicationCopy = createMedicationCopy(existingMedicationCopy, orderData, newStatus);
   }
 
   const transactionRequests: BatchInputRequest<FhirResource>[] = [];

--- a/packages/zambdas/src/ehr/create-update-medication-order/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/create-update-medication-order/validateRequestParameters.ts
@@ -41,6 +41,10 @@ export function validateRequestParameters(
 
   validateInteractions(interactions);
 
+  if (orderData.expDate) {
+    orderData.expDate = orderData.expDate.split('T')[0];
+  }
+
   console.groupEnd();
   console.debug('validateRequestParameters success');
 


### PR DESCRIPTION
#3308

- [x] lints and builds
- [x] e2e tests pass

---

i also could not find a single indication in the ui of what the expiry date is supposed to look like (month, apparently, but even then i still don't know if it means e.g "Feb", "February", "2", "02", etc), so i made it an ISO date. not sure if this breaks things, seemed to work fine in my testing