### PR TITLE
fix(harvest): Handle empty SSN answer

### DIFF
--- a/packages/zambdas/src/ehr/shared/harvest/index.ts
+++ b/packages/zambdas/src/ehr/shared/harvest/index.ts
@@ -944,7 +944,7 @@ export function createMasterRecordPatchOperations(
           return;
         }
 
-        if (item.linkId === 'patient-ssn' && value) {
+        if (item.linkId === 'patient-ssn') {
           const currentValue = getTaxID(patient);
           if (currentValue !== value) {
             const ssnIdentifier = makeSSNIdentifier(value as string);
@@ -968,12 +968,14 @@ export function createMasterRecordPatchOperations(
                   value: ssnIdentifier,
                 });
               } else {
-                // Scenario 3: SSN entry exists - replace entire identifier to ensure type field is included
-                tempOperations.patient.push({
-                  op: 'replace',
-                  path: `/identifier/${ssnIndex}`,
-                  value: ssnIdentifier,
-                });
+                // Scenario 3: SSN entry exists - replace entire identifier to ensure type field is included, but only if value is provided
+                if (value) {
+                  tempOperations.patient.push({
+                    op: 'replace',
+                    path: `/identifier/${ssnIndex}`,
+                    value: ssnIdentifier,
+                  });
+                }
               }
             }
           }

--- a/packages/zambdas/test/harvest.test.ts
+++ b/packages/zambdas/test/harvest.test.ts
@@ -551,4 +551,73 @@ describe('Patient Master Record Tests', () => {
       relatedPerson: {},
     });
   });
+
+  test('should handle empty SSN answer, produce no patch operations', () => {
+    const patientWithOtherIdentifier: Patient = {
+      id: 'patient-with-other-identifier',
+      resourceType: 'Patient',
+      name: [{ given: ['Jane'], family: 'Smith' }],
+      identifier: [
+        {
+          system: 'http://example.org/mrn',
+          value: 'MRN-12345',
+        },
+      ],
+    };
+    const ssnItems: QuestionnaireResponseItem[] = [{ linkId: 'patient-ssn' }];
+
+    let result = createMasterRecordPatchOperations(ssnItems, patientWithOtherIdentifier);
+    expect(result).toEqual({
+      coverage: {},
+      patient: {
+        conflictingUpdates: [],
+        patchOpsForDirectUpdate: [],
+      },
+      relatedPerson: {},
+    });
+
+    const patientWithNoIdentifier: Patient = {
+      id: 'patient-with-other-identifier',
+      resourceType: 'Patient',
+      name: [{ given: ['Jane'], family: 'Smith' }],
+    };
+    result = createMasterRecordPatchOperations(ssnItems, patientWithNoIdentifier);
+    expect(result).toEqual({
+      coverage: {},
+      patient: {
+        conflictingUpdates: [],
+        patchOpsForDirectUpdate: [],
+      },
+      relatedPerson: {},
+    });
+
+    const patientWithSSNIdentifier: Patient = {
+      id: 'patient-with-other-identifier',
+      resourceType: 'Patient',
+      name: [{ given: ['Jane'], family: 'Smith' }],
+      identifier: [
+        {
+          system: 'http://hl7.org/fhir/sid/us-ssn',
+          type: {
+            coding: [
+              {
+                system: 'http://terminology.hl7.org/CodeSystem/v2-0203',
+                code: 'SS',
+              },
+            ],
+          },
+          value: '444-44-4444',
+        },
+      ],
+    };
+    result = createMasterRecordPatchOperations(ssnItems, patientWithSSNIdentifier);
+    expect(result).toEqual({
+      coverage: {},
+      patient: {
+        conflictingUpdates: [],
+        patchOpsForDirectUpdate: [],
+      },
+      relatedPerson: {},
+    });
+  });
 });


### PR DESCRIPTION
This change preserves the existing behavior where an empty answer does not add an "empty" identifier entry for SSN, or clear the value out of an existing one.