### PR TITLE
OTR-1302: Fix previous immunization orders

### DIFF
--- a/apps/ehr/src/features/immunization/components/OrderHistoryTable.tsx
+++ b/apps/ehr/src/features/immunization/components/OrderHistoryTable.tsx
@@ -15,6 +15,7 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { COLLAPSED_MEDS_COUNT } from 'src/features/visits/in-person/hooks/useMedicationHistory';
 import { useAppointmentData } from 'src/features/visits/shared/stores/appointment/appointment.store';
+import { GetImmunizationOrdersRequest } from 'utils/lib/types/data/immunization/types';
 import { useGetImmunizationOrders } from '../../visits/in-person/hooks/useImmunization';
 import { ordersRecentFirstComparator } from '../common';
 import { OrderHistoryTableRow } from './OrderHistoryTableRow';
@@ -23,17 +24,20 @@ import { OrderHistoryTableSkeletonBody } from './OrderHistoryTableSkeletonBody';
 interface Props {
   showActions: boolean;
   administeredOnly?: boolean;
+  immunizationInput?: GetImmunizationOrdersRequest;
 }
 
-export const OrderHistoryTable: React.FC<Props> = ({ showActions, administeredOnly }) => {
+export const OrderHistoryTable: React.FC<Props> = ({ showActions, administeredOnly, immunizationInput }) => {
   const [seeMoreOpen, setSeeMoreOpen] = useState(false);
   const { id: appointmentId } = useParams();
 
   const { encounter, isLoading: patientIdLoading } = useAppointmentData(appointmentId);
 
-  const { data: ordersResponse, isLoading: ordersLoading } = useGetImmunizationOrders({
-    encounterId: encounter.id,
-  });
+  const { data: ordersResponse, isLoading: ordersLoading } = useGetImmunizationOrders(
+    immunizationInput ?? {
+      encounterId: encounter.id,
+    }
+  );
 
   const orders = (ordersResponse?.orders ?? [])
     .sort(ordersRecentFirstComparator)

--- a/apps/ehr/src/features/immunization/pages/ImmunizationOrderCreateEdit.tsx
+++ b/apps/ehr/src/features/immunization/pages/ImmunizationOrderCreateEdit.tsx
@@ -26,7 +26,7 @@ export const ImmunizationOrderCreateEdit: React.FC = () => {
   const { id: appointmentId, orderId } = useParams();
 
   const {
-    resources: { encounter },
+    resources: { encounter, patient },
   } = useAppointmentData(appointmentId);
 
   const [isImmunizationHistoryCollapsed, setIsImmunizationHistoryCollapsed] = useState(false);
@@ -131,7 +131,7 @@ export const ImmunizationOrderCreateEdit: React.FC = () => {
             onSwitch={() => setIsImmunizationHistoryCollapsed((prev) => !prev)}
             withBorder={false}
           >
-            <OrderHistoryTable showActions={false} administeredOnly />
+            <OrderHistoryTable showActions={false} administeredOnly immunizationInput={{ patientId: patient?.id }} />
           </AccordionCard>
         </Stack>
       </form>


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1302/ehr-immunization-order-isnt-displayed-in-pre-visit-immunization