### PR TITLE
fix name displayed in modal for existing patient error

### DIFF
--- a/apps/intake/src/pages/PatientInformation.tsx
+++ b/apps/intake/src/pages/PatientInformation.tsx
@@ -196,8 +196,10 @@ const PatientInformation = (): JSX.Element => {
       }
       if (foundDuplicate) {
         setErrorDialog({
-          title: `${t('aboutPatient.errors.foundDuplicate.title')} ${data.firstName}`,
-          description: `${t('aboutPatient.errors.foundDuplicate.description1')} ${data.firstName} ${data.lastName}, 
+          title: `${t('aboutPatient.errors.foundDuplicate.title')} ${postedPatientInfo.firstName}`,
+          description: `${t('aboutPatient.errors.foundDuplicate.description1')} ${postedPatientInfo.firstName} ${
+            postedPatientInfo.lastName
+          }, 
            ${postedPatientInfo?.dateOfBirth ? mdyStringFromISOString(postedPatientInfo?.dateOfBirth) : ''}. ${t(
              'aboutPatient.errors.foundDuplicate.description2'
            )}`,


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1857/undefined-values-shown-in-existing-patient-account-confirmation-modal