### PR TITLE
tweak(apps): Skip dynamic stripe script injection

### DIFF
--- a/apps/ehr/index.html
+++ b/apps/ehr/index.html
@@ -1,18 +1,22 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="./public/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="The production-ready, open-source EHR" />
-    <link rel="apple-touch-icon" href="./public/logo192.png" />
-    <link rel="manifest" href="./public/manifest.json" />
-    <title>%VITE_APP_NAME% EHR</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <script type="module" src="./src/index.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="./public/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="The production-ready, open-source EHR" />
+  <link rel="apple-touch-icon" href="./public/logo192.png" />
+  <link rel="manifest" href="./public/manifest.json" />
+  <title>%VITE_APP_NAME% EHR</title>
+  <script src="https://js.stripe.com/clover/stripe.js" async></script>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <script type="module" src="./src/index.tsx"></script>
+</body>
+
 </html>

--- a/apps/intake/index.html
+++ b/apps/intake/index.html
@@ -1,30 +1,25 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="./public/favicon.ico" />
-    <link
-      rel="stylesheet"
-      rel="prefetch"
-      as="font"
-      crossorigin="anonymous"
-      href="https://fonts.googleapis.com/css?family=Dancing+Script"
-    />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="%VITE_APP_NAME% Patient Portal"
-      build-version="%REACT_APP_VERSION%"
-      build-commit="%REACT_APP_SHA%"
-    />
-    <link rel="apple-touch-icon" href="./public/logo192.png" />
-    <link rel="manifest" href="./public/manifest.json" />
-    <title>%VITE_APP_NAME% Intake</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <script type="module" src="./src/index.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="./public/favicon.ico" />
+  <link rel="stylesheet" rel="prefetch" as="font" crossorigin="anonymous"
+    href="https://fonts.googleapis.com/css?family=Dancing+Script" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="%VITE_APP_NAME% Patient Portal" build-version="%REACT_APP_VERSION%"
+    build-commit="%REACT_APP_SHA%" />
+  <link rel="apple-touch-icon" href="./public/logo192.png" />
+  <link rel="manifest" href="./public/manifest.json" />
+  <title>%VITE_APP_NAME% Intake</title>
+  <script src="https://js.stripe.com/clover/stripe.js" async></script>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <script type="module" src="./src/index.tsx"></script>
+</body>
+
 </html>


### PR DESCRIPTION
Retrying `loadStripe` (#5346) didn't fix the issue for iOS users, so maybe it's a script injection thing. By default the `loadStripe` function will dynamically add a `<script>` tag for `stripe.js`. This PR adds a static tag instead, as per [the docs](https://github.com/stripe/stripe-js?tab=readme-ov-file#manually-include-the-script-tag).