### PR TITLE
Return 400 error on unsupported file format from "get-presigned-file-url"

### DIFF
--- a/packages/zambdas/src/patient/get-presigned-file-url/validateRequestParameters.ts
+++ b/packages/zambdas/src/patient/get-presigned-file-url/validateRequestParameters.ts
@@ -4,6 +4,9 @@ import {
   INSURANCE_CARD_BACK_ID,
   INSURANCE_CARD_FRONT_2_ID,
   INSURANCE_CARD_FRONT_ID,
+  INVALID_INPUT_ERROR,
+  MISSING_REQUEST_BODY,
+  MISSING_REQUIRED_PARAMETERS,
   PATIENT_PHOTO_ID_PREFIX,
   PHOTO_ID_BACK_ID,
   PHOTO_ID_FRONT_ID,
@@ -29,29 +32,29 @@ export function validateRequestParameters(input: ZambdaInput): GetPresignedFileU
   secrets: Secrets | null;
 } {
   if (!input.body) {
-    throw new Error('No request body provided');
+    throw MISSING_REQUEST_BODY;
   }
 
   const { appointmentID, fileType, fileFormat } = JSON.parse(input.body);
 
   if (appointmentID === undefined || appointmentID === '') {
-    throw new Error('"appointmentID" is required');
+    throw MISSING_REQUIRED_PARAMETERS(['appointmentID']);
   }
 
   if (fileType === undefined || fileType === '') {
-    throw new Error('"fileType" is required');
+    throw MISSING_REQUIRED_PARAMETERS(['fileType']);
   }
 
   if (!fileTypes.includes(fileType) && !fileType.startsWith(PATIENT_PHOTO_ID_PREFIX)) {
-    throw new Error(`fileType must be one of the following values: ${Object.values(fileTypes).join(', ')}`);
+    throw INVALID_INPUT_ERROR(`fileType must be one of the following values: ${Object.values(fileTypes).join(', ')}`);
   }
 
   if (fileFormat === undefined || fileFormat === '') {
-    throw new Error('"fileFormat" is required');
+    throw MISSING_REQUIRED_PARAMETERS(['fileFormat']);
   }
 
   if (!fileFormats.includes(fileFormat)) {
-    throw new Error(
+    throw INVALID_INPUT_ERROR(
       `fileFormat ${fileFormat} must be one of the following values: ${Object.values(fileFormats).join(', ')}`
     );
   }


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2007/get-presigned-file-url-throws-a-500-instead-of-400-when-a-file-with-an