### PR TITLE
Set nonNormalResult to Neutral instead of undefined for normal observations

### DIFF
--- a/packages/zambdas/src/ehr/lab/in-house/handle-in-house-lab-results/index.ts
+++ b/packages/zambdas/src/ehr/lab/in-house/handle-in-house-lab-results/index.ts
@@ -691,7 +691,7 @@ const formatObsValueAndInterpretation = (
     const obsInterpretation = {
       interpretation: [NORMAL_OBSERVATION_INTERPRETATION],
     };
-    return { obsValue, obsInterpretation, nonNormalResult: undefined };
+    return { obsValue, obsInterpretation, nonNormalResult: NonNormalResult.Neutral };
   }
   throw new Error('Cannot format Obs value and interpretation. Unrecognized obsDef.permittedDataType');
 };


### PR DESCRIPTION
## Summary
Updated the `formatObsValueAndInterpretation` function to return `NonNormalResult.Neutral` instead of `undefined` for the `nonNormalResult` field when an observation has a normal interpretation.

## Key Changes
- Changed the return value of `nonNormalResult` from `undefined` to `NonNormalResult.Neutral` when formatting observations with normal interpretation
- This ensures consistent typing and explicit representation of normal results rather than using undefined as a sentinel value

## Implementation Details
- The change affects the code path that handles observations with normal interpretation (marked with `NORMAL_OBSERVATION_INTERPRETATION`)
- This makes the data structure more explicit and type-safe by using an enum value instead of undefined to represent the neutral/normal state

https://claude.ai/code/session_01FdtwuMheWfSiQ4bWFo2isH