### PR TITLE
Alex/fix sentry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30711,6 +30711,7 @@
         "@types/xml2js": "^0.4.14",
         "archiver": "^7.0.1",
         "cors": "^2.8.5",
+        "dotenv": "^17.4.0",
         "esbuild": "^0.25.1",
         "esbuild-plugin-copy": "^2.1.1",
         "express": "^4.21.2",
@@ -30908,6 +30909,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "packages/zambdas/node_modules/dotenv": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
+      "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "packages/zambdas/node_modules/events": {

--- a/packages/zambdas/bundle.ts
+++ b/packages/zambdas/bundle.ts
@@ -221,6 +221,12 @@ const main = async (): Promise<void> => {
     !['local', 'e2e', 'e2e2', 'e2e3'].includes(process.env.ENV || '') &&
     Boolean(process.env.SENTRY_AUTH_TOKEN && process.env.SENTRY_ORG && process.env.SENTRY_PROJECT);
 
+  console.log('env, ', process.env.ENV);
+  console.log('sentry token ', process.env.SENTRY_AUTH_TOKEN);
+  console.log('sentry org ', process.env.SENTRY_ORG);
+  console.log('sentry project ', process.env.SENTRY_PROJECT);
+  console.log('Sentry enabled:', isSentryEnabled);
+
   const icd10Zambdas = zambdas.filter((zambda) => zambdasWithIcd10Search.includes(zambda.name));
   const regularZambdas = zambdas.filter((zambda) => !zambdasWithIcd10Search.includes(zambda.name));
 

--- a/packages/zambdas/bundle.ts
+++ b/packages/zambdas/bundle.ts
@@ -1,10 +1,13 @@
 import { sentryEsbuildPlugin } from '@sentry/esbuild-plugin';
 import archiver from 'archiver';
+import dotenv from 'dotenv';
 import * as esbuild from 'esbuild';
 import { type Options } from 'execa';
 import fs from 'fs';
 import path from 'path';
 import zambdasSpec from '../../config/oystehr-core/zambdas.json';
+
+dotenv.config({ path: path.join(process.cwd(), '.env.sentry-build-plugin') });
 
 interface ZambdaSpec {
   name: string;
@@ -220,12 +223,6 @@ const main = async (): Promise<void> => {
   const isSentryEnabled =
     !['local', 'e2e', 'e2e2', 'e2e3'].includes(process.env.ENV || '') &&
     Boolean(process.env.SENTRY_AUTH_TOKEN && process.env.SENTRY_ORG && process.env.SENTRY_PROJECT);
-
-  console.log('env, ', process.env.ENV);
-  console.log('sentry token ', process.env.SENTRY_AUTH_TOKEN);
-  console.log('sentry org ', process.env.SENTRY_ORG);
-  console.log('sentry project ', process.env.SENTRY_PROJECT);
-  console.log('Sentry enabled:', isSentryEnabled);
 
   const icd10Zambdas = zambdas.filter((zambda) => zambdasWithIcd10Search.includes(zambda.name));
   const regularZambdas = zambdas.filter((zambda) => !zambdasWithIcd10Search.includes(zambda.name));

--- a/packages/zambdas/package.json
+++ b/packages/zambdas/package.json
@@ -87,6 +87,7 @@
     "@types/xml2js": "^0.4.14",
     "archiver": "^7.0.1",
     "cors": "^2.8.5",
+    "dotenv": "^17.4.0",
     "esbuild": "^0.25.1",
     "esbuild-plugin-copy": "^2.1.1",
     "express": "^4.21.2",

--- a/turbo.json
+++ b/turbo.json
@@ -1,17 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalPassThroughEnv": [
-    "ENV",
-    "PLAYWRIGHT_SUITE_ID",
-    "PLAYWRIGHT_REPORT_SUFFIX",
-    "PLAYWRIGHT_EXTRA_ARGS",
-    "IS_LOGIN_TEST",
-    "INTEGRATION_TEST",
-    "SMOKE_TEST",
-    "SENTRY_AUTH_TOKEN",
-    "SENTRY_ORG",
-    "SENTRY_PROJECT"
-  ],
+  "globalPassThroughEnv": ["ENV", "PLAYWRIGHT_SUITE_ID", "PLAYWRIGHT_REPORT_SUFFIX", "PLAYWRIGHT_EXTRA_ARGS", "IS_LOGIN_TEST", "INTEGRATION_TEST", "SMOKE_TEST"],
   "tasks": {
     "start": {
       "cache": false,

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalPassThroughEnv": ["ENV", "PLAYWRIGHT_SUITE_ID", "PLAYWRIGHT_REPORT_SUFFIX", "PLAYWRIGHT_EXTRA_ARGS", "IS_LOGIN_TEST", "INTEGRATION_TEST", "SMOKE_TEST"],
+  "globalPassThroughEnv": [
+    "ENV",
+    "PLAYWRIGHT_SUITE_ID",
+    "PLAYWRIGHT_REPORT_SUFFIX",
+    "PLAYWRIGHT_EXTRA_ARGS",
+    "IS_LOGIN_TEST",
+    "INTEGRATION_TEST",
+    "SMOKE_TEST",
+    "SENTRY_AUTH_TOKEN",
+    "SENTRY_ORG",
+    "SENTRY_PROJECT"
+  ],
   "tasks": {
     "start": {
       "cache": false,


### PR DESCRIPTION
We now check these variables directly in the code before the sentry plugin loads from the env file directly. So we need to get the variables loaded in order to do that logic that skips sourcemap work if they are not there.