### PR TITLE
ensure timezones can't cause issues when generating seed data

### DIFF
--- a/scripts/generate-seed-data.ts
+++ b/scripts/generate-seed-data.ts
@@ -174,7 +174,7 @@ async function main(): Promise<void> {
       }
       jsonStr = jsonStr.split(questionnaireUrl).join('{{questionnaireUrl}}');
       jsonStr = jsonStr.split(today).join('{{date}}');
-      // eliminate timezone issues with dates being at midnight
+      // eliminate timezone issues with early morning appointments
       jsonStr = jsonStr.replace(/\{\{date\}\}T\d\d:/g, '{{date}}T12:');
 
       const entry = {


### PR DESCRIPTION
making all times at noon eliminates a lot of timezone bugs from est/edt conversion

trigger tests:
/run-intake-e2e
/run-ehr-e2e