### PR TITLE
allow HPI fields to get a new value when set by template

### DIFF
--- a/apps/ehr/src/telemed/features/appointment/MedicalHistoryTab/ChiefComplaint/ChiefComplaintCard.tsx
+++ b/apps/ehr/src/telemed/features/appointment/MedicalHistoryTab/ChiefComplaint/ChiefComplaintCard.tsx
@@ -18,7 +18,7 @@ export const ChiefComplaintCard: FC = () => {
 
   return (
     <MedicalHistoryDoubleCard
-      label="Chief complaint & HPI"
+      label="Chief Complaint & HPI"
       collapsed={css ? undefined : isHPICollapsed}
       onSwitch={css ? undefined : () => setIsHPICollapsed((state) => !state)}
       patientSide={<ChiefComplaintPatientColumn />}

--- a/apps/ehr/src/telemed/features/appointment/MedicalHistoryTab/ChiefComplaint/ChiefComplaintProviderColumn.tsx
+++ b/apps/ehr/src/telemed/features/appointment/MedicalHistoryTab/ChiefComplaint/ChiefComplaintProviderColumn.tsx
@@ -15,11 +15,11 @@ export const ChiefComplaintProviderColumn: FC = () => {
   });
 
   useEffect(() => {
-    if (!methods.getValues('chiefComplaint') && chartData?.chiefComplaint?.text) {
+    if (chartData?.chiefComplaint?.text !== undefined) {
       methods.setValue('chiefComplaint', chartData.chiefComplaint.text);
     }
 
-    if (!methods.getValues('ros') && chartData?.ros?.text) {
+    if (chartData?.ros?.text !== undefined) {
       methods.setValue('ros', chartData.ros.text);
     }
   }, [chartData?.chiefComplaint?.text, chartData?.ros?.text, methods]);


### PR DESCRIPTION
When applying templates, the HPI text field was not getting updated due to this bug which says "if it already has a value, do not do anything in the use effect".

Also capitalize one letter I noticed.