### PR TITLE
fix(labs): include prelim results in task title

### DIFF
--- a/packages/zambdas/src/subscriptions/diagnostic-report/handle-lab-result/index.ts
+++ b/packages/zambdas/src/subscriptions/diagnostic-report/handle-lab-result/index.ts
@@ -159,7 +159,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
     if (
       serviceRequestId &&
-      (code === LAB_ORDER_TASK.code.reviewFinalResult || code === LAB_ORDER_TASK.code.reviewCorrectedResult)
+      (code === LAB_ORDER_TASK.code.reviewFinalResult ||
+        code === LAB_ORDER_TASK.code.reviewCorrectedResult ||
+        code === LAB_ORDER_TASK.code.reviewPreliminaryResult)
     ) {
       title = `Review results for “${fullTestName}” for ${patientName}`;
     }


### PR DESCRIPTION
Does not add the task to the task board, just makes fhir happy so the subscription zambda doesn't 500