### PR TITLE
Add Source column to Recent Patients report

### DIFF
--- a/apps/ehr/src/pages/reports/RecentPatients.tsx
+++ b/apps/ehr/src/pages/reports/RecentPatients.tsx
@@ -342,6 +342,13 @@ export default function RecentPatients(): React.ReactElement {
           ),
         },
         {
+          field: 'pointOfDiscovery',
+          headerName: 'Source',
+          flex: 1,
+          minWidth: 150,
+          sortable: true,
+        },
+        {
           field: 'mostRecentVisitDate',
           headerName: 'Most Recent Visit',
           flex: 1,

--- a/packages/utils/lib/types/api/recent-patients-report.types.ts
+++ b/packages/utils/lib/types/api/recent-patients-report.types.ts
@@ -18,6 +18,7 @@ export interface RecentPatientRecord {
     serviceCategory: string; // e.g., "General Care", "Urgent Care", etc.
   };
   patientStatus: 'new' | 'existing'; // New or existing patient based on visit history
+  pointOfDiscovery?: string; // "How did you hear about us?" value
 }
 
 export interface RecentPatientsReportZambdaOutput {

--- a/packages/zambdas/src/ehr/recent-patients-report/index.ts
+++ b/packages/zambdas/src/ehr/recent-patients-report/index.ts
@@ -7,6 +7,7 @@ import {
   getPhoneNumberForIndividual,
   getSecret,
   OTTEHR_MODULE,
+  PATIENT_POINT_OF_DISCOVERY_URL,
   RecentPatientRecord,
   RecentPatientsReportZambdaOutput,
   SecretsKeys,
@@ -336,6 +337,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
       const hasHistoricalAppointments = patientHistoryMap.get(patientId) || false;
       const patientStatus: 'new' | 'existing' = hasHistoricalAppointments ? 'existing' : 'new';
 
+      // Get "How did you hear about us?" value
+      const pointOfDiscovery = patient.extension?.find((e) => e.url === PATIENT_POINT_OF_DISCOVERY_URL)?.valueString;
+
       patientRecords.push({
         patientId,
         firstName,
@@ -348,6 +352,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
           serviceCategory,
         },
         patientStatus,
+        pointOfDiscovery,
       });
     }
 


### PR DESCRIPTION
## Summary
- Add a "Source" column to the Recent Patients report displaying the "How did you hear about us?" (point-of-discovery) value from the Patient FHIR extension
- No new API calls needed — the Patient resource is already fetched by the zambda

## Test plan
- [x] Manual verification: navigate to Reports > Recent Patients, confirm "Source" column displays with correct values
- [ ] Verify CSV export includes the new Source column

🤖 Generated with [Claude Code](https://claude.com/claude-code)