### PR TITLE
[EHR] Telemed provider tab display incorrect visits

### DIFF
--- a/apps/ehr/src/pages/TaskAdmin.tsx
+++ b/apps/ehr/src/pages/TaskAdmin.tsx
@@ -24,7 +24,8 @@ import { Task } from 'fhir/r4b';
 import { DateTime } from 'luxon';
 import React from 'react';
 import { Bar } from 'react-chartjs-2';
-import { getAllFhirSearchPages, getAllTaskTypes, TaskTypeOption } from 'utils';
+import { getAllTaskTypes, TaskTypeOption } from 'utils';
+import { getAllFhirSearchPages } from 'utils/lib/fhir/getAllFhirSearchPages';
 import { useApiClients } from '../hooks/useAppClients';
 import PageContainer from '../layout/PageContainer';
 

--- a/packages/utils/lib/fhir/chat.ts
+++ b/packages/utils/lib/fhir/chat.ts
@@ -157,6 +157,11 @@ export const getCommunicationsAndSenders = async (
   oystehr: Oystehr,
   uniqueNumbers: string[]
 ): Promise<(Communication | RelatedPerson)[]> => {
+  // // If there are no phone numbers, return empty array to avoid FHIR error
+  if (uniqueNumbers.length === 0) {
+    return [];
+  }
+
   return (
     await oystehr.fhir.search<Communication | RelatedPerson>({
       resourceType: 'Communication',

--- a/packages/utils/lib/fhir/constants.ts
+++ b/packages/utils/lib/fhir/constants.ts
@@ -27,7 +27,7 @@ import {
   SCHOOL_WORK_NOTE_TEMPLATE_CODE,
   VISIT_NOTE_SUMMARY_CODE,
 } from '../types';
-import { ottehrCodeSystemUrl, ottehrExtensionUrl, ottehrIdentifierSystem } from './helpers';
+import { ottehrCodeSystemUrl, ottehrExtensionUrl, ottehrIdentifierSystem } from './systemUrls';
 
 // nota bene: some legacy resources could be using 'http' instead of 'https' here, and there are still some string vals out there with http
 export const PRIVATE_EXTENSION_BASE_URL = 'https://fhir.zapehr.com/r4/StructureDefinitions';

--- a/packages/utils/lib/fhir/deduplicateUnbundledResources.ts
+++ b/packages/utils/lib/fhir/deduplicateUnbundledResources.ts
@@ -1,0 +1,9 @@
+import { Resource } from 'fhir/r4b';
+
+export const deduplicateUnbundledResources = <T extends Resource>(unbundledResources: T[]): T[] => {
+  const uniqueObjects: Record<string, T> = {};
+  unbundledResources.forEach((object) => {
+    uniqueObjects[`${object.resourceType}/${object.id}`] = object;
+  });
+  return Object.values(uniqueObjects);
+};

--- a/packages/utils/lib/fhir/getAllFhirSearchPages.ts
+++ b/packages/utils/lib/fhir/getAllFhirSearchPages.ts
@@ -1,0 +1,42 @@
+import Oystehr, { FhirResource, FhirSearchParams } from '@oystehr/sdk';
+import { Resource } from 'fhir/r4b';
+import { deduplicateUnbundledResources } from './deduplicateUnbundledResources';
+
+export async function getAllFhirSearchPages<T extends FhirResource>(
+  fhirSearchParams: FhirSearchParams<T>,
+  oystehr: Oystehr,
+  maxMatchPerBatch = 1000
+): Promise<T[]> {
+  let currentIndex = 0;
+  let total = 1;
+  const result: T[] = [];
+  // Create a new array to avoid mutating the original params
+  const params = [
+    ...(fhirSearchParams.params ?? []),
+    { name: '_count', value: `${maxMatchPerBatch}` },
+    { name: '_total', value: 'accurate' },
+  ];
+  while (currentIndex < total) {
+    const bundledResponse = await oystehr.fhir.search<T>({
+      resourceType: fhirSearchParams.resourceType,
+      params: [...params, { name: '_offset', value: `${currentIndex}` }],
+    });
+    const matchedCount = bundledResponse.entry?.filter((entry) => entry.search?.mode === 'match').length || 0;
+    total = bundledResponse.total || 0;
+    const unbundled = bundledResponse.unbundle();
+    result.push(...unbundled);
+    currentIndex += matchedCount;
+  }
+
+  // Deduplicate to ensure idempotency - same params should return same results regardless of batch size
+  const deduplicated = deduplicateUnbundledResources(result as Resource[]);
+  const duplicateCount = result.length - deduplicated.length;
+
+  console.log(
+    'Found',
+    currentIndex,
+    `${fhirSearchParams.resourceType} resources and ${result.length - currentIndex} included resources`,
+    duplicateCount > 0 ? `(removed ${duplicateCount} duplicates)` : ''
+  );
+  return deduplicated as T[];
+}

--- a/packages/utils/lib/fhir/helpers.getAllFhirSearchPages.test.ts
+++ b/packages/utils/lib/fhir/helpers.getAllFhirSearchPages.test.ts
@@ -1,0 +1,444 @@
+import { Bundle, FhirResource, Patient } from 'fhir/r4b';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAllFhirSearchPages } from './getAllFhirSearchPages';
+
+// Mock Oystehr SDK
+const mockOystehr = {
+  fhir: {
+    search: vi.fn(),
+  },
+};
+
+describe('getAllFhirSearchPages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch all resources from a single page when total matches count', async () => {
+    const mockPatients: Patient[] = [
+      { resourceType: 'Patient', id: '1', name: [{ family: 'Smith', given: ['John'] }] },
+      { resourceType: 'Patient', id: '2', name: [{ family: 'Doe', given: ['Jane'] }] },
+    ];
+
+    const mockBundle: Bundle<Patient> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      total: 2,
+      entry: mockPatients.map((patient) => ({
+        resource: patient,
+        search: { mode: 'match' },
+      })),
+      link: [{ relation: 'self', url: 'http://example.com/Patient?_count=100&_offset=0' }],
+    };
+
+    // Mock unbundle method
+    (mockBundle as any).unbundle = () => mockPatients;
+
+    mockOystehr.fhir.search.mockResolvedValueOnce(mockBundle);
+
+    const result = await getAllFhirSearchPages<Patient>(
+      {
+        resourceType: 'Patient',
+        params: [{ name: 'name', value: 'Smith' }],
+      },
+      mockOystehr as any,
+      100
+    );
+
+    expect(result).toEqual(mockPatients);
+    expect(mockOystehr.fhir.search).toHaveBeenCalledTimes(1);
+    expect(mockOystehr.fhir.search).toHaveBeenCalledWith({
+      resourceType: 'Patient',
+      params: expect.arrayContaining([
+        { name: 'name', value: 'Smith' },
+        { name: '_count', value: '100' },
+        { name: '_total', value: 'accurate' },
+        { name: '_offset', value: '0' },
+      ]),
+    });
+  });
+
+  it('should fetch all resources across multiple pages', async () => {
+    const page1Patients: Patient[] = [
+      { resourceType: 'Patient', id: '1', name: [{ family: 'Smith', given: ['John'] }] },
+      { resourceType: 'Patient', id: '2', name: [{ family: 'Doe', given: ['Jane'] }] },
+    ];
+
+    const page2Patients: Patient[] = [
+      { resourceType: 'Patient', id: '3', name: [{ family: 'Brown', given: ['Bob'] }] },
+      { resourceType: 'Patient', id: '4', name: [{ family: 'White', given: ['Alice'] }] },
+    ];
+
+    const page3Patients: Patient[] = [
+      { resourceType: 'Patient', id: '5', name: [{ family: 'Green', given: ['Charlie'] }] },
+    ];
+
+    const mockBundle1: Bundle<Patient> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      total: 5,
+      entry: page1Patients.map((patient) => ({
+        resource: patient,
+        search: { mode: 'match' },
+      })),
+      link: [
+        { relation: 'self', url: 'http://example.com/Patient?_count=2&_offset=0' },
+        { relation: 'next', url: 'http://example.com/Patient?_count=2&_offset=2' },
+      ],
+    };
+
+    const mockBundle2: Bundle<Patient> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      total: 5,
+      entry: page2Patients.map((patient) => ({
+        resource: patient,
+        search: { mode: 'match' },
+      })),
+      link: [
+        { relation: 'self', url: 'http://example.com/Patient?_count=2&_offset=2' },
+        { relation: 'next', url: 'http://example.com/Patient?_count=2&_offset=4' },
+      ],
+    };
+
+    const mockBundle3: Bundle<Patient> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      total: 5,
+      entry: page3Patients.map((patient) => ({
+        resource: patient,
+        search: { mode: 'match' },
+      })),
+      link: [{ relation: 'self', url: 'http://example.com/Patient?_count=2&_offset=4' }],
+    };
+
+    // Mock unbundle method for each bundle
+    (mockBundle1 as any).unbundle = () => page1Patients;
+    (mockBundle2 as any).unbundle = () => page2Patients;
+    (mockBundle3 as any).unbundle = () => page3Patients;
+
+    mockOystehr.fhir.search
+      .mockResolvedValueOnce(mockBundle1)
+      .mockResolvedValueOnce(mockBundle2)
+      .mockResolvedValueOnce(mockBundle3);
+
+    const result = await getAllFhirSearchPages<Patient>(
+      {
+        resourceType: 'Patient',
+        params: [],
+      },
+      mockOystehr as any,
+      2
+    );
+
+    expect(result).toEqual([...page1Patients, ...page2Patients, ...page3Patients]);
+    expect(mockOystehr.fhir.search).toHaveBeenCalledTimes(3);
+    expect(mockOystehr.fhir.search).toHaveBeenNthCalledWith(1, {
+      resourceType: 'Patient',
+      params: expect.arrayContaining([
+        { name: '_count', value: '2' },
+        { name: '_total', value: 'accurate' },
+        { name: '_offset', value: '0' },
+      ]),
+    });
+    expect(mockOystehr.fhir.search).toHaveBeenNthCalledWith(2, {
+      resourceType: 'Patient',
+      params: expect.arrayContaining([
+        { name: '_count', value: '2' },
+        { name: '_total', value: 'accurate' },
+        { name: '_offset', value: '2' },
+      ]),
+    });
+    expect(mockOystehr.fhir.search).toHaveBeenNthCalledWith(3, {
+      resourceType: 'Patient',
+      params: expect.arrayContaining([
+        { name: '_count', value: '2' },
+        { name: '_total', value: 'accurate' },
+        { name: '_offset', value: '4' },
+      ]),
+    });
+  });
+
+  it('should handle included resources (non-match entries)', async () => {
+    const matchPatients: Patient[] = [
+      { resourceType: 'Patient', id: '1', name: [{ family: 'Smith', given: ['John'] }] },
+    ];
+
+    const includedOrganization = {
+      resourceType: 'Organization',
+      id: 'org-1',
+      name: 'Test Organization',
+    };
+
+    const mockBundle: Bundle<FhirResource> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      total: 1,
+      entry: [
+        {
+          resource: matchPatients[0],
+          search: { mode: 'match' },
+        },
+        {
+          resource: includedOrganization as any,
+          search: { mode: 'include' },
+        },
+      ],
+      link: [{ relation: 'self', url: 'http://example.com/Patient?_count=100&_offset=0' }],
+    };
+
+    // Mock unbundle to return all entries
+    (mockBundle as any).unbundle = () => [matchPatients[0], includedOrganization];
+
+    mockOystehr.fhir.search.mockResolvedValueOnce(mockBundle);
+
+    const result = await getAllFhirSearchPages<FhirResource>(
+      {
+        resourceType: 'Patient',
+        params: [{ name: '_include', value: 'Patient:organization' }],
+      },
+      mockOystehr as any,
+      100
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual([matchPatients[0], includedOrganization]);
+    expect(mockOystehr.fhir.search).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return empty array when no resources found', async () => {
+    const mockBundle: Bundle<Patient> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      total: 0,
+      entry: [],
+      link: [{ relation: 'self', url: 'http://example.com/Patient?_count=100&_offset=0' }],
+    };
+
+    (mockBundle as any).unbundle = () => [];
+
+    mockOystehr.fhir.search.mockResolvedValueOnce(mockBundle);
+
+    const result = await getAllFhirSearchPages<Patient>(
+      {
+        resourceType: 'Patient',
+        params: [{ name: 'identifier', value: 'non-existent' }],
+      },
+      mockOystehr as any,
+      100
+    );
+
+    expect(result).toEqual([]);
+    expect(mockOystehr.fhir.search).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use custom maxMatchPerBatch parameter', async () => {
+    const mockPatients: Patient[] = [
+      { resourceType: 'Patient', id: '1', name: [{ family: 'Smith', given: ['John'] }] },
+    ];
+
+    const mockBundle: Bundle<Patient> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      total: 1,
+      entry: mockPatients.map((patient) => ({
+        resource: patient,
+        search: { mode: 'match' },
+      })),
+      link: [{ relation: 'self', url: 'http://example.com/Patient?_count=50&_offset=0' }],
+    };
+
+    (mockBundle as any).unbundle = () => mockPatients;
+
+    mockOystehr.fhir.search.mockResolvedValueOnce(mockBundle);
+
+    await getAllFhirSearchPages<Patient>(
+      {
+        resourceType: 'Patient',
+        params: [],
+      },
+      mockOystehr as any,
+      50
+    );
+
+    expect(mockOystehr.fhir.search).toHaveBeenCalledWith({
+      resourceType: 'Patient',
+      params: expect.arrayContaining([{ name: '_count', value: '50' }]),
+    });
+  });
+
+  it('should preserve original search parameters across pagination', async () => {
+    const page1Patients: Patient[] = [
+      { resourceType: 'Patient', id: '1', name: [{ family: 'Smith', given: ['John'] }] },
+    ];
+
+    const page2Patients: Patient[] = [
+      { resourceType: 'Patient', id: '2', name: [{ family: 'Smith', given: ['Jane'] }] },
+    ];
+
+    const mockBundle1: Bundle<Patient> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      total: 2,
+      entry: page1Patients.map((patient) => ({
+        resource: patient,
+        search: { mode: 'match' },
+      })),
+      link: [
+        { relation: 'self', url: 'http://example.com/Patient?_count=1&_offset=0' },
+        { relation: 'next', url: 'http://example.com/Patient?_count=1&_offset=1' },
+      ],
+    };
+
+    const mockBundle2: Bundle<Patient> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      total: 2,
+      entry: page2Patients.map((patient) => ({
+        resource: patient,
+        search: { mode: 'match' },
+      })),
+      link: [{ relation: 'self', url: 'http://example.com/Patient?_count=1&_offset=1' }],
+    };
+
+    (mockBundle1 as any).unbundle = () => page1Patients;
+    (mockBundle2 as any).unbundle = () => page2Patients;
+
+    mockOystehr.fhir.search.mockResolvedValueOnce(mockBundle1).mockResolvedValueOnce(mockBundle2);
+
+    await getAllFhirSearchPages<Patient>(
+      {
+        resourceType: 'Patient',
+        params: [
+          { name: 'family', value: 'Smith' },
+          { name: '_sort', value: 'name' },
+        ],
+      },
+      mockOystehr as any,
+      1
+    );
+
+    expect(mockOystehr.fhir.search).toHaveBeenNthCalledWith(1, {
+      resourceType: 'Patient',
+      params: expect.arrayContaining([
+        { name: 'family', value: 'Smith' },
+        { name: '_sort', value: 'name' },
+      ]),
+    });
+
+    expect(mockOystehr.fhir.search).toHaveBeenNthCalledWith(2, {
+      resourceType: 'Patient',
+      params: expect.arrayContaining([
+        { name: 'family', value: 'Smith' },
+        { name: '_sort', value: 'name' },
+      ]),
+    });
+  });
+
+  it('should not mutate the original params array', async () => {
+    const originalParams = [{ name: 'family', value: 'Smith' }];
+    const mockPatients: Patient[] = [
+      { resourceType: 'Patient', id: '1', name: [{ family: 'Smith', given: ['John'] }] },
+    ];
+
+    const mockBundle: Bundle<Patient> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      total: 1,
+      entry: mockPatients.map((patient) => ({
+        resource: patient,
+        search: { mode: 'match' },
+      })),
+      link: [{ relation: 'self', url: 'http://example.com/Patient?_count=100&_offset=0' }],
+    };
+
+    (mockBundle as any).unbundle = () => mockPatients;
+
+    mockOystehr.fhir.search.mockResolvedValueOnce(mockBundle);
+
+    await getAllFhirSearchPages<Patient>(
+      {
+        resourceType: 'Patient',
+        params: originalParams,
+      },
+      mockOystehr as any,
+      100
+    );
+
+    // Verify original params array was not mutated
+    expect(originalParams).toEqual([{ name: 'family', value: 'Smith' }]);
+    expect(originalParams.length).toBe(1);
+  });
+
+  it('should handle duplicate resources across pages', async () => {
+    // Simulate pagination where the same Patient appears in multiple pages
+    // This can happen with included resources
+    const sharedPatient: Patient = {
+      resourceType: 'Patient',
+      id: 'shared-1',
+      name: [{ family: 'Shared', given: ['Patient'] }],
+    };
+
+    const page1Patients: Patient[] = [
+      { resourceType: 'Patient', id: '1', name: [{ family: 'Smith', given: ['John'] }] },
+      sharedPatient, // Same patient in page 1
+    ];
+
+    const page2Patients: Patient[] = [
+      { resourceType: 'Patient', id: '2', name: [{ family: 'Doe', given: ['Jane'] }] },
+      sharedPatient, // Same patient in page 2 (duplicate)
+    ];
+
+    const mockBundle1: Bundle<Patient> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      total: 2, // Total of 2 match entries (patient 1 and patient 2)
+      entry: page1Patients.map((patient) => ({
+        resource: patient,
+        search: { mode: patient.id === 'shared-1' ? 'include' : 'match' },
+      })),
+      link: [
+        { relation: 'self', url: 'http://example.com/Patient?_count=2&_offset=0' },
+        { relation: 'next', url: 'http://example.com/Patient?_count=2&_offset=1' },
+      ],
+    };
+
+    const mockBundle2: Bundle<Patient> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      total: 2, // Total of 2 match entries (patient 1 and patient 2)
+      entry: page2Patients.map((patient) => ({
+        resource: patient,
+        search: { mode: patient.id === 'shared-1' ? 'include' : 'match' },
+      })),
+      link: [{ relation: 'self', url: 'http://example.com/Patient?_count=2&_offset=1' }],
+    };
+
+    (mockBundle1 as any).unbundle = () => page1Patients;
+    (mockBundle2 as any).unbundle = () => page2Patients;
+
+    mockOystehr.fhir.search.mockResolvedValueOnce(mockBundle1).mockResolvedValueOnce(mockBundle2);
+
+    const result = await getAllFhirSearchPages<Patient>(
+      {
+        resourceType: 'Patient',
+        params: [{ name: '_include', value: 'Patient:organization' }],
+      },
+      mockOystehr as any,
+      2
+    );
+
+    // Should deduplicate automatically for idempotency
+    // The function now ensures that changing batch size doesn't affect the result
+    expect(result).toHaveLength(3);
+
+    // Verify each unique patient appears only once
+    const patient1Occurrences = result.filter((p) => p.id === '1');
+    const patient2Occurrences = result.filter((p) => p.id === '2');
+    const sharedPatientOccurrences = result.filter((p) => p.id === 'shared-1');
+
+    expect(patient1Occurrences).toHaveLength(1);
+    expect(patient2Occurrences).toHaveLength(1);
+    expect(sharedPatientOccurrences).toHaveLength(1);
+  });
+});

--- a/packages/utils/lib/fhir/helpers.ts
+++ b/packages/utils/lib/fhir/helpers.ts
@@ -1,4 +1,4 @@
-import Oystehr, { BatchInputPostRequest, FhirSearchParams, SearchParam } from '@oystehr/sdk';
+import Oystehr, { BatchInputPostRequest, SearchParam } from '@oystehr/sdk';
 import { Operation } from 'fast-json-patch';
 import {
   Account,
@@ -1317,14 +1317,6 @@ export function slashPathToLodashPath(slashPath: string): string {
     .replace(/\.\[/g, '[');
 }
 
-export const deduplicateUnbundledResources = <T extends Resource>(unbundledResources: T[]): T[] => {
-  const uniqueObjects: Record<string, T> = {};
-  unbundledResources.forEach((object) => {
-    uniqueObjects[`${object.resourceType}/${object.id}`] = object;
-  });
-  return Object.values(uniqueObjects);
-};
-
 export const takeContainedOrFind = <T extends Resource>(
   referenceString: string,
   resourceList: Resource[],
@@ -1384,55 +1376,6 @@ export const getSlugForBookableResource = (resource: BookableResource): string |
     return id.system === SLUG_SYSTEM;
   })?.value;
 };
-
-const OTTEHR_FHIR_URL = 'https://fhir.ottehr.com';
-
-export const ottehrCodeSystemUrl = (name: string): string => {
-  return OTTEHR_FHIR_URL + '/CodeSystem/' + name;
-};
-
-export const ottehrValueSetUrl = (name: string): string => {
-  return OTTEHR_FHIR_URL + '/ValueSet/' + name;
-};
-
-export const ottehrExtensionUrl = (name: string): string => {
-  return OTTEHR_FHIR_URL + '/Extension/' + name;
-};
-
-export const ottehrIdentifierSystem = (name: string): string => {
-  return OTTEHR_FHIR_URL + '/Identifier/' + name;
-};
-
-export async function getAllFhirSearchPages<T extends FhirResource>(
-  fhirSearchParams: FhirSearchParams<T>,
-  oystehr: Oystehr,
-  maxMatchPerBatch = 1000
-): Promise<T[]> {
-  let currentIndex = 0;
-  let total = 1;
-  const result: T[] = [];
-  const params = fhirSearchParams.params ?? [];
-  params.push({ name: '_count', value: `${maxMatchPerBatch}` }); // Set the count to 100 for each page
-  params.push({ name: '_total', value: 'accurate' });
-  while (currentIndex < total) {
-    const bundledResponse = await oystehr.fhir.search<T>({
-      resourceType: fhirSearchParams.resourceType,
-      params: [...params, { name: '_offset', value: `${currentIndex}` }],
-    });
-    const matchedCount = bundledResponse.entry?.filter((entry) => entry.search?.mode === 'match').length || 0;
-    total = bundledResponse.total || 0;
-    const unbundled = bundledResponse.unbundle();
-    result.push(...unbundled);
-    currentIndex += matchedCount;
-  }
-
-  console.log(
-    'Found',
-    currentIndex,
-    `${fhirSearchParams.resourceType} resources and ${result.length - currentIndex} included resources`
-  );
-  return result;
-}
 
 export function getCoding(
   codeableConcept: CodeableConcept | CodeableConcept[] | undefined,

--- a/packages/utils/lib/fhir/systemUrls.ts
+++ b/packages/utils/lib/fhir/systemUrls.ts
@@ -1,0 +1,17 @@
+const OTTEHR_FHIR_URL = 'https://fhir.ottehr.com';
+
+export const ottehrCodeSystemUrl = (name: string): string => {
+  return OTTEHR_FHIR_URL + '/CodeSystem/' + name;
+};
+
+export const ottehrValueSetUrl = (name: string): string => {
+  return OTTEHR_FHIR_URL + '/ValueSet/' + name;
+};
+
+export const ottehrExtensionUrl = (name: string): string => {
+  return OTTEHR_FHIR_URL + '/Extension/' + name;
+};
+
+export const ottehrIdentifierSystem = (name: string): string => {
+  return OTTEHR_FHIR_URL + '/Identifier/' + name;
+};

--- a/packages/utils/lib/types/api/medication-administration.constants.ts
+++ b/packages/utils/lib/types/api/medication-administration.constants.ts
@@ -1,4 +1,4 @@
-import { ottehrCodeSystemUrl } from '../../fhir/helpers';
+import { ottehrCodeSystemUrl } from '../../fhir/systemUrls';
 
 // todo review all this systems and codes
 export const MEDICATION_TYPE_SYSTEM = 'virtual-medication-type';

--- a/packages/utils/lib/types/api/procedures.constants.ts
+++ b/packages/utils/lib/types/api/procedures.constants.ts
@@ -1,4 +1,4 @@
-import { ottehrExtensionUrl, ottehrValueSetUrl } from '../../fhir/helpers';
+import { ottehrExtensionUrl, ottehrValueSetUrl } from '../../fhir/systemUrls';
 
 export const PROCEDURE_TYPES_VALUE_SET_URL = ottehrValueSetUrl('procedure-type');
 export const MEDICATIONS_USED_VALUE_SET_URL = ottehrValueSetUrl('procedure-medications-used');

--- a/packages/utils/lib/utils/e2eCleanup.ts
+++ b/packages/utils/lib/utils/e2eCleanup.ts
@@ -1,7 +1,8 @@
 import Oystehr, { BatchInputDeleteRequest, FhirSearchParams } from '@oystehr/sdk';
 import { Operation } from 'fast-json-patch';
 import { Appointment, Coding, FhirResource, Observation, Patient, Person } from 'fhir/r4b';
-import { chunkThings, getAllFhirSearchPages } from '../fhir';
+import { chunkThings } from '../fhir';
+import { getAllFhirSearchPages } from '../fhir/getAllFhirSearchPages';
 import { sleep } from '../helpers';
 
 export const cleanAppointmentGraph = async (tag: Coding, oystehr: Oystehr): Promise<boolean> => {

--- a/packages/zambdas/src/ehr/get-telemed-appointments/helpers/fhir-utils.ts
+++ b/packages/zambdas/src/ehr/get-telemed-appointments/helpers/fhir-utils.ts
@@ -9,6 +9,7 @@ import {
   OTTEHR_MODULE,
   PatientFilterType,
 } from 'utils';
+import { getAllFhirSearchPages } from 'utils/lib/fhir/getAllFhirSearchPages';
 import { joinLocationsIdsForFhirSearch } from './helpers';
 import { mapStatesToLocationIds, mapTelemedStatusToEncounterAndAppointment } from './mappers';
 import { LocationIdToStateAbbreviationMap } from './types';
@@ -39,7 +40,6 @@ export const getAllResourcesFromFhir = async (
         name: '_sort',
         value: 'date',
       },
-      { name: '_count', value: '1000' },
       {
         name: '_include',
         value: 'Appointment:patient',
@@ -95,9 +95,11 @@ export const getAllResourcesFromFhir = async (
     ],
   };
 
-  return (await oystehr.fhir.search<FhirResource>(fhirSearchParams))
-    .unbundle()
-    .filter((resource) => isNonPaperworkQuestionnaireResponse(resource) === false);
+  const allResources = await getAllFhirSearchPages<FhirResource>(fhirSearchParams, oystehr, 100);
+
+  const filtered = allResources.filter((resource) => isNonPaperworkQuestionnaireResponse(resource) === false);
+
+  return filtered;
 };
 
 export const getPractitionerLicensesLocationsAbbreviations = async (oystehr: Oystehr): Promise<string[]> => {

--- a/packages/zambdas/src/ehr/immunization/common.ts
+++ b/packages/zambdas/src/ehr/immunization/common.ts
@@ -7,11 +7,11 @@ import {
   MEDICATION_ADMINISTRATION_PERFORMER_TYPE_SYSTEM,
   MEDICATION_ADMINISTRATION_ROUTES_CODES_SYSTEM,
   MEDICATION_ADMINISTRATION_UNITS_SYSTEM,
-  ottehrExtensionUrl,
   PRACTITIONER_ORDERED_BY_MEDICATION_CODE,
   searchMedicationLocation,
   searchRouteByCode,
 } from 'utils';
+import { ottehrExtensionUrl } from 'utils/lib/fhir/systemUrls';
 import { createMedicationCopy } from '../create-update-medication-order/helpers';
 
 export const CONTAINED_MEDICATION_ID = 'medication';

--- a/packages/zambdas/src/ehr/shared/harvest/index.ts
+++ b/packages/zambdas/src/ehr/shared/harvest/index.ts
@@ -52,7 +52,6 @@ import {
   deduplicateContactPoints,
   deduplicateIdentifiers,
   deduplicateObjectsByStrictKeyValEquality,
-  deduplicateUnbundledResources,
   extractResourceTypeAndPath,
   FHIR_BASE_URL,
   FHIR_EXTENSION,
@@ -116,6 +115,7 @@ import {
   takeContainedOrFind,
   uploadPDF,
 } from 'utils';
+import { deduplicateUnbundledResources } from 'utils/lib/fhir/deduplicateUnbundledResources';
 import { createOrUpdateFlags } from '../../../patient/paperwork/sharedHelpers';
 import { createPdfBytes, ensureStripeCustomerId } from '../../../shared';
 

--- a/packages/zambdas/src/scripts/delete-patient-data.ts
+++ b/packages/zambdas/src/scripts/delete-patient-data.ts
@@ -1,7 +1,8 @@
 import Oystehr, { BatchInputDeleteRequest, FhirSearchParams } from '@oystehr/sdk';
 import { Appointment, DocumentReference, Encounter, FhirResource, Patient, Person, RelatedPerson } from 'fhir/r4b';
 import { DateTime } from 'luxon';
-import { chunkThings, getAllFhirSearchPages, NEVER_DELETE } from 'utils';
+import { chunkThings, NEVER_DELETE } from 'utils';
+import { getAllFhirSearchPages } from 'utils/lib/fhir/getAllFhirSearchPages';
 
 const CHUNK_SIZE = 50;
 // in this script, deleting RelatedPersons is expected

--- a/packages/zambdas/src/shared/tasks.ts
+++ b/packages/zambdas/src/shared/tasks.ts
@@ -1,6 +1,7 @@
 import { CodeableConcept, Coding, Task, TaskInput } from 'fhir/r4b';
 import { DateTime } from 'luxon';
-import { ottehrCodeSystemUrl, ottehrIdentifierSystem, undefinedIfEmptyArray } from 'utils';
+import { undefinedIfEmptyArray } from 'utils';
+import { ottehrCodeSystemUrl, ottehrIdentifierSystem } from 'utils/lib/fhir/systemUrls';
 
 export const TASK_TYPE_SYSTEM = ottehrCodeSystemUrl('task-type');
 const TASK_LOCATION_SYSTEM = ottehrCodeSystemUrl('task-location');


### PR DESCRIPTION
Changes:

- Split large Telemed appointment request (1000 appointments) into paginated requests to avoid FHIR errors
- Skip requests to FHIR when data is incomplete to prevent FHIR errors
- Added deduplication to updated pagination fetch function for consistent results
- Added unit tests for updated fetching function
- Fixed cyclic dependency errors in unit tests (moved some code from utils into separate files)