### PR TITLE
Config: setup labcorp local env

### DIFF
--- a/apps/ehr/package.json
+++ b/apps/ehr/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "scripts": {
-    "start": "vite --mode default",
+    "start": "vite --mode ${ENV:-default}",
     "start:iac": "vite --mode default",
     "preview": "vite preview --port 4002",
     "lint": "NODE_OPTIONS='--max-old-space-size=8192' eslint --ext .ts,.tsx,.js,.jsx --report-unused-disable-directives --max-warnings 0 .",

--- a/apps/ehr/package.json
+++ b/apps/ehr/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "scripts": {
-    "start": "vite --mode ${ENV:-default}",
+    "start": "vite --mode $([ \"$ENV\" = \"local\" ] && echo default || echo ${ENV:-default})",
     "start:iac": "vite --mode default",
     "preview": "vite preview --port 4002",
     "lint": "NODE_OPTIONS='--max-old-space-size=8192' eslint --ext .ts,.tsx,.js,.jsx --report-unused-disable-directives --max-warnings 0 .",

--- a/apps/ehr/package.json
+++ b/apps/ehr/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "scripts": {
-    "start": "vite --mode ${ENV:-default}",
+    "start": "vite --mode default",
     "start:iac": "vite --mode default",
     "preview": "vite preview --port 4002",
     "lint": "NODE_OPTIONS='--max-old-space-size=8192' eslint --ext .ts,.tsx,.js,.jsx --report-unused-disable-directives --max-warnings 0 .",

--- a/apps/ehr/vite.config.ts
+++ b/apps/ehr/vite.config.ts
@@ -8,7 +8,14 @@ import svgr from 'vite-plugin-svgr';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 
 export default ({ mode }: { mode: string }): UserConfig => {
-  console.log(`Mode is: ${mode}`);
+  console.log(`Passed mode is: ${mode}`);
+
+  // to make e2e tests happy, we need mode = default when ENV === local
+  if (mode === 'local') {
+    console.log('Updating mode to default');
+    mode = 'default';
+  }
+
   const envDir = './env';
   const env = loadEnv(mode, path.join(process.cwd(), envDir), '');
 

--- a/apps/ehr/vite.config.ts
+++ b/apps/ehr/vite.config.ts
@@ -8,6 +8,7 @@ import svgr from 'vite-plugin-svgr';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 
 export default ({ mode }: { mode: string }): UserConfig => {
+  console.log(`Mode is: ${mode}`);
   const envDir = './env';
   const env = loadEnv(mode, path.join(process.cwd(), envDir), '');
 

--- a/apps/ehr/vite.config.ts
+++ b/apps/ehr/vite.config.ts
@@ -8,13 +8,7 @@ import svgr from 'vite-plugin-svgr';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 
 export default ({ mode }: { mode: string }): UserConfig => {
-  console.log(`Passed mode is: ${mode}`);
-
-  // to make e2e tests happy, we need mode = default when ENV === local
-  if (mode === 'local') {
-    console.log('Updating mode to default');
-    mode = 'default';
-  }
+  console.log(`Mode is: ${mode}`);
 
   const envDir = './env';
   const env = loadEnv(mode, path.join(process.cwd(), envDir), '');

--- a/apps/intake/package.json
+++ b/apps/intake/package.json
@@ -7,6 +7,7 @@
     "start": "vite --mode ${ENV:-default}",
     "start:local": "ENV=default npm run start",
     "start:demo": "ENV=demo npm run start",
+    "start:labcorp": "ENV=labcorp-local npm run start",
     "start:iac": "vite --mode ${ENV:-default}",
     "start:local:iac": "ENV=default npm run start:iac",
     "start:demo:iac": "ENV=demo npm run start:iac",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "zambdas:start": "turbo start --filter=zambdas",
     "apps:start": "turbo start --filter=intake-ui --filter=ehr-ui --filter=zambdas",
     "apps:start:iac": "npm run apply-local --workspace deploy && turbo start:iac --filter=intake-ui --filter=ehr-ui --filter=zambdas",
+    "apps:start:labcorp": "ENV=labcorp-local turbo start --filter=intake-ui --filter=ehr-ui --filter=zambdas",
     "integration:zambdas": "npm run build && ENV=local && cd packages/zambdas && DEBUG=start-server-and-test && npm run test:integration:ci",
     "test": "turbo test",
     "prepare": "husky",

--- a/packages/zambdas/package.json
+++ b/packages/zambdas/package.json
@@ -7,6 +7,7 @@
     "start:local": "ENV=local npm run start",
     "start:demo": "ENV=demo npm run start",
     "start:iac": "tsx watch --include './src/**/*' src/local-server/index.ts -- env=.env/${ENV:-local}.json iac=true",
+    "start:labcorp": "ENV=labcorp-local npm run start",
     "start:local:iac": "ENV=local npm run start:iac",
     "start:demo:iac": "ENV=demo npm run start:iac",
     "cancel-telemed-appointments": "tsx src/scripts/cancel-telemed-appointments.ts",


### PR DESCRIPTION
Setup separate env for LabCorp testing so we don't change in-use resources in the ottehr envs. 

Secrets have been added to the ottehr secrets repo.