### PR TITLE
Tasks. "Review results" tasks read "undefined for undefined ordered by undefined"

### DIFF
--- a/packages/zambdas/src/subscriptions/diagnostic-report/handle-lab-result/index.ts
+++ b/packages/zambdas/src/subscriptions/diagnostic-report/handle-lab-result/index.ts
@@ -97,7 +97,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
       ? appointmentRef?.replace('Appointment/', '')
       : undefined;
 
-    const taskInput: { type: string; value?: string }[] | TaskInput[] | undefined = preSubmissionTask
+    const taskInput: { type: string; value?: string }[] | TaskInput[] | undefined = preSubmissionTask?.input
       ? preSubmissionTask.input
       : [
           {


### PR DESCRIPTION
Fix for https://linear.app/zapehr/issue/OTR-1269/tasks-review-results-tasks-read-undefined-for-undefined-ordered-by