### PR TITLE
fix: add space between multiple CPT codes in in-house lab order form

### DIFF
--- a/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx
+++ b/apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx
@@ -170,7 +170,7 @@ export const InHouseLabOrderCreatePage: React.FC = () => {
 
       return `${c.code}${modifier}${!isStandard ? ' (QW)' : ''}`;
     });
-    return cptCodesFormatted.join(',');
+    return cptCodesFormatted.join(', ');
   };
 
   const handleSubmit = async (e: React.FormEvent | React.MouseEvent, shouldPrintLabel = false): Promise<void> => {


### PR DESCRIPTION
## Summary
Multiple CPT codes in the in-house lab order form's table cell are now joined with `", "` instead of `","`, so they render with proper spacing.

Fixes #6872

## Root Cause
`formatCptCodesForCell` in `InHouseLabOrderCreatePage.tsx` was joining the formatted CPT code strings with `','` (no space). For a test with multiple CPT codes (e.g. a panel that includes two or more codes), the cell rendered them jammed together, matching the screenshot in the issue.

## Design Decision
Went with `', '` (comma + space) because that's what every other CPT code join in the codebase uses — e.g. `ProcedureQuickPicksPage.tsx:145` (`join(', ')`), `Procedures.tsx:191` (`join(', ')`). Staying consistent with the rest of the codebase rather than introducing a third format. The only exception is `visit-note/procedures.ts` which uses `'; '` for a slightly different context (multi-CPT within a procedure row), but `', '` is the dominant convention in table-cell contexts.

Note: left the inner modifier join on line 162 (`.join(',')`) untouched because that join produces strings like `-91-XYZ` where commas are structural to the CPT modifier format, not human-facing separators.

## What Changed
- `apps/ehr/src/features/in-house-labs/pages/InHouseLabOrderCreatePage.tsx`: Changed `cptCodesFormatted.join(',')` to `cptCodesFormatted.join(', ')` on line 173

## Test Results
- Pre-commit lint-staged (ESLint) passed
- Change is a single-character addition to a formatting join — no behavioral or type changes