### PR TITLE
Refetch orders when create task dialog opens

### DIFF
--- a/apps/ehr/src/features/tasks/common.ts
+++ b/apps/ehr/src/features/tasks/common.ts
@@ -40,7 +40,10 @@ export interface Order {
   label: string;
 }
 
-export function useInHouseLabOrdersOptions(encounterId: string): {
+export function useInHouseLabOrdersOptions(
+  encounterId: string,
+  refreshKey?: number
+): {
   inHouseLabOrdersLoading: boolean;
   inHouseLabOrdersOptions: Order[];
 } {
@@ -49,6 +52,7 @@ export function useInHouseLabOrdersOptions(encounterId: string): {
       field: 'encounterId',
       value: encounterId,
     },
+    refreshKey,
   });
   return {
     inHouseLabOrdersLoading: loading,
@@ -61,7 +65,10 @@ export function useInHouseLabOrdersOptions(encounterId: string): {
   };
 }
 
-export function useExternalLabOrdersOptions(encounterId: string): {
+export function useExternalLabOrdersOptions(
+  encounterId: string,
+  refreshKey?: number
+): {
   externalLabOrdersLoading: boolean;
   externalLabOrdersOptions: Order[];
 } {
@@ -70,6 +77,7 @@ export function useExternalLabOrdersOptions(encounterId: string): {
       field: 'encounterId',
       value: encounterId,
     },
+    refreshKey,
   });
   return {
     externalLabOrdersLoading: loading,
@@ -87,12 +95,16 @@ export function useExternalLabOrdersOptions(encounterId: string): {
   };
 }
 
-export function useNursingOrdersOptions(encounterId: string): {
+export function useNursingOrdersOptions(
+  encounterId: string,
+  refreshKey?: number
+): {
   nursingOrdersLoading: boolean;
   nursingOrdersOptions: Order[];
 } {
   const { nursingOrders, loading } = useGetNursingOrders({
     searchBy: { field: 'encounterId', value: encounterId },
+    refreshKey,
   });
   return {
     nursingOrdersLoading: loading,
@@ -105,12 +117,16 @@ export function useNursingOrdersOptions(encounterId: string): {
   };
 }
 
-export function useRadiologyOrdersOptions(encounterId: string): {
+export function useRadiologyOrdersOptions(
+  encounterId: string,
+  refreshKey?: number
+): {
   radiologyOrdersLoading: boolean;
   radiologyOrdersOptions: Order[];
 } {
   const { orders, loading } = usePatientRadiologyOrders({
     encounterIds: encounterId,
+    refreshKey,
   });
   return {
     radiologyOrdersLoading: loading,

--- a/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
+++ b/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '@mui/material';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import { EmployeeSelectInput } from 'src/components/input/EmployeeSelectInput';
@@ -34,10 +34,13 @@ export const CreateTaskDialog: React.FC<Props> = ({ open, handleClose }) => {
   const methods = useForm();
   const formValue = methods.watch();
 
+  const [refreshKey, setRefreshKey] = useState(0);
+
   useEffect(() => {
     if (!open) {
       methods.reset();
     }
+    setRefreshKey(Date.now());
   }, [open, methods]);
 
   const { mutateAsync: createManualTask } = useCreateManualTask();
@@ -73,10 +76,10 @@ export const CreateTaskDialog: React.FC<Props> = ({ open, handleClose }) => {
   );
   const encounterId = encounter?.id ?? '';
 
-  const { inHouseLabOrdersLoading, inHouseLabOrdersOptions } = useInHouseLabOrdersOptions(encounterId);
-  const { externalLabOrdersLoading, externalLabOrdersOptions } = useExternalLabOrdersOptions(encounterId);
-  const { nursingOrdersLoading, nursingOrdersOptions } = useNursingOrdersOptions(encounterId);
-  const { radiologyOrdersLoading, radiologyOrdersOptions } = useRadiologyOrdersOptions(encounterId);
+  const { inHouseLabOrdersLoading, inHouseLabOrdersOptions } = useInHouseLabOrdersOptions(encounterId, refreshKey);
+  const { externalLabOrdersLoading, externalLabOrdersOptions } = useExternalLabOrdersOptions(encounterId, refreshKey);
+  const { nursingOrdersLoading, nursingOrdersOptions } = useNursingOrdersOptions(encounterId, refreshKey);
+  const { radiologyOrdersLoading, radiologyOrdersOptions } = useRadiologyOrdersOptions(encounterId, refreshKey);
   const { proceduresLoading, proceduresOptions } = useProceduresOptions(encounterId);
   const { inHouseMedicationsLoading, inHouseMedicationsOptions } = useInHouseMedicationsOptions(encounterId);
 
@@ -203,7 +206,7 @@ export const CreateTaskDialog: React.FC<Props> = ({ open, handleClose }) => {
               name="order"
               label="Order"
               options={orderOptions.map((order) => order.id)}
-              getOptionLabel={(option) => orderOptions.find((opt) => opt.id === option)?.label ?? option}
+              getOptionLabel={(option) => orderOptions.find((opt) => opt.id === option)?.label ?? ''}
               loading={ordersLoading}
               disabled={!formValue.appointment || !formValue.category}
             />


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2072/tasks-in-new-task-modal-order-id-is-displayed-instead-of-the-order