### PR TITLE
Handle rejected ABN case

### DIFF
--- a/apps/ehr/src/components/dialogs/DeleteDialog.tsx
+++ b/apps/ehr/src/components/dialogs/DeleteDialog.tsx
@@ -1,3 +1,4 @@
+import { LoadingButton } from '@mui/lab';
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, useTheme } from '@mui/material';
 import { MouseEventHandler, ReactElement } from 'react';
 
@@ -9,6 +10,7 @@ interface DeleteDialogProps {
   handleDelete: MouseEventHandler<HTMLButtonElement>;
   open: boolean;
   title: string;
+  loadingDelete?: boolean;
 }
 
 export default function DeleteDialog({
@@ -19,6 +21,7 @@ export default function DeleteDialog({
   handleDelete,
   open,
   title,
+  loadingDelete,
 }: DeleteDialogProps): ReactElement {
   const theme = useTheme();
   const buttonSx = {
@@ -54,9 +57,16 @@ export default function DeleteDialog({
         <Button variant="outlined" onClick={handleClose} size="medium" sx={buttonSx}>
           {closeButtonText}
         </Button>
-        <Button variant="contained" onClick={handleDelete} size="medium" color="error" sx={buttonSx}>
+        <LoadingButton
+          variant="contained"
+          onClick={handleDelete}
+          size="medium"
+          color="error"
+          sx={buttonSx}
+          loading={loadingDelete}
+        >
           {deleteButtonText}
-        </Button>
+        </LoadingButton>
       </DialogActions>
     </Dialog>
   );

--- a/apps/ehr/src/features/external-labs/components/ExternalLabsStatusChip.tsx
+++ b/apps/ehr/src/features/external-labs/components/ExternalLabsStatusChip.tsx
@@ -122,6 +122,14 @@ export const ExternalLabsStatusPalette: {
       primary: '#D32F2F',
     },
   },
+  'rejected abn': {
+    background: {
+      primary: '#FFCDD2',
+    },
+    color: {
+      primary: '#D32F2F',
+    },
+  },
   unknown: {
     background: {
       primary: '#e3c254',

--- a/apps/ehr/src/features/external-labs/components/labs-orders/LabsTable.tsx
+++ b/apps/ehr/src/features/external-labs/components/labs-orders/LabsTable.tsx
@@ -26,6 +26,7 @@ interface LabsTableProps {
   }) => void;
   allowDelete?: boolean;
   bundleRow?: ReactElement;
+  handleRejectedAbn?: (serviceRequestId: string) => Promise<void>;
 }
 
 export const LabsTable = ({
@@ -34,6 +35,7 @@ export const LabsTable = ({
   allowDelete,
   showDeleteLabOrderDialog,
   bundleRow,
+  handleRejectedAbn,
 }: LabsTableProps): ReactElement => {
   const navigateTo = useNavigate();
 
@@ -94,6 +96,7 @@ export const LabsTable = ({
                   onRowClick={() => onRowClick(order)}
                   columns={columns}
                   allowDelete={allowDelete}
+                  handleRejectedAbn={handleRejectedAbn}
                 />
               );
             }

--- a/apps/ehr/src/features/external-labs/components/labs-orders/LabsTableContainer.tsx
+++ b/apps/ehr/src/features/external-labs/components/labs-orders/LabsTableContainer.tsx
@@ -35,6 +35,7 @@ type LabsTableContainerProps<SearchBy extends LabOrdersSearchBy> = {
     testItemName: string;
   }) => void;
   DeleteOrderDialog: ReactElement<any, string | JSXElementConstructor<any>> | null;
+  handleRejectedAbn?: (serviceRequestId: string) => Promise<void>;
 };
 
 export const LabsTableContainer = <SearchBy extends LabOrdersSearchBy>({
@@ -48,6 +49,7 @@ export const LabsTableContainer = <SearchBy extends LabOrdersSearchBy>({
   fetchLabOrders,
   showDeleteLabOrderDialog,
   DeleteOrderDialog,
+  handleRejectedAbn,
 }: LabsTableContainerProps<SearchBy>): ReactElement => {
   const { oystehrZambda: oystehr } = useApiClients();
 
@@ -197,6 +199,7 @@ export const LabsTableContainer = <SearchBy extends LabOrdersSearchBy>({
               bundleRow={bundleHeaderRow}
               allowDelete={allowDelete}
               showDeleteLabOrderDialog={showDeleteLabOrderDialog}
+              handleRejectedAbn={handleRejectedAbn}
             />
           </>
         </Box>

--- a/apps/ehr/src/features/external-labs/components/labs-orders/LabsTablePatientChart.tsx
+++ b/apps/ehr/src/features/external-labs/components/labs-orders/LabsTablePatientChart.tsx
@@ -31,6 +31,7 @@ export const LabsTablePatientChart = <SearchBy extends LabOrdersSearchBy>({
     showDeleteLabOrderDialog,
     DeleteOrderDialog,
     fetchLabOrders,
+    handleRejectedAbn,
   } = usePatientLabOrders(searchBy);
 
   if (loading) {
@@ -91,6 +92,7 @@ export const LabsTablePatientChart = <SearchBy extends LabOrdersSearchBy>({
                 fetchLabOrders={fetchLabOrders}
                 showDeleteLabOrderDialog={showDeleteLabOrderDialog}
                 DeleteOrderDialog={DeleteOrderDialog}
+                handleRejectedAbn={handleRejectedAbn}
               />
             ))}
             {bundlesWithResults.length > 0 && (

--- a/apps/ehr/src/features/external-labs/components/labs-orders/usePatientLabOrders.ts
+++ b/apps/ehr/src/features/external-labs/components/labs-orders/usePatientLabOrders.ts
@@ -53,6 +53,7 @@ interface UsePatientLabOrdersResult<SearchBy extends LabOrdersSearchBy> {
   saveSpecimenDate: (parameters: SpecimenDateChangedParameters) => Promise<void>;
   patientLabItems: PatientLabItem[];
   groupedLabOrdersForChartTable: LabOrderListPageDTOGrouped | undefined;
+  handleRejectedAbn: (serviceRequestId: string) => Promise<void>;
 }
 
 export const usePatientLabOrders = <SearchBy extends LabOrdersSearchBy>(
@@ -246,6 +247,18 @@ export const usePatientLabOrders = <SearchBy extends LabOrdersSearchBy>(
     deleteOrder: handleDeleteLabOrder,
   });
 
+  const handleRejectedAbn = useCallback(
+    async (serviceRequestId: string): Promise<void> => {
+      if (!oystehrZambda) throw Error('oystehrZambda missing');
+      await updateLabOrderResources(oystehrZambda, {
+        event: 'rejectedAbn',
+        serviceRequestId: serviceRequestId,
+      });
+      setSearchParams({ pageNumber: 1 });
+    },
+    [oystehrZambda, setSearchParams]
+  );
+
   const markTaskAsReviewed = useCallback(
     async ({
       taskId,
@@ -311,6 +324,7 @@ export const usePatientLabOrders = <SearchBy extends LabOrdersSearchBy>(
     saveSpecimenDate,
     patientLabItems,
     groupedLabOrdersForChartTable,
+    handleRejectedAbn,
   };
 };
 

--- a/apps/ehr/src/features/external-labs/pages/OrderDetails.tsx
+++ b/apps/ehr/src/features/external-labs/pages/OrderDetails.tsx
@@ -58,7 +58,7 @@ export const OrderDetailsPage: React.FC = () => {
 
   const pageName = labOrder.testItem;
 
-  if (status === 'pending' || status === 'ready' || status?.includes('sent')) {
+  if (status === 'pending' || status === 'ready' || status?.includes('sent') || status === 'rejected abn') {
     return (
       <DetailPageContainer>
         <LabBreadcrumbs sectionName={pageName}>

--- a/packages/utils/lib/types/data/labs/labs.constants.ts
+++ b/packages/utils/lib/types/data/labs/labs.constants.ts
@@ -199,6 +199,7 @@ export const PROVENANCE_ACTIVITY_CODES = {
   createOrder: 'CREATE ORDER',
   inputResults: 'INPUT RESULTS',
   completePstTask: 'COMPLETE PST TASK',
+  abnRejected: 'ABN REJECTED',
 } as const;
 
 export const PROVENANCE_ACTIVITY_DISPLAY = {
@@ -207,6 +208,7 @@ export const PROVENANCE_ACTIVITY_DISPLAY = {
   createOrder: 'create order',
   inputResults: 'input results',
   completePstTask: 'complete pst task',
+  abnRejected: 'ABN marked rejected',
 } as const;
 
 export const PROVENANCE_ACTIVITY_CODING_ENTITY = {
@@ -234,6 +236,11 @@ export const PROVENANCE_ACTIVITY_CODING_ENTITY = {
   completePstTask: {
     code: PROVENANCE_ACTIVITY_CODES.completePstTask,
     display: PROVENANCE_ACTIVITY_DISPLAY.completePstTask,
+    system: PROVENANCE_ACTIVITY_TYPE_SYSTEM,
+  },
+  abnRejected: {
+    code: PROVENANCE_ACTIVITY_CODES.abnRejected,
+    display: PROVENANCE_ACTIVITY_DISPLAY.abnRejected,
     system: PROVENANCE_ACTIVITY_TYPE_SYSTEM,
   },
 } as const;
@@ -278,3 +285,8 @@ export const OYSTEHR_LABS_ADDITIONAL_LAB_CODE_SYSTEM =
 
 export const OYSTEHR_LABS_ADDITIONAL_PLACER_ID_SYSTEM =
   'https://identifiers.fhir.oystehr.com/lab-result-additional-placer-id';
+
+export const SR_REVOKED_REASON_EXT = {
+  url: 'https://extensions.fhir.oystehr.com/reason-sr-revoked',
+  valueCode: 'rejected-abn',
+};

--- a/packages/utils/lib/types/data/labs/labs.types.ts
+++ b/packages/utils/lib/types/data/labs/labs.types.ts
@@ -73,11 +73,12 @@ export enum ExternalLabsStatus {
   corrected = 'corrected',
   'cancelled by lab' = 'cancelled by lab',
   'sent manually' = 'sent manually',
+  'rejected abn' = 'rejected abn',
   unknown = 'unknown', // for debugging purposes
 }
 
 export type LabOrderUnreceivedHistoryRow = {
-  action: 'created' | 'performed' | 'ready' | 'ordered' | 'cancelled by lab';
+  action: 'created' | 'performed' | 'ready' | 'ordered' | 'cancelled by lab' | 'rejected abn';
   performer: string;
   date: string;
 };
@@ -318,6 +319,7 @@ export const LAB_ORDER_UPDATE_RESOURCES_EVENTS = {
   saveOrderCollectionData: 'saveOrderCollectionData',
   cancelUnsolicitedResultTask: 'cancelUnsolicitedResultTask', // match or review tasks
   matchUnsolicitedResult: 'matchUnsolicitedResult',
+  rejectedAbn: 'rejectedAbn',
 } as const;
 
 export type TaskReviewedParameters = {
@@ -362,7 +364,8 @@ export type UpdateLabOrderResourcesInput =
   | (SpecimenDateChangedParameters & { event: typeof LAB_ORDER_UPDATE_RESOURCES_EVENTS.specimenDateChanged })
   | (SaveOrderCollectionData & { event: typeof LAB_ORDER_UPDATE_RESOURCES_EVENTS.saveOrderCollectionData })
   | CancelMatchUnsolicitedResultTask
-  | FinalizeUnsolicitedResultMatch;
+  | FinalizeUnsolicitedResultMatch
+  | { serviceRequestId: string; event: typeof LAB_ORDER_UPDATE_RESOURCES_EVENTS.rejectedAbn };
 
 export type DeleteLabOrderZambdaInput = {
   serviceRequestId: string;

--- a/packages/zambdas/src/ehr/shared/labs.ts
+++ b/packages/zambdas/src/ehr/shared/labs.ts
@@ -62,6 +62,7 @@ import {
   OYSTEHR_LAB_GUID_SYSTEM,
   OYSTEHR_LAB_OI_CODE_SYSTEM,
   PATIENT_BILLING_ACCOUNT_TYPE,
+  SR_REVOKED_REASON_EXT,
 } from 'utils';
 import { parseLabOrderStatusWithSpecificTask } from '../get-lab-orders/helpers';
 
@@ -854,6 +855,12 @@ export const docRefIsAbnAndCurrent = (docRef: DocumentReference): boolean => {
       )
   );
   return isCurrent && isAbn;
+};
+
+export const srHasRejectedAbnExt = (sr: ServiceRequest): boolean => {
+  return !!sr.extension?.some(
+    (ext) => ext.url === SR_REVOKED_REASON_EXT.url && ext.valueCode === SR_REVOKED_REASON_EXT.valueCode
+  );
 };
 
 export interface AOEDisplayForOrderForm {

--- a/packages/zambdas/src/ehr/update-lab-order-resources/helpers.ts
+++ b/packages/zambdas/src/ehr/update-lab-order-resources/helpers.ts
@@ -1,6 +1,14 @@
-import Oystehr, { BatchInputPatchRequest, BatchInputRequest } from '@oystehr/sdk';
+import Oystehr, { BatchInputPatchRequest, BatchInputPostRequest, BatchInputRequest } from '@oystehr/sdk';
 import { Operation } from 'fast-json-patch';
-import { DiagnosticReport, Provenance, QuestionnaireResponse, ServiceRequest, Specimen, Task } from 'fhir/r4b';
+import {
+  DiagnosticReport,
+  DocumentReference,
+  Provenance,
+  QuestionnaireResponse,
+  ServiceRequest,
+  Specimen,
+  Task,
+} from 'fhir/r4b';
 import { DateTime } from 'luxon';
 import { uuid } from 'short-uuid';
 import {
@@ -11,8 +19,9 @@ import {
   OYSTEHR_SAME_TRANSMISSION_DR_REF_URL,
   PROVENANCE_ACTIVITY_CODING_ENTITY,
   SpecimenCollectionDateConfig,
+  SR_REVOKED_REASON_EXT,
 } from 'utils';
-import { parseAccessionNumberFromDr, populateQuestionnaireResponseItems } from '../shared/labs';
+import { docRefIsAbnAndCurrent, parseAccessionNumberFromDr, populateQuestionnaireResponseItems } from '../shared/labs';
 
 export const getSpecimenPatchAndMostRecentCollectionDate = (
   specimenResources: Specimen[],
@@ -288,4 +297,92 @@ export const handleMatchUnsolicitedRequest = async ({
 
   console.log('making fhir requests, total requests to make: ', requests.length);
   await oystehr.fhir.transaction<DiagnosticReport | Task | ServiceRequest>({ requests });
+};
+
+export const handleRejectedAbn = async ({
+  oystehr,
+  serviceRequestId,
+  practitionerIdFromCurrentUser,
+}: {
+  oystehr: Oystehr;
+  serviceRequestId: string;
+  practitionerIdFromCurrentUser: string;
+}): Promise<void> => {
+  const resourceSearch = (
+    await oystehr.fhir.search<ServiceRequest | DocumentReference>({
+      resourceType: 'ServiceRequest',
+      params: [
+        {
+          name: '_id',
+          value: serviceRequestId,
+        },
+        {
+          name: '_revinclude:iterate',
+          value: 'DocumentReference:related', // to validate there is an abn doc
+        },
+      ],
+    })
+  ).unbundle();
+  console.log(`resource search for handleRejectedAbn returned ${resourceSearch.length}`);
+
+  const initial: { abnDocRef: DocumentReference | undefined; serviceRequest: ServiceRequest | undefined } = {
+    abnDocRef: undefined,
+    serviceRequest: undefined,
+  };
+  const { abnDocRef, serviceRequest } = resourceSearch.reduce((acc, resource) => {
+    if (resource.resourceType === 'ServiceRequest') acc.serviceRequest = resource;
+    if (resource.resourceType === 'DocumentReference') {
+      const isAbnAndCurrent = docRefIsAbnAndCurrent(resource);
+      if (isAbnAndCurrent) acc.abnDocRef = resource;
+    }
+    return acc;
+  }, initial);
+
+  if (!abnDocRef) {
+    throw new Error(
+      `ABN rejection failed: there is no current abn document reference for this lab. ${serviceRequestId}`
+    );
+  }
+
+  console.log('formatting requests for handleRejectedAbn');
+
+  const srExtension = serviceRequest?.extension;
+  const srPatch: BatchInputPatchRequest<ServiceRequest> = {
+    method: 'PATCH',
+    url: `ServiceRequest/${serviceRequestId}`,
+    operations: [
+      {
+        op: 'replace',
+        path: '/status',
+        value: 'revoked',
+      },
+      {
+        op: 'add',
+        path: srExtension ? '/extension/-' : '/extension',
+        value: srExtension ? SR_REVOKED_REASON_EXT : [SR_REVOKED_REASON_EXT],
+      },
+    ],
+  };
+
+  const curUserReference = { reference: `Practitioner/${practitionerIdFromCurrentUser}` };
+  const provenancePost: BatchInputPostRequest<Provenance> = {
+    method: 'POST',
+    url: '/Provenance',
+    resource: {
+      resourceType: 'Provenance',
+      target: [
+        {
+          reference: `ServiceRequest/${serviceRequestId}`,
+        },
+      ],
+      recorded: DateTime.now().toISO(),
+      agent: [{ who: curUserReference }],
+      activity: {
+        coding: [PROVENANCE_ACTIVITY_CODING_ENTITY.abnRejected],
+      },
+    },
+  };
+
+  console.log('revoking the service request due to rejected abn');
+  await oystehr.fhir.transaction({ requests: [srPatch, provenancePost] });
 };

--- a/packages/zambdas/src/ehr/update-lab-order-resources/index.ts
+++ b/packages/zambdas/src/ehr/update-lab-order-resources/index.ts
@@ -48,6 +48,7 @@ import { diagnosticReportSpecificResultType, getExternalLabOrderResourcesViaServ
 import {
   getSpecimenPatchAndMostRecentCollectionDate,
   handleMatchUnsolicitedRequest,
+  handleRejectedAbn,
   makePstCompletePatchRequests,
   makeQrPatchRequest,
   makeSpecimenPatchRequest,
@@ -106,7 +107,6 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
           }),
         };
       }
-
       case 'specimenDateChanged': {
         const { serviceRequestId, specimenId, date } = validatedParameters;
 
@@ -126,7 +126,6 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
           }),
         };
       }
-
       case 'saveOrderCollectionData': {
         const { serviceRequestId, data, specimenCollectionDates } = validatedParameters;
         const { presignedLabelURL } = await handleSaveCollectionData(
@@ -149,7 +148,6 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
           }),
         };
       }
-
       case LAB_ORDER_UPDATE_RESOURCES_EVENTS.cancelUnsolicitedResultTask: {
         console.log('handling cancel task to match unsolicited result');
         const { taskId } = validatedParameters;
@@ -175,7 +173,6 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
           }),
         };
       }
-
       case LAB_ORDER_UPDATE_RESOURCES_EVENTS.matchUnsolicitedResult: {
         const { taskId, diagnosticReportId, srToMatchId, patientToMatchId } = validatedParameters;
         console.log('handling match unsolicited result');
@@ -184,6 +181,17 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
           statusCode: 200,
           body: JSON.stringify({
             message: `Successfully matched unsolicited result`,
+          }),
+        };
+      }
+      case LAB_ORDER_UPDATE_RESOURCES_EVENTS.rejectedAbn: {
+        const { serviceRequestId } = validatedParameters;
+        console.log('handling rejected abn');
+        await handleRejectedAbn({ oystehr, serviceRequestId, practitionerIdFromCurrentUser });
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            message: `Successfully revoked sr for lab with rejected abn`,
           }),
         };
       }

--- a/packages/zambdas/src/ehr/update-lab-order-resources/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/update-lab-order-resources/validateRequestParameters.ts
@@ -120,6 +120,14 @@ export function validateRequestParameters(
       secrets,
       userToken,
     };
+  } else if (params.event === LAB_ORDER_UPDATE_RESOURCES_EVENTS.rejectedAbn) {
+    const { event, serviceRequestId } = params;
+    return {
+      event,
+      serviceRequestId,
+      secrets,
+      userToken,
+    };
   }
 
   throw Error('event is not supported');


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-766/ehr-labs-able-to-cancel-a-sent-test-if-an-abn-was-required-from-labs