### PR TITLE
Tasks. Fix in-house medication selecting

### DIFF
--- a/apps/ehr/src/features/tasks/common.ts
+++ b/apps/ehr/src/features/tasks/common.ts
@@ -138,7 +138,7 @@ export function useInHouseMedicationsOptions(encounterId: string): {
     inHouseMedicationsOptions: (data?.orders ?? []).map((order) => {
       return {
         label: order.medicationName,
-        value: order.medicationId ?? '',
+        value: order.id ?? '',
       };
     }),
   };


### PR DESCRIPTION
Surprisingly, `medicationId` property of any medication order is `"medicationId"` string. Use `order.id` instead.