### PR TITLE
Need to tag task as unsolicited correctly format link and display on front end

### DIFF
--- a/apps/ehr/src/features/visits/in-person/hooks/useTasks.ts
+++ b/apps/ehr/src/features/visits/in-person/hooks/useTasks.ts
@@ -8,6 +8,7 @@ import {
   getExtension,
   IN_HOUSE_LAB_TASK,
   LAB_ORDER_TASK,
+  LabType,
   TASK_ASSIGNED_DATE_TIME_EXTENSION_URL,
   TASK_CATEGORY_IDENTIFIER,
   TASK_INPUT_SYSTEM,
@@ -220,6 +221,8 @@ function fhirTaskToTask(task: FhirTask): Task {
       ?.reference?.split('/')?.[1];
     const providerName = getInput(LAB_ORDER_TASK.input.providerName, task);
     const orderDate = getInput(LAB_ORDER_TASK.input.orderDate, task);
+    const labTypeString = getInput(LAB_ORDER_TASK.input.drTag, task);
+
     if (code === LAB_ORDER_TASK.code.preSubmission) {
       title = `Collect sample for “${testName}” for ${patientName}`;
       subtitle = `Ordered by ${providerName} on ${
@@ -254,6 +257,7 @@ function fhirTaskToTask(task: FhirTask): Task {
     }
     if (
       diagnosticReportId &&
+      labTypeString === LabType.unsolicited &&
       (code === LAB_ORDER_TASK.code.reviewFinalResult || code === LAB_ORDER_TASK.code.reviewCorrectedResult)
     ) {
       const receivedDate = getInput(LAB_ORDER_TASK.input.receivedDate, task);

--- a/packages/utils/lib/helpers/labs/helpers.ts
+++ b/packages/utils/lib/helpers/labs/helpers.ts
@@ -4,6 +4,7 @@ import {
   LabsTableColumn,
   MANUAL_EXTERNAL_LAB_ORDER_CATEGORY_CODING,
   ORDER_NUMBER_LEN,
+  OYSTEHR_LAB_OI_CODE_SYSTEM,
   OYSTEHR_LAB_ORDER_PLACER_ID_SYSTEM,
   PSC_HOLD_CONFIG,
 } from '../../types';
@@ -148,3 +149,25 @@ export function createOrderNumber(length = ORDER_NUMBER_LEN): string {
   });
   return result;
 }
+
+export const getTestNameFromDr = (dr: DiagnosticReport): string | undefined => {
+  const testName =
+    dr.code.coding?.find((temp) => temp.system === OYSTEHR_LAB_OI_CODE_SYSTEM)?.display ||
+    dr.code.coding?.find((temp) => temp.system === 'http://loinc.org')?.display ||
+    dr.code.coding?.find((temp) => temp.system === '(HL7_V2)')?.display;
+  return testName;
+};
+
+export const getTestItemCodeFromDr = (dr: DiagnosticReport): string | undefined => {
+  const testName =
+    dr.code.coding?.find((temp) => temp.system === OYSTEHR_LAB_OI_CODE_SYSTEM)?.code ||
+    dr.code.coding?.find((temp) => temp.system === 'http://loinc.org')?.code;
+  return testName;
+};
+
+export const getTestNameOrCodeFromDr = (dr: DiagnosticReport): string => {
+  const testName = getTestNameFromDr(dr);
+  const testItemCode = getTestItemCodeFromDr(dr);
+  const testDescription = testName || testItemCode || 'missing test name';
+  return testDescription;
+};

--- a/packages/utils/lib/types/data/labs/labs.constants.ts
+++ b/packages/utils/lib/types/data/labs/labs.constants.ts
@@ -33,6 +33,7 @@ export const LAB_ORDER_TASK = {
     orderDate: 'order-date',
     appointmentId: 'appointment-id',
     receivedDate: 'received-date',
+    drTag: 'dr-tag',
   },
 } as const;
 export type LabOrderTaskCode = (typeof LAB_ORDER_TASK.code)[keyof typeof LAB_ORDER_TASK.code];

--- a/packages/zambdas/src/ehr/get-unsolicited-results-resources/helpers.ts
+++ b/packages/zambdas/src/ehr/get-unsolicited-results-resources/helpers.ts
@@ -15,6 +15,8 @@ import {
   DR_CONTAINED_PRACTITIONER_REF,
   DR_UNSOLICITED_PATIENT_REF,
   getFullestAvailableName,
+  getTestItemCodeFromDr,
+  getTestNameOrCodeFromDr,
   GetUnsolicitedResultsDetailOutput,
   GetUnsolicitedResultsIconStatusOutput,
   GetUnsolicitedResultsMatchDataOutput,
@@ -31,8 +33,6 @@ import { parseLabOrderStatusWithSpecificTask } from '../get-lab-orders/helpers';
 import {
   AllResources,
   formatResourcesIntoDiagnosticReportLabDTO,
-  getTestItemCodeFromDr,
-  getTestNameOrCodeFromDr,
   groupResourcesByDr,
   parseAccessionNumberFromDr,
   ResourcesByDr,

--- a/packages/zambdas/src/ehr/shared/labs.ts
+++ b/packages/zambdas/src/ehr/shared/labs.ts
@@ -36,6 +36,7 @@ import {
   getCoding,
   getOrderNumber,
   getPresignedURL,
+  getTestNameOrCodeFromDr,
   getTimezone,
   IN_HOUSE_DIAGNOSTIC_REPORT_CATEGORY_CONFIG,
   IN_HOUSE_TEST_CODE_SYSTEM,
@@ -1171,26 +1172,4 @@ export const parseAccessionNumberFromDr = (result: DiagnosticReport): string => 
   }
 
   return NOT_FOUND;
-};
-
-export const getTestNameFromDr = (dr: DiagnosticReport): string | undefined => {
-  const testName =
-    dr.code.coding?.find((temp) => temp.system === OYSTEHR_LAB_OI_CODE_SYSTEM)?.display ||
-    dr.code.coding?.find((temp) => temp.system === 'http://loinc.org')?.display ||
-    dr.code.coding?.find((temp) => temp.system === '(HL7_V2)')?.display;
-  return testName;
-};
-
-export const getTestItemCodeFromDr = (dr: DiagnosticReport): string | undefined => {
-  const testName =
-    dr.code.coding?.find((temp) => temp.system === OYSTEHR_LAB_OI_CODE_SYSTEM)?.code ||
-    dr.code.coding?.find((temp) => temp.system === 'http://loinc.org')?.code;
-  return testName;
-};
-
-export const getTestNameOrCodeFromDr = (dr: DiagnosticReport): string => {
-  const testName = getTestNameFromDr(dr);
-  const testItemCode = getTestItemCodeFromDr(dr);
-  const testDescription = testName || testItemCode || 'missing test name';
-  return testDescription;
 };


### PR DESCRIPTION
While testing i noticed tasks were being incorrectly described as unsolicited because the logic assumed if there was a diagnostic report, unsolicited but all result tasks will be linked to a diagnostic report. I've just pulled an additional input which has the dr specific tag which will more definitively tell us that the task is for unsolicited results. 

There are other types of dr specific tags that we should probably handle in a more specific way, like reflex. 