### PR TITLE
E2E. Update in-house labs tests.

### DIFF
--- a/apps/ehr/src/constants/data-test-ids.ts
+++ b/apps/ehr/src/constants/data-test-ids.ts
@@ -473,6 +473,7 @@ export const dataTestIds = {
     orderInHouseLabButton: 'order-in-house-lab-button',
     orderAndPrintLabelButton: 'order-and-print-label-button',
     testTypeField: 'test-type',
+    testTypeList: 'test-type-list',
     CPTCodeField: 'cpt-code',
     diagnosis: 'diagnosis',
     additionalDx: 'additionalDx',

--- a/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx
+++ b/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx
@@ -274,6 +274,11 @@ export const InHouseLabOrderCreatePage: React.FC = () => {
                       value={selectedTest?.name || ''}
                       label="Test"
                       onChange={(e) => handleTestSelection(e.target.value)}
+                      MenuProps={{
+                        PaperProps: {
+                          'data-testid': dataTestIds.orderInHouseLabPage.testTypeList,
+                        },
+                      }}
                     >
                       {availableTests.map((test) => (
                         <MenuItem key={test.name} value={test.name}>

--- a/apps/ehr/tests/e2e/page/OrderInHouseLabPage.ts
+++ b/apps/ehr/tests/e2e/page/OrderInHouseLabPage.ts
@@ -41,10 +41,14 @@ export class OrderInHouseLabPage {
   async clickOrderAndPrintLabelButton(): Promise<void> {
     await this.#page.getByTestId(dataTestIds.orderInHouseLabPage.orderAndPrintLabelButton).click();
   }
-  async selectTestType(testType: string): Promise<void> {
+  async selectTestType(): Promise<string> {
     await this.#page.getByTestId(dataTestIds.orderInHouseLabPage.testTypeField).click();
-    await this.#page.getByText(testType).waitFor({ state: 'visible' });
-    await this.#page.getByText(testType, { exact: true }).click();
+    await this.#page.getByTestId(dataTestIds.orderInHouseLabPage.testTypeList).waitFor({ state: 'visible' });
+    await this.#page.getByTestId(dataTestIds.orderInHouseLabPage.testTypeList).locator('li').first().click();
+    const firstOption = this.#page.getByTestId(dataTestIds.orderInHouseLabPage.testTypeList).locator('li').first();
+    const optionValue = await firstOption.innerText();
+    await firstOption.click();
+    return optionValue;
   }
   async verifyCPTCode(CPTCode: string): Promise<void> {
     await expect(this.#page.getByTestId(dataTestIds.orderInHouseLabPage.CPTCodeField).locator('input')).toHaveValue(

--- a/apps/ehr/tests/e2e/page/OrderInHouseLabPage.ts
+++ b/apps/ehr/tests/e2e/page/OrderInHouseLabPage.ts
@@ -44,7 +44,6 @@ export class OrderInHouseLabPage {
   async selectTestType(): Promise<string> {
     await this.#page.getByTestId(dataTestIds.orderInHouseLabPage.testTypeField).click();
     await this.#page.getByTestId(dataTestIds.orderInHouseLabPage.testTypeList).waitFor({ state: 'visible' });
-    await this.#page.getByTestId(dataTestIds.orderInHouseLabPage.testTypeList).locator('li').first().click();
     const firstOption = this.#page.getByTestId(dataTestIds.orderInHouseLabPage.testTypeList).locator('li').first();
     const optionValue = await firstOption.innerText();
     await firstOption.click();

--- a/apps/ehr/tests/e2e/specs/in-person/inHouseLabsPage.spec.ts
+++ b/apps/ehr/tests/e2e/specs/in-person/inHouseLabsPage.spec.ts
@@ -9,11 +9,26 @@ import { ResourceHandler } from '../../../e2e-utils/resource-handler';
 import { expectAssessmentPage } from '../../page/in-person/InPersonAssessmentPage';
 import { expectOrderDetailsPage, OrderInHouseLabPage } from '../../page/OrderInHouseLabPage';
 
+const TEST_TYPE_TO_CPT: Record<string, string> = {
+  'COVID-19 Antigen': '87635',
+  'Flu A': '87501',
+  'Flu B': '87501',
+  'Flu-Vid': '87428',
+  'Glucose Finger/Heel Stick': '82962',
+  'ID Now Strep': '87651',
+  'Monospot test': '86308',
+  'Rapid COVID-19 Antigen': '87426',
+  'Rapid Influenza A': '87804',
+  'Rapid Influenza B': '87804',
+  'Rapid RSV': '87807',
+  'Rapid Strep A': '87880',
+  RSV: '87634',
+  'Stool Guaiac': '82270',
+  'Urinalysis (UA)': '81003',
+  'Urine Pregnancy Test (HCG)': '81025',
+};
 const PROCESS_ID = `inHouseLabsPage.spec.ts-${DateTime.now().toMillis()}`;
 const resourceHandler = new ResourceHandler(PROCESS_ID, 'in-person');
-
-const TEST_TYPE = 'Flu A';
-const CPT_CODE = '87501';
 const DIAGNOSIS = 'Situs inversus';
 const SOURCE = 'Nasopharyngeal swab';
 const TEST_RESULT_DETECTED = 'Detected';
@@ -38,11 +53,13 @@ test.afterAll(async () => {
 });
 
 test('IHL-1 In-house labs. Happy Path', async ({ page }) => {
+  let TEST_TYPE: string;
   await test.step('IHL-1.1 Open In-house Labs and place order', async () => {
     const orderInHouseLabPage = await prepareAndOpenInHouseLabsPage(page);
     await orderInHouseLabPage.verifyOrderAndPrintLabeButtonDisabled();
     await orderInHouseLabPage.verifyOrderInHouseLabButtonDisabled();
-    await orderInHouseLabPage.selectTestType(TEST_TYPE);
+    TEST_TYPE = await orderInHouseLabPage.selectTestType();
+    const CPT_CODE = TEST_TYPE_TO_CPT[TEST_TYPE];
     await orderInHouseLabPage.verifyCPTCode(CPT_CODE);
     await orderInHouseLabPage.verifyOrderInHouseLabButtonEnabled();
     await orderInHouseLabPage.verifyOrderAndPrintLabelButtonEnabled();


### PR DESCRIPTION
Earlier, `TEST_TYPE` was hardcoded to `'Flu A'`, which caused test failures when the list of tests didn’t include the `Flu A` option. The tests have been updated to select the first available test from the list and verify that the CPT code is autofilled correctly based on the selected test. 