### PR TITLE
fix(ehr): send name and email and number to stripe for multi account …

### DIFF
--- a/packages/utils/lib/fhir/helpers.ts
+++ b/packages/utils/lib/fhir/helpers.ts
@@ -1283,6 +1283,23 @@ export const getStripeCustomerIdFromAccount = (
   }
 };
 
+export const getAllStripeCustomerAccountPairs = (
+  account: Account
+): { stripeAccount: string | undefined; customerId: string }[] => {
+  const stripeIdentifiers = account.identifier?.filter((ident) => {
+    return ident.system === ACCOUNT_PAYMENT_PROVIDER_ID_SYSTEM_STRIPE;
+  });
+  if (!stripeIdentifiers) {
+    return [];
+  }
+  return stripeIdentifiers.map((ident) => {
+    const stripeAccount = ident.extension?.find((ext) => {
+      return ext.url === ACCOUNT_PAYMENT_PROVIDER_ID_SYSTEM_STRIPE_ACCOUNT;
+    })?.valueString;
+    return { stripeAccount, customerId: ident.value ?? '' };
+  });
+};
+
 export const getActiveAccountGuarantorReference = (account: Account): string | undefined => {
   const guarantor = account?.guarantor?.find((g) => g.period?.end === undefined)?.party;
   return guarantor?.reference;

--- a/packages/zambdas/src/ehr/patient-account/update/index.ts
+++ b/packages/zambdas/src/ehr/patient-account/update/index.ts
@@ -128,14 +128,11 @@ const performEffect = async (input: FinishedInput, oystehr: Oystehr): Promise<vo
     if (!account || !guarantorResource) {
       console.log('could not find account or guarantor, skipping stripe update');
     } else {
-      await updateStripeCustomer(
-        {
-          account,
-          guarantorResource,
-          stripeClient,
-        },
-        oystehr
-      );
+      await updateStripeCustomer({
+        account,
+        guarantorResource,
+        stripeClient,
+      });
     }
   } catch (e) {
     console.error('error updating stripe details', e);

--- a/packages/zambdas/src/ehr/shared/harvest/index.ts
+++ b/packages/zambdas/src/ehr/shared/harvest/index.ts
@@ -61,6 +61,7 @@ import {
   flattenIntakeQuestionnaireItems,
   flattenItems,
   formatPhoneNumber,
+  getAllStripeCustomerAccountPairs,
   getArrayInfo,
   getConsentAndRelatedDocRefsForAppointment,
   getCurrentValue,
@@ -110,7 +111,6 @@ import {
   SCHOOL_WORK_NOTE_WORK_ID,
   Secrets,
   SecretsKeys,
-  STRIPE_CUSTOMER_ID_NOT_FOUND_ERROR,
   SUBSCRIBER_RELATIONSHIP_CODE_MAP,
   takeContainedOrFind,
   uploadPDF,
@@ -119,7 +119,7 @@ import {
 } from 'utils';
 import { deduplicateUnbundledResources } from 'utils/lib/fhir/deduplicateUnbundledResources';
 import { createOrUpdateFlags } from '../../../patient/paperwork/sharedHelpers';
-import { createPdfBytes, ensureStripeCustomerId } from '../../../shared';
+import { createPdfBytes } from '../../../shared';
 
 export const PATIENT_CONTAINED_PHARMACY_ID = 'pharmacy';
 
@@ -3782,30 +3782,26 @@ interface UpdateStripeCustomerInput {
   guarantorResource: RelatedPerson | Patient;
   stripeClient: Stripe;
 }
-export const updateStripeCustomer = async (input: UpdateStripeCustomerInput, oystehr: Oystehr): Promise<void> => {
+export const updateStripeCustomer = async (input: UpdateStripeCustomerInput): Promise<void> => {
   const { guarantorResource, account, stripeClient } = input;
   console.log('updating Stripe customer for account', account.id);
   console.log('guarantor resource:', `${guarantorResource?.resourceType}/${guarantorResource?.id}`);
-  const { customerId: stripeCustomerId } = await ensureStripeCustomerId(
-    {
-      patientId: account.subject?.[0]?.reference?.split('/')[1] || '',
-      account,
-      guarantorResource,
-      stripeClient,
-    },
-    oystehr
-  );
+
   const email = getEmailForIndividual(guarantorResource);
   const name = getFullName(guarantorResource);
   const phone = getPhoneNumberForIndividual(guarantorResource);
-  if (stripeCustomerId) {
-    await stripeClient.customers.update(stripeCustomerId, {
-      email,
-      name,
-      phone,
-    });
-  } else {
-    throw STRIPE_CUSTOMER_ID_NOT_FOUND_ERROR;
+
+  const stripeCustomerAccountPairs = getAllStripeCustomerAccountPairs(account);
+  for (const pair of stripeCustomerAccountPairs) {
+    await stripeClient.customers.update(
+      pair.customerId,
+      {
+        email,
+        name,
+        phone,
+      },
+      { stripeAccount: pair.stripeAccount }
+    );
   }
 };
 

--- a/packages/zambdas/src/subscriptions/questionnaire-response/sub-intake-harvest/index.ts
+++ b/packages/zambdas/src/subscriptions/questionnaire-response/sub-intake-harvest/index.ts
@@ -211,14 +211,11 @@ export const performEffect = async (input: QRSubscriptionInput, oystehr: Oystehr
     if (updatedAccount && updatedGuarantorResource) {
       console.time('updating stripe customer');
       const stripeClient = getStripeClient(secrets);
-      await updateStripeCustomer(
-        {
-          account: updatedAccount,
-          guarantorResource: updatedGuarantorResource,
-          stripeClient,
-        },
-        oystehr
-      );
+      await updateStripeCustomer({
+        account: updatedAccount,
+        guarantorResource: updatedGuarantorResource,
+        stripeClient,
+      });
       console.timeEnd('updating stripe customer');
     } else {
       console.log('Stripe customer id, account or guarantor resource missing, skipping stripe customer update');


### PR DESCRIPTION
…case

This is for this issue, "For single stripe account we display responsible party's name and email, but for multi account we display only identifier value, is it expected or should we fix it? " of https://linear.app/zapehr/issue/OTR-1533/configurable-stripe-per-location-practitioner-group