### PR TITLE
EHR. Reports. Load data only by click "Refresh" for custom dates

### DIFF
--- a/apps/ehr/src/pages/reports/AiAssistedEncounters.tsx
+++ b/apps/ehr/src/pages/reports/AiAssistedEncounters.tsx
@@ -202,7 +202,7 @@ const useAiAssistedEncounters = (
         return DateTime.fromISO(bTime).toMillis() - DateTime.fromISO(aTime).toMillis();
       });
     },
-    enabled: Boolean(oystehrZambda),
+    enabled: Boolean(oystehrZambda && dateRange !== 'custom' && dateRange !== 'customRange'),
     refetchOnWindowFocus: false,
     staleTime: 1000 * 60 * 5, // 5 minutes
   });

--- a/apps/ehr/src/pages/reports/CompleteEncounters.tsx
+++ b/apps/ehr/src/pages/reports/CompleteEncounters.tsx
@@ -310,7 +310,7 @@ const useCompleteEncounters = (
         return DateTime.fromISO(aTime).toMillis() - DateTime.fromISO(bTime).toMillis();
       });
     },
-    enabled: Boolean(oystehrZambda),
+    enabled: Boolean(oystehrZambda && dateRange !== 'custom' && dateRange !== 'customRange'),
     refetchOnWindowFocus: false,
     staleTime: 1000 * 60 * 5, // 5 minutes
   });

--- a/apps/ehr/src/pages/reports/DailyPayments.tsx
+++ b/apps/ehr/src/pages/reports/DailyPayments.tsx
@@ -228,37 +228,34 @@ export default function DailyPayments(): React.ReactElement {
   );
 
   useEffect(() => {
-    void fetchReport(dateFilter);
+    // Only auto-fetch for preset date filters (today, yesterday, etc.)
+    // Custom date/range selections require the user to click Refresh
+    if (dateFilter !== 'custom' && dateFilter !== 'customRange') {
+      void fetchReport(dateFilter);
+    }
   }, [dateFilter, fetchReport, customDate, selectedLocationId]);
 
   const handleDateFilterChange = (event: SelectChangeEvent<string>): void => {
     const newFilter = event.target.value;
     setDateFilter(newFilter);
-    void fetchReport(newFilter);
+    if (newFilter === 'custom' || newFilter === 'customRange') {
+      setReportData(null);
+    }
   };
 
   const handleCustomDateChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const newDate = event.target.value;
     setCustomDate(newDate);
-    if (dateFilter === 'custom') {
-      void fetchReport('custom');
-    }
   };
 
   const handleCustomStartDateChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const newDate = event.target.value;
     setCustomStartDate(newDate);
-    if (dateFilter === 'customRange') {
-      void fetchReport('customRange');
-    }
   };
 
   const handleCustomEndDateChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const newDate = event.target.value;
     setCustomEndDate(newDate);
-    if (dateFilter === 'customRange') {
-      void fetchReport('customRange');
-    }
   };
 
   const handleLocationFilterChange = (event: SelectChangeEvent<string>): void => {

--- a/apps/ehr/src/pages/reports/IncompleteEncounters.tsx
+++ b/apps/ehr/src/pages/reports/IncompleteEncounters.tsx
@@ -192,7 +192,7 @@ const useIncompleteEncounters = (
         return DateTime.fromISO(aTime).toMillis() - DateTime.fromISO(bTime).toMillis();
       });
     },
-    enabled: Boolean(oystehrZambda),
+    enabled: Boolean(oystehrZambda && dateRange !== 'custom' && dateRange !== 'customRange'),
     refetchOnWindowFocus: false,
     staleTime: 1000 * 60 * 5, // 5 minutes
   });

--- a/apps/ehr/src/pages/reports/PracticeKpis.tsx
+++ b/apps/ehr/src/pages/reports/PracticeKpis.tsx
@@ -3,6 +3,7 @@ import InsightsIcon from '@mui/icons-material/Insights';
 import {
   Alert,
   Box,
+  Button,
   Card,
   CardContent,
   CircularProgress,
@@ -120,26 +121,19 @@ export default function PracticeKpis(): React.ReactElement {
   );
 
   useEffect(() => {
-    void fetchReport(dateFilter);
+    // Only auto-fetch for preset date filters (today, yesterday, etc.)
+    // Custom date/range selections require the user to click Refresh
+    if (dateFilter !== 'custom' && dateFilter !== 'customRange') {
+      void fetchReport(dateFilter);
+    }
   }, [dateFilter, fetchReport]);
-
-  // Trigger fetch when custom date changes
-  useEffect(() => {
-    if (dateFilter === 'custom') {
-      void fetchReport('custom');
-    }
-  }, [customDate, dateFilter, fetchReport]);
-
-  // Trigger fetch when custom date range changes
-  useEffect(() => {
-    if (dateFilter === 'customRange') {
-      void fetchReport('customRange');
-    }
-  }, [customStartDate, customEndDate, dateFilter, fetchReport]);
 
   const handleDateFilterChange = (event: SelectChangeEvent<string>): void => {
     const newFilter = event.target.value;
     setDateFilter(newFilter);
+    if (newFilter === 'custom' || newFilter === 'customRange') {
+      setReportData(null);
+    }
   };
 
   const handleCustomDateChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -544,6 +538,10 @@ export default function PracticeKpis(): React.ReactElement {
                   />
                 </>
               )}
+
+              <Button variant="outlined" onClick={() => void fetchReport(dateFilter)} disabled={loading}>
+                Refresh
+              </Button>
 
               <Typography variant="body2" color="text.secondary" sx={{ ml: 'auto' }}>
                 Showing: {getDateRangeLabel(dateFilter)}

--- a/apps/ehr/src/pages/reports/RecentPatients.tsx
+++ b/apps/ehr/src/pages/reports/RecentPatients.tsx
@@ -3,6 +3,7 @@ import PeopleIcon from '@mui/icons-material/People';
 import {
   Alert,
   Box,
+  Button,
   Chip,
   CircularProgress,
   FormControl,
@@ -210,15 +211,12 @@ export default function RecentPatients(): React.ReactElement {
   );
 
   useEffect(() => {
-    void fetchReport(dateFilter);
-  }, [dateFilter, fetchReport]);
-
-  // Trigger fetch when custom date range changes
-  useEffect(() => {
-    if (dateFilter === 'customRange') {
-      void fetchReport('customRange');
+    // Only auto-fetch for preset date filters (today, yesterday, etc.)
+    // Custom date/range selections require the user to click Refresh
+    if (dateFilter !== 'custom' && dateFilter !== 'customRange') {
+      void fetchReport(dateFilter);
     }
-  }, [customStartDate, customEndDate, dateFilter, fetchReport]);
+  }, [dateFilter, fetchReport]);
 
   const handleDateFilterChange = (event: SelectChangeEvent<string>): void => {
     const newFilter = event.target.value;
@@ -457,6 +455,10 @@ export default function RecentPatients(): React.ReactElement {
                 ))}
             </Select>
           </FormControl>
+
+          <Button variant="outlined" onClick={() => void fetchReport(dateFilter)} disabled={loading}>
+            Refresh
+          </Button>
         </Box>
 
         {/* Error display */}


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2068/ehr-reports-page-unresponsive-when-user-is-typing-year-in-custom-date