### PR TITLE
mark all search tests as flaky

### DIFF
--- a/apps/ehr/tests/e2e/specs/ehr.spec.ts
+++ b/apps/ehr/tests/e2e/specs/ehr.spec.ts
@@ -128,7 +128,7 @@ test('CSS intake assessment page is available', async ({ page }) => {
   await awaitCSSHeaderInit(page);
 });
 
-test.describe('Patient search', () => {
+test.describe('Patient search', { tag: '@flaky' }, () => {
   const patientData = {
     firstName: PATIENT_FIRST_NAME,
     lastName: PATIENT_LAST_NAME,
@@ -187,7 +187,7 @@ test.describe('Patient search', () => {
     });
   });
 
-  test.skip('Search by Address', { tag: '@flaky' }, async ({ page }) => {
+  test.skip('Search by Address', async ({ page }) => {
     await page.goto('/patients');
 
     const patientsPage = await expectPatientsPage(page);


### PR DESCRIPTION
OTR-810

- [x] lints and builds
- [x] e2e tests pass

---

this entire test suite [has been flaky before](https://github.com/masslight/ottehr/pull/2625/files#diff-b20583be6cc85cbf2a69e83feed95de1ad24814b2889482e056a060f7a956adbL211), but is a lot more stable now. i'm marking the entire suite as flaky though