### PR TITLE
OTR-1736: Add header menu for task and follow-up creation

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/Header.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/Header.tsx
@@ -558,7 +558,7 @@ export const Header = (): JSX.Element => {
                     <ListItemIcon sx={{ color: theme.palette.primary.main }}>
                       <CalendarMonthOutlinedIcon fontSize="small" />
                     </ListItemIcon>
-                    Create follow-up visit
+                    Create Follow-Up Visit
                   </MenuItem>
                   <MenuItem
                     onClick={() => {
@@ -570,7 +570,7 @@ export const Header = (): JSX.Element => {
                     <ListItemIcon sx={{ color: theme.palette.primary.main }}>
                       <AddOutlinedIcon fontSize="small" />
                     </ListItemIcon>
-                    Create task
+                    Create Task
                   </MenuItem>
                 </Menu>
                 <CreateTaskDialog open={showCreateTaskDialog} handleClose={() => setShowCreateTaskDialog(false)} />


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1736/add-create-follow-up-button-to-the-patient-chart

<img width="752" height="352" alt="image" src="https://github.com/user-attachments/assets/d7cdbe6c-3c45-4b86-800a-6b5a8fe0d480" />

