### PR TITLE
fix(ehr): prevent AI transcript fabrication on silent audio recordings

### DIFF
--- a/packages/zambdas/src/ehr/create-resources-from-audio-recording/index.ts
+++ b/packages/zambdas/src/ehr/create-resources-from-audio-recording/index.ts
@@ -16,7 +16,7 @@ let m2mToken: string;
 const ZAMBDA_NAME = 'create-resources-from-audio-recording';
 
 const TRANSCRIPT_PROMPT =
-  'give a transcript of this file, include only the transcript without other input, include who the speaker is with labels for the provider and the patient';
+  'give a transcript of this file, include only the transcript without other input, include who the speaker is with labels for the provider and the patient. If the audio is silent or contains no speech, respond with exactly "No audio captured".';
 export interface CreateResourcesFromAudioRecordingInputValidated extends CreateResourcesFromAudioRecordingInput {
   userToken: string;
   secrets: Secrets | null;

--- a/packages/zambdas/src/shared/ai.ts
+++ b/packages/zambdas/src/shared/ai.ts
@@ -231,17 +231,21 @@ export async function createResourcesFromAiInterview(
     fields = 'labs, erx, procedures, ' + fields;
   }
 
-  const aiResponseString = await invokeChatbotVertexAI(
-    [{ text: getPrompt(patientInfoDetails || 'unknown patient details', fields) + '\n' + chatTranscript }],
-    secrets
-  );
-  console.log(`AI response: "${aiResponseString}"`);
-  let aiResponse;
-  try {
-    aiResponse = JSON.parse(aiResponseString);
-  } catch (error) {
-    console.warn('Failed to parse AI response, attempting to fix JSON format:', error);
-    aiResponse = fixAndParseJsonObjectFromString(aiResponseString);
+  let aiResponse = {};
+  if (chatTranscript.trim() !== 'No audio captured') {
+    const aiResponseString = await invokeChatbotVertexAI(
+      [{ text: getPrompt(patientInfoDetails || 'unknown patient details', fields) + '\n' + chatTranscript }],
+      secrets
+    );
+    console.log(`AI response: "${aiResponseString}"`);
+    try {
+      aiResponse = JSON.parse(aiResponseString);
+    } catch (error) {
+      console.warn('Failed to parse AI response, attempting to fix JSON format:', error);
+      aiResponse = fixAndParseJsonObjectFromString(aiResponseString);
+    }
+  } else {
+    console.log('Skipping AI response generation as no audio was captured');
   }
 
   if (!encounter) {


### PR DESCRIPTION
## Description
This PR addresses issues where the Ambient Scribe would incorrectly fabricate visit content (hallucinate) when provided with a silent audio recording (e.g., if the microphone was disabled).

### Fixes:
1.  **Updated TRANSCRIPT_PROMPT**: Instructs the Vertex AI model to return exactly "No audio captured" if the audio is silent or contains no speech.
2.  **Graceful Handling in createResourcesFromAiInterview**: Intercepts the "No audio captured" transcript and skips the second LLM call (which generates clinical notes). This prevents the creation of hallucinated Observations and Conditions while still preserving the original audio DocumentReference for audit.

Fixes #4100
Fixes #4225