### PR TITLE
 fix: version bump script to properly stage all workspace package.jso…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "turbo build lint",
-    "version": "npm version $npm_package_version --workspaces && git add **/package.json",
+    "version": "npm version $npm_package_version --workspaces && git add package.json '**/package.json'",
     "lint": "npm run lint:eslint",
     "lint:eslint": "turbo lint",
     "lint:eslint:fix": "turbo lint:fix",


### PR DESCRIPTION
  The git add pattern was failing to stage apps/* and packages/* package.json files because bash glob ** doesn't work without `globstar` enabled. Fixed by using quoted pattern that git handles directly.