### PR TITLE
tweak(rcm): Stop capturing expected secondary insurance error

### DIFF
--- a/packages/zambdas/src/patient/get-eligibility/index.ts
+++ b/packages/zambdas/src/patient/get-eligibility/index.ts
@@ -63,8 +63,8 @@ export const index = wrapHandler('get-eligibility', async (input: ZambdaInput): 
         { ...complexInput, apiUrl, accessToken: oystehrToken, secrets: secrets },
         oystehr
       );
-      console.log('prevalidation primary', result.primary);
-      console.log('prevalidation secondary', result.primary);
+      console.log('prevalidation primary', JSON.stringify(result.primary));
+      console.log('prevalidation secondary', JSON.stringify(result.secondary));
       primary = result.primary;
       secondary = result.secondary;
     } else {

--- a/packages/zambdas/src/patient/get-eligibility/validation.ts
+++ b/packages/zambdas/src/patient/get-eligibility/validation.ts
@@ -1,6 +1,5 @@
 // cSpell:ignore olicy
 import Oystehr from '@oystehr/sdk';
-import { captureException } from '@sentry/aws-serverless';
 import { Appointment, QuestionnaireResponseItem } from 'fhir/r4b';
 import {
   APIErrorCode,
@@ -165,7 +164,6 @@ export const complexInsuranceValidation = async (
         secondaryPolicyHolder = mapResponseItemsToInsurancePolicyHolder(secondaryInsuranceItem?.item ?? [], '-2');
         secondaryInsuranceData = mapResponseItemsToInsuranceData(secondaryInsuranceItem.item ?? [], '-2');
       } catch (e) {
-        captureException(e);
         console.error('Error parsing secondary insurance data', e);
         secondaryPolicyHolder = undefined;
         secondaryInsuranceData = undefined;


### PR DESCRIPTION
Currently we are capturing an error related to parsing secondary insurance when there is none registered.

These otherwise valid QRs have a secondary insurance object filled out with all valid `linkId`s, but the objects don't have an `answer` in them, only the `linkId`.

Valid primary insurance example:
```json
        {
            "linkId": "insurance-carrier",
            "answer": [
                {
                    "valueReference": {
                        "reference": "Organization/...",
                        "display": "..."
                    }
                }
            ]
        },
```

Invalid but present secondary insurance example in the same QR:
```json
                {
                    "linkId": "insurance-carrier-2"
                },
```

This seems to be expected behavior, so I'm removing the error capture.

This PR also fixes a set of log messages so they display nested error objects correctly, and display the correct result.