### PR TITLE
remove optimistic setting partial data for diagnoses

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/assessment-tab/DiagnosesContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/assessment-tab/DiagnosesContainer.tsx
@@ -66,7 +66,6 @@ export const DiagnosesContainer: FC = () => {
         },
       }
     );
-    setPartialChartData({ diagnosis: newDiagnoses });
   };
 
   const onDelete = async (resourceId: string): Promise<void> => {
@@ -120,7 +119,6 @@ export const DiagnosesContainer: FC = () => {
         );
       }
     }
-    setPartialChartData({ diagnosis: localDiagnoses });
   };
 
   const onMakePrimary = (resourceId: string): void => {
@@ -151,18 +149,6 @@ export const DiagnosesContainer: FC = () => {
         },
       }
     );
-
-    setPartialChartData({
-      diagnosis: diagnoses.map((item) => {
-        if (item.isPrimary) {
-          return { ...item, isPrimary: false };
-        }
-        if (item.resourceId === resourceId) {
-          return { ...item, isPrimary: true };
-        }
-        return item;
-      }),
-    });
   };
 
   const handleSetup = (): void => {


### PR DESCRIPTION
- [x] lints and builds
- [x] e2e tests pass

i suspect the optimistic updates were causing the triple update issue jon found. removing those.
https://github.com/masslight/ottehr/pull/4149#discussion_r2375738889