### PR TITLE
OTR-1629: Fix follow-ups order

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/EncounterSwitcher.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/EncounterSwitcher.tsx
@@ -1,6 +1,7 @@
 import AssignmentIcon from '@mui/icons-material/Assignment';
 import { Box, Button, Collapse, List, ListItem, ListItemButton, ListItemText, Typography } from '@mui/material';
 import { Encounter } from 'fhir/r4b';
+import { DateTime } from 'luxon';
 import { FC, useState } from 'react';
 import { formatISOStringToDateAndTime } from 'src/helpers/formatDateTime';
 import { useAppointmentData } from '../../shared/stores/appointment/appointment.store';
@@ -16,7 +17,12 @@ export const EncounterSwitcher: FC<EncounterSwitcherProps> = ({ open }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const { setInteractionMode } = useInPersonNavigationContext();
 
-  const allEncounters = [followUpOriginEncounter, ...(followupEncounters || [])].filter(Boolean) as Encounter[];
+  const sortedFollowupEncounters = [...(followupEncounters || [])].filter(Boolean).sort((a, b) => {
+    return DateTime.fromISO(a.period?.start ?? '').diff(DateTime.fromISO(b.period?.start ?? ''), 'milliseconds')
+      .milliseconds;
+  });
+
+  const allEncounters = [followUpOriginEncounter, ...sortedFollowupEncounters].filter(Boolean) as Encounter[];
 
   const handleEncounterSelect = (encounterId: string): void => {
     setSelectedEncounter(encounterId);


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1629/ehr-follow-up-follow-ups-should-be-shown-in-chronological-order

<img width="368" height="530" alt="image" src="https://github.com/user-attachments/assets/e6edb48e-82d3-4e00-a18b-95641af6a095" />
