### PR TITLE
Issue 3207. EHR. eRx - Allow opening eRx in full-screen mode

### DIFF
--- a/apps/ehr/src/telemed/features/appointment/ERXDialog.tsx
+++ b/apps/ehr/src/telemed/features/appointment/ERXDialog.tsx
@@ -1,4 +1,6 @@
-import { Box } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import OpenInFullIcon from '@mui/icons-material/OpenInFull';
+import { Box, IconButton } from '@mui/material';
 import { ReactElement, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { FHIR_EXTENSION } from 'utils';
@@ -6,7 +8,7 @@ import { useAppointmentData } from '../../state';
 
 export const ERXDialog = ({ ssoLink }: { ssoLink: string }): ReactElement => {
   const { patient } = useAppointmentData();
-
+  const [isOverlayOpen, setIsOverlayOpen] = useState(false);
   let weight: number | undefined = Number.parseFloat(
     patient?.extension?.find((ext) => ext.url === FHIR_EXTENSION.Patient.weight.url)?.valueString ?? ''
   );
@@ -35,7 +37,31 @@ export const ERXDialog = ({ ssoLink }: { ssoLink: string }): ReactElement => {
     <>
       {erxPortalElement &&
         createPortal(
-          <Box sx={{ minHeight: '600px', flex: '1 0 auto' }}>
+          <Box
+            sx={
+              isOverlayOpen
+                ? {
+                    position: 'fixed',
+                    top: 0,
+                    left: 0,
+                    width: '100vw',
+                    height: '100vh',
+                    zIndex: 1300,
+                  }
+                : {
+                    minHeight: 600,
+                    flex: '1 0 auto',
+                  }
+            }
+          >
+            <IconButton
+              onClick={() => setIsOverlayOpen(!isOverlayOpen)}
+              title={isOverlayOpen ? 'Close full screen' : 'Open full screen'}
+              size="small"
+              sx={{ position: 'absolute', right: isOverlayOpen ? 16 : 38 }}
+            >
+              {isOverlayOpen ? <CloseIcon /> : <OpenInFullIcon />}
+            </IconButton>
             <iframe src={ssoLink} width="100%" height="100%" />
           </Box>,
           erxPortalElement

--- a/apps/ehr/src/telemed/features/appointment/ERXDialog.tsx
+++ b/apps/ehr/src/telemed/features/appointment/ERXDialog.tsx
@@ -47,6 +47,7 @@ export const ERXDialog = ({ ssoLink }: { ssoLink: string }): ReactElement => {
                     width: '100vw',
                     height: '100vh',
                     zIndex: 1300,
+                    backgroundColor: 'white',
                   }
                 : {
                     minHeight: 600,


### PR DESCRIPTION
#3207

**Visual updates:**

Added button in the top-right corner
_inline eRx iframe:_
<img width="197" height="78" alt="Screenshot from 2025-09-25 14-07-11" src="https://github.com/user-attachments/assets/2f1c1b9c-aff2-4737-b829-c15d5a60d189" />
_full screen mode:_
<img width="197" height="78" alt="Screenshot from 2025-09-25 14-07-21" src="https://github.com/user-attachments/assets/4e8ded45-cd66-432f-92f3-e0ed752db4ea" />