### PR TITLE
feat(ehr): make header sticky on progress note

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/Header.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/Header.tsx
@@ -48,6 +48,9 @@ import { InternalNotes } from './InternalNotes';
 import { PrintVisitLabelButton } from './PrintVisitLabelButton';
 
 const HeaderWrapper = styled(Box)(({ theme }) => ({
+  position: 'sticky',
+  top: 0,
+  zIndex: 100,
   backgroundColor: theme.palette.background.paper,
   padding: '8px 16px 8px 0',
   borderBottom: `1px solid ${theme.palette.divider}`,

--- a/apps/ehr/src/features/visits/shared/components/Sidebar.tsx
+++ b/apps/ehr/src/features/visits/shared/components/Sidebar.tsx
@@ -358,12 +358,14 @@ export const Sidebar = (): JSX.Element => {
           position: 'relative',
           width: open ? drawerWidth : (theme) => theme.spacing(7),
           flexShrink: 0,
+          zIndex: 50,
           '& .MuiDrawer-paper': {
             position: 'relative',
             width: open ? drawerWidth : (theme) => theme.spacing(7),
             boxSizing: 'border-box',
             overflowX: 'hidden',
             transition: 'width 0.1s',
+            zIndex: 50,
           },
         }}
       >


### PR DESCRIPTION
[OTR-479: Anchor the Top Navigation Bar on Provider/Intake view](https://linear.app/zapehr/issue/OTR-479/anchor-the-top-navigation-bar-on-providerintake-view)

<img width="3830" height="1928" alt="image" src="https://github.com/user-attachments/assets/4fb4b363-1321-4e82-b4e7-121f0374ec55" />
