### PR TITLE
Improve AI chat

### DIFF
--- a/config/oystehr/ottehr-spec.json
+++ b/config/oystehr/ottehr-spec.json
@@ -967,6 +967,7 @@
       "name": "ai-interview-summary",
       "type": "subscription",
       "runtime": "nodejs20.x",
+      "timeout": "300",
       "src": "src/subscriptions/questionnaire-response/ai-interview-summary/index",
       "zip": ".dist/zips/ai-interview-summary.zip",
       "subscription": {

--- a/packages/zambdas/src/patient/ai-interview/start/index.ts
+++ b/packages/zambdas/src/patient/ai-interview/start/index.ts
@@ -14,12 +14,16 @@ import { invokeChatbot } from '../../../shared/ai';
 
 export const INTERVIEW_COMPLETED = 'Interview completed.';
 
-const INITIAL_USER_MESSAGE = `Perform a medical history intake session with me by asking me relevant questions.
- Ask no more than 30 questions.
- Ask one question at a time.
- Don't numerate questions.
- When you'll have no new questions to ask just say 
- "No further questions, thanks for chatting. We've sent the information to your nurse or doctor to review. ${INTERVIEW_COMPLETED}"`;
+const INITIAL_USER_MESSAGE = `Perform a medical history intake session as if you were a physician preparing me or my dependent for an urgent care visit.
+•	Use a friendly and concerned physician's tone
+•	Determine who the patient is
+•	Ask only one question at a time.
+•	Ask no more than 20 questions in total.
+•	Don't number the questions.
+•	Cover all the major domains efficiently: chief complaint, history of present illness, past medical history, past surgical history, medications, allergies, family history, social history, hospitalizations, and relevant review of systems.
+•	Phrase questions in a clear, patient-friendly way that keeps the conversation moving quickly.
+•	If I give vague or incomplete answers, ask a brief follow-up before moving on.
+•	When you have gathered all useful information, end by saying: "No further questions, thanks for chatting. We've sent the information to your nurse or doctor to review. ${INTERVIEW_COMPLETED}"`;
 const QUESTIONNAIRE_ID = 'aiInterviewQuestionnaire';
 
 let oystehrToken: string;

--- a/packages/zambdas/src/patient/ai-interview/start/index.ts
+++ b/packages/zambdas/src/patient/ai-interview/start/index.ts
@@ -14,7 +14,7 @@ import { invokeChatbot } from '../../../shared/ai';
 
 export const INTERVIEW_COMPLETED = 'Interview completed.';
 
-const INITIAL_USER_MESSAGE = `Perform a medical history intake session as if you were a physician preparing me or my dependent for an urgent care visit.
+const INITIAL_USER_MESSAGE = `Perform a medical history intake session in the manner of a physician  preparing me or my dependent for an urgent care visit, without using a fake name:
 •	Use a friendly and concerned physician's tone
 •	Determine who the patient is
 •	Ask only one question at a time.

--- a/packages/zambdas/src/scripts/deploy-zambdas.ts
+++ b/packages/zambdas/src/scripts/deploy-zambdas.ts
@@ -8,6 +8,7 @@ import { getAuth0Token } from '../shared';
 interface DeployZambda {
   type: 'http_open' | 'http_auth' | 'subscription' | 'cron';
   runtime: ZambdaCreateParams['runtime'];
+  timeout?: string;
   subscriptionDetails?: SubscriptionZambdaDetails[];
   schedule?: {
     start?: string;
@@ -28,6 +29,7 @@ Object.entries(ottehrSpec.zambdas).forEach(([_key, spec]) => {
   const zambdaDefinition: DeployZambda = {
     type: spec.type,
     runtime: spec.runtime as ZambdaCreateParams['runtime'],
+    timeout: (spec as any).timeout,
   };
 
   if (spec.type === 'subscription') {
@@ -164,6 +166,7 @@ const updateZambdas = async (config: any, selectedTriggerMethod: string | undefi
       currentDeployedZambda = await oystehr.zambda.create({
         name: zambdaName,
         runtime: currentZambda.runtime,
+        timeoutInSeconds: currentZambda.timeout ? parseInt(currentZambda.timeout) : undefined,
       });
       console.log(`Zambda ${zambda} with ID ${currentDeployedZambda.id}`);
     }

--- a/packages/zambdas/src/scripts/deploy-zambdas.ts
+++ b/packages/zambdas/src/scripts/deploy-zambdas.ts
@@ -283,6 +283,7 @@ async function updateProjectZambda(
       triggerMethod: zambda.type,
       schedule: zambda.schedule,
       name: zambdaName,
+      timeoutInSeconds: zambda.timeout ? parseInt(zambda.timeout) : undefined,
     }),
   });
   if (updateZambda.status !== 200) {

--- a/packages/zambdas/src/shared/ai.ts
+++ b/packages/zambdas/src/shared/ai.ts
@@ -72,7 +72,7 @@ export async function invokeChatbot(input: BaseMessageLike[], secrets: Secrets |
   process.env.ANTHROPIC_API_KEY = getSecret(SecretsKeys.ANTHROPIC_API_KEY, secrets);
   if (chatbot == null) {
     chatbot = new ChatAnthropic({
-      model: 'claude-3-7-sonnet-20250219',
+      model: 'claude-sonnet-4-20250514',
       temperature: 0,
     });
   }


### PR DESCRIPTION
- Update initial AI chat prompt.
- Set `ai-interview-summary` zambda timeout to 300 seconds and fix zambda's timeout setting during deploy.
- Use Sonnet 4 model.