### PR TITLE
Fix tag bug in mock reflex test script

### DIFF
--- a/packages/zambdas/src/scripts/labs/lab-script-consts.ts
+++ b/packages/zambdas/src/scripts/labs/lab-script-consts.ts
@@ -19,6 +19,12 @@ export const DR_UNSOLICITED_RESULT_TAG = {
   display: LAB_DR_TYPE_TAG.display.unsolicited,
 };
 
+export const DR_REFLEX_TAG = {
+  system: LAB_DR_TYPE_TAG.system,
+  code: LAB_DR_TYPE_TAG.code.reflex,
+  display: LAB_DR_TYPE_TAG.display.reflex,
+};
+
 export const LAB_PDF_ATTACHMENT_DR_TAG = {
   system: LAB_DR_TYPE_TAG.system,
   code: LAB_DR_TYPE_TAG.code.attachment,

--- a/packages/zambdas/src/scripts/labs/reflex-test-helper.ts
+++ b/packages/zambdas/src/scripts/labs/reflex-test-helper.ts
@@ -4,7 +4,7 @@ import { CodeableConcept, DiagnosticReport, Observation, ServiceRequest } from '
 import fs from 'fs';
 import { LAB_DR_TYPE_TAG } from 'utils';
 import { createOystehrClient, getAuth0Token } from '../../shared';
-import { LAB_PDF_ATTACHMENT_DR_TAG, PDF_ATTACHMENT_CODE } from './lab-script-consts';
+import { DR_REFLEX_TAG, LAB_PDF_ATTACHMENT_DR_TAG, PDF_ATTACHMENT_CODE } from './lab-script-consts';
 import { createPdfAttachmentObs } from './lab-script-helpers';
 
 // Creates a DiagnosticReport and Observation(s) to mock a reflex test
@@ -116,9 +116,7 @@ const main = async (): Promise<void> => {
 
   const reflexDR: DiagnosticReport = { ...drToDuplicate, code: REFLEX_TEST_CODE };
   reflexDR.meta = {};
-  reflexDR.meta.tag = [
-    { system: LAB_DR_TYPE_TAG.system, code: LAB_DR_TYPE_TAG.code.reflex, display: LAB_DR_TYPE_TAG.display.reflex },
-  ];
+  reflexDR.meta.tag = [DR_REFLEX_TAG];
   reflexDR.result = resultRefsForReflexTest;
 
   // override existing filler id value
@@ -140,8 +138,11 @@ const main = async (): Promise<void> => {
   });
 
   // mock pdf attachment for reflex
-  const pdfAttachmentDR: DiagnosticReport = { ...reflexDR, code: PDF_ATTACHMENT_CODE };
-  pdfAttachmentDR.meta?.tag?.push(LAB_PDF_ATTACHMENT_DR_TAG);
+  const pdfAttachmentDR: DiagnosticReport = {
+    ...reflexDR,
+    code: PDF_ATTACHMENT_CODE,
+    meta: { tag: [DR_REFLEX_TAG, LAB_PDF_ATTACHMENT_DR_TAG] },
+  };
   const pdfAttachmentObsFullUrl = `urn:uuid:${randomUUID()}`;
   const pdfAttachmentResultRefs = [{ reference: pdfAttachmentObsFullUrl }];
   const newObsResource: Observation = createPdfAttachmentObs();


### PR DESCRIPTION
Noticed an extra pdf attachment tag was being added to the reflex DR while helping QA with regression testing