### PR TITLE
Fix delete order with clinical info note bug

### DIFF
--- a/packages/zambdas/src/ehr/delete-lab-order/helpers.ts
+++ b/packages/zambdas/src/ehr/delete-lab-order/helpers.ts
@@ -170,7 +170,7 @@ export const makeCommunicationRequestForOrderNote = (
   orderLevelNotes: Communication[] | undefined,
   serviceRequest: ServiceRequest
 ): BatchInputPatchRequest<Communication> | BatchInputDeleteRequest | undefined => {
-  if (!orderLevelNotes) return;
+  if (!orderLevelNotes || orderLevelNotes.length === 0) return;
 
   if (orderLevelNotes.length !== 1) {
     throw new Error(


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1648/ehr-external-labs-error-when-deleting-lab-with-clinical-info-notes