### PR TITLE
Fix(admin): in house lab QA feedback

### DIFF
--- a/apps/ehr/src/features/in-house-labs/components/details/InHouseLabResults.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/details/InHouseLabResults.tsx
@@ -1,9 +1,11 @@
 import { BiotechOutlined } from '@mui/icons-material';
 import { Box, Button, Paper, Typography } from '@mui/material';
+import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { dataTestIds } from 'src/constants/data-test-ids';
 import { useGetAppointmentAccessibility } from 'src/features/visits/shared/hooks/useGetAppointmentAccessibility';
+import { useAppointmentData } from 'src/features/visits/shared/stores/appointment/appointment.store';
 import { DiagnosisDTO, EntryMode, getFormattedDiagnoses, InHouseOrderDetailPageItemDTO, LoadingState } from 'utils';
 import { configResultPageContainerTestId } from '../../utils/test-ids';
 import { InHouseLabResultCard } from './InHouseLabResultCard';
@@ -23,6 +25,8 @@ export const InHouseLabResults: React.FC<InHouseLabResultsProps> = ({
 }) => {
   const navigate = useNavigate();
   const { isAppointmentReadOnly: isReadOnly } = useGetAppointmentAccessibility();
+  const { encounter } = useAppointmentData();
+  const queryClient = useQueryClient();
 
   // we sort the tests on the back end, most recent will always be first
   // const sortedOrders = inHouseOrders.sort((a, b) => compareDates(a.orderAddedDate, b.orderAddedDate));
@@ -66,6 +70,14 @@ export const InHouseLabResults: React.FC<InHouseLabResultsProps> = ({
   );
 
   const handleRepeatOnClick = (): void => {
+    if (encounter?.id) {
+      // completely clears the cache and does not serve old data while the cache is refreshing
+      // we do this to make sure that any changes to repeat tests are picked up properly
+      queryClient.removeQueries({
+        queryKey: ['inhouse lab resource search', encounter.id],
+      });
+    }
+
     navigate(`/in-person/${testDetails?.[0].appointmentId}/in-house-lab-orders/create`, {
       state: {
         testItemName: testDetails?.[0]?.testItemName,

--- a/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx
+++ b/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx
@@ -129,7 +129,7 @@ export const InHouseLabOrderCreatePage: React.FC = () => {
   const labSets = createInHouseLabResources?.labSets;
 
   useEffect(() => {
-    if (!prefillData || didPrefillInit.current) {
+    if (!prefillData || didPrefillInit.current || !availableTests.length) {
       return;
     }
 
@@ -137,13 +137,17 @@ export const InHouseLabOrderCreatePage: React.FC = () => {
 
     if (testItemName) {
       const found = availableTests.find((test) => test.name === testItemName);
-      if (found) {
-        if (prefillData.type === 'repeat') {
-          found.orderMode = 'repeat';
-        }
-        setSelectedTests([found]);
+      if (!found) {
+        console.log(`Cannot find test ${testItemName} in available tests`, availableTests);
+        return;
       }
+      if (prefillData.type === 'repeat') {
+        found.orderMode = 'repeat';
+      }
+      console.log('"found" test', found);
+      setSelectedTests([found]);
     }
+
     if (diagnoses) {
       setSelectedAssessmentDiagnoses(diagnoses);
     }

--- a/apps/ehr/src/features/visits/telemed/components/admin/in-house-labs/AdminInHouseLabDetails.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/in-house-labs/AdminInHouseLabDetails.tsx
@@ -25,9 +25,10 @@ export default function AdminInHouseLabDetails(): ReactElement {
   const currentUser = useEvolveUser();
   const currentUserId = currentUser?.id ?? '';
 
-  const { mutateAsync: updateInHouseLabMutateAsync, isPending: isSubmitting } = useAdminUpdateInHouseLab(
-    activityDefinitionId ?? ''
-  );
+  const [editButtonLoading, setEditButtonLoading] = useState(false);
+  const [statusButtonLoading, setStatusButtonLoading] = useState(false);
+
+  const { mutateAsync: updateInHouseLabMutateAsync } = useAdminUpdateInHouseLab(activityDefinitionId ?? '');
   const {
     data: existingData,
     isPending,
@@ -55,6 +56,7 @@ export default function AdminInHouseLabDetails(): ReactElement {
     async (formData: AdminInHouseLabItemDefinition) => {
       console.log('submitted formData', formData);
       if (!existingData) return;
+      setEditButtonLoading(true);
 
       try {
         const result = await updateInHouseLabMutateAsync({
@@ -79,6 +81,8 @@ export default function AdminInHouseLabDetails(): ReactElement {
       } catch (err: unknown) {
         console.error('edit in house lab failed', err);
         setSubmitError(err as OystehrSdkError | APIError);
+      } finally {
+        setEditButtonLoading(false);
       }
     },
     [updateInHouseLabMutateAsync, navigate, currentUserId, existingData]
@@ -86,6 +90,7 @@ export default function AdminInHouseLabDetails(): ReactElement {
 
   const onUpdateStatusSubmit = useCallback(async () => {
     if (!existingData) return;
+    setStatusButtonLoading(true);
 
     try {
       const result = await updateInHouseLabMutateAsync({
@@ -103,6 +108,8 @@ export default function AdminInHouseLabDetails(): ReactElement {
     } catch (err: unknown) {
       console.error('toggle status in house lab failed', err);
       setSubmitError(err as OystehrSdkError | APIError);
+    } finally {
+      setStatusButtonLoading(false);
     }
   }, [updateInHouseLabMutateAsync, existingData, currentUserId]);
 
@@ -133,7 +140,7 @@ export default function AdminInHouseLabDetails(): ReactElement {
                   defaultValues={dataToRender}
                   formMode="edit"
                   onSubmit={onEditSubmit}
-                  isSubmitting={isSubmitting}
+                  isSubmitting={editButtonLoading}
                   submitError={submitError}
                   disableEdits={disableEdits}
                   disableEditsMessage={disableEditsMessage}
@@ -148,7 +155,7 @@ export default function AdminInHouseLabDetails(): ReactElement {
               <ToggleStatusSection
                 testItemStatus={existingData?.activityDefinitionStatus}
                 onSubmit={onUpdateStatusSubmit}
-                isSubmitting={isSubmitting}
+                isSubmitting={statusButtonLoading}
                 submitError={submitError}
                 disableEdits={disableEdits}
                 disableEditsMessage={disableEditsMessage}

--- a/packages/utils/lib/types/data/in-house/in-house.schema.ts
+++ b/packages/utils/lib/types/data/in-house/in-house.schema.ts
@@ -115,6 +115,7 @@ const CptCodeInHouseLabDefinitionSchema = z.object({
         display: nonEmptyString('Modifier display required'),
       })
     )
+    .transform((modArray) => (modArray?.length ? modArray : undefined)) // make sure we don't get empty arrays
     .optional(),
 });
 
@@ -132,6 +133,7 @@ export const AdminInHouseLabItemDefinitionSchema = z.object({
   loincCode: z
     .array(nonEmptyString('LOINC must be non-empty if provided'))
     .min(1, 'At least on LOINC code required when provided')
+    .transform((loincArr) => (loincArr?.length ? loincArr : undefined)) // make sure we don't get empty arrays
     .optional(),
   repeatTest: z.boolean(),
   components: z.array(TestItemComponentSchema).min(1, 'Test must contain at least one component'),

--- a/packages/zambdas/src/ehr/lab/in-house/create-in-house-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/in-house/create-in-house-lab-order/index.ts
@@ -16,6 +16,7 @@ import {
   getFullestAvailableName,
   getSecret,
   IN_HOUSE_LAB_ERROR,
+  IN_HOUSE_LAB_LATEST_TAG_DEFINITION,
   IN_HOUSE_TEST_CODE_SYSTEM,
   isApiError,
   REFLEX_ARTIFACT_DISPLAY,
@@ -70,6 +71,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     const oystehrCurrentUser = createOystehrClient(validatedParameters.userToken, validatedParameters.secrets);
 
     const { encounterId, testItems, diagnosesAll, diagnosesNew, notes } = validatedParameters;
+    console.log('This is testItems in create-in-house-lab-order', JSON.stringify(testItems, undefined, 2));
 
     const encounterResourcesRequest = async (): Promise<(Encounter | Patient | Location | Coverage | Account)[]> =>
       (
@@ -108,7 +110,11 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
               resourceType: 'ActivityDefinition',
               params: [
                 { name: 'url', value: item.adUrl },
-                { name: 'version', value: item.adVersion },
+                { name: 'status', value: 'active' },
+                {
+                  name: '_tag',
+                  value: `${IN_HOUSE_LAB_LATEST_TAG_DEFINITION.system}|${IN_HOUSE_LAB_LATEST_TAG_DEFINITION.code}`, // we care less about the version and more that it is latest
+                },
               ],
             })
             .then((result) => result.unbundle() as ActivityDefinition[]);
@@ -250,8 +256,10 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
       if (orderMode === 'repeat') {
         if (!serviceRequests || serviceRequests.length === 0) {
+          // edge case: if a repeat test is ordered, then the version is updated, and the user clicks the "repeat" button from the order details screen
+          // We still try to match SRs to the ad url and version, and so a match cannot be found. Alternative is to find too many matches
           throw IN_HOUSE_LAB_ERROR(
-            `You cannot run ${activityDefinition.name} as repeat, no initial tests could be found for this encounter.`
+            `You cannot run '${activityDefinition.name}' as repeat. No initial tests could be found for this encounter. Ask an admin if the version of the test you are trying to run has changed, or re-run the test not as repeat.`
           );
         }
         const possibleInitialSRs = serviceRequests.reduce((acc: ServiceRequest[], sr) => {

--- a/packages/zambdas/src/ehr/lab/shared/in-house-labs.ts
+++ b/packages/zambdas/src/ehr/lab/shared/in-house-labs.ts
@@ -444,7 +444,24 @@ export const fetchActiveInHouseLabActivityDefinitions = async (oystehr: Oystehr)
         { name: 'status', value: 'active' },
       ],
     })
-    .then((response) => response.unbundle());
+    .then((response) => {
+      const unbundled = response.unbundle();
+      console.log(
+        `These are the ActivityDefinitions found in fetchActiveInHouseLabActivityDefinitions: `,
+        JSON.stringify(
+          unbundled.map((ad) => ({
+            name: ad.name,
+            id: ad.id,
+            url: ad.url,
+            version: ad.version,
+            status: ad.status,
+          })),
+          undefined,
+          2
+        )
+      );
+      return unbundled;
+    });
 };
 
 export const getInHouseLabTestUrlAndVersionForADFromServiceRequest = (


### PR DESCRIPTION
Addresses: 
* Save button on edit view spinning separately for deactivate button 
* Fixes bug when editing a test to remove a cpt modifier, which used to then break the test going forward
* Adds a better error message for a repeat edge case
  * **Note:** Even after this, if a repeat test is edited in Admin between when a user results the first test and before they try to run the repeat, they still won't be able to run the repeat. We can think about how we want that to look, but it is very edge case and not worth handling in 1.31
