### PR TITLE
fix: progress notes buttons loading state

### DIFF
--- a/apps/ehr/src/components/RoundedButton.tsx
+++ b/apps/ehr/src/components/RoundedButton.tsx
@@ -4,12 +4,17 @@ import { Link } from 'react-router-dom';
 
 export const RoundedButton = styled(
   (
-    props: ButtonProps & { to?: string; target?: '_self' | '_blank' | '_parent' | '_top' | string; loading?: boolean }
+    props: ButtonProps & {
+      to?: string;
+      target?: '_self' | '_blank' | '_parent' | '_top' | string;
+      loading?: boolean;
+      loadingPosition?: 'start' | 'end' | 'center';
+    }
   ) => (
     <LoadingButton
       variant="outlined"
       size="large"
-      loadingPosition="start"
+      loadingPosition={props.loadingPosition || 'center'}
       {...props}
       {...(props.to ? { component: Link, to: props.to, target: props.target } : {})}
     />

--- a/apps/ehr/src/telemed/features/appointment/ReviewTab/DischargeSummaryButton.tsx
+++ b/apps/ehr/src/telemed/features/appointment/ReviewTab/DischargeSummaryButton.tsx
@@ -53,6 +53,7 @@ export const DischargeSummaryButton: FC<DischargeSummaryButtonProps> = ({ appoin
   return (
     <RoundedButton
       loading={statusLoading}
+      loadingPosition="start"
       variant="outlined"
       onClick={handleCreateDischargeSummary}
       startIcon={<PrintOutlinedIcon color="inherit" />}


### PR DESCRIPTION
Discharge button specific loading state was causing progress notes buttons, fixed it so it's centered.

https://github.com/user-attachments/assets/aa97d691-d7be-4635-ab7f-3f2725cad5db


https://github.com/user-attachments/assets/c75b8f6c-401a-440f-940a-709c9f183de5

