### PR TITLE
fix failing ehr test multiline textbox

### DIFF
--- a/apps/ehr/tests/e2e/specs/telemed/examTab.spec.ts
+++ b/apps/ehr/tests/e2e/specs/telemed/examTab.spec.ts
@@ -34,8 +34,8 @@ test.describe('Fields tests', async () => {
   test("Should enter some text in 'Provider' field", async () => {
     await page
       .getByTestId(dataTestIds.telemedEhrFlow.examTabTable)
-      .locator("input[type='text']:not([role='combobox'])")
-      .first()
+      .getByRole('row', { name: 'General' })
+      .getByRole('textbox')
       .fill(providerComment);
     await waitForSaveChartDataResponse(page);
   });


### PR DESCRIPTION
it couldn't find the text input because [now it's a textbox](https://github.com/masslight/ottehr/pull/4425/files#diff-af9ba2e5e144a9e644be90cadec89e4be1691b5c47d47689d6d3b6bf3a056620R50)

it still couldn't find it with just that one change so i used the selector in playwright, which helped remove the `.first`, which is always great