### PR TITLE
Feat(labs): add ordering office info to order details

### DIFF
--- a/apps/ehr/src/features/external-labs/components/OrderCollection.tsx
+++ b/apps/ehr/src/features/external-labs/components/OrderCollection.tsx
@@ -137,6 +137,14 @@ export const OrderCollection: React.FC<SampleCollectionProps> = ({
           </Typography>
         </Box>
 
+        {labOrder.location?.name && (
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="body1">
+              <span style={{ fontWeight: 500 }}>Ordering Office: </span> {labOrder.location.name}
+            </Typography>
+          </Box>
+        )}
+
         <Box sx={{ mt: 2 }}>
           <OrderHistoryCard
             isPSCPerformed={labOrder.isPSC}

--- a/packages/utils/lib/types/data/labs/labs.types.ts
+++ b/packages/utils/lib/types/data/labs/labs.types.ts
@@ -2,6 +2,7 @@
 import {
   DocumentReference,
   Encounter,
+  Location,
   Questionnaire,
   QuestionnaireResponse,
   QuestionnaireResponseItem,
@@ -128,6 +129,7 @@ export type LabOrderListPageDTO = {
   encounterTimezone: string | undefined; // used to format dates correctly on the front end
   orderNumber: string | undefined; // ServiceRequest.identifier.value (system === OYSTEHR_LAB_ORDER_PLACER_ID_SYSTEM)
   abnPdfUrl: string | undefined; // DocRef containing OYSTEHR_LAB_DOC_CATEGORY_CODING and related to SR (only for labCorp + quest)
+  location: Location | undefined; // Location that ordered the test. Was previously not required for lab orders, so can be undefined
 };
 
 export type LabOrderDetailedPageDTO = LabOrderListPageDTO & {

--- a/packages/utils/lib/types/data/labs/labs.types.ts
+++ b/packages/utils/lib/types/data/labs/labs.types.ts
@@ -168,6 +168,7 @@ export type DiagnosticReportLabDetailPageDTO = Omit<
   | 'labelPdfUrl'
   | 'orderPdfUrl'
   | 'abnPdfUrl'
+  | 'location'
 >;
 
 export type ReflexLabDTO = DiagnosticReportLabDetailPageDTO & {


### PR DESCRIPTION
OTR-672

Note, did not add to Reflex Detail view as we can't be sure which SR the reflex test came from, so we can't really pinpoint an ordering location

For orders made before Locations were required, we simply show nothing. So it is backwards compatible.