### PR TITLE
add a skip for duplicate patients checks when sending to candid 

### DIFF
--- a/packages/zambdas/src/shared/candid.ts
+++ b/packages/zambdas/src/shared/candid.ts
@@ -633,6 +633,7 @@ async function createPreEncounterPatient(
   }
 
   const patientResponse = await apiClient.preEncounter.patients.v1.createWithMrn({
+    skipDuplicateCheck: true, // continue adding to candid, even if it's a duplicate
     body: {
       mrn: medicalRecordNumber,
       name: {


### PR DESCRIPTION
need to allow duplicate patients to be inserted, regardless of the potential dupes. we can resolve in candid with billers. 