### PR TITLE
Telemed. Don't show "Oystehr AI" section when a patient hasn't completed AI chat

### DIFF
--- a/apps/ehr/src/telemed/features/appointment/AppointmentTabsHeader.tsx
+++ b/apps/ehr/src/telemed/features/appointment/AppointmentTabsHeader.tsx
@@ -82,7 +82,7 @@ export const AppointmentTabsHeader: FC = () => {
           data-testid={dataTestIds.telemedEhrFlow.appointmentVisitTabs(TelemedAppointmentVisitTabs.sign)}
           value={TelemedAppointmentVisitTabs.sign}
         />
-        {chartData?.aiChat != null ? (
+        {chartData?.aiChat?.documents?.[0] ? (
           <Tab
             label={
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>


### PR DESCRIPTION
Fix for https://linear.app/zapehr/issue/OTR-757/ehr-oystehr-ai-chat-section-shouldnt-be-present-if-patient-didnt-start