### PR TITLE
Patient. Fix logo overlap on mobile

### DIFF
--- a/apps/intake/src/components/CustomContainerFactory.tsx
+++ b/apps/intake/src/components/CustomContainerFactory.tsx
@@ -116,7 +116,15 @@ export const CustomContainer: FC<ContainerProps> = ({
       >
         <Grid container justifyContent="space-between" alignItems="center">
           {/* Left section - for now is empty but we will have language select here  */}
-          <Grid item xs={3}></Grid>
+          <Grid
+            item
+            xs={3}
+            sx={{
+              '@media (max-width: 500px)': {
+                display: 'none',
+              },
+            }}
+          ></Grid>
 
           {/* Logo section  */}
           <Grid item xs={6} display="flex" justifyContent="center" alignItems="center">


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1983/patient-app-header-ui-element-overlap

<img width="400" alt="image" src="https://github.com/user-attachments/assets/ec5f0aac-209a-48ae-b4ca-583f6e3d83a8" />
