### PR TITLE
refactor: remove the publish now feature from EHR chart

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/SchoolWorkExcuseCard.tsx
+++ b/apps/ehr/src/features/visits/shared/components/SchoolWorkExcuseCard.tsx
@@ -78,29 +78,6 @@ export const SchoolWorkExcuseCard: FC<SchoolWorkExcuseCardProps> = ({ locationNa
     );
   };
 
-  const onPublish = (id: string): void => {
-    const schoolWorkNotes = chartData?.schoolWorkNotes || [];
-    const note = schoolWorkNotes.find((note) => note.id === id)!;
-
-    saveChartData(
-      {
-        schoolWorkNotes: [{ id: note.id, published: true }],
-      },
-      {
-        onSuccess: () => {
-          setPartialChartData({
-            schoolWorkNotes: schoolWorkNotes.map((note) => (note.id === id ? { ...note, published: true } : note)),
-          });
-        },
-        onError: () => {
-          enqueueSnackbar('An error has occurred while publishing excuse. Please try again.', {
-            variant: 'error',
-          });
-        },
-      }
-    );
-  };
-
   const schoolWorkNoteChoice = getStringAnswer(questionnaireResponse, `${SCHOOL_WORK_NOTE}-choice`);
 
   let title = '';
@@ -166,7 +143,6 @@ export const SchoolWorkExcuseCard: FC<SchoolWorkExcuseCardProps> = ({ locationNa
               type="school"
               excuse={schoolExcuse}
               onDelete={onDelete}
-              onPublish={onPublish}
               isLoading={isLoading || isReadOnly}
               generateTemplateOpen={setGenerateSchoolTemplateOpen}
               generateFreeOpen={setGenerateSchoolFreeOpen}
@@ -179,7 +155,6 @@ export const SchoolWorkExcuseCard: FC<SchoolWorkExcuseCardProps> = ({ locationNa
               type="work"
               excuse={workExcuse}
               onDelete={onDelete}
-              onPublish={onPublish}
               isLoading={isLoading}
               generateTemplateOpen={setGenerateWorkTemplateOpen}
               generateFreeOpen={setGenerateWorkFreeOpen}

--- a/apps/ehr/src/features/visits/shared/components/plan-tab/components/ExcuseCard.tsx
+++ b/apps/ehr/src/features/visits/shared/components/plan-tab/components/ExcuseCard.tsx
@@ -1,7 +1,6 @@
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { Box, Popover, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { DateTime } from 'luxon';
-import React, { FC, useState } from 'react';
+import { FC } from 'react';
 import { RoundedButton } from 'src/components/RoundedButton';
 import { UppercaseCaptionTypography } from 'src/features/visits/shared/components/UppercaseCaptionTypography';
 import { SchoolWorkNoteExcuseDocFileDTO } from 'utils';
@@ -13,27 +12,13 @@ type ExcuseCardProps = {
   excuse?: SchoolWorkNoteExcuseDocFileDTO & { presignedUrl?: string };
   isLoading: boolean;
   onDelete: (id: string) => void;
-  onPublish: (id: string) => void;
   generateTemplateOpen: (value: boolean) => void;
   generateFreeOpen: (value: boolean) => void;
   disabled?: boolean;
 };
 
 export const ExcuseCard: FC<ExcuseCardProps> = (props) => {
-  const { label, type, excuse, isLoading, onDelete, onPublish, generateTemplateOpen, generateFreeOpen, disabled } =
-    props;
-
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-
-  const handlePopoverOpen = (event: React.MouseEvent<HTMLElement>): void => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handlePopoverClose = (): void => {
-    setAnchorEl(null);
-  };
-
-  const open = Boolean(anchorEl);
+  const { label, type, excuse, isLoading, onDelete, generateTemplateOpen, generateFreeOpen, disabled } = props;
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -51,44 +36,6 @@ export const ExcuseCard: FC<ExcuseCardProps> = (props) => {
           <Typography>
             Generated: {DateTime.fromISO(excuse.date!).toLocaleString(DateTime.DATETIME_SHORT, { locale: 'en-us' })}
           </Typography>
-          <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', justifyContent: 'end' }}>
-            <Box
-              onMouseEnter={handlePopoverOpen}
-              onMouseLeave={handlePopoverClose}
-              sx={{ display: 'flex', alignItems: 'center' }}
-            >
-              <InfoOutlinedIcon color="primary" />
-            </Box>
-            <RoundedButton
-              variant="contained"
-              disabled={excuse.published || isLoading || disabled}
-              onClick={() => onPublish(excuse.id)}
-              data-testid={type === 'school' ? 'publish-school-button' : 'publish-work-button'}
-            >
-              {excuse.published ? 'Published' : 'Publish now'}
-            </RoundedButton>
-          </Box>
-          <Popover
-            sx={{
-              pointerEvents: 'none',
-            }}
-            open={open}
-            anchorEl={anchorEl}
-            anchorOrigin={{
-              vertical: 'top',
-              horizontal: 'center',
-            }}
-            transformOrigin={{
-              vertical: 'bottom',
-              horizontal: 'center',
-            }}
-            onClose={handlePopoverClose}
-            disableRestoreFocus
-          >
-            <Typography sx={{ p: 2, width: '300px' }}>
-              Optional - you can publish note now or it will publish automatically after you review and sign visit note
-            </Typography>
-          </Popover>
         </>
       )}
 

--- a/apps/ehr/tests/component/SchoolWorkExcuseCard.test.tsx
+++ b/apps/ehr/tests/component/SchoolWorkExcuseCard.test.tsx
@@ -162,7 +162,7 @@ describe('SchoolWorkExcuseCard', () => {
       expect(() => screen.getByText('My work note')).toThrowError();
     });
 
-    it('unpublished notes should have publish/published button', () => {
+    it('should not render manual publish controls for existing notes', () => {
       const schoolWorkNotes: SchoolWorkNoteExcuseDocFileDTO[] = [
         { name: 'My school note', id: 'note-1', type: 'school', date: new Date().toISOString(), published: false },
         { name: 'My work note', id: 'note-2', type: 'work', date: new Date().toISOString(), published: true },
@@ -174,12 +174,10 @@ describe('SchoolWorkExcuseCard', () => {
 
       render(<SchoolWorkExcuseCard />, { wrapper: createWrapper() });
 
-      const publishSchoolButton = screen.getByTestId('publish-school-button');
-      expect(publishSchoolButton).toBeInTheDocument();
-      expect(publishSchoolButton).toHaveTextContent('Publish now');
-      const publishWorkButton = screen.getByTestId('publish-work-button');
-      expect(publishWorkButton).toBeInTheDocument();
-      expect(publishWorkButton).toHaveTextContent('Published');
+      expect(screen.queryByTestId('publish-school-button')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('publish-work-button')).not.toBeInTheDocument();
+      expect(screen.queryByText('Publish now')).not.toBeInTheDocument();
+      expect(screen.queryByText('Published')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
I still left the backend for the feature in case we might implement it, we will have the option to reintroduce manual publish later without rebuilding that backend behavior