### PR TITLE
[EHR] tracking board visit time tracking doesn't work correctly

### DIFF
--- a/apps/ehr/src/components/PatientEncountersGrid.tsx
+++ b/apps/ehr/src/components/PatientEncountersGrid.tsx
@@ -21,8 +21,8 @@ import {
   EmployeeDetails,
   formatMinutes,
   getInPersonVisitStatus,
+  getTelemedVisitStatus,
   isInPersonAppointment,
-  mapStatusToTelemed,
   ServiceMode,
   TelemedCallStatusesArr,
   useSuccessQuery,
@@ -78,7 +78,7 @@ const columns: GridColDef<AppointmentHistoryRow>[] = [
         if (!encounter) {
           return;
         }
-        const status = mapStatusToTelemed(encounter.status, appointment.status);
+        const status = getTelemedVisitStatus(encounter.status, appointment.status);
         return !!status && <TelemedAppointmentStatusChip status={status} />;
       } else {
         if (!encounter) return;
@@ -235,7 +235,7 @@ export const PatientEncountersGrid: FC<PatientEncountersGridProps> = (props) => 
     if (!appointmentHistory.encounter) return false;
     const appointmentStatus =
       appointmentHistory.serviceMode === ServiceMode.virtual
-        ? mapStatusToTelemed(appointmentHistory.encounter.status, appointmentHistory.appointment.status)
+        ? getTelemedVisitStatus(appointmentHistory.encounter.status, appointmentHistory.appointment.status)
         : getInPersonVisitStatus(appointmentHistory.appointment, appointmentHistory.encounter);
     return filterStatus === appointmentStatus;
   }

--- a/apps/ehr/src/features/visits/in-person/components/ChangeStatusDropdown.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/ChangeStatusDropdown.tsx
@@ -3,7 +3,15 @@ import { styled } from '@mui/system';
 import { enqueueSnackbar } from 'notistack';
 import React, { useEffect, useState } from 'react';
 import { IN_PERSON_CHIP_STATUS_MAP } from 'src/components/InPersonAppointmentStatusChip';
-import { getInPersonVisitStatus, visitStatusArray, VisitStatusLabel, VisitStatusWithoutUnknown } from 'utils';
+import { FEATURE_FLAGS } from 'src/constants/feature-flags';
+import {
+  getAdmitterPractitionerId,
+  getAttendingPractitionerId,
+  getInPersonVisitStatus,
+  visitStatusArray,
+  VisitStatusLabel,
+  VisitStatusWithoutUnknown,
+} from 'utils';
 import { dataTestIds } from '../../../../constants/data-test-ids';
 import { handleChangeInPersonVisitStatus } from '../../../../helpers/inPersonVisitStatusUtils';
 import { useApiClients } from '../../../../hooks/useAppClients';
@@ -64,6 +72,8 @@ export const ChangeStatusDropdown = ({
   const user = useEvolveUser();
   const { visitState: telemedData, appointmentRefetch } = useAppointmentData(appointmentID);
   const { appointment, encounter } = telemedData;
+  const assignedIntakePerformerId = encounter ? getAdmitterPractitionerId(encounter) : undefined;
+  const assignedProviderId = encounter ? getAttendingPractitionerId(encounter) : undefined;
 
   useEffect(() => {
     if (!encounter?.id || !appointment) {
@@ -95,8 +105,18 @@ export const ChangeStatusDropdown = ({
   const hasDropdown = !nonDropdownStatuses.includes(status);
 
   const updateInPersonVisitStatus = async (event: SelectChangeEvent<VisitStatusLabel | unknown>): Promise<void> => {
-    if ((event.target.value as VisitStatusWithoutUnknown) === 'completed') {
+    const targetValue = event.target.value as VisitStatusWithoutUnknown;
+
+    if (targetValue === 'completed') {
       alert('To mark a visit as completed, scroll to the bottom of the "Progress Note" and click "Review & Sign"');
+      return;
+    }
+    if (
+      !assignedIntakePerformerId &&
+      !assignedProviderId &&
+      !(targetValue === 'pending' || targetValue === 'arrived')
+    ) {
+      alert('Select an intake performer and a provider to change the status.');
       return;
     }
     setStatusLoading(true);
@@ -169,6 +189,9 @@ export const ChangeStatusDropdown = ({
                 ];
                 if (status === 'ready for provider' || status === 'intake') {
                   allHiddenStatuses = allHiddenStatuses.filter((s) => s !== 'provider');
+                }
+                if (!FEATURE_FLAGS.SUPERVISOR_APPROVAL_ENABLED) {
+                  allHiddenStatuses.push('awaiting supervisor approval');
                 }
                 return !allHiddenStatuses.includes(statusTemp);
               })

--- a/apps/ehr/src/features/visits/shared/components/review-tab/components/VisitDetailsContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/components/VisitDetailsContainer.tsx
@@ -4,7 +4,7 @@ import {
   formatDateTimeToLocalTimezone,
   getProviderNameWithProfession,
   getQuestionnaireResponseByLinkId,
-  mapEncounterStatusHistory,
+  getTelemedEncounterStatusHistory,
 } from 'utils';
 import { useGetInsurancePlan } from '../../../stores/appointment/appointment.queries';
 import { useAppointmentData } from '../../../stores/appointment/appointment.store';
@@ -24,7 +24,7 @@ export const VisitDetailsContainer: FC = () => {
   const statuses = useMemo(
     () =>
       encounter.statusHistory && appointment?.status
-        ? mapEncounterStatusHistory(encounter.statusHistory, appointment.status)
+        ? getTelemedEncounterStatusHistory(encounter.statusHistory, appointment.status)
         : undefined,
     [encounter.statusHistory, appointment?.status]
   );

--- a/apps/ehr/src/features/visits/shared/utils/appointment-accessibility.helper.ts
+++ b/apps/ehr/src/features/visits/shared/utils/appointment-accessibility.helper.ts
@@ -3,8 +3,8 @@ import { EvolveUser } from 'src/hooks/useEvolveUser';
 import {
   allLicensesForPractitioner,
   checkEncounterHasPractitioner,
+  getTelemedVisitStatus,
   isAppointmentLocked,
-  mapStatusToTelemed,
   PractitionerLicense,
   StateType,
   TelemedAppointmentStatusEnum,
@@ -42,12 +42,15 @@ export const getAppointmentAccessibilityData = ({
   const allLicenses = user?.profileResource && allLicensesForPractitioner(user.profileResource);
   const licensedPractitionerStates = allLicenses?.map((item) => item.state);
   const state = locationVirtual?.address?.state as StateType;
+
   const isPractitionerLicensedInState =
     !!state && !!licensedPractitionerStates && licensedPractitionerStates.includes(state as StateType);
 
-  const status = mapStatusToTelemed(encounter.status, appointment?.status);
+  const status = getTelemedVisitStatus(encounter.status, appointment?.status);
+
   const isEncounterAssignedToCurrentPractitioner =
     !!user?.profileResource && checkEncounterHasPractitioner(encounter, user.profileResource);
+
   const isStatusEditable =
     !!status && ![TelemedAppointmentStatusEnum.complete, TelemedAppointmentStatusEnum.ready].includes(status);
 

--- a/apps/ehr/src/features/visits/telemed/components/appointment/AppointmentFooter.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/appointment/AppointmentFooter.tsx
@@ -6,7 +6,7 @@ import { useAppointmentData } from 'src/features/visits/shared/stores/appointmen
 import {
   getAppointmentWaitingTime,
   getSelectors,
-  mapEncounterStatusHistory,
+  getTelemedEncounterStatusHistory,
   TelemedAppointmentStatusEnum,
 } from 'utils';
 import { useVideoCallStore } from '../../state/video-call/video-call.store';
@@ -23,7 +23,7 @@ export const AppointmentFooter: FC = () => {
 
   const statuses =
     encounter.statusHistory && appointment?.status
-      ? mapEncounterStatusHistory(encounter.statusHistory, appointment.status)
+      ? getTelemedEncounterStatusHistory(encounter.statusHistory, appointment.status)
       : undefined;
   const waitingTime = getAppointmentWaitingTime(statuses);
 

--- a/apps/ehr/src/features/visits/telemed/components/appointment/AppointmentFooterButton.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/appointment/AppointmentFooterButton.tsx
@@ -19,7 +19,7 @@ import {
   useInitTelemedSessionMutation,
 } from 'src/features/visits/shared/stores/tracking-board/tracking-board.queries';
 import useEvolveUser from 'src/hooks/useEvolveUser';
-import { mapStatusToTelemed, TelemedAppointmentStatusEnum } from 'utils';
+import { getTelemedVisitStatus, TelemedAppointmentStatusEnum } from 'utils';
 import { useVideoCallStore } from '../../state/video-call/video-call.store';
 import { updateEncounterStatusHistory } from '../../utils/appointments';
 
@@ -100,7 +100,7 @@ export const AppointmentFooterButton: FC = () => {
   };
 
   const onConnect = useCallback(async (): Promise<void> => {
-    if (mapStatusToTelemed(encounter.status, appointment?.status) === TelemedAppointmentStatusEnum['on-video']) {
+    if (getTelemedVisitStatus(encounter.status, appointment?.status) === TelemedAppointmentStatusEnum['on-video']) {
       const meetingDataResponse = await getMeetingData.refetch({ throwOnError: true });
       useVideoCallStore.setState({
         meetingData: meetingDataResponse.data,

--- a/apps/ehr/src/features/visits/telemed/components/appointment/AppointmentSidePanel.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/appointment/AppointmentSidePanel.tsx
@@ -42,9 +42,9 @@ import { getPatientName } from 'src/shared/utils';
 import {
   calculatePatientAge,
   getQuestionnaireResponseByLinkId,
+  getTelemedVisitStatus,
   INTERPRETER_PHONE_NUMBER,
   isInPersonAppointment,
-  mapStatusToTelemed,
   TelemedAppointmentStatusEnum,
   TelemedAppointmentVisitTabs,
 } from 'utils';
@@ -141,7 +141,7 @@ export const AppointmentSidePanel: FC = () => {
       .join(', ');
   };
 
-  const telemedStatus = mapStatusToTelemed(encounter.status, appointment?.status);
+  const telemedStatus = getTelemedVisitStatus(encounter.status, appointment?.status);
 
   return (
     <Drawer

--- a/apps/ehr/src/features/visits/telemed/pages/AppointmentPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/pages/AppointmentPage.tsx
@@ -7,7 +7,7 @@ import { ThemeProvider } from 'styled-components';
 import {
   getQuestionnaireResponseByLinkId,
   getSelectors,
-  mapStatusToTelemed,
+  getTelemedVisitStatus,
   RefreshableAppointmentData,
   TelemedAppointmentStatusEnum,
 } from 'utils';
@@ -83,7 +83,7 @@ export const AppointmentPage: FC = () => {
   };
 
   const shouldPeriodicallyRefreshAppointmentData = useMemo(() => {
-    const appointmentStatus = mapStatusToTelemed(encounter.status, appointment?.status);
+    const appointmentStatus = getTelemedVisitStatus(encounter.status, appointment?.status);
     return (
       appointmentStatus === TelemedAppointmentStatusEnum.ready ||
       appointmentStatus === TelemedAppointmentStatusEnum['pre-video'] ||

--- a/apps/ehr/src/features/visits/telemed/utils/appointments.ts
+++ b/apps/ehr/src/features/visits/telemed/utils/appointments.ts
@@ -3,7 +3,7 @@ import { DateTime, Duration } from 'luxon';
 import {
   ApptTelemedTab,
   GetTelemedAppointmentsInput,
-  mapStatusToTelemed,
+  getTelemedVisitStatus,
   PATIENT_PHOTO_CODE,
   PROJECT_NAME,
   RefreshableAppointmentData,
@@ -205,7 +205,7 @@ export const extractReviewAndSignAppointmentData = (data: AppointmentResources[]
     return;
   }
 
-  const telemedAppointmentStatus = mapStatusToTelemed(encounterStatus, appointmentStatus);
+  const telemedAppointmentStatus = getTelemedVisitStatus(encounterStatus, appointmentStatus);
 
   return telemedAppointmentStatus === TelemedAppointmentStatusEnum.complete
     ? { signedOnDate: finishedAtTime }

--- a/apps/ehr/src/helpers/index.ts
+++ b/apps/ehr/src/helpers/index.ts
@@ -54,7 +54,11 @@ export const checkInPatient = async (
     updatedByOverride: checkedInBy,
   });
 
-  const encounterStatusHistoryUpdate: Operation = getEncounterStatusHistoryUpdateOp(encounterToUpdate, 'arrived');
+  const encounterStatusHistoryUpdate: Operation = getEncounterStatusHistoryUpdateOp(
+    encounterToUpdate,
+    'arrived',
+    'arrived'
+  );
 
   const patchOp: Operation = {
     op: 'replace',

--- a/apps/ehr/src/pages/VisitDetailsPage.tsx
+++ b/apps/ehr/src/pages/VisitDetailsPage.tsx
@@ -46,11 +46,11 @@ import {
   getLastName,
   getMiddleName,
   getPatchOperationForNewMetaTag,
+  getTelemedVisitStatus,
   getUnconfirmedDOBForAppointment,
   isApiError,
   isEncounterSelfPay,
   isInPersonAppointment,
-  mapStatusToTelemed,
   TelemedAppointmentStatus,
   UpdateVisitDetailsInput,
   VisitDocuments,
@@ -447,7 +447,7 @@ export default function VisitDetailsPage(): ReactElement {
     if (appointment && encounter) {
       const encounterStatus = isInPerson
         ? getInPersonVisitStatus(appointment, encounter)
-        : mapStatusToTelemed(encounter.status, appointment.status);
+        : getTelemedVisitStatus(encounter.status, appointment.status);
 
       setStatus(encounterStatus);
     } else {

--- a/apps/ehr/src/rcm/utils/claims-queue-columns.helper.tsx
+++ b/apps/ehr/src/rcm/utils/claims-queue-columns.helper.tsx
@@ -46,7 +46,7 @@ export const ClaimsQueueColumns: Record<string, GridColDef<ClaimsQueueItem, any,
       // const statuses = useMemo(
       //   () =>
       //     encounter.statusHistory && appointment?.status
-      //       ? mapEncounterStatusHistory(encounter.statusHistory, appointment.status)
+      //       ? getTelemedEncounterStatusHistory(encounter.statusHistory, appointment.status)
       //       : undefined,
       //   [encounter.statusHistory, appointment?.status]
       // );

--- a/packages/utils/lib/fhir/constants.ts
+++ b/packages/utils/lib/fhir/constants.ts
@@ -63,6 +63,11 @@ export const FHIR_EXTENSION = {
       },
     },
   },
+  EncounterStatusHistory: {
+    ottehrVisitStatus: {
+      url: `${PUBLIC_EXTENSION_BASE_URL}/visit-status`,
+    },
+  },
   Location: {
     locationFormPreRelease: {
       url: `${PUBLIC_EXTENSION_BASE_URL}/location-form-pre-release`,

--- a/packages/utils/lib/fhir/encounter.ts
+++ b/packages/utils/lib/fhir/encounter.ts
@@ -5,12 +5,13 @@ import { DateTime } from 'luxon';
 import { CODE_SYSTEM_ACT_CODE_V3 } from '../helpers';
 import {
   FhirEncounterStatus,
-  mapStatusToTelemed,
+  getTelemedVisitStatus,
   PatientFollowupDetails,
   ProviderDetails,
   TelemedStatusHistoryElement,
+  VisitStatusWithoutUnknown,
 } from '../types';
-import { ENCOUNTER_PAYMENT_VARIANT_EXTENSION_URL, FHIR_BASE_URL } from './constants';
+import { ENCOUNTER_PAYMENT_VARIANT_EXTENSION_URL, FHIR_BASE_URL, FHIR_EXTENSION } from './constants';
 
 // follow up encounter consts
 export const FOLLOWUP_TYPES = ['Telephone Encounter', 'Non-Billable'] as const;
@@ -117,7 +118,7 @@ export const getEncounterForAppointment = async (appointmentID: string, oystehr:
   return encounter;
 };
 
-export const mapEncounterStatusHistory = (
+export const getTelemedEncounterStatusHistory = (
   statusHistory: EncounterStatusHistory[],
   appointmentStatus: string
 ): TelemedStatusHistoryElement[] => {
@@ -127,9 +128,10 @@ export const mapEncounterStatusHistory = (
     result.push({
       start: statusElement.period.start,
       end: statusElement.period.end,
-      status: mapStatusToTelemed(statusElement.status, undefined),
+      status: getTelemedVisitStatus(statusElement.status, undefined),
     });
   });
+
   if (appointmentStatus === 'fulfilled' && result.at(-1)?.status === 'unsigned') {
     result.push({
       start: result.at(-1)?.end,
@@ -156,19 +158,42 @@ export const getSpentTime = (history?: EncounterStatusHistory[]): string | undef
   return `${minutesSpent}`;
 };
 
-export const getEncounterStatusHistoryUpdateOp = (encounter: Encounter, newStatus: FhirEncounterStatus): Operation => {
+export const getEncounterStatusHistoryUpdateOp = (
+  encounter: Encounter,
+  newStatus: FhirEncounterStatus,
+  ottehrVisitStatus: VisitStatusWithoutUnknown
+): Operation => {
   const now = DateTime.now().setZone('UTC').toISO() || '';
+
   const newStatusHistory: EncounterStatusHistory = {
     status: newStatus,
     period: {
       start: now,
     },
   };
+
+  newStatusHistory.extension = [
+    {
+      url: FHIR_EXTENSION.EncounterStatusHistory.ottehrVisitStatus.url,
+      valueCode: ottehrVisitStatus,
+    },
+  ];
+
   let statusHistory = encounter.statusHistory;
   const op = statusHistory ? 'replace' : 'add';
+
   if (statusHistory) {
     const curStatus = encounter.statusHistory?.find((h) => !h.period.end);
-    if (curStatus && curStatus?.status !== newStatus) {
+
+    const didFhirStatusHistoryChange = curStatus?.status !== newStatus;
+
+    const ottehrHistoryStatusExtension = curStatus?.extension?.find(
+      (ext) => ext.url === FHIR_EXTENSION.EncounterStatusHistory.ottehrVisitStatus.url
+    );
+
+    const didOttEhrStatusHistoryChange = ottehrHistoryStatusExtension?.valueCode !== ottehrVisitStatus;
+
+    if (curStatus && (didFhirStatusHistoryChange || didOttEhrStatusHistoryChange)) {
       curStatus.period.end = now;
       statusHistory.push(newStatusHistory);
     } else if (!curStatus) {

--- a/packages/utils/lib/types/api/appointment.types.ts
+++ b/packages/utils/lib/types/api/appointment.types.ts
@@ -12,7 +12,7 @@ export type RefreshableAppointmentData = {
   patientConditionPhotoUrls: string[];
 };
 
-export const mapStatusToTelemed = (
+export const getTelemedVisitStatus = (
   encounterStatus: string,
   appointmentStatus: string | undefined
 ): TelemedAppointmentStatusEnum | undefined => {
@@ -38,7 +38,6 @@ export type FhirAppointmentStatus = Appointment['status'];
 export const visitStatusArray = [
   'pending',
   'arrived',
-  'awaiting supervisor approval',
   'ready',
   'intake',
   'ready for provider',
@@ -46,6 +45,7 @@ export const visitStatusArray = [
   'discharged',
   'cancelled',
   'no show',
+  'awaiting supervisor approval',
   'completed',
   'unknown',
 ] as const;

--- a/packages/utils/lib/utils/visitUtils.ts
+++ b/packages/utils/lib/utils/visitUtils.ts
@@ -7,14 +7,24 @@ import {
   VisitStatusHistoryLabel,
   VisitStatusLabel,
 } from 'utils';
+import { FHIR_EXTENSION } from '../fhir/constants';
+
+export const STATUSES_WITHOUT_TIME_TRACKER: VisitStatusHistoryLabel[] = [
+  'pending',
+  'no show',
+  'cancelled',
+  'completed',
+  'discharged',
+];
 
 export const getDurationOfStatus = (statusEntry: VisitStatusHistoryEntry, dateTimeNow: DateTime): number => {
   if (statusEntry.period.start && statusEntry.period.end) {
-    return DateTime.fromISO(statusEntry.period.end).diff(DateTime.fromISO(statusEntry.period.start), 'minutes').minutes;
+    return Math.floor(
+      DateTime.fromISO(statusEntry.period.end).diff(DateTime.fromISO(statusEntry.period.start), 'minutes').minutes
+    );
   } else if (statusEntry.period.start) {
-    const stopCountingForStatus: VisitStatusHistoryLabel[] = ['cancelled', 'no show', 'completed'];
-    if (!stopCountingForStatus.includes(statusEntry.status)) {
-      return dateTimeNow.diff(DateTime.fromISO(statusEntry.period.start), 'minutes').minutes;
+    if (!STATUSES_WITHOUT_TIME_TRACKER.includes(statusEntry.status)) {
+      return Math.floor(dateTimeNow.diff(DateTime.fromISO(statusEntry.period.start), 'minutes').minutes);
     }
   }
   return 0;
@@ -27,7 +37,7 @@ export const getVisitTotalTime = (
 ): number => {
   if (appointment.start) {
     return visitStatusHistory
-      .filter((status) => status.status !== 'pending')
+      .filter((status) => !STATUSES_WITHOUT_TIME_TRACKER.includes(status.status))
       .reduce((accumulator, statusTemp) => {
         return accumulator + getDurationOfStatus(statusTemp, dateTimeNow);
       }, 0);
@@ -93,7 +103,20 @@ export const getVisitStatusHistory = (encounter: Encounter): VisitStatusHistoryE
 
   encounter?.statusHistory?.forEach((statusHist: EncounterStatusHistory) => {
     if (statusHist.status === 'in-progress') {
-      if (encounter?.participant) {
+      const ottehrStatusFromExtension = statusHist.extension?.find(
+        (ext) => ext.url === FHIR_EXTENSION.EncounterStatusHistory.ottehrVisitStatus.url
+      )?.valueCode;
+
+      if (ottehrStatusFromExtension) {
+        visitHistory.push({
+          status: ottehrStatusFromExtension as VisitStatusHistoryLabel,
+          period: {
+            ...(statusHist.period.start && { start: statusHist.period.start }),
+            ...(statusHist.period.end && { end: statusHist.period.end }),
+          },
+        });
+      } else if (encounter?.participant) {
+        // fallback: that's old logic, but that's wrong, because we need to compare with history participants, not with current ones
         const inProgressHistories = getInProgressVisitHistories(statusHist, encounter.participant);
         visitHistory.push(...inProgressHistories);
       }
@@ -115,6 +138,7 @@ export const getVisitStatusHistory = (encounter: Encounter): VisitStatusHistoryE
   return visitHistory;
 };
 
+// for backward compatibility
 const getInProgressVisitHistories = (
   statusHistory: EncounterStatusHistory,
   participantArray: EncounterParticipant[]

--- a/packages/zambdas/src/cron/notifications-updater/index.ts
+++ b/packages/zambdas/src/cron/notifications-updater/index.ts
@@ -10,7 +10,7 @@ import {
   getPatchOperationForNewMetaTag,
   getProviderNotificationSettingsForPractitioner,
   getSecret,
-  mapStatusToTelemed,
+  getTelemedVisitStatus,
   OTTEHR_MODULE,
   PROVIDER_NOTIFICATION_TAG_SYSTEM,
   PROVIDER_NOTIFICATION_TYPE_SYSTEM,
@@ -137,7 +137,10 @@ export const index = wrapHandler('notification-Updater', async (input: ZambdaInp
         const { appointment, encounter, practitioner, location, communications } =
           readyOrUnsignedVisitPackages[appointmentId];
         if (encounter && appointment) {
-          const status: TelemedAppointmentStatus | undefined = mapStatusToTelemed(encounter.status, appointment.status);
+          const status: TelemedAppointmentStatus | undefined = getTelemedVisitStatus(
+            encounter.status,
+            appointment.status
+          );
           if (!status) return;
 
           // getting communications that were postponed after practitioner will become not busy

--- a/packages/zambdas/src/ehr/change-in-person-visit-status/helpers/helpers.ts
+++ b/packages/zambdas/src/ehr/change-in-person-visit-status/helpers/helpers.ts
@@ -39,8 +39,8 @@ export const changeInPersonVisitStatusIfPossible = async (
     updatedStatus
   );
 
-  console.log('Appointment Patch Ops:', updateInPersonAppointmentStatusOp);
-  console.log('Encounter Patch Ops:', updateInPersonEncounterStatusOp);
+  console.log('Appointment Patch Ops:', JSON.stringify(updateInPersonAppointmentStatusOp, null, 2));
+  console.log('Encounter Patch Ops:', JSON.stringify(updateInPersonEncounterStatusOp, null, 2));
 
   if (updateInPersonAppointmentStatusOp.length > 0 || updateInPersonEncounterStatusOp.length > 0) {
     const requests = [
@@ -128,6 +128,72 @@ const getUpdateInPersonAppointmentStatusOperation = async (
   return appointmentPatchOps;
 };
 
+/**
+ * Periods are handled based on the status determination logic:
+ *
+ * const STATUS_DEFINITIONS = {
+ *   PENDING: {
+ *     appointmentStatus: 'booked',
+ *     encounterStatus: 'planned',
+ *     admParticipant: 'N/A',
+ *     atndParticipant: 'N/A'
+ *   },
+ *   ARRIVED: {
+ *     appointmentStatus: 'arrived',
+ *     encounterStatus: 'arrived',
+ *     admParticipant: 'N/A',
+ *     atndParticipant: 'N/A'
+ *   },
+ *   READY: {
+ *     appointmentStatus: 'checked-in',
+ *     encounterStatus: 'arrived',
+ *     admParticipant: 'N/A',
+ *     atndParticipant: 'N/A'
+ *   },
+ *   INTAKE: {
+ *     appointmentStatus: 'checked-in',
+ *     encounterStatus: 'in-progress',
+ *     admParticipant: '{start: T1} ← NO END!',
+ *     atndParticipant: 'N/A'
+ *   },
+ *   READY_FOR_PROVIDER: {
+ *     appointmentStatus: 'fulfilled',
+ *     encounterStatus: 'in-progress',
+ *     admParticipant: '{start: T1, end: T2} ← CLOSED',
+ *     atndParticipant: 'N/A'
+ *   },
+ *   PROVIDER: {
+ *     appointmentStatus: 'fulfilled',
+ *     encounterStatus: 'in-progress',
+ *     admParticipant: '{start: T1, end: T2}',
+ *     atndParticipant: '{start: T3} ← NO END!'
+ *   },
+ *   DISCHARGED: {
+ *     appointmentStatus: 'fulfilled',
+ *     encounterStatus: 'in-progress',
+ *     admParticipant: '{start: T1, end: T2}',
+ *     atndParticipant: '{start: T3, end: T4} ← CLOSED'
+ *   },
+ *   COMPLETED: {
+ *     appointmentStatus: 'fulfilled',
+ *     encounterStatus: 'finished',
+ *     admParticipant: '{start: T1, end: T2}',
+ *     atndParticipant: '{start: T3, end: T4}'
+ *   },
+ *   CANCELLED: {
+ *     appointmentStatus: 'cancelled',
+ *     encounterStatus: 'cancelled',
+ *     admParticipant: 'depends',
+ *     atndParticipant: 'depends'
+ *   },
+ *   NO_SHOW: {
+ *     appointmentStatus: 'noshow',
+ *     encounterStatus: 'cancelled',
+ *     admParticipant: 'N/A',
+ *     atndParticipant: 'N/A'
+ *   }
+ * };
+ */
 const getUpdateInPersonEncounterStatusOperation = async (
   encounter: Encounter,
   oystehr: Oystehr,
@@ -139,49 +205,242 @@ const getUpdateInPersonEncounterStatusOperation = async (
   }
 
   const encounterStatus = visitStatusToFhirEncounterStatusMap[updatedStatus];
+
   if (!encounterStatus) {
     console.warn(`Unknown encounter status: ${updatedStatus}`);
     return [];
   }
 
   const encounterPatchOps: Operation[] = [{ op: 'replace', path: '/status', value: encounterStatus }];
+  const dateNow = new Date().toISOString();
 
-  if (updatedStatus === 'discharged') {
-    const attenderIndex = encounter.participant?.findIndex(
-      (p) => p?.type?.some((t) => t?.coding?.some((coding) => coding.code === PRACTITIONER_CODINGS.Attender[0].code))
-    );
-
-    if (attenderIndex !== undefined && attenderIndex >= 0) {
-      const now = new Date().toISOString();
-      const attenderPeriod = encounter.participant?.[attenderIndex]?.period;
-
-      encounterPatchOps.push({
-        op: 'add',
-        path: `/participant/${attenderIndex}/period`,
-        value: attenderPeriod ? { start: attenderPeriod.start, end: now } : { end: now },
-      });
-    }
+  if (
+    updatedStatus === 'pending' ||
+    updatedStatus === 'arrived' ||
+    updatedStatus === 'ready' ||
+    updatedStatus === 'cancelled' ||
+    updatedStatus === 'no show'
+  ) {
+    updateAdmitterPeriod(encounterPatchOps, { encounter, deleteStartTime: true, deleteEndTime: true });
+    updateAttenderPeriod(encounterPatchOps, { encounter, deleteStartTime: true, deleteEndTime: true });
+  } else if (updatedStatus === 'intake') {
+    updateAdmitterPeriod(encounterPatchOps, {
+      encounter,
+      startTime: dateNow,
+      overrideStartTimeIfExists: true,
+      deleteEndTime: true,
+    });
+    updateAttenderPeriod(encounterPatchOps, { encounter, deleteStartTime: true, deleteEndTime: true });
+  } else if (updatedStatus === 'ready for provider') {
+    updateAdmitterPeriod(encounterPatchOps, {
+      encounter,
+      startTime: dateNow,
+      overrideStartTimeIfExists: false,
+      endTime: dateNow,
+      overrideEndTimeIfExists: true,
+    });
+    updateAttenderPeriod(encounterPatchOps, { encounter, deleteStartTime: true, deleteEndTime: true });
+  } else if (updatedStatus === 'provider') {
+    updateAdmitterPeriod(encounterPatchOps, {
+      encounter,
+      startTime: dateNow,
+      overrideStartTimeIfExists: false,
+      endTime: dateNow,
+      overrideEndTimeIfExists: false,
+    });
+    updateAttenderPeriod(encounterPatchOps, {
+      encounter,
+      startTime: dateNow,
+      overrideStartTimeIfExists: true,
+      deleteEndTime: true,
+    });
+  } else if (
+    updatedStatus === 'discharged' ||
+    updatedStatus === 'awaiting supervisor approval' ||
+    updatedStatus === 'completed'
+  ) {
+    updateAdmitterPeriod(encounterPatchOps, {
+      encounter,
+      startTime: dateNow,
+      overrideStartTimeIfExists: false,
+      endTime: dateNow,
+      overrideEndTimeIfExists: false,
+    });
+    updateAttenderPeriod(encounterPatchOps, {
+      encounter,
+      startTime: dateNow,
+      overrideStartTimeIfExists: false,
+      endTime: dateNow,
+      overrideEndTimeIfExists: true,
+    });
   }
 
-  // if the status is change to provider, we need to set the period start for the attender participant
-  if (updatedStatus === 'provider') {
-    const attenderIndex = encounter.participant?.findIndex(
-      (p) => p?.type?.some((t) => t?.coding?.some((coding) => coding.code === PRACTITIONER_CODINGS.Attender[0].code))
-    );
-    if (attenderIndex !== undefined && attenderIndex >= 0) {
-      const now = new Date().toISOString();
-      const attenderPeriod = encounter.participant?.[attenderIndex]?.period;
+  const encounterStatusHistoryUpdate: Operation = getEncounterStatusHistoryUpdateOp(
+    encounter,
+    encounterStatus,
+    updatedStatus
+  );
 
-      encounterPatchOps.push({
-        op: 'add',
-        path: `/participant/${attenderIndex}/period`,
-        value: attenderPeriod?.start ? attenderPeriod : { start: now },
-      });
-    }
-  }
-
-  const encounterStatusHistoryUpdate: Operation = getEncounterStatusHistoryUpdateOp(encounter, encounterStatus);
   encounterPatchOps.push(encounterStatusHistoryUpdate);
 
   return encounterPatchOps;
+};
+
+const updateAdmitterPeriod = (
+  operations: Operation[],
+  {
+    encounter,
+    endTime,
+    startTime,
+    overrideEndTimeIfExists,
+    overrideStartTimeIfExists,
+    deleteEndTime,
+    deleteStartTime,
+  }: {
+    encounter: Encounter;
+    startTime?: string;
+    endTime?: string;
+    overrideEndTimeIfExists?: boolean;
+    overrideStartTimeIfExists?: boolean;
+    deleteEndTime?: boolean;
+    deleteStartTime?: boolean;
+  }
+): void => {
+  const participantIndex = findAdmitterIndex(encounter);
+
+  if (participantIndex >= 0) {
+    operations.push(
+      ...updateParticipantPeriod({
+        encounter,
+        endTime,
+        startTime,
+        participantIndex,
+        overrideEndTimeIfExists,
+        overrideStartTimeIfExists,
+        deleteEndTime,
+        deleteStartTime,
+      })
+    );
+  }
+};
+
+const updateAttenderPeriod = (
+  operations: Operation[],
+  {
+    encounter,
+    endTime,
+    startTime,
+    overrideEndTimeIfExists,
+    overrideStartTimeIfExists,
+    deleteEndTime,
+    deleteStartTime,
+  }: {
+    encounter: Encounter;
+    startTime?: string;
+    endTime?: string;
+    overrideEndTimeIfExists?: boolean;
+    overrideStartTimeIfExists?: boolean;
+    deleteEndTime?: boolean;
+    deleteStartTime?: boolean;
+  }
+): void => {
+  const participantIndex = findAttenderIndex(encounter);
+
+  if (participantIndex >= 0) {
+    operations.push(
+      ...updateParticipantPeriod({
+        encounter,
+        endTime,
+        startTime,
+        participantIndex,
+        overrideEndTimeIfExists,
+        overrideStartTimeIfExists,
+        deleteEndTime,
+        deleteStartTime,
+      })
+    );
+  }
+};
+
+const updateParticipantPeriod = ({
+  encounter,
+  endTime,
+  startTime,
+  deleteEndTime = false,
+  deleteStartTime = false,
+  overrideEndTimeIfExists = false,
+  overrideStartTimeIfExists = false,
+  participantIndex,
+}: {
+  encounter: Encounter;
+  startTime?: string;
+  endTime?: string;
+  overrideEndTimeIfExists?: boolean;
+  overrideStartTimeIfExists?: boolean;
+  deleteEndTime?: boolean;
+  deleteStartTime?: boolean;
+  participantIndex: number;
+}): Operation[] => {
+  const participantPeriod = encounter.participant?.[participantIndex]?.period;
+
+  const canUpdateStart = Boolean(startTime && (!participantPeriod?.start || overrideStartTimeIfExists));
+  const canUpdateEnd = Boolean(endTime && (!participantPeriod?.end || overrideEndTimeIfExists));
+
+  const canDeleteEnd = Boolean(deleteEndTime && participantPeriod?.end);
+  const canDeleteStart = Boolean(deleteStartTime && participantPeriod?.start);
+
+  if (!canUpdateStart && !canUpdateEnd && !canDeleteEnd && !canDeleteStart) {
+    return [];
+  }
+
+  const updatedPeriod = { ...participantPeriod };
+
+  if (canUpdateStart) {
+    updatedPeriod.start = startTime;
+  }
+
+  if (canUpdateEnd) {
+    updatedPeriod.end = endTime;
+  }
+
+  if (canDeleteEnd) {
+    delete updatedPeriod.end;
+  }
+
+  if (canDeleteStart) {
+    delete updatedPeriod.start;
+  }
+
+  if (Object.keys(updatedPeriod).length === 0) {
+    return [
+      {
+        op: 'remove',
+        path: `/participant/${participantIndex}/period`,
+      },
+    ];
+  }
+
+  return [
+    {
+      op: 'add',
+      path: `/participant/${participantIndex}/period`,
+      value: updatedPeriod,
+    },
+  ];
+};
+
+const findAdmitterIndex = (encounter: Encounter): number => {
+  const index = encounter.participant?.findIndex(
+    (p) => p?.type?.some((t) => t?.coding?.some((coding) => coding.code === PRACTITIONER_CODINGS.Admitter[0].code))
+  );
+
+  return typeof index === 'number' ? index : -1;
+};
+
+const findAttenderIndex = (encounter: Encounter): number => {
+  const index = encounter.participant?.findIndex(
+    (p) => p?.type?.some((t) => t?.coding?.some((coding) => coding.code === PRACTITIONER_CODINGS.Attender[0].code))
+  );
+
+  return typeof index === 'number' ? index : -1;
 };

--- a/packages/zambdas/src/ehr/change-telemed-appointment-status/index.ts
+++ b/packages/zambdas/src/ehr/change-telemed-appointment-status/index.ts
@@ -8,7 +8,7 @@ import {
   getPatientContactEmail,
   getQuestionnaireResponseByLinkId,
   getSecret,
-  mapStatusToTelemed,
+  getTelemedVisitStatus,
   SecretsKeys,
   TelemedAppointmentStatusEnum,
   TelemedCompletionTemplateData,
@@ -101,7 +101,7 @@ export const performEffect = async (
   }
 
   console.log(`appointment and encounter statuses: ${appointment.status}, ${encounter.status}`);
-  const currentStatus = mapStatusToTelemed(encounter.status, appointment.status);
+  const currentStatus = getTelemedVisitStatus(encounter.status, appointment.status);
   if (currentStatus) {
     const myPractitionerId = await getMyPractitionerId(oystehrCurrentUser);
     const ENVIRONMENT = getSecret(SecretsKeys.ENVIRONMENT, secrets);

--- a/packages/zambdas/src/ehr/get-telemed-appointments/helpers/fhir-resources-filters.ts
+++ b/packages/zambdas/src/ehr/get-telemed-appointments/helpers/fhir-resources-filters.ts
@@ -2,11 +2,12 @@ import { Appointment, Encounter, Patient, Practitioner, QuestionnaireResponse, R
 import {
   AppointmentLocation,
   appointmentTypeForAppointment,
+  getTelemedEncounterStatusHistory,
+  getTelemedVisitStatus,
   isTruthy,
-  mapEncounterStatusHistory,
   TelemedCallStatuses,
 } from 'utils';
-import { mapStatusToTelemed, removePrefix } from '../../../shared/appointment/helpers';
+import { removePrefix } from '../../../shared/appointment/helpers';
 import { getVideoRoomResourceExtension } from '../../../shared/helpers';
 import { getLocationIdFromAppointment } from './helpers';
 import { mapQuestionnaireToEncountersIds, mapTelemedEncountersToAppointmentsIdsMap } from './mappers';
@@ -105,7 +106,7 @@ export const filterAppointmentsAndCreatePackages = ({
 
     const encounter = appointmentEncounterMap[appointment.id!];
     if (encounter) {
-      const telemedStatus = mapStatusToTelemed(encounter.status, appointment.status);
+      const telemedStatus = getTelemedVisitStatus(encounter.status, appointment.status);
       const paperwork = encounterQuestionnaireMap[encounter.id!];
 
       if (telemedStatus && statusesFilter.includes(telemedStatus)) {
@@ -125,7 +126,7 @@ export const filterAppointmentsAndCreatePackages = ({
           telemedStatus,
           practitioner,
           telemedStatusHistory: encounter.statusHistory
-            ? mapEncounterStatusHistory(encounter.statusHistory, appointment.status)
+            ? getTelemedEncounterStatusHistory(encounter.statusHistory, appointment.status)
             : [],
         });
       }

--- a/packages/zambdas/src/ehr/get-telemed-appointments/test/get-telemed-appointments.test.ts
+++ b/packages/zambdas/src/ehr/get-telemed-appointments/test/get-telemed-appointments.test.ts
@@ -1,7 +1,6 @@
 import Oystehr, { OystehrConfig, User } from '@oystehr/sdk';
-import { mapEncounterStatusHistory } from 'utils';
+import { getTelemedEncounterStatusHistory, getTelemedVisitStatus } from 'utils';
 import { vi } from 'vitest';
-import { mapStatusToTelemed } from '../../../shared/appointment/helpers';
 import { getVideoRoomResourceExtension } from '../../../shared/helpers';
 import { filterAppointmentsAndCreatePackages } from '../helpers/fhir-resources-filters';
 import { getPractitionerLicensesLocationsAbbreviations } from '../helpers/fhir-utils';
@@ -30,22 +29,22 @@ import {
 describe('Test "get-telemed-appointments" endpoint', () => {
   describe('Test "filterAppointmentsFromResources" function', () => {
     test('Map encounter statuses to telemed, success', async () => {
-      let status = mapStatusToTelemed('planned', undefined);
+      let status = getTelemedVisitStatus('planned', undefined);
       expect(status).toEqual('ready');
 
-      status = mapStatusToTelemed('arrived', undefined);
+      status = getTelemedVisitStatus('arrived', undefined);
       expect(status).toEqual('pre-video');
 
-      status = mapStatusToTelemed('in-progress', undefined);
+      status = getTelemedVisitStatus('in-progress', undefined);
       expect(status).toEqual('on-video');
 
-      status = mapStatusToTelemed('finished', undefined);
+      status = getTelemedVisitStatus('finished', undefined);
       expect(status).toEqual('unsigned');
 
-      status = mapStatusToTelemed('finished', 'fulfilled');
+      status = getTelemedVisitStatus('finished', 'fulfilled');
       expect(status).toEqual('complete');
 
-      status = mapStatusToTelemed('wrong', undefined);
+      status = getTelemedVisitStatus('wrong', undefined);
       expect(status).toBeUndefined();
     });
 
@@ -153,10 +152,10 @@ describe('Test "get-telemed-appointments" endpoint', () => {
 
   describe('Encounter tests', () => {
     test('Test encounter status history mapping, success', async () => {
-      let history = mapEncounterStatusHistory(fullEncounterStatusHistory, 'arrived');
+      let history = getTelemedEncounterStatusHistory(fullEncounterStatusHistory, 'arrived');
       expect(history).toEqual(unsignedEncounterMappedStatusHistory);
 
-      history = mapEncounterStatusHistory(fullEncounterStatusHistory, 'fulfilled');
+      history = getTelemedEncounterStatusHistory(fullEncounterStatusHistory, 'fulfilled');
       expect(history).toEqual(completeEncounterMappedStatusHistory);
     });
   });

--- a/packages/zambdas/src/ehr/pending-supervisor-approval/index.ts
+++ b/packages/zambdas/src/ehr/pending-supervisor-approval/index.ts
@@ -5,6 +5,7 @@ import { Encounter, FhirResource, Provenance } from 'fhir/r4b';
 import {
   createExtensionValue,
   findExtensionIndex,
+  getEncounterStatusHistoryUpdateOp,
   getPatchBinary,
   getSecret,
   PendingSupervisorApprovalInputValidated,
@@ -67,6 +68,15 @@ export const index = wrapHandler(
           value: encounterStatus,
         },
       ];
+
+      // Add statusHistory with Ottehr status extension
+      const statusHistoryUpdate = getEncounterStatusHistoryUpdateOp(
+        encounter,
+        encounterStatus,
+        'awaiting supervisor approval'
+      );
+
+      encounterPatchOps.push(statusHistoryUpdate);
 
       const awaitingSupervisorApprovalExtension = createExtensionValue(
         'awaiting-supervisor-approval',

--- a/packages/zambdas/src/ehr/sign-appointment/index.ts
+++ b/packages/zambdas/src/ehr/sign-appointment/index.ts
@@ -149,8 +149,10 @@ const changeStatusToCompleted = async (
 
   const encounterStatusHistoryUpdate: Operation = getEncounterStatusHistoryUpdateOp(
     resourcesToUpdate.encounter,
-    encounterStatus
+    encounterStatus,
+    'completed'
   );
+
   encounterPatchOps.push(encounterStatusHistoryUpdate);
 
   let provenanceCreate: BatchInputRequest<Provenance> | undefined;

--- a/packages/zambdas/src/patient/appointment/get-past-visits/index.ts
+++ b/packages/zambdas/src/patient/appointment/get-past-visits/index.ts
@@ -10,8 +10,8 @@ import {
   GetPastVisitsResponse,
   getPatientsForUser,
   getSecret,
+  getTelemedVisitStatus,
   getTimezone,
-  mapStatusToTelemed,
   SecretsKeys,
   TIMEZONE_EXTENSION_URL,
   TIMEZONES,
@@ -100,7 +100,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
         let status: AppointmentStatus | undefined;
         if (appointmentType === 'Telemedicine') {
-          status = mapStatusToTelemed(encounter.status, fhirAppointment.status);
+          status = getTelemedVisitStatus(encounter.status, fhirAppointment.status);
         } else if (appointmentType === 'In-Person') {
           status = getInPersonVisitStatus(fhirAppointment, encounter);
         }

--- a/packages/zambdas/src/patient/appointment/telemed-get-appointments/index.ts
+++ b/packages/zambdas/src/patient/appointment/telemed-get-appointments/index.ts
@@ -6,7 +6,7 @@ import {
   getPatientsForUser,
   getSecret,
   GetTelemedAppointmentsResponse,
-  mapStatusToTelemed,
+  getTelemedVisitStatus,
   SecretsKeys,
   TelemedAppointmentInformationIntake,
 } from 'utils';
@@ -71,7 +71,8 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
           return;
         }
 
-        const telemedStatus = mapStatusToTelemed(encounter.status, fhirAppointment.status);
+        const telemedStatus = getTelemedVisitStatus(encounter.status, fhirAppointment.status);
+
         if (!telemedStatus) {
           console.log('No telemed status for appointment');
           return;

--- a/packages/zambdas/src/patient/check-in/index.ts
+++ b/packages/zambdas/src/patient/check-in/index.ts
@@ -7,6 +7,7 @@ import {
   APPOINTMENT_NOT_FOUND_ERROR,
   CheckInInput,
   CheckInZambdaOutput,
+  FHIR_EXTENSION,
   formatPhoneNumberDisplay,
   getAppointmentMetaTagOpForStatusUpdate,
   getEncounterStatusHistoryIdx,
@@ -210,6 +211,12 @@ async function checkIn(
         period: {
           start: now,
         },
+        extension: [
+          {
+            url: FHIR_EXTENSION.EncounterStatusHistory.ottehrVisitStatus.url,
+            valueCode: 'arrived',
+          },
+        ],
       },
     });
   }

--- a/packages/zambdas/src/patient/get-wait-status/index.ts
+++ b/packages/zambdas/src/patient/get-wait-status/index.ts
@@ -8,7 +8,7 @@ import {
   getAppointmentResourceById,
   getLocationIdFromAppointment,
   getSecret,
-  mapStatusToTelemed,
+  getTelemedVisitStatus,
   PROJECT_WEBSITE,
   SecretsKeys,
   TelemedAppointmentStatusEnum,
@@ -109,7 +109,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
       };
     }
 
-    const telemedStatus = mapStatusToTelemed(videoEncounter.status, appointment.status);
+    const telemedStatus = getTelemedVisitStatus(videoEncounter.status, appointment.status);
 
     if (telemedStatus === 'ready' || telemedStatus === 'pre-video' || telemedStatus === 'on-video') {
       const appointments = await getAppointmentsForLocation(oystehr, locationId);

--- a/packages/zambdas/src/shared/appointment/helpers.ts
+++ b/packages/zambdas/src/shared/appointment/helpers.ts
@@ -11,7 +11,6 @@ import {
   formatPhoneNumber,
   getPatchBinary,
   getPatientResourceWithVerifiedPhoneNumber,
-  mapStatusToTelemed,
   normalizePhoneNumber,
   PATIENT_NOT_FOUND_ERROR,
   PatientInfo,
@@ -62,8 +61,6 @@ export async function patchEncounterResource(
     throw new Error(`Failed to patch Encounter: ${JSON.stringify(error)}`);
   }
 }
-
-export { mapStatusToTelemed };
 
 export const telemedStatusToEncounter = (telemedStatus: TelemedCallStatuses): Encounter['status'] => {
   switch (telemedStatus) {

--- a/packages/zambdas/src/shared/pdf/visit-details-pdf/visit-note-pdf-creation.ts
+++ b/packages/zambdas/src/shared/pdf/visit-details-pdf/visit-note-pdf-creation.ts
@@ -19,12 +19,12 @@ import {
   getProviderNameWithProfession,
   getQuestionnaireResponseByLinkId,
   getSpentTime,
+  getTelemedEncounterStatusHistory,
   ImmunizationOrder,
   isDropdownComponent,
   isInPersonAppointment,
   isMultiSelectComponent,
   mapDispositionTypeToLabel,
-  mapEncounterStatusHistory,
   mapVitalsToDisplay,
   NOTE_TYPE,
   NOTHING_TO_EAT_OR_DRINK_FIELD,
@@ -382,7 +382,7 @@ function getStatusRelatedDates(
 ): { dateOfService?: string; signedOnDate?: string } {
   const statuses =
     encounter.statusHistory && appointment?.status
-      ? mapEncounterStatusHistory(encounter.statusHistory, appointment.status)
+      ? getTelemedEncounterStatusHistory(encounter.statusHistory, appointment.status)
       : undefined;
   const dateOfService = formatDateTimeToZone(statuses?.find((item) => item.status === 'on-video')?.start, timezone);
   const currentTimeISO = DateTime.now().toISO();


### PR DESCRIPTION
## Description

The goal of this PR is to fix bugs related to appointment time tracking, especially those caused by incorrect resource updates during status transitions, and to improve the history status model. The old model loses history because it relies heavily on appointment status and Participant period but only tracks FHIR encounter status and other data retrieved from the current app state rather than from the 'actual historical state'.

The main change is that we're now writing Ottehr statuses to history, while maintaining full backward compatibility. This is especially important because historical status calculation in the old system is tightly coupled with current appointment status calculation—which we didn't plan to change in this task. So when displaying status in history, the system first checks for the new extension for that status, and if not found, uses the old calculation method. The old method will work slightly better in some cases, but can't be fully relied upon since it doesn't track all necessary data—like the appointment status at that moment and other required resources. This means statuses will work correctly in new appointments, while in old appointments they'll work roughly as before. Importantly, this mainly affects in-progress statuses, so **we don't actually need to store all statuses in the statusHistory extension—only those that would be impossible to calculate later**.

## Changes and improvements:

Added required 3rd argument to `getEncounterStatusHistoryUpdateOp` for tracking ottehr history status. This sets an extension to encounter.historyStatus for tracking history.

Updated `getUpdateInPersonEncounterStatusOperation` **to support any status transition in any direction** and to close/add correct periods (only 2 statuses was supported previously). Please review this code: https://github.com/masslight/ottehr/pull/4465/files#diff-71181667cf7f82830eaf34ed7436089cab141deea959ca33d93b9f200e2b4583R131-R276.

Prevented status changes except 'pending' and 'arrived' if ATND and AMD are not set up (this dropdown will be removed later, so i made a quick fix to prevent possible bugs). I blocked 'ready' status by this alert because, according to the current logic, if we allow 'ready' it makes it possible to set a 'provider' or other unexpected status on the next attempt without setting ATND and AMD (that was possible previously but it causes bugs later). Please review this logic:
<img width="1127" height="403" alt="image" src="https://github.com/user-attachments/assets/7968ac86-884f-466a-97a6-0c3ab24bd617" />

Hidden "awaiting supervisor approval" in dropdown if feature is disabled:
<img width="209" height="292" alt="image" src="https://github.com/user-attachments/assets/d59a0e98-a36e-4eb2-98e3-ed53c9d1e506" />

Added scrolling to tooltips:
https://github.com/user-attachments/assets/55c88519-d904-407c-b8f9-3e725238f414

Highlighted long waits:
<img width="355" height="298" alt="image" src="https://github.com/user-attachments/assets/caecedba-bd64-4a6f-a6f6-307f36ab6094" />

Stopped showing time for the following statuses:
```
export const STATUSES_WITHOUT_TIME_TRACKER: VisitStatusHistoryLabel[] = [
  'pending',
  'no show',
  'cancelled',
  'completed',
  'discharged',
];
```

Fixed time calculation for statuses and overall time calculation.


