### PR TITLE
exclude canceled and no shows from visit overview report

### DIFF
--- a/packages/zambdas/src/ehr/visits-overview-report/index.ts
+++ b/packages/zambdas/src/ehr/visits-overview-report/index.ts
@@ -151,7 +151,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     const activeAppointments = appointments.filter((appointment) => {
       if (!appointment.id) return false;
       const encounter = encounterMap.get(`Appointment/${appointment.id}`);
-      if (!encounter) return true; // Keep appointments without encounters
+      if (!encounter) return false;
       const visitStatus = getInPersonVisitStatus(appointment, encounter);
       return visitStatus !== 'cancelled' && visitStatus !== 'no show';
     });


### PR DESCRIPTION
AI generated:

Claude Sonnet 4.5.

Prompt:

> In the 'visits overview report' we want to exclude 'cancelled' and 'no show' visits from the report. You can see how to use `getInPersonVisitStatus` to get the status by looking at how the WorkflowEfficiency report does it.

Summary:

> Summary
I've successfully updated the visits overview report to exclude 'cancelled' and 'no show' visits, following the same pattern used in the WorkflowEfficiency report.
Changes Made:
Added Import: Imported [getInPersonVisitStatus](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) from the utils package (line 8)
Created Encounter Map: Added a map to quickly lookup encounters by appointment reference (lines 142-148), which is needed to determine visit status
Filtered Appointments: Created a new [activeAppointments](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) array that filters out visits with 'cancelled' or 'no show' status (lines 150-157)
Added Logging: Added a log statement showing how many appointments were excluded (lines 159-162)
Updated Processing: Changed all subsequent appointment processing to use [activeAppointments](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of [appointments](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html):
Daily visits counting (line 193)
Total appointments calculation (line 234)
Location visits counting (line 239)
Practitioner visits counting (line 301)
Updated Empty Message: Changed the "no appointments found" message to "no active appointments found" to be more accurate (line 166)
The implementation uses [getInPersonVisitStatus()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to determine each visit's status and excludes those with 'cancelled' or 'no show' statuses, exactly as the WorkflowEfficiency report does. The code compiles without errors and maintains all the existing functionality while properly filtering out the unwanted visit types.
