### PR TITLE
Redirect correctly after matching or rejecting unsolicited results

### DIFF
--- a/apps/ehr/src/features/external-labs/components/details/FinalCardView.tsx
+++ b/apps/ehr/src/features/external-labs/components/details/FinalCardView.tsx
@@ -3,9 +3,11 @@ import BiotechOutlinedIcon from '@mui/icons-material/BiotechOutlined';
 import InfoIcon from '@mui/icons-material/InfoOutlined';
 import { LoadingButton } from '@mui/lab';
 import { Box, Button, Divider, Stack, Typography } from '@mui/material';
+import { useQueryClient } from '@tanstack/react-query';
 import { enqueueSnackbar } from 'notistack';
 import { FC } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { GET_TASKS_KEY } from 'src/features/visits/in-person/hooks/useTasks';
 import { useCancelMatchUnsolicitedResultTask } from 'src/features/visits/shared/stores/appointment/appointment.queries';
 import { ExternalLabsStatus, LAB_ORDER_UPDATE_RESOURCES_EVENTS } from 'utils';
 
@@ -27,6 +29,7 @@ export const FinalCardView: FC<FinalCardViewProps> = ({
   taskId,
 }) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const openPdf = (): void => {
     if (resultPdfUrl) {
       window.open(resultPdfUrl, '_blank');
@@ -44,8 +47,12 @@ export const FinalCardView: FC<FinalCardViewProps> = ({
           event: LAB_ORDER_UPDATE_RESOURCES_EVENTS.cancelUnsolicitedResultTask,
         },
         {
-          onSuccess: () => {
-            navigate('/unsolicited-results');
+          onSuccess: async () => {
+            await queryClient.invalidateQueries({
+              queryKey: [GET_TASKS_KEY],
+              exact: false,
+            });
+            navigate('/tasks');
           },
           onError: (error) => {
             console.error('Cancel task failed:', error);

--- a/apps/ehr/src/features/external-labs/pages/UnsolicitedResultsMatch.tsx
+++ b/apps/ehr/src/features/external-labs/pages/UnsolicitedResultsMatch.tsx
@@ -16,11 +16,13 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { useQueryClient } from '@tanstack/react-query';
 import { enqueueSnackbar } from 'notistack';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import DetailPageContainer from 'src/features/common/DetailPageContainer';
+import { GET_TASKS_KEY } from 'src/features/visits/in-person/hooks/useTasks';
 import { SearchResultParsedPatient } from 'src/features/visits/shared/components/patients-search/types';
 import {
   useCancelMatchUnsolicitedResultTask,
@@ -34,6 +36,7 @@ import { UnsolicitedVisitMatchCard } from '../components/unsolicited-results/Uns
 
 export const UnsolicitedResultsMatch: React.FC = () => {
   const { diagnosticReportId } = useParams();
+  const queryClient = useQueryClient();
   const { mutate: cancelTask, isPending: isCancelling } = useCancelMatchUnsolicitedResultTask();
   const { mutate: matchResult, isPending: isMatching } = useFinalizeUnsolicitedResultMatch();
   const navigate = useNavigate();
@@ -117,8 +120,12 @@ export const UnsolicitedResultsMatch: React.FC = () => {
           event: LAB_ORDER_UPDATE_RESOURCES_EVENTS.cancelUnsolicitedResultTask,
         },
         {
-          onSuccess: () => {
-            navigate('/unsolicited-results');
+          onSuccess: async () => {
+            await queryClient.invalidateQueries({
+              queryKey: [GET_TASKS_KEY],
+              exact: false,
+            });
+            navigate('/tasks');
           },
           onError: (error) => {
             console.error('Cancel task failed:', error);
@@ -143,8 +150,12 @@ export const UnsolicitedResultsMatch: React.FC = () => {
           srToMatchId: srIdForConfirmedMatchedVisit,
         },
         {
-          onSuccess: () => {
-            navigate('/unsolicited-results');
+          onSuccess: async () => {
+            await queryClient.invalidateQueries({
+              queryKey: [GET_TASKS_KEY],
+              exact: false,
+            });
+            navigate('/tasks');
           },
           onError: (error) => {
             console.error('Matching unsolicited result failed:', error);

--- a/apps/ehr/src/features/visits/in-person/hooks/useTasks.ts
+++ b/apps/ehr/src/features/visits/in-person/hooks/useTasks.ts
@@ -15,7 +15,7 @@ import {
   TASK_LOCATION_SYSTEM,
 } from 'utils';
 
-const GET_TASKS_KEY = 'get-tasks';
+export const GET_TASKS_KEY = 'get-tasks';
 const GO_TO_LAB_TEST = 'Go to Lab Test';
 
 export const TASKS_PAGE_SIZE = 20;
@@ -87,6 +87,10 @@ export const useGetTasks = ({
         {
           name: '_count',
           value: TASKS_PAGE_SIZE,
+        },
+        {
+          name: 'status:not',
+          value: 'cancelled',
         },
       ];
       if (page) {

--- a/apps/ehr/src/features/visits/shared/stores/appointment/appointment.queries.ts
+++ b/apps/ehr/src/features/visits/shared/stores/appointment/appointment.queries.ts
@@ -498,12 +498,14 @@ export function useFinalizeUnsolicitedResultMatch(): UseMutationResult<void, Err
   return useMutation({
     mutationFn: async (input: FinalizeUnsolicitedResultMatch) => {
       const data = await apiClient?.updateLabOrderResources(input);
-
       if (data && 'possibleRelatedSRsWithVisitDate' in data) {
         return data;
       }
-
       return;
+    },
+    onSuccess: async () => {
+      // slight delay so that the subscription zambda has time to run and when the tasks are reloaded the new ones will be there
+      await new Promise((res) => setTimeout(res, 800));
     },
   });
 }


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1147/tasks-unsolicited-results-issues