### PR TITLE
OTR-1401: Add 'Patient could not confirm dosage' checkbox

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/medical-history-tab/CurrentMedications/CurrentMedicationGroup.tsx
+++ b/apps/ehr/src/features/visits/shared/components/medical-history-tab/CurrentMedications/CurrentMedicationGroup.tsx
@@ -53,7 +53,13 @@ function CurrentMedicationItem({ value }: { value: MedicationDTO }): JSX.Element
   if (lastIntakeDate instanceof DateTime) {
     lastIntakeDateDisplay = `${lastIntakeDate.toFormat(DATE_FORMAT)} at ${lastIntakeDate.toFormat('HH:mm a')}`;
   }
-  const additionalInfo = [value.intakeInfo?.dose, lastIntakeDateDisplay].filter(Boolean).join(' ');
+  const additionalInfo = [
+    value.intakeInfo?.dose,
+    lastIntakeDateDisplay,
+    value.intakeInfo?.patientCouldNotConfirmDosage ? 'Patient could not confirm dosage' : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
 
   return (
     <Typography variant="body2">

--- a/apps/ehr/src/features/visits/shared/components/medical-history-tab/CurrentMedications/CurrentMedicationsProviderColumn.tsx
+++ b/apps/ehr/src/features/visits/shared/components/medical-history-tab/CurrentMedications/CurrentMedicationsProviderColumn.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   Card,
+  Checkbox,
   debounce,
   FormControlLabel,
   Radio,
@@ -34,11 +35,18 @@ interface CurrentMedicationsProviderColumnForm {
   type: MedicationDTO['type'];
   date: DateTime | null;
   dose: string | null;
+  patientCouldNotConfirmDosage: boolean;
 }
 
 export const CurrentMedicationsProviderColumn: FC = () => {
   const methods = useForm<CurrentMedicationsProviderColumnForm>({
-    defaultValues: { medication: null, dose: null, date: null, type: 'scheduled' },
+    defaultValues: {
+      medication: null,
+      dose: null,
+      date: null,
+      type: 'scheduled',
+      patientCouldNotConfirmDosage: false,
+    },
   });
   const { isLoading: isChartDataLoading } = useChartData();
   const { isAppointmentReadOnly: isReadOnly } = useGetAppointmentAccessibility();
@@ -96,11 +104,18 @@ export const CurrentMedicationsProviderColumn: FC = () => {
         intakeInfo: {
           date: data.date?.toUTC().toString(),
           dose: data.dose ?? undefined,
+          patientCouldNotConfirmDosage: data.patientCouldNotConfirmDosage || undefined,
         },
         status: 'active',
       });
       if (success) {
-        reset({ medication: null, date: null, dose: null, type: 'scheduled' });
+        reset({
+          medication: null,
+          date: null,
+          dose: null,
+          type: 'scheduled',
+          patientCouldNotConfirmDosage: false,
+        });
         void refetchHistory();
       }
     }
@@ -230,6 +245,7 @@ export const CurrentMedicationsProviderColumn: FC = () => {
                     onChange={(_e, data) => {
                       onChange(data);
                     }}
+                    sx={{ gridColumn: 'span 2' }}
                     renderInput={(params) => (
                       <TextField
                         {...params}
@@ -266,6 +282,23 @@ export const CurrentMedicationsProviderColumn: FC = () => {
                   />
                 )}
               ></Controller>
+              <Controller
+                name="patientCouldNotConfirmDosage"
+                control={control}
+                render={({ field: { value, onChange } }) => (
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={!!value}
+                        onChange={(e) => onChange(e.target.checked)}
+                        disabled={isLoading || isChartDataLoading}
+                        size="small"
+                      />
+                    }
+                    label="Patient could not confirm dosage"
+                  />
+                )}
+              />
               <Controller
                 name="date"
                 control={control}

--- a/packages/utils/lib/types/api/chart-data/chart-data.types.ts
+++ b/packages/utils/lib/types/api/chart-data/chart-data.types.ts
@@ -157,6 +157,7 @@ export interface MedicationDTO extends SaveableDTO {
 export interface MedicationIntakeInfo {
   date?: string;
   dose?: string;
+  patientCouldNotConfirmDosage?: boolean;
 }
 
 export interface PrescribedMedicationDTO extends SaveableDTO {

--- a/packages/zambdas/src/shared/chart-data/index.ts
+++ b/packages/zambdas/src/shared/chart-data/index.ts
@@ -247,6 +247,8 @@ export function makeAllergyDTO(allergy: AllergyIntolerance): AllergyDTO {
   };
 }
 
+const PATIENT_COULD_NOT_CONFIRM_DOSAGE_NOTE = 'Patient could not confirm dosage';
+
 export function makeMedicationResource(
   encounterId: string,
   patientId: string,
@@ -265,6 +267,9 @@ export function makeMedicationResource(
     effectiveDateTime: data.intakeInfo.date,
     informationSource: { reference: `Practitioner/${practitionerId}` },
     meta: getMetaWFieldName(fieldName),
+    ...(data.intakeInfo.patientCouldNotConfirmDosage && {
+      note: [{ text: PATIENT_COULD_NOT_CONFIRM_DOSAGE_NOTE }],
+    }),
     medicationCodeableConcept: {
       coding: [
         {
@@ -291,6 +296,7 @@ export function makeMedicationDTO(medication: MedicationStatement): MedicationDT
     intakeInfo: {
       dose: getMedicationDosage(medication, medication.meta?.tag?.[0].code || ''),
       date: medication.effectiveDateTime,
+      patientCouldNotConfirmDosage: medication.note?.[0]?.text === PATIENT_COULD_NOT_CONFIRM_DOSAGE_NOTE || undefined,
     },
     status: ['active', 'completed'].includes(medication.status)
       ? (medication.status as 'active' | 'completed')


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1401/add-patient-could-not-confirm-dosage-checkbox-to-medical-history

<img width="992" height="942" alt="image" src="https://github.com/user-attachments/assets/56a68188-e910-4e11-b96d-572ae3074ef8" />
