### PR TITLE
improve screening questions form handling

### DIFF
--- a/apps/ehr/src/features/css-module/components/screening/useScreeningQuestionsHandler.ts
+++ b/apps/ehr/src/features/css-module/components/screening/useScreeningQuestionsHandler.ts
@@ -1,9 +1,5 @@
-import { UseMutateAsyncFunction } from '@tanstack/react-query';
-import { enqueueSnackbar } from 'notistack';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
-  ChartDataFields,
-  DeleteChartDataResponse,
   Field,
   GetChartDataResponse,
   getFhirValueOrFallback,
@@ -14,28 +10,25 @@ import {
   NoteField,
   ObservationDTO,
   patientScreeningQuestionsConfig,
-  SchoolWorkNoteExcuseDocFileDTO,
   shouldWaitForNote,
 } from 'utils';
-import { OystehrTelemedAPIClient } from '../../../../telemed/data/oystehrApi';
 
 type FieldValue = string | boolean | [string | null, string | null] | null;
 
+type ObservationPayload = {
+  field: string;
+  value?: string | null;
+  note?: string;
+  resourceId?: string;
+};
+
 interface ScreeningQuestionsHandlerDeps {
   chartData?: GetChartDataResponse;
-  updateObservation: (observation: ObservationDTO) => void;
-  encounterId?: string;
-  apiClient?: OystehrTelemedAPIClient | null;
-  refetchChartData: () => Promise<void>;
-  deleteChartData: UseMutateAsyncFunction<
-    DeleteChartDataResponse,
-    Error,
-    ChartDataFields & { schoolWorkNotes?: SchoolWorkNoteExcuseDocFileDTO[] | undefined },
-    unknown
-  >;
-  debounce: (fn: () => void) => void;
-  setNavigationDisable: (state: Record<string, boolean>) => void;
-  setFieldLoadingState: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
+  debounce: (fn: () => void, key?: string) => void;
+  currentFormValues: Record<string, FieldValue>;
+  deleteObservation: (observation: ObservationDTO, fieldId: string) => Promise<void>;
+  saveObservation: (observation: ObservationDTO, fieldId: string) => Promise<void>;
+  getUiData: (fhirField: string) => ObservationDTO | undefined;
 }
 
 export const useScreeningQuestionsHandler = (
@@ -46,28 +39,7 @@ export const useScreeningQuestionsHandler = (
   shouldShowNoteField: (noteFieldId: string, parentValue: string) => boolean;
   initialValues: Record<string, FieldValue>;
 } => {
-  const pendingOperationsRef = useRef(new Set<string>());
-
-  const {
-    chartData,
-    updateObservation,
-    encounterId,
-    apiClient,
-    refetchChartData,
-    deleteChartData,
-    debounce,
-    setFieldLoadingState,
-  } = deps;
-
-  /**
-   * Refetch data only after all pending requests complete to avoid:
-   * - Setting stale state from earlier requests
-   * - Making redundant API calls during concurrent operations
-   */ const refetchChartDataIfNotPendingRequests = useCallback(async (): Promise<void> => {
-    if (pendingOperationsRef.current.size === 0) {
-      await refetchChartData();
-    }
-  }, [refetchChartData]);
+  const { chartData, debounce, deleteObservation, saveObservation, getUiData } = deps;
 
   const getCurrentObservation = useCallback(
     (fhirField: string): ObservationDTO | undefined => {
@@ -76,118 +48,8 @@ export const useScreeningQuestionsHandler = (
     [chartData]
   );
 
-  const setLoading = useCallback(
-    (fieldId: string, isLoading: boolean): void => {
-      setFieldLoadingState((prev) => ({
-        ...prev,
-        [fieldId]: isLoading,
-      }));
-    },
-    [setFieldLoadingState]
-  );
-
-  const getFieldDisplayName = useCallback((fieldId: string): string => {
-    const field = getFieldById(fieldId);
-    if (field) return field.question;
-
-    const noteFieldInfo = getNoteFieldById(fieldId);
-    if (noteFieldInfo) return noteFieldInfo.noteField.label || noteFieldInfo.field.question;
-
-    return fieldId;
-  }, []);
-
-  const applyOptimisticUpdate = useCallback(
-    (observation: ObservationDTO): void => {
-      updateObservation(observation);
-    },
-    [updateObservation]
-  );
-
-  const rollbackOptimisticUpdate = useCallback(
-    (originalObservation: ObservationDTO | undefined): void => {
-      if (originalObservation) {
-        updateObservation(originalObservation);
-      }
-    },
-    [updateObservation]
-  );
-
-  const saveObservation = useCallback(
-    async (observation: ObservationDTO, fieldId: string): Promise<void> => {
-      // Prevent duplicate operations
-      if (pendingOperationsRef.current.has(fieldId)) {
-        return;
-      }
-
-      pendingOperationsRef.current.add(fieldId);
-      setLoading(fieldId, true);
-      const originalObservation = getCurrentObservation(observation.field);
-      applyOptimisticUpdate(observation);
-
-      try {
-        const result = await apiClient?.saveChartData?.({
-          encounterId: encounterId || '',
-          observations: [observation],
-        });
-
-        if (result?.chartData?.observations?.[0]) {
-          updateObservation(result.chartData.observations[0]);
-        }
-      } catch (error) {
-        console.error('Error saving observation:', error);
-        const fieldDisplayName = getFieldDisplayName(fieldId);
-        enqueueSnackbar(
-          `An error occurred while saving the answer for question: "${fieldDisplayName}". Please try again.`,
-          {
-            variant: 'error',
-          }
-        );
-        rollbackOptimisticUpdate(originalObservation);
-      } finally {
-        setLoading(fieldId, false);
-        pendingOperationsRef.current.delete(fieldId);
-      }
-    },
-    [
-      setLoading,
-      getCurrentObservation,
-      applyOptimisticUpdate,
-      apiClient,
-      encounterId,
-      updateObservation,
-      getFieldDisplayName,
-      rollbackOptimisticUpdate,
-    ]
-  );
-
-  const deleteObservation = useCallback(
-    async (observation: ObservationDTO, fieldId: string): Promise<DeleteChartDataResponse | null> => {
-      if (pendingOperationsRef.current.has(fieldId)) {
-        return null;
-      }
-
-      pendingOperationsRef.current.add(fieldId);
-      setLoading(fieldId, true);
-
-      return deleteChartData(
-        { observations: [observation] },
-        {
-          onSuccess: async () => {
-            setLoading(fieldId, false);
-            pendingOperationsRef.current.delete(fieldId);
-          },
-          onError: () => {
-            setLoading(fieldId, false);
-            pendingOperationsRef.current.delete(fieldId);
-          },
-        }
-      );
-    },
-    [deleteChartData, setLoading]
-  );
-
   const handleMainFieldChange = useCallback(
-    async (field: Field, value: FieldValue): Promise<void> => {
+    async (field: Field, value: FieldValue): Promise<undefined> => {
       if (!field.fhirField) {
         console.warn(`No backend field specified for: ${field.id}`);
         return;
@@ -200,111 +62,113 @@ export const useScreeningQuestionsHandler = (
         return;
       }
 
-      const currentObs = getCurrentObservation(field.fhirField);
+      const currentObs = getUiData(field.fhirField);
 
       // current observation keep resource Id, in that case the resource will be updated.
       // for the new observation, we send only field and value.
-      // so it's important to use resource Id when the new observation is created, we can use partial update or refetch chart data for this.
       const baseObservation = currentObs
         ? { ...currentObs, value: fhirValue }
         : { field: field.fhirField, value: fhirValue };
 
-      const observation = baseObservation as Partial<ObservationDTO> & Record<string, unknown>;
+      const observation = baseObservation as ObservationPayload;
 
       // If field has noteField but it shouldn't be visible for this value, remove note
       if (field.noteField && field.noteField.conditionalValue) {
         const shouldShowNote = field.noteField.conditionalValue === fhirValue;
         if (!shouldShowNote && 'note' in observation && observation.note !== undefined) {
-          const observationWithNote = observation as ObservationDTO & { note?: string };
-          delete observationWithNote.note;
+          delete observation.note;
         }
       }
 
       if (observation.value === null) {
         if (currentObs) {
           await deleteObservation(currentObs, field.id);
-          await refetchChartDataIfNotPendingRequests();
         }
       } else {
         const saveAction = (): Promise<void> => saveObservation(observation as ObservationDTO, field.id);
         await saveAction();
-        await refetchChartDataIfNotPendingRequests();
       }
     },
-    [deleteObservation, getCurrentObservation, refetchChartDataIfNotPendingRequests, saveObservation]
+    [deleteObservation, getUiData, saveObservation]
   );
 
-  // Process note field change
   const processNoteFieldChange = useCallback(
     async (parentField: Field, noteField: NoteField, value: string): Promise<void> => {
+      console.log('🔍 processNoteFieldChange called:', {
+        parentFieldId: parentField.id,
+        noteFieldId: noteField.id,
+        valueParameter: value,
+      });
+
       if (!noteField.fhirField) {
         console.warn(`No fhir field specified for note: ${noteField.id}`);
         return;
       }
 
-      const currentObs = getCurrentObservation(noteField.fhirField);
+      const currentObs = getUiData(noteField.fhirField);
+      console.log('🔍 Current observation:', currentObs);
 
-      // If value is empty and can be deleted
       if (!value && parentField.canDelete) {
         if (currentObs) {
           await deleteObservation(currentObs, noteField.id);
-          await refetchChartDataIfNotPendingRequests();
         }
         return;
       }
 
-      // checkbox value may have additional note, that's the noteField.conditionalValue case,
-      // if it doesn't have conditional value, it's just a note field.
+      const parentFieldValue = deps.currentFormValues[parentField.id];
+      const correctFhirValue = getFhirValueOrFallback(parentField, parentFieldValue as string);
+
       const observation = noteField.conditionalValue
-        ? {
+        ? ({
             ...currentObs,
             field: noteField.fhirField,
-            value: noteField.conditionalValue,
+            value: correctFhirValue,
             note: value,
-          }
-        : {
+          } as ObservationPayload)
+        : ({
             ...currentObs,
             field: noteField.fhirField,
             note: value,
-          };
+          } as ObservationPayload);
 
       await saveObservation(observation as ObservationDTO, noteField.id);
-      await refetchChartDataIfNotPendingRequests();
     },
-    [getCurrentObservation, saveObservation, deleteObservation, refetchChartDataIfNotPendingRequests]
+    [getUiData, saveObservation, deleteObservation, deps.currentFormValues]
   );
 
-  // Handle note field change
-  const handleNoteFieldChange = useCallback(
-    (parentField: Field, noteField: NoteField, value: string): void => {
-      const saveAction = (): Promise<void> => processNoteFieldChange(parentField, noteField, value);
-
-      // Use debounce if specified in configuration
-      if (parentField.debounced || noteField.type === 'textarea') {
-        debounce(saveAction);
-      } else {
-        void saveAction();
-      }
-    },
-    [processNoteFieldChange, debounce]
-  );
-
-  // Main field change handler
   const handleFieldChange = useCallback(
-    (fieldId: string, value: FieldValue): void => {
-      // Determine field type by configuration
+    async (fieldId: string, value: FieldValue): Promise<void> => {
       const field = getFieldById(fieldId);
       const noteFieldInfo = getNoteFieldById(fieldId);
+      const mainFieldId = field?.id || noteFieldInfo?.field?.id; // used in debounce because base field and its note are connected and share debounce key
+
+      if (!mainFieldId) {
+        console.warn(`Field not found in config: ${fieldId}`);
+        return;
+      }
 
       if (field) {
-        void handleMainFieldChange(field, value);
+        const shouldDebounce = field.noteField !== undefined;
+
+        if (shouldDebounce) {
+          const saveAction = (): Promise<void> => {
+            return handleMainFieldChange(field, value);
+          };
+          debounce(saveAction, mainFieldId);
+        } else {
+          const executeMainFieldChange = async (): Promise<void> => {
+            await handleMainFieldChange(field, value);
+          };
+          void executeMainFieldChange();
+        }
       } else if (noteFieldInfo) {
-        handleNoteFieldChange(noteFieldInfo.field, noteFieldInfo.noteField, value as string);
-      } else {
-        console.warn(`Field not found in config: ${fieldId}`);
+        const saveAction = (): Promise<void> => {
+          return processNoteFieldChange(noteFieldInfo.field, noteFieldInfo.noteField, value as string);
+        };
+        debounce(saveAction, mainFieldId);
       }
     },
-    [handleMainFieldChange, handleNoteFieldChange]
+    [debounce, handleMainFieldChange, processNoteFieldChange]
   );
 
   // Get initial values from current data
@@ -325,8 +189,9 @@ export const useScreeningQuestionsHandler = (
           // Check if note field should be shown
           const parentBackendValue = observation.value;
           if (!field.noteField.conditionalValue || field.noteField.conditionalValue === parentBackendValue) {
-            const observationWithNote = observation as ObservationDTO & { note: string };
-            values[field.noteField.id] = observationWithNote.note;
+            if ('note' in observation && typeof observation.note === 'string') {
+              values[field.noteField.id] = observation.note;
+            }
           }
         }
       }

--- a/apps/ehr/src/telemed/hooks/useDebounce.ts
+++ b/apps/ehr/src/telemed/hooks/useDebounce.ts
@@ -1,20 +1,37 @@
 import { useRef } from 'react';
 
-export const useDebounce = (timeout = 500): { debounce: (func: () => void) => void; clear: () => void } => {
-  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+export const useDebounce = (
+  timeout = 500
+): {
+  debounce: (func: () => void, key?: string) => void;
+  clear: (key?: string) => void;
+} => {
+  const timeoutsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
-  const debounce = (func: () => void): void => {
-    if (timeoutRef.current) {
-      clear();
+  const debounce = (func: () => void, key: string = 'default'): void => {
+    if (timeoutsRef.current.has(key)) {
+      clearTimeout(timeoutsRef.current.get(key));
     }
-    timeoutRef.current = setTimeout(() => {
+
+    const timeoutId = setTimeout(() => {
       func();
+      timeoutsRef.current.delete(key);
     }, timeout);
+
+    timeoutsRef.current.set(key, timeoutId);
   };
 
-  const clear = (): void => {
-    clearTimeout(timeoutRef.current);
-    timeoutRef.current = undefined;
+  const clear = (key?: string): void => {
+    if (key) {
+      const timeoutId = timeoutsRef.current.get(key);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutsRef.current.delete(key);
+      }
+    } else {
+      timeoutsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
+      timeoutsRef.current.clear();
+    }
   };
 
   return { debounce, clear };

--- a/packages/utils/lib/types/data/screening-questions/utils.ts
+++ b/packages/utils/lib/types/data/screening-questions/utils.ts
@@ -1,6 +1,6 @@
 import { patientScreeningQuestionsConfig } from '../../../main';
 import { HistorySourceKeys, historySourceLabels, RecentVisitKeys, recentVisitLabels } from './constants';
-import { Field, NoteField } from './types';
+import { Field, NoteField, ObservationDTO } from './types';
 
 export function getHistorySourceLabel(key: HistorySourceKeys): string {
   return historySourceLabels[key];
@@ -10,9 +10,9 @@ export function getRecentVisitLabel(key: RecentVisitKeys): string {
   return recentVisitLabels[key];
 }
 
-export const getFhirValueOrFallback = (field: Field, uiValue: string): string => {
+export const getFhirValueOrFallback = (field: Field, uiValue: string): ObservationDTO['value'] => {
   const option = field.options?.find((opt) => opt.value === uiValue);
-  return option?.fhirValue || uiValue;
+  return (option?.fhirValue || uiValue) as ObservationDTO['value'];
 };
 
 export const getUiValueOrFallback = (field: Field, fhirValue: string): string => {


### PR DESCRIPTION
Fixed several edge cases, main changes:
1 - Fast sequential note editing. Added a key to debounce so individual notes are saved, rather than canceling the saving of other notes as happened with the shared debounce
2 - Fixed UI flickering when quickly switching radio buttons
3 - Fixed the case when input and note change rapidly - in this case a general request is sent and data is not lost
4 - Simplified implementation, eliminated the need to track current requests by removing the general chart data refetch and doing selective chart data updates, simplified the useScreeningQuestionsHandler.ts structure
5 - More clearly separated and simplified data - now only react-hook-form is responsible for optimistic data updates, while chart data is updated only on successful saving or deletion of data to provide resourceId