### PR TITLE
Tweak(labs): remove result status character

### DIFF
--- a/packages/zambdas/src/shared/pdf/types.ts
+++ b/packages/zambdas/src/shared/pdf/types.ts
@@ -212,7 +212,6 @@ export interface ExternalLabResultsData extends LabResultsData {
   accessionNumber: string;
   orderSubmitDate: string;
   collectionDate: string;
-  resultPhase: string;
   resultsReceivedDate: string;
   reviewed?: boolean; // todo why is this possibly undefined ??
   reviewingProvider: Practitioner | undefined;


### PR DESCRIPTION
OTR-442

Removes the extraneous status character, and also fixes a bug in the drawVariableColumn util. Also fixes a bug with very long test names running off the edge of the page.