### PR TITLE
fix(deploy): Do not escape terraform function call $s

### DIFF
--- a/packages/spec/src/escape-terraform.test.ts
+++ b/packages/spec/src/escape-terraform.test.ts
@@ -207,10 +207,16 @@ describe('escapeTerraformTemplateSyntax', () => {
 
     it('should handle terraform replace function', () => {
       // This is a real terraform function call that should be preserved
-      // But since it doesnt start with oystehr_, it will be escaped
-      // This is expected - such functions should be in the terraform config directly
+      // If it is escaped, Terraform will not interpret it correctly
       const input = '${replace("value", " ", "_")}';
-      expect(escapeTerraformTemplateSyntax(input)).toBe('$${replace("value", " ", "_")}');
+      expect(escapeTerraformTemplateSyntax(input)).toBe('${replace("value", " ", "_")}');
+    });
+
+    it('should handle terraform replace function with nested references', () => {
+      const input = '${replace("${oystehr_fhir_resource.LOCATION_PHYSICAL_NY.data.name}", " ", "_")}';
+      expect(escapeTerraformTemplateSyntax(input)).toBe(
+        '${replace("${oystehr_fhir_resource.LOCATION_PHYSICAL_NY.data.name}", " ", "_")}'
+      );
     });
 
     it('should handle complex secret values with all special chars', () => {

--- a/packages/spec/src/escape-terraform.ts
+++ b/packages/spec/src/escape-terraform.ts
@@ -43,7 +43,10 @@ export function escapeTerraformTemplateSyntax(
     const isValidReference =
       terraformResourcePrefixes.length > 0 && terraformResourcePrefixes.some((prefix) => afterBrace.startsWith(prefix));
 
-    if (isValidReference && dollars.length === 1) {
+    // Check if this is a Terraform function call (e.g., replace(...), join(...), etc.)
+    const isFunctionCall = afterBrace.match(/^[a-zA-Z_][a-zA-Z0-9_]*\s*\(/) !== null;
+
+    if ((isValidReference || isFunctionCall) && dollars.length === 1) {
       // Single $ with valid prefix - preserve as-is
       return match;
     }


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1703/page-not-found-at-click-on-walk-in-if-office-is-closed