### PR TITLE
replace e2e tests with component test

### DIFF
--- a/apps/ehr/tests/component/AddPatientValidation.test.tsx
+++ b/apps/ehr/tests/component/AddPatientValidation.test.tsx
@@ -1,0 +1,327 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter, useNavigate } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dataTestIds } from '../../src/constants/data-test-ids';
+import AddPatient from '../../src/pages/AddPatient';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: vi.fn(),
+  };
+});
+
+// Mock the API client hooks to avoid authentication errors
+vi.mock('../../src/hooks/useAppClients', () => ({
+  useApiClients: () => ({
+    oystehr: {
+      fhir: {
+        search: vi.fn().mockResolvedValue({
+          unbundle: () => [],
+        }),
+      },
+    },
+    oystehrZambda: null,
+  }),
+}));
+
+describe('AddPatient - Validation Tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Cancel button navigates back to visits page', async () => {
+    const user = userEvent.setup();
+    const navigateMock = vi.fn();
+    vi.mocked(useNavigate).mockReturnValue(navigateMock);
+
+    render(
+      <BrowserRouter>
+        <AddPatient />
+      </BrowserRouter>
+    );
+
+    const cancelButton = screen.getByTestId(dataTestIds.addPatientPage.cancelButton);
+    expect(cancelButton).toBeVisible();
+
+    await user.click(cancelButton);
+    expect(navigateMock).toHaveBeenCalledWith('/visits');
+  });
+
+  it('Shows validation error on mobile phone field when searching without entering a phone number', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BrowserRouter>
+        <AddPatient />
+      </BrowserRouter>
+    );
+
+    await user.click(screen.getByTestId(dataTestIds.addPatientPage.searchForPatientsButton));
+
+    const errorMessage = screen.getByText('Phone number must be 10 digits in the format (xxx) xxx-xxxx');
+    expect(errorMessage).toBeVisible();
+  });
+
+  it('Shows validation error on mobile phone field when searching with an invalid phone number', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BrowserRouter>
+        <AddPatient />
+      </BrowserRouter>
+    );
+
+    const phoneNumberInput = screen.getByTestId(dataTestIds.addPatientPage.mobilePhoneInput).querySelector('input');
+
+    await user.click(phoneNumberInput!);
+    await user.paste('123'); // Invalid number (less than 10 digits)
+
+    await user.click(screen.getByTestId(dataTestIds.addPatientPage.searchForPatientsButton));
+
+    const errorMessage = screen.getByText('Phone number must be 10 digits in the format (xxx) xxx-xxxx');
+    expect(errorMessage).toBeVisible();
+  });
+
+  it('Shows validation error on date of birth field when entering an invalid date format', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BrowserRouter>
+        <AddPatient />
+      </BrowserRouter>
+    );
+
+    // First, complete the phone search flow to reveal the date of birth field
+    const phoneNumberInput = screen.getByTestId(dataTestIds.addPatientPage.mobilePhoneInput).querySelector('input');
+
+    await user.click(phoneNumberInput!);
+    await user.paste('1234567890');
+    await user.click(screen.getByTestId(dataTestIds.addPatientPage.searchForPatientsButton));
+
+    // Wait for the dialog to appear and then click the "Patient Not Found" button
+    const notFoundButton = await screen.findByTestId(dataTestIds.addPatientPage.patientNotFoundButton);
+    await user.click(notFoundButton);
+
+    // Now test the date validation
+    const dateOfBirthInput = await screen.findByPlaceholderText('MM/DD/YYYY');
+    expect(dateOfBirthInput).toBeVisible();
+
+    await user.click(dateOfBirthInput);
+    await user.paste('3'); // Invalid date format
+    await user.tab(); // Trigger validation by moving focus away
+
+    const errorMessage = screen.getByText('please enter date in format MM/DD/YYYY');
+    expect(errorMessage).toBeVisible();
+  });
+
+  describe('Required field validation', () => {
+    it('Shows error when clicking Add button without selecting a location', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <BrowserRouter>
+          <AddPatient />
+        </BrowserRouter>
+      );
+
+      const addButton = screen.getByTestId(dataTestIds.addPatientPage.addButton);
+      await user.click(addButton);
+
+      // HTML5 validation should prevent submission - form should still be visible
+      expect(screen.getByTestId(dataTestIds.addPatientPage.locationHeader)).toBeInTheDocument();
+
+      // Verify location input has required attribute
+      const locationInput = screen.getByTestId(dataTestIds.dashboard.locationSelect).querySelector('input');
+      expect(locationInput).toHaveAttribute('required');
+    });
+
+    it('Shows error message when clicking Add button without searching for patient', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <BrowserRouter>
+          <AddPatient />
+        </BrowserRouter>
+      );
+
+      // Enter phone number but don't search
+      const phoneNumberInput = screen.getByTestId(dataTestIds.addPatientPage.mobilePhoneInput).querySelector('input');
+      await user.click(phoneNumberInput!);
+      await user.paste('1234567890');
+
+      const addButton = screen.getByTestId(dataTestIds.addPatientPage.addButton);
+      await user.click(addButton);
+
+      // Should show specific error about needing to search
+      const errorMessage = screen.getByText('Please search for patients before adding');
+      expect(errorMessage).toBeVisible();
+    });
+
+    it('Validates all required fields are present after patient search', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <BrowserRouter>
+          <AddPatient />
+        </BrowserRouter>
+      );
+
+      // Complete phone search flow
+      const phoneNumberInput = screen.getByTestId(dataTestIds.addPatientPage.mobilePhoneInput).querySelector('input');
+      await user.click(phoneNumberInput!);
+      await user.paste('1234567890');
+      await user.click(screen.getByTestId(dataTestIds.addPatientPage.searchForPatientsButton));
+
+      const notFoundButton = await screen.findByTestId(dataTestIds.addPatientPage.patientNotFoundButton);
+      await user.click(notFoundButton);
+
+      // Verify all required fields are present with required attribute
+      const firstNameInput = screen.getByTestId(dataTestIds.addPatientPage.firstNameInput).querySelector('input');
+      expect(firstNameInput).toHaveAttribute('required');
+
+      const lastNameInput = screen.getByTestId(dataTestIds.addPatientPage.lastNameInput).querySelector('input');
+      expect(lastNameInput).toHaveAttribute('required');
+
+      const dateOfBirthInput = await screen.findByPlaceholderText('MM/DD/YYYY');
+      expect(dateOfBirthInput).toHaveAttribute('required');
+
+      const sexAtBirthInput = screen.getByTestId(dataTestIds.addPatientPage.sexAtBirthDropdown).querySelector('input');
+      expect(sexAtBirthInput).toHaveAttribute('required');
+
+      const reasonForVisitInput = screen
+        .getByTestId(dataTestIds.addPatientPage.reasonForVisitDropdown)
+        .querySelector('input');
+      expect(reasonForVisitInput).toHaveAttribute('required');
+
+      const visitTypeInput = screen.getByTestId(dataTestIds.addPatientPage.visitTypeDropdown).querySelector('input');
+      expect(visitTypeInput).toHaveAttribute('required');
+    });
+
+    it('Shows dialog when clicking Add for prebook visit without selecting a time slot', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <BrowserRouter>
+          <AddPatient />
+        </BrowserRouter>
+      );
+
+      // Complete the form up to visit type selection
+      const phoneNumberInput = screen.getByTestId(dataTestIds.addPatientPage.mobilePhoneInput).querySelector('input');
+      await user.click(phoneNumberInput!);
+      await user.paste('1234567890');
+      await user.click(screen.getByTestId(dataTestIds.addPatientPage.searchForPatientsButton));
+
+      const notFoundButton = await screen.findByTestId(dataTestIds.addPatientPage.patientNotFoundButton);
+      await user.click(notFoundButton);
+
+      // Fill required fields
+      const firstNameInput = screen.getByTestId(dataTestIds.addPatientPage.firstNameInput).querySelector('input');
+      await user.click(firstNameInput!);
+      await user.paste('John');
+
+      const lastNameInput = screen.getByTestId(dataTestIds.addPatientPage.lastNameInput).querySelector('input');
+      await user.click(lastNameInput!);
+      await user.paste('Doe');
+
+      const dateOfBirthInput = await screen.findByPlaceholderText('MM/DD/YYYY');
+      await user.click(dateOfBirthInput);
+      await user.paste('01/01/2000');
+
+      // Select sex at birth
+      const sexAtBirthDropdown = screen.getByTestId(dataTestIds.addPatientPage.sexAtBirthDropdown);
+      const sexAtBirthButton = sexAtBirthDropdown.querySelector('[role="combobox"]');
+      await user.click(sexAtBirthButton!);
+      const maleOption = await screen.findByText('Male');
+      await user.click(maleOption);
+
+      // Select reason for visit
+      const reasonDropdown = screen.getByTestId(dataTestIds.addPatientPage.reasonForVisitDropdown);
+      const reasonButton = reasonDropdown.querySelector('[role="combobox"]');
+      await user.click(reasonButton!);
+      // Use the first available option
+      const reasonOptions = await screen.findAllByRole('option');
+      await user.click(reasonOptions[0]);
+
+      // Select prebook visit type
+      const visitTypeDropdown = screen.getByTestId(dataTestIds.addPatientPage.visitTypeDropdown);
+      const visitTypeButton = visitTypeDropdown.querySelector('[role="combobox"]');
+      await user.click(visitTypeButton!);
+      const prebookOption = await screen.findByText('Pre-booked In Person Visit');
+      await user.click(prebookOption);
+
+      // Try to submit without selecting a slot
+      const addButton = screen.getByTestId(dataTestIds.addPatientPage.addButton);
+      await user.click(addButton);
+
+      // Should show warning dialog
+      const dialogMessage = await screen.findByText('To continue, please select an available appointment.');
+      expect(dialogMessage).toBeVisible();
+    });
+
+    it('Shows dialog when clicking Add for post-telemed visit without selecting a time slot', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <BrowserRouter>
+          <AddPatient />
+        </BrowserRouter>
+      );
+
+      // Complete the form up to visit type selection
+      const phoneNumberInput = screen.getByTestId(dataTestIds.addPatientPage.mobilePhoneInput).querySelector('input');
+      await user.click(phoneNumberInput!);
+      await user.paste('1234567890');
+      await user.click(screen.getByTestId(dataTestIds.addPatientPage.searchForPatientsButton));
+
+      const notFoundButton = await screen.findByTestId(dataTestIds.addPatientPage.patientNotFoundButton);
+      await user.click(notFoundButton);
+
+      // Fill required fields
+      const firstNameInput = screen.getByTestId(dataTestIds.addPatientPage.firstNameInput).querySelector('input');
+      await user.click(firstNameInput!);
+      await user.paste('John');
+
+      const lastNameInput = screen.getByTestId(dataTestIds.addPatientPage.lastNameInput).querySelector('input');
+      await user.click(lastNameInput!);
+      await user.paste('Doe');
+
+      const dateOfBirthInput = await screen.findByPlaceholderText('MM/DD/YYYY');
+      await user.click(dateOfBirthInput);
+      await user.paste('01/01/2000');
+
+      // Select sex at birth
+      const sexAtBirthDropdown = screen.getByTestId(dataTestIds.addPatientPage.sexAtBirthDropdown);
+      const sexAtBirthButton = sexAtBirthDropdown.querySelector('[role="combobox"]');
+      await user.click(sexAtBirthButton!);
+      const maleOption = await screen.findByText('Male');
+      await user.click(maleOption);
+
+      // Select reason for visit
+      const reasonDropdown = screen.getByTestId(dataTestIds.addPatientPage.reasonForVisitDropdown);
+      const reasonButton = reasonDropdown.querySelector('[role="combobox"]');
+      await user.click(reasonButton!);
+      const reasonOptions = await screen.findAllByRole('option');
+      await user.click(reasonOptions[0]);
+
+      // Select post-telemed visit type
+      const visitTypeDropdown = screen.getByTestId(dataTestIds.addPatientPage.visitTypeDropdown);
+      const visitTypeButton = visitTypeDropdown.querySelector('[role="combobox"]');
+      await user.click(visitTypeButton!);
+      const postTelemOption = await screen.findByText('Post Telemed Lab Only');
+      await user.click(postTelemOption);
+
+      // Try to submit without selecting a slot
+      const addButton = screen.getByTestId(dataTestIds.addPatientPage.addButton);
+      await user.click(addButton);
+
+      // Should show warning dialog
+      const dialogMessage = await screen.findByText('To continue, please select an available appointment.');
+      expect(dialogMessage).toBeVisible();
+    });
+  });
+});

--- a/apps/ehr/tests/component/MIGRATION_SUMMARY.md
+++ b/apps/ehr/tests/component/MIGRATION_SUMMARY.md
@@ -1,0 +1,74 @@
+# E2E to Component Test Migration Summary
+
+## Overview
+
+This document tracks the migration of E2E tests to component tests for improved speed and reliability.
+
+## Completed Migrations
+
+### addPatientPage.spec.ts → AddPatientValidation.test.tsx
+
+**Date**: October 30, 2025
+
+**Migrated Tests** (5 E2E tests removed):
+1. ✅ Open "Add patient page", click "Cancel", navigates back to visits page
+2. ✅ Open "Add patient page", click "Search patient", validation error on "Mobile phone" field shown
+3. ✅ Open "Add patient page" then enter invalid phone number, click "Search patient", validation error shown
+4. ✅ Add button does nothing when any required field is empty (comprehensive validation test)
+5. ✅ Open "Add patient page" then enter invalid date of birth, validation error shown
+
+**Component Tests Created** (9 tests):
+1. Cancel button navigates back to visits page
+2. Shows validation error on mobile phone field when searching without entering a phone number
+3. Shows validation error on mobile phone field when searching with an invalid phone number
+4. Shows validation error on date of birth field when entering an invalid date format
+5. Shows error when clicking Add button without selecting a location
+6. Shows error message when clicking Add button without searching for patient
+7. Validates all required fields are present after patient search
+8. Shows dialog when clicking Add for prebook visit without selecting a time slot
+9. Shows dialog when clicking Add for post-telemed visit without selecting a time slot
+
+**Performance Impact**:
+- **Before**: 5 E2E tests × ~12 seconds = ~60 seconds
+- **After**: 9 component tests = ~4 seconds total
+- **Improvement**: ~93% faster (15x speed improvement)
+
+**Test Coverage**:
+- More comprehensive (9 tests vs 5 tests)
+- Better isolation (no network/backend dependencies)
+- More reliable (no browser timing issues)
+
+## Remaining E2E Tests in addPatientPage.spec.ts
+
+These tests still require E2E because they involve:
+- Full appointment creation workflow with backend
+- Patient data persistence verification
+- Multi-step processes with API calls
+
+1. Add walk-in visit for new patient
+2. Add pre-book visit for new patient
+3. Add post-telemed visit for new patient (skipped - flaky)
+4. Tests for existing patients (currently skipped)
+
+## Guidelines for Future Migrations
+
+**Migrate to Component Tests when**:
+- Testing client-side validation only
+- Testing UI state changes
+- Testing error message display
+- Testing navigation (mock router)
+- No backend/API integration required
+
+**Keep as E2E Tests when**:
+- Creating/modifying data in backend
+- Testing full user workflows
+- Verifying data persistence
+- Testing multi-service integration
+- Testing real routing/navigation between pages
+
+## Total Impact
+
+- **Tests migrated**: 5 → 9 (more comprehensive)
+- **Time saved per run**: ~56 seconds
+- **Reliability improvement**: Component tests don't suffer from E2E flakiness
+- **CI/CD impact**: Faster feedback loops, less flaky builds

--- a/apps/ehr/tests/component/README.md
+++ b/apps/ehr/tests/component/README.md
@@ -1,0 +1,71 @@
+# Component Tests Migration
+
+This directory contains component tests that have been migrated from E2E tests to improve test speed and reliability.
+
+## Migrated Tests
+
+### AddPatientValidation.test.tsx
+
+Migrated from `tests/e2e/specs/addPatientPage.spec.ts`
+
+These tests were originally E2E tests but were converted to component tests because they only test simple client-side validation logic that doesn't require a full browser environment or backend integration.
+
+**Tests included:**
+
+1. ✅ Cancel button navigates back to visits page
+2. ✅ Shows validation error on mobile phone field when searching without entering a phone number  
+3. ✅ Shows validation error on mobile phone field when searching with an invalid phone number
+4. ✅ Shows validation error on date of birth field when entering an invalid date format
+5. ✅ Shows error when clicking Add button without selecting a location
+6. ✅ Shows error message when clicking Add button without searching for patient
+7. ✅ Validates all required fields are present after patient search
+8. ✅ Shows dialog when clicking Add for prebook visit without selecting a time slot
+9. ✅ Shows dialog when clicking Add for post-telemed visit without selecting a time slot
+
+**Benefits of migration:**
+
+- **Speed**: Component tests run ~10-50x faster than E2E tests
+- **Reliability**: No flakiness from network requests, browser timing, or backend state
+- **Isolation**: Tests focus on component behavior without external dependencies
+- **CI efficiency**: Faster feedback loop in continuous integration
+
+## Running Component Tests
+
+```bash
+# Run all component tests
+npm run component-tests
+
+# Run a specific test file
+npx vitest --config ./vitest.config.component-tests.ts tests/component/AddPatientValidation.test.tsx
+
+# Run in watch mode
+npx vitest --config ./vitest.config.component-tests.ts --watch
+```
+
+## Writing Component Tests
+
+Component tests in this directory should:
+
+- Focus on UI validation logic and user interactions
+- Mock external dependencies (API clients, router, etc.)
+- Use `@testing-library/react` for rendering and queries
+- Use `@testing-library/user-event` for simulating user interactions
+- Be fast and deterministic
+
+## When to Use Component Tests vs E2E Tests
+
+**Use Component Tests for:**
+
+- Client-side validation logic
+- UI state changes and interactions
+- Form behavior without backend integration
+- Error message display
+- Navigation calls (mock router)
+
+**Keep as E2E Tests for:**
+
+- Full user workflows requiring backend integration
+- Tests that verify data persistence
+- Multi-page flows with real routing
+- Tests that verify backend state changes
+- Integration between multiple services

--- a/apps/ehr/tests/e2e/specs/addPatientPage.spec.ts
+++ b/apps/ehr/tests/e2e/specs/addPatientPage.spec.ts
@@ -18,8 +18,6 @@ import { expectAddPatientPage } from '../page/AddPatientPage';
 import { expectVisitsPage } from '../page/VisitsPage';
 
 const PATIENT_PREFILL_NAME = PATIENT_FIRST_NAME + ' ' + PATIENT_LAST_NAME;
-const PATIENT_INPUT_BIRTHDAY = PATIENT_BIRTH_DATE_SHORT;
-const REASON_FOR_VISIT = PATIENT_REASON_FOR_VISIT;
 
 // todo: remove hardcoded values, use constants from resource-handler
 const NEW_PATIENT_1_LAST_NAME = 'new_1' + PATIENT_LAST_NAME;
@@ -41,91 +39,9 @@ test.beforeEach(async ({ page }) => {
   await page.goto('/visits/add');
 });
 
-test('Open "Add patient page", click "Cancel", navigates back to visits page', async ({ page }) => {
-  const addPatientPage = await expectAddPatientPage(page);
-  await addPatientPage.clickCancelButton();
-
-  await expectVisitsPage(page);
-});
-
-test('Open "Add patient page", click "Search patient", validation error on "Mobile phone" field shown', async ({
-  page,
-}) => {
-  const addPatientPage = await expectAddPatientPage(page);
-  await addPatientPage.clickSearchForPatientsButton();
-  await addPatientPage.verifyMobilePhoneNumberValidationErrorShown();
-});
-
-test('Open "Add patient page" then enter invalid phone number, click "Search patient", validation error on "Mobile phone" field shown', async ({
-  page,
-}) => {
-  const addPatientPage = await expectAddPatientPage(page);
-  await addPatientPage.enterMobilePhone('123');
-  await addPatientPage.clickSearchForPatientsButton();
-  await addPatientPage.verifyMobilePhoneNumberValidationErrorShown();
-});
-
-test('Add button does nothing when any required field is empty', async ({ page }) => {
-  const addPatientPage = await expectAddPatientPage(page);
-  await addPatientPage.clickAddButton();
-  await addPatientPage.verifyPageStillOpened();
-
-  await addPatientPage.selectOffice(ENV_LOCATION_NAME!);
-  await addPatientPage.clickAddButton();
-  await addPatientPage.verifyPageStillOpened();
-
-  await addPatientPage.enterMobilePhone(PATIENT_PHONE_NUMBER);
-  await addPatientPage.clickAddButton();
-  await addPatientPage.verifySearchForPatientsErrorShown();
-  await addPatientPage.verifyPageStillOpened();
-
-  await addPatientPage.clickSearchForPatientsButton();
-  await addPatientPage.clickPatientNotFoundButton();
-  await addPatientPage.clickAddButton();
-  await addPatientPage.verifyPageStillOpened();
-
-  await addPatientPage.enterFirstName(PATIENT_FIRST_NAME);
-  await addPatientPage.clickAddButton();
-  await addPatientPage.verifyPageStillOpened();
-
-  await addPatientPage.enterLastName(PATIENT_LAST_NAME);
-  await addPatientPage.clickAddButton();
-  await addPatientPage.verifyPageStillOpened();
-
-  await addPatientPage.enterDateOfBirth(PATIENT_INPUT_BIRTHDAY);
-  await addPatientPage.clickAddButton();
-  await addPatientPage.verifyPageStillOpened();
-
-  await addPatientPage.selectSexAtBirth(PATIENT_INPUT_GENDER);
-  await addPatientPage.clickAddButton();
-  await addPatientPage.verifyPageStillOpened();
-
-  await addPatientPage.selectReasonForVisit(REASON_FOR_VISIT);
-  await addPatientPage.clickAddButton();
-  await addPatientPage.verifyPageStillOpened();
-
-  await addPatientPage.selectVisitType(VISIT_TYPES.PRE_BOOK);
-  await addPatientPage.clickAddButton();
-  await addPatientPage.clickCloseSelectDateWarningDialog();
-  await addPatientPage.verifyPageStillOpened();
-
-  await addPatientPage.selectVisitType(VISIT_TYPES.POST_TELEMED);
-  await addPatientPage.clickAddButton();
-  await addPatientPage.clickCloseSelectDateWarningDialog();
-  await addPatientPage.verifyPageStillOpened();
-});
-
-test('Open "Add patient page" then enter invalid date of birth, click "Add", validation error on "Date of Birth" field shown', async ({
-  page,
-}) => {
-  const addPatientPage = await expectAddPatientPage(page);
-  await addPatientPage.selectOffice(ENV_LOCATION_NAME!);
-  await addPatientPage.enterMobilePhone(PATIENT_PHONE_NUMBER);
-  await addPatientPage.clickSearchForPatientsButton();
-  await addPatientPage.clickPatientNotFoundButton();
-  await addPatientPage.enterDateOfBirth('3');
-  await addPatientPage.verifyDateFormatValidationErrorShown();
-});
+// Note: Simple validation tests have been migrated to component tests
+// See: tests/component/AddPatientValidation.test.tsx
+// These tests run much faster (~4s vs ~60s) and are more reliable
 
 test.describe('For new patient', () => {
   test(


### PR DESCRIPTION
What once took parallelization and 12 - 30 seconds per test now takes 10 seconds for all of the cases.

Old:

<img width="2574" height="1612" alt="image" src="https://github.com/user-attachments/assets/1e9ee990-75ef-495f-9c2a-d6f4cb321559" />

New:

```
npx vitest --config ./vitest.config.component-te
sts.ts --run tests/component/AddPatientValidation.test.tsx

 RUN  v3.0.9

 ✓ tests/component/AddPatientValidation.test.tsx (9 tests) 4073ms
   ✓ AddPatient - Validation Tests > Cancel button navigates back to visits page
   ✓ AddPatient - Validation Tests > Shows validation error on mobile phone field when searching without entering a phone number
   ✓ AddPatient - Validation Tests > Shows validation error on mobile phone field when searching with an invalid phone number
   ✓ AddPatient - Validation Tests > Shows validation error on date of birth field when entering an invalid date format 577ms
   ✓ AddPatient - Validation Tests > Required field validation > Shows error when clicking Add button without selecting a location
   ✓ AddPatient - Validation Tests > Required field validation > Shows error message when clicking Add button without searching for patient
   ✓ AddPatient - Validation Tests > Required field validation > Validates all required fields are present after patient search
   ✓ AddPatient - Validation Tests > Required field validation > Shows dialog when clicking Add for prebook visit without selecting a time slot 1281ms
   ✓ AddPatient - Validation Tests > Required field validation > Shows dialog when clicking Add for post-telemed visit without selecting a time slot 1310ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  18:14:54
   Duration  9.90s (transform 1.75s, setup 114ms, collect 5.32s, tests 4.07s, environment 181ms, prepare 46ms)
```

Note: I think we should remove the AI-generated README files, but they are useful to explain what I've done here for the purpose of PR review and discussion. So I've left them in for review.