### PR TITLE
fix: sanitize filenames with spaces in document upload URLs

### DIFF
--- a/packages/zambdas/src/ehr/create-upload-document-url/index.ts
+++ b/packages/zambdas/src/ehr/create-upload-document-url/index.ts
@@ -74,8 +74,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
     logIt(`Folder name => [${folderName}]`);
 
-    const sanitizedFileName = sanitizeFileNameForZ3(fileName);
-    const fileZ3Url = makeZ3Url({ secrets, patientID: patientId, bucketName: folderName, fileName: sanitizedFileName });
+    const fileZ3Url = makeZ3Url({ secrets, patientID: patientId, bucketName: folderName, fileName });
     const presignedFileUploadUrl = await createPresignedUrl(m2mToken, fileZ3Url, 'upload');
 
     logIt(`created fileZ3Url: [${fileZ3Url}] :: presignedFileUploadUrl: [${presignedFileUploadUrl}]`);
@@ -257,8 +256,4 @@ function createDocumentReferenceRequest(input: CreateDocRefInput): BatchInputPos
 const resolveDocumentReferenceType = ({ folder }: { folder: List }): CodeableConcept | undefined => {
   console.log(folder);
   return;
-};
-
-const sanitizeFileNameForZ3 = (fileName: string): string => {
-  return fileName.replace(/[^a-zA-Z0-9+!\-_'()\\.@$]/g, '_');
 };

--- a/packages/zambdas/src/shared/presigned-file-urls/helpers.ts
+++ b/packages/zambdas/src/shared/presigned-file-urls/helpers.ts
@@ -22,13 +22,24 @@ type Z3UrlInput =
       fileName: string;
     };
 
+/**
+ * Sanitizes a filename for use in Z3 URLs by replacing any characters
+ * that are not URL-safe with hyphens. This prevents upload failures
+ * when filenames contain spaces or other special characters.
+ */
+export const sanitizeFileName = (fileName: string): string => {
+  return fileName.replace(/[^a-zA-Z0-9.\-_()]/g, '-');
+};
+
 export const makeZ3UrlForVisitAudio = (input: Z3UrlAudioInput): string => {
   const { secrets, bucketName } = input;
   const projectId = getSecret(SecretsKeys.PROJECT_ID, secrets);
   const dateTimeNow = DateTime.now().toUTC().toFormat('yyyy-MM-dd-x');
-  const fileURL = `${getSecret(SecretsKeys.PROJECT_API, secrets)}/z3/${projectId}-${bucketName}/${dateTimeNow}-${
-    input.fileName
-  }`;
+  const sanitizedFileName = sanitizeFileName(input.fileName);
+  const fileURL = `${getSecret(
+    SecretsKeys.PROJECT_API,
+    secrets
+  )}/z3/${projectId}-${bucketName}/${dateTimeNow}-${sanitizedFileName}`;
   console.log('created z3 url: ', fileURL);
   return fileURL;
 };
@@ -39,7 +50,7 @@ export const makeZ3Url = (input: Z3UrlInput): string => {
   const dateTimeNow = DateTime.now().toUTC().toFormat('yyyy-MM-dd-x');
   let resolvedFileName: string;
   if ('fileName' in input) {
-    resolvedFileName = input.fileName;
+    resolvedFileName = sanitizeFileName(input.fileName);
   } else {
     resolvedFileName = `${input.fileType}.${input.fileFormat}`;
   }


### PR DESCRIPTION
## Summary
Filenames with spaces (and other special characters) now get sanitized before being used in Z3 URLs, preventing upload failures.

Fixes #6771

## Root Cause
`makeZ3Url` in the shared helpers didn't sanitize filenames. A local `sanitizeFileNameForZ3` function existed in the upload handler but only protected that one caller — any other code path using `makeZ3Url` with user-provided filenames would fail.

## Design Decision
Moved sanitization into the shared `makeZ3Url` and `makeZ3UrlForVisitAudio` helpers rather than keeping it local to the upload handler. This way every caller that passes a user-provided filename is automatically protected. The alternative of keeping it local would require each caller to remember to sanitize, which is error-prone.

## What Changed
- Added exported `sanitizeFileName` function in `presigned-file-urls/helpers.ts` — replaces non-URL-safe characters with hyphens
- Applied sanitization inside both `makeZ3Url` and `makeZ3UrlForVisitAudio`
- Removed redundant local `sanitizeFileNameForZ3` from the upload handler

## Test Results
- Pre-commit lint-staged passed
- Zambda unit tests require local secrets/server config that isn't available without a full environment setup — relying on CI

---

Happy to adjust the approach if you'd prefer a different direction!