### PR TITLE
EHR. Fix money fomatting in statements

### DIFF
--- a/packages/zambdas/src/subscriptions/task/sub-generate-statement/draw.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-generate-statement/draw.ts
@@ -226,6 +226,10 @@ function restoreY(pdfClient: PdfClient, draw: () => void): void {
   pdfClient.setY(y);
 }
 
-function formatMoney(cents: number): string {
-  return '$' + cents / 100 + '.' + String(cents % 100).padStart(2, '0');
+export function formatMoney(cents: number): string {
+  const formatMoneyTemp = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  });
+  return formatMoneyTemp.format(cents / 100);
 }

--- a/packages/zambdas/test/statement.test.ts
+++ b/packages/zambdas/test/statement.test.ts
@@ -1,0 +1,14 @@
+import { formatMoney } from '../src/subscriptions/task/sub-generate-statement/draw';
+
+describe('Statement generation tests', () => {
+  test('formatMoney tests', () => {
+    expect(formatMoney(0)).toBe('$0.00');
+    expect(formatMoney(1)).toBe('$0.01');
+    expect(formatMoney(10)).toBe('$0.10');
+    expect(formatMoney(11)).toBe('$0.11');
+    expect(formatMoney(123)).toBe('$1.23');
+    expect(formatMoney(1234)).toBe('$12.34');
+    expect(formatMoney(9450)).toBe('$94.50');
+    expect(formatMoney(10199)).toBe('$101.99');
+  });
+});


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1614/rcm-ehr-patient-statement-pdf-has-odd-values-for-dollar-amounts