### PR TITLE
fixes a few unsolicited results bugs

### DIFF
--- a/apps/ehr/src/features/external-labs/components/details/FinalCardView.tsx
+++ b/apps/ehr/src/features/external-labs/components/details/FinalCardView.tsx
@@ -41,7 +41,7 @@ export const FinalCardView: FC<FinalCardViewProps> = ({
 
   // todo later, this function is pretty much duplicated from /external-labs/pages/UnsolicitedResultsMatch.tsx
   // we should deduplicate
-  const handleReject = (): void => {
+  const handleRejectUnsolicitedResult = (): void => {
     if (taskId) {
       cancelTask(
         {
@@ -50,10 +50,10 @@ export const FinalCardView: FC<FinalCardViewProps> = ({
         },
         {
           onSuccess: async () => {
-            await queryClient.invalidateQueries({
-              queryKey: [GET_TASKS_KEY],
-              exact: false,
-            });
+            await Promise.all([
+              queryClient.invalidateQueries({ queryKey: [GET_TASKS_KEY], exact: false }),
+              queryClient.invalidateQueries({ queryKey: ['get unsolicited results resources'], exact: false }),
+            ]);
             navigate('/tasks');
           },
           onError: (error) => {
@@ -152,7 +152,7 @@ export const FinalCardView: FC<FinalCardViewProps> = ({
                 }}
                 color="error"
                 size={'medium'}
-                onClick={handleReject}
+                onClick={handleRejectUnsolicitedResult}
               >
                 Reject
               </LoadingButton>

--- a/apps/ehr/src/features/external-labs/components/details/ResultItem.tsx
+++ b/apps/ehr/src/features/external-labs/components/details/ResultItem.tsx
@@ -62,7 +62,9 @@ export const ResultItem = ({ onMarkAsReviewed, labOrder, resultDetails, loading 
         </Box>
       </Box>
 
-      {(resultDetails.resultType === 'final' || resultDetails.resultType === 'cancelled') && (
+      {(resultDetails.resultType === 'final' ||
+        resultDetails.resultType === 'cancelled' ||
+        resultDetails.resultType === 'corrected') && (
         <FinalCardView
           isUnsolicited={isUnsolicitedPage}
           resultPdfUrl={resultDetails.resultPdfUrl}
@@ -74,8 +76,7 @@ export const ResultItem = ({ onMarkAsReviewed, labOrder, resultDetails, loading 
         />
       )}
 
-      {/* todo will configure this for unsolicited results post mvp */}
-      {!isUnsolicitedPage && resultDetails.resultType === 'preliminary' && (
+      {resultDetails.resultType === 'preliminary' && (
         <PrelimCardView
           resultPdfUrl={resultDetails.resultPdfUrl}
           receivedDate={resultDetails.receivedDate}

--- a/apps/ehr/src/features/visits/in-person/hooks/useTasks.ts
+++ b/apps/ehr/src/features/visits/in-person/hooks/useTasks.ts
@@ -332,7 +332,9 @@ function fhirTaskToTask(task: FhirTask): Task {
     }
     if (
       diagnosticReportId &&
-      (code === LAB_ORDER_TASK.code.reviewFinalResult || code === LAB_ORDER_TASK.code.reviewCorrectedResult)
+      (code === LAB_ORDER_TASK.code.reviewFinalResult ||
+        code === LAB_ORDER_TASK.code.reviewCorrectedResult ||
+        code === LAB_ORDER_TASK.code.reviewPreliminaryResult)
     ) {
       if (labTypeString === LabType.unsolicited && !serviceRequestId) {
         const receivedDate = getInputString(LAB_ORDER_TASK.input.receivedDate, task);

--- a/packages/utils/lib/types/data/labs/labs.types.ts
+++ b/packages/utils/lib/types/data/labs/labs.types.ts
@@ -97,7 +97,7 @@ export type LabOrderHistoryRow = LabOrderUnreceivedHistoryRow | LabOrderReceived
 export type LabOrderResultDetails = {
   testItem: string;
   testType: 'ordered' | LabDrTypeTagCode;
-  resultType: 'final' | 'preliminary' | 'cancelled';
+  resultType: 'final' | 'preliminary' | 'cancelled' | 'corrected';
   labStatus: ExternalLabsStatus;
   diagnosticReportId: string;
   taskId: string;

--- a/packages/zambdas/src/ehr/shared/labs.ts
+++ b/packages/zambdas/src/ehr/shared/labs.ts
@@ -1186,6 +1186,8 @@ const getResultDetailsBasedOnDr = async (
         return 'preliminary';
       case 'cancelled':
         return 'cancelled';
+      case 'corrected':
+        return 'corrected';
       default:
         throw Error(`Error parsing result type for diagnostic report: ${diagnosticReport.id}`);
     }

--- a/packages/zambdas/src/ehr/update-lab-order-resources/helpers.ts
+++ b/packages/zambdas/src/ehr/update-lab-order-resources/helpers.ts
@@ -436,3 +436,79 @@ export const handleRejectedAbn = async ({
   console.log('revoking the service request due to rejected abn');
   await oystehr.fhir.transaction({ requests: [srPatch, provenancePost] });
 };
+
+export const handleRejectedUnsolicitedResult = async ({
+  oystehr,
+  taskId,
+}: {
+  oystehr: Oystehr;
+  taskId: string;
+}): Promise<void> => {
+  console.log('searching for task and diagnostic report within handleRejectedUnsolicitedResult');
+  const resources = (
+    await oystehr.fhir.search<Task | DiagnosticReport>({
+      resourceType: 'Task',
+      params: [
+        {
+          name: '_id',
+          value: taskId,
+        },
+        {
+          name: '_include:iterate',
+          value: 'Task:based-on',
+        },
+      ],
+    })
+  ).unbundle();
+
+  console.log('number of resources returned from search:', resources.length);
+
+  const { fhirTask, fhirDiagnosticReport } = resources.reduce(
+    (acc: { fhirTask: Task | undefined; fhirDiagnosticReport: DiagnosticReport | undefined }, resource) => {
+      if (resource.resourceType === 'Task') acc.fhirTask = resource;
+      if (resource.resourceType === 'DiagnosticReport') acc.fhirDiagnosticReport = resource;
+      return acc;
+    },
+    { fhirTask: undefined, fhirDiagnosticReport: undefined }
+  );
+
+  if (!fhirTask)
+    throw new Error(`Something has gone awry getting this task during handleRejectedUnsolicitedResult: ${taskId}`);
+
+  const requests: BatchInputPatchRequest<Task | DiagnosticReport>[] = [
+    {
+      method: 'PATCH',
+      url: `Task/${taskId}`,
+      operations: [
+        {
+          op: 'replace',
+          path: '/status',
+          value: 'cancelled',
+        },
+      ],
+    },
+  ];
+
+  // this means it was matched and is being rejected AFTER being matched
+  if (fhirDiagnosticReport && fhirDiagnosticReport.subject?.reference?.startsWith('Patient/')) {
+    console.log(
+      'it appears this unsolicited result has been matched to a patient - the subject patient will be removed and the task will be cancelled'
+    );
+    requests.push({
+      method: 'PATCH',
+      url: `DiagnosticReport/${fhirDiagnosticReport.id}`,
+      operations: [
+        {
+          op: 'remove',
+          path: '/subject',
+        },
+      ],
+    });
+  } else {
+    console.log(
+      'this unsolicited result is being rejected before matching to a patient, the only action to be taken is cancelling the task'
+    );
+  }
+
+  await oystehr.fhir.transaction({ requests });
+};

--- a/packages/zambdas/src/ehr/update-lab-order-resources/index.ts
+++ b/packages/zambdas/src/ehr/update-lab-order-resources/index.ts
@@ -52,6 +52,7 @@ import {
   getSpecimenPatchAndMostRecentCollectionDate,
   handleMatchUnsolicitedRequest,
   handleRejectedAbn,
+  handleRejectedUnsolicitedResult,
   makePstCompletePatchRequests,
   makeQrPatchRequest,
   makeSpecimenPatchRequest,
@@ -154,21 +155,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
       case LAB_ORDER_UPDATE_RESOURCES_EVENTS.cancelUnsolicitedResultTask: {
         console.log('handling cancel task to match unsolicited result');
         const { taskId } = validatedParameters;
-        await oystehr.fhir.batch({
-          requests: [
-            getPatchBinary({
-              resourceType: 'Task',
-              resourceId: taskId,
-              patchOperations: [
-                {
-                  op: 'replace',
-                  path: '/status',
-                  value: 'cancelled',
-                },
-              ],
-            }),
-          ],
-        });
+        await handleRejectedUnsolicitedResult({ oystehr, taskId });
         return {
           statusCode: 200,
           body: JSON.stringify({

--- a/packages/zambdas/src/subscriptions/diagnostic-report/handle-lab-result/index.ts
+++ b/packages/zambdas/src/subscriptions/diagnostic-report/handle-lab-result/index.ts
@@ -141,7 +141,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     }
 
     // Don't show "preliminary" result task on the tasks board
-    const showTaskOnBoard = diagnosticReport.status !== 'preliminary';
+    // we do need to show tasks for if the preliminary result is unsolicited otherwise theres no way for users to see it
+    const showTaskOnBoard = diagnosticReport.status !== 'preliminary' || isUnsolicited;
+    console.log('showTaskOnBoard', showTaskOnBoard);
 
     const newTask = createTask(
       {


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-626/ehr-labs-unsolicited-results-handle-preliminarycorrect-results
https://linear.app/zapehr/issue/OTR-1406/ehr-external-labs-rejected-matched-unsolicited-results-fail