### PR TITLE
Fix: update zipcode formatting for 9 digit zipcodes

### DIFF
--- a/apps/ehr/src/components/dialogs/EditPatientDialog.tsx
+++ b/apps/ehr/src/components/dialogs/EditPatientDialog.tsx
@@ -258,7 +258,6 @@ const EditPatientDialog = ({ modalOpen, onClose }: EditPatientDialogProps): Reac
 
   const onSubmit = useCallback(
     async (data: FormInputs): Promise<void> => {
-      console.log('>>>this is form data on submit', data);
       try {
         if (!patient?.id) {
           throw new Error('Patient reference not provided');
@@ -589,7 +588,6 @@ const EditPatientDialog = ({ modalOpen, onClose }: EditPatientDialogProps): Reac
               </FormControl>
             </Grid>
             <Grid item xs={12} sm={4} md={4}>
-              {/* ATHENA TODO: I don't even think this is rendering idk */}
               <FormControl fullWidth required>
                 <Controller
                   name="zipCode"

--- a/apps/intake/src/features/paperwork/PagedQuestionnaire.tsx
+++ b/apps/intake/src/features/paperwork/PagedQuestionnaire.tsx
@@ -26,8 +26,10 @@ import { FC, ReactElement, useCallback, useEffect, useMemo, useState } from 'rea
 import { Controller, FormProvider, useForm, useFormContext } from 'react-hook-form';
 import Markdown from 'react-markdown';
 import { useBeforeUnload } from 'react-router-dom';
+import { zipRegex } from 'src/helpers';
 import { usePaperworkStore } from 'src/pages/PaperworkPage';
 import {
+  formatZipcodeForDisplay,
   IntakeQuestionnaireItem,
   makeValidationSchema,
   pickFirstValueFromAnswerItem,
@@ -617,7 +619,7 @@ const FormInputField: FC<GetFormInputFieldProps> = ({
         return (
           <TextField
             id={fieldId}
-            value={unwrappedValue}
+            value={item.dataType === 'ZIP' ? formatZipcodeForDisplay(unwrappedValue) : unwrappedValue}
             type={getUCInputType(item?.dataType)}
             aria-labelledby={`${item.linkId}-label`}
             aria-describedby={`${item.linkId}-helper-text`}
@@ -630,7 +632,7 @@ const FormInputField: FC<GetFormInputFieldProps> = ({
                   : item.type === 'integer' || item.dataType === 'ZIP'
                   ? 'numeric'
                   : 'text'),
-              ...(item.dataType === 'ZIP' && { pattern: '[0-9]*', maxLength: 5 }),
+              ...(item.dataType === 'ZIP' && { pattern: zipRegex, maxLength: 10 }),
             }}
             placeholder={item.placeholder}
             required={item.required}

--- a/packages/utils/lib/fhir/patient.ts
+++ b/packages/utils/lib/fhir/patient.ts
@@ -17,7 +17,7 @@ import {
   RelatedPerson,
   Resource,
 } from 'fhir/r4b';
-import { removePrefix } from '../helpers';
+import { formatZipcodeForDisplay, removePrefix } from '../helpers';
 import {
   ORG_TYPE_CODE_SYSTEM,
   PATIENT_INDIVIDUAL_PRONOUNS_URL,
@@ -577,7 +577,7 @@ export const getPatientAddress = (
   const country = address?.[0]?.city;
   const addressLine = address?.[0]?.line?.[0];
   const addressLine2 = address?.[0]?.line?.[1];
-  const postalCode = address?.[0]?.postalCode;
+  const postalCode = address?.[0].postalCode ? formatZipcodeForDisplay(address?.[0].postalCode) : undefined;
   const state = address?.[0]?.state;
 
   const cityStateZIP = [city, state, postalCode].filter((value) => !!value).join(', ');

--- a/packages/zambdas/src/shared/pdf/external-labs-order-form-pdf.ts
+++ b/packages/zambdas/src/shared/pdf/external-labs-order-form-pdf.ts
@@ -512,7 +512,12 @@ function drawInsuranceDetail(
     pdfClient.newLine(STANDARD_NEW_LINE);
   }
   if (insuranceAddress) {
-    pdfClient = drawFieldLineBoldHeader(pdfClient, textStyles, 'Insurance Address:', insuranceAddress.toUpperCase());
+    pdfClient = drawFieldLineBoldHeader(
+      pdfClient,
+      textStyles,
+      'Insurance Address:',
+      formatZipcodeForDisplay(insuranceAddress.toUpperCase())
+    );
     pdfClient.newLine(STANDARD_NEW_LINE);
   }
   if (insuranceSubNum) {
@@ -524,7 +529,7 @@ function drawInsuranceDetail(
     pdfClient.newLine(STANDARD_NEW_LINE);
   }
   if (insuredAddress) {
-    pdfClient = drawFieldLineBoldHeader(pdfClient, textStyles, 'Address:', insuredAddress);
+    pdfClient = drawFieldLineBoldHeader(pdfClient, textStyles, 'Address:', formatZipcodeForDisplay(insuredAddress));
     pdfClient.newLine(STANDARD_NEW_LINE);
   }
 


### PR DESCRIPTION
Fixes it on lab order forms for insurance/insured addresses
Fixes it in patient header on patient details
Fixes it in patient app zipcode fields