### PR TITLE
fix: autotest and e2e without telemed flow

### DIFF
--- a/apps/ehr/tests/component/UpdateMedicationPage.test.tsx
+++ b/apps/ehr/tests/component/UpdateMedicationPage.test.tsx
@@ -79,8 +79,10 @@ describe('UpdateMedicationPage', () => {
 
   it('renders medication name after data loads', async () => {
     render(<UpdateMedicationPage />, { wrapper: createWrapper() });
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Update medication' })).toBeInTheDocument());
-    expect(screen.getByLabelText('Name')).toHaveValue('Ibuprofen 200mg');
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Update medication' })).toBeInTheDocument();
+      expect(screen.getByLabelText('Name')).toHaveValue('Ibuprofen 200mg');
+    });
   });
 
   it('renders loaded CPT codes as chips', async () => {

--- a/scripts/e2e-test-setup.ts
+++ b/scripts/e2e-test-setup.ts
@@ -294,15 +294,17 @@ async function setTestEhrUserCredentials(ehrConfig: EhrConfig): Promise<void> {
     ],
   });
 
+  if (!isVirtualEnabled) {
+    console.warn('Virtual mode not configured for this project — skipping telemed practitioner setup');
+    return;
+  }
+
   const virtualLocations = locationsResponse.unbundle().filter(isLocationVirtual);
 
   if (virtualLocations.length === 0) {
-    if (isVirtualEnabled) {
-      throw Error('No virtual locations found in FHIR API');
-    }
-    console.warn('No virtual locations found — skipping telemed practitioner setup (virtual mode not configured)');
-    return;
+    throw Error('No virtual locations found in FHIR API');
   }
+
   const firstDefaultVirtualLocation = virtualDefaultLocations[0];
 
   const licenses = allLicensesForPractitioner(practitioner);


### PR DESCRIPTION
Use the e2e configuration, not the presence of telemedicine locations, when verifying the e2e setup condition, since locations may be added without actually using the telemedicine flow.