### PR TITLE
Feat: add optional lab route params to Terraform

### DIFF
--- a/packages/spec/src/schema-20250925.ts
+++ b/packages/spec/src/schema-20250925.ts
@@ -254,6 +254,21 @@ export class Schema20250925 implements Schema<Spec20250925> {
       labRoutesResources.resource.oystehr_lab_route[routeName] = {
         account_number: this.getValue(route.accountNumber, this.resources),
         lab_id: this.getValue(route.labId, this.resources),
+        primary_name: this.getValue(route.primaryName, this.resources),
+        primary_phone: this.getValue(route.primaryPhone, this.resources),
+        primary_address: route.primaryAddress
+          ? {
+              address1: this.getValue(route.primaryAddress.address1, this.resources),
+              address2: this.getValue(route.primaryAddress.address2, this.resources),
+              city: this.getValue(route.primaryAddress.city, this.resources),
+              state_province_code: this.getValue(route.primaryAddress.stateProvinceCode, this.resources),
+              postal_code: this.getValue(route.primaryAddress.postalCode, this.resources),
+            }
+          : undefined,
+        client_site_id: this.getValue(route.clientSiteId, this.resources),
+        eula_version: this.getValue(route.eulaVersion, this.resources),
+        eula_accepter_full_name: this.getValue(route.eulaAccepterFullName, this.resources),
+        eula_acceptance_date_time_utc: this.getValue(route.eulaAcceptanceDateTimeUtc, this.resources),
       };
     }
     if (Object.keys(labRoutesResources.resource.oystehr_lab_route).length) {


### PR DESCRIPTION
Just making sure the optional route params like primary address etc get pulled into the files that call oystehr