### PR TITLE
OTR-1750: Set encounter switcher to display expanded by default

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/EncounterSwitcher.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/EncounterSwitcher.tsx
@@ -14,7 +14,7 @@ type EncounterSwitcherProps = {
 export const EncounterSwitcher: FC<EncounterSwitcherProps> = ({ open }) => {
   const { followUpOriginEncounter, followupEncounters, selectedEncounterId, setSelectedEncounter } =
     useAppointmentData();
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(true);
   const { setInteractionMode } = useInPersonNavigationContext();
 
   const sortedFollowupEncounters = [...(followupEncounters || [])].filter(Boolean).sort((a, b) => {


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1750/follow-up-note-defaults-to-collapsed