### PR TITLE
fix(labs): resolve string splitting pdf bug

### DIFF
--- a/packages/zambdas/src/ehr/submit-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/submit-lab-order/index.ts
@@ -83,11 +83,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
             body: JSON.stringify(params),
           });
 
-          // commenting this out for now
           if (!res.ok) {
-            const _body = await res.json(); // ATHENA TODO un _ this
-            console.error('There was an error submitting, but we are ignoring it');
-            // throw new Error(`Error submitting order number: ${orderNumber}. Error: ${body.message}`);
+            const body = await res.json();
+            throw new Error(`Error submitting order number: ${orderNumber}. Error: ${body.message}`);
           }
 
           const result = await res.json();
@@ -107,9 +105,6 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
             console.log(`eReq generated for order ${res.orderNumber} - docRef id: ${res.eReqDocumentReference.id}`);
             successfulBundledOrders[res.orderNumber] = { ...resources, labGeneratedEReq: res.eReqDocumentReference };
           } else {
-            // ATHENA TODO REMOVE THIS
-            resources.accountNumber = 'ottehr-demo-autolab-account-number';
-            console.log('this is account number after reset', resources.accountNumber);
             successfulBundledOrders[res.orderNumber] = { ...resources };
           }
         } else if (res.status === 'rejected') {


### PR DESCRIPTION
Implements [OTR-546](https://linear.app/zapehr/issue/OTR-546/ehr-labs-intermittent-pdf-failure)

Instead of just splitting on spaces in the text, we try to split on words, and if that fails, we default to writing a single character at a time until we run out of space.

Example showing nicely split account number (which had been failing on Ottehr Demo)
<img width="798" height="805" alt="Screenshot 2025-09-11 at 2 05 10 AM" src="https://github.com/user-attachments/assets/ef6b9fb7-a427-40e0-9175-5407f82bd43b" />

Example showing nicely split problem Observation from PathGroup
<img width="861" height="920" alt="Screenshot 2025-09-11 at 2 06 36 AM" src="https://github.com/user-attachments/assets/64a3f4d1-6e31-48a3-a558-b295ccfc1214" />
