### PR TITLE
Dont show unsolicited labs table if there are no rows

### DIFF
--- a/apps/ehr/src/features/external-labs/components/labs-orders/UnsolicitedLabsTable.tsx
+++ b/apps/ehr/src/features/external-labs/components/labs-orders/UnsolicitedLabsTable.tsx
@@ -38,7 +38,7 @@ export const UnsolicitedLabsTable: FC<UnsolicitedLabsTableProps> = ({
   });
   const unsolicitedLabListDTOs = data?.unsolicitedLabListDTOs;
 
-  if (!unsolicitedLabListDTOs) return null;
+  if (!unsolicitedLabListDTOs || unsolicitedLabListDTOs.length === 0) return null;
 
   const onRowClick = (unsolicitedLab: UnsolicitedLabListPageDTO): void => {
     navigate(`/unsolicited-results/${unsolicitedLab.diagnosticReportId}/review`);


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-825/ehr-external-labs-patient-record-should-not-show-unsolicited-labs