### PR TITLE
fix broken specialty note test

### DIFF
--- a/apps/ehr/tests/e2e/specs/telemed/planTab.spec.ts
+++ b/apps/ehr/tests/e2e/specs/telemed/planTab.spec.ts
@@ -187,7 +187,7 @@ test.describe('Disposition', async () => {
     test("Should check 'Note' field is empty by default for 'Specialty transfer' selected", async () => {
       await expect(
         page.getByTestId(dataTestIds.telemedEhrFlow.planTabDispositionNote).locator('textarea').first()
-      ).toHaveText('');
+      ).toHaveText('N/A');
     });
 
     test("Should select some 'Follow up visit in' option", async () => {


### PR DESCRIPTION
OTR-799

- [x] lints and builds
- [x] e2e tests pass

---

the save-chart-data zambda replaces blank strings with `N/A`. not sure why it's only started being an issue now, but my guess is either our zambdas got faster or playwright got slower