### PR TITLE
OTR-1629: Fix follow-ups order in patient grid

### DIFF
--- a/apps/ehr/src/components/PatientEncountersGrid.tsx
+++ b/apps/ehr/src/components/PatientEncountersGrid.tsx
@@ -545,7 +545,11 @@ export const PatientEncountersGrid: FC<PatientEncountersGridProps> = (props) => 
             ) : (
               paginatedData.map((row, index) => {
                 const rowId = row.appointmentId || `row-${index}`;
-                const followupEncountersForRow = row.followUps ?? [];
+                const followupEncountersForRow = [...(row.followUps ?? [])].sort(
+                  (a, b) =>
+                    DateTime.fromISO(a.dateTime ?? '').diff(DateTime.fromISO(b.dateTime ?? ''), 'milliseconds')
+                      .milliseconds
+                );
                 const hasFollowups = followupEncountersForRow.length > 0;
 
                 return (


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1629/ehr-follow-up-follow-ups-should-be-shown-in-chronological-order

<img width="984" height="1164" alt="image" src="https://github.com/user-attachments/assets/30ebb63f-37ef-4065-bd38-fbd90b1067ef" />
