### PR TITLE
fix: updated error handling for create-invoices zambda and for FE, improved logs

### DIFF
--- a/apps/ehr/src/pages/reports/InvoiceablePatients.tsx
+++ b/apps/ehr/src/pages/reports/InvoiceablePatients.tsx
@@ -251,27 +251,29 @@ export default function InvoiceablePatients(): React.ReactElement {
   };
 
   const updateInvoice = (taskId: string | undefined): void => {
-    try {
-      if (oystehrZambda && taskId) {
-        setUpdatingTaskIds((prev) => new Set(prev).add(taskId));
+    if (!oystehrZambda || !taskId) return;
 
-        void updateInvoiceTask(oystehrZambda, {
-          taskId,
-          status: mapDisplayToInvoiceTaskStatus('updating'),
-          userTimezone: DateTime.local().zoneName,
-        }).finally(async () => {
-          enqueueSnackbar('Invoice status changed to "updating"', { variant: 'success' });
-          await refetchInvoiceablePatients();
-          setUpdatingTaskIds((prev) => {
-            const next = new Set(prev);
-            next.delete(taskId);
-            return next;
-          });
+    setUpdatingTaskIds((prev) => new Set(prev).add(taskId));
+
+    updateInvoiceTask(oystehrZambda, {
+      taskId,
+      status: mapDisplayToInvoiceTaskStatus('updating'),
+      userTimezone: DateTime.local().zoneName,
+    })
+      .then(async () => {
+        enqueueSnackbar('Invoice status changed to "updating"', { variant: 'success' });
+        await refetchInvoiceablePatients();
+      })
+      .catch(() => {
+        enqueueSnackbar('Error occurred, please try again', { variant: 'error' });
+      })
+      .finally(() => {
+        setUpdatingTaskIds((prev) => {
+          const next = new Set(prev);
+          next.delete(taskId);
+          return next;
         });
-      }
-    } catch {
-      enqueueSnackbar('Error occurred, please try again', { variant: 'error' });
-    }
+      });
   };
 
   useEffect(() => {

--- a/packages/utils/lib/fhir/helpers.ts
+++ b/packages/utils/lib/fhir/helpers.ts
@@ -790,7 +790,9 @@ function parseBundleIntoResources(bundle: Bundle): Resource[] {
       const innerBundle = entry.resource as Bundle;
       const innerEntry = innerBundle.entry;
       if (!innerEntry) {
-        throw new Error('could not parse search bundle');
+        console.log('no inner entry found in bundle');
+        // A FHIR searchset bundle with 0 results may omit the entry field entirely — that's valid.
+        return;
       }
       innerEntry.forEach((e) => {
         if (e.resource?.resourceType && e.resource?.id) result.push(e.resource);

--- a/packages/utils/lib/helpers/candidApi.ts
+++ b/packages/utils/lib/helpers/candidApi.ts
@@ -106,12 +106,13 @@ async function getCandidInventoryPageRecursive(input: {
   });
 
   if (inventoryResponse && inventoryResponse.ok && inventoryResponse.body) {
-    let records = inventoryResponse.body.records as InventoryRecord[];
+    const allRecords = inventoryResponse.body.records as InventoryRecord[];
     const nextPageToken = inventoryResponse.body.nextPageToken;
 
-    if (onlyInvoiceable) records = records.filter((record) => record.patientArStatus === 'invoiceable');
+    let records = allRecords;
+    if (onlyInvoiceable) records = allRecords.filter((record) => record.patientArStatus === 'invoiceable');
 
-    console.log(`📄 Page ${pageCount}: Found ${records.length} total claims`);
+    console.log(`📄 Page ${pageCount}: Found ${allRecords.length} total claims, ${records.length} invoiceable`);
 
     if (nextPageToken)
       return await getCandidInventoryPageRecursive({

--- a/packages/zambdas/src/cron/create-invoices-tasks/index.ts
+++ b/packages/zambdas/src/cron/create-invoices-tasks/index.ts
@@ -49,13 +49,20 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     const candid = createCandidApiClient(secrets);
 
     const twoDaysAgo = DateTime.now().minus({ days: 2 });
+    console.log('Fetching invoiceable Candid claims since:', twoDaysAgo.toISO());
     const candidClaims = await getAllCandidClaims(candid, twoDaysAgo);
-    console.log('getting candid claims for the past two days');
 
-    console.log('getting pending and to create packages');
     const packagesToCreate = await getEncountersWithoutTaskFhir(oystehr, candid, candidClaims);
 
-    console.log('encounters without a task: ', packagesToCreate.length);
+    console.log(
+      `Packages to create tasks for: ${packagesToCreate.length} ${JSON.stringify(
+        packagesToCreate.map((p) => ({
+          encounterId: p.encounter.id,
+          claimId: p.claim.claimId,
+          amountCents: p.amountCents,
+        }))
+      )}`
+    );
 
     await Promise.all(packagesToCreate.map((pkg) => createTaskForEncounter(oystehr, pkg)));
 
@@ -106,7 +113,7 @@ export async function createTaskForEncounter(oystehr: Oystehr, encounterPkg: Enc
     const prefilledInvoiceInfo = await getInvoiceTaskInput(claim.claimId, claim.timestamp, amountCents);
 
     console.log(
-      `Creating task. patient: ${claim.patientExternalId}, claim: ${claim.claimId}, oyst encounter: ${encounter.id} balance (cents): ${amountCents}`
+      `Creating task. patient: ${claim.patientExternalId}, claim: ${claim.claimId}, encounter: ${encounter.id}, balance (cents): ${amountCents}`
     );
 
     const task: Task = {
@@ -129,7 +136,7 @@ export async function createTaskForEncounter(oystehr: Oystehr, encounterPkg: Enc
 
     const created = await oystehr.fhir.create(task);
 
-    console.log('Created task: ', created.id);
+    console.log(`Created task: ${created.id} (encounter: ${encounter.id}, claim: ${claim.claimId})`);
   } catch (error) {
     console.error(
       `Failed to create task for encounter ${encounterPkg.encounter.id}, claim ${encounterPkg.claim.claimId}:`,
@@ -150,7 +157,13 @@ export async function getEncountersWithoutTaskFhir(
   candid: CandidApiClient,
   claims: InventoryRecord[]
 ): Promise<EncounterPackage[]> {
-  console.log('Getting encounters with a task');
+  if (claims.length === 0) {
+    console.log('No claims to check for existing FHIR tasks');
+    return [];
+  }
+
+  console.log(`Checking ${claims.length} Candid claims for existing FHIR tasks`);
+
   const fhirResources = await getResourcesFromBatchInlineRequests(
     oystehr,
     claims.map(
@@ -158,7 +171,6 @@ export async function getEncountersWithoutTaskFhir(
         `Encounter?identifier=${CANDID_ENCOUNTER_ID_IDENTIFIER_SYSTEM}|${claim.encounterId}&_has:Task:encounter:code=${RcmTaskCodings.sendInvoiceToPatient.coding?.[0].system}|${RcmTaskCodings.sendInvoiceToPatient.coding?.[0].code}`
     )
   );
-  console.log('Encounters with tasks: ', fhirResources.length);
   const allEncountersCandidIds = claims.map((claim) => claim.encounterId);
   const allEncountersCandidIdsWithTasks = fhirResources
     .filter((res) => res.resourceType === 'Encounter')
@@ -167,29 +179,50 @@ export async function getEncountersWithoutTaskFhir(
     (id) => !allEncountersCandidIdsWithTasks.includes(id)
   );
 
-  console.log('Searching for encounters without a task');
+  console.log(
+    `Candid encounters: ${claims.length} total, ${allEncountersCandidIdsWithTasks.length} already have a task, ${candidEncountersIdsWithoutTasks.length} need one`
+  );
+
+  if (candidEncountersIdsWithoutTasks.length === 0) {
+    console.log('No Candid encounters without tasks found');
+    return [];
+  }
+
   const encountersWithoutTasksResponse = await getResourcesFromBatchInlineRequests(
     oystehr,
     candidEncountersIdsWithoutTasks.map(
       (claimId) => `Encounter?identifier=${CANDID_ENCOUNTER_ID_IDENTIFIER_SYSTEM}|${claimId}`
     )
   );
+
   const encountersWithoutTasks = encountersWithoutTasksResponse.filter(
     (res) => res.resourceType === 'Encounter'
   ) as Encounter[];
-  console.log('Encounters without a task found raw: ', encountersWithoutTasks.length);
+
+  console.log(
+    `FHIR encounters found for ${encountersWithoutTasks.length} of ${candidEncountersIdsWithoutTasks.length} Candid IDs without a task`
+  );
 
   const result: Omit<EncounterPackage, 'amountCents' | 'invoiceTask'>[] = [];
   encountersWithoutTasks.forEach((encounter) => {
-    const claim = claims.find((claim) => claim.encounterId === getCandidEncounterIdFromEncounter(encounter));
+    const candidId = getCandidEncounterIdFromEncounter(encounter);
+    const claim = claims.find((claim) => claim.encounterId === candidId);
+
     if (claim) {
-      result.push({
-        encounter,
-        claim,
-      });
+      result.push({ encounter, claim });
+    } else {
+      console.warn(`No Candid claim matched FHIR encounter ${encounter.id} (candidId: ${candidId})`);
     }
   });
-  console.log('Getting amounts for encounters and populating packages with patient balances:');
+
+  if (candidEncountersIdsWithoutTasks.length !== encountersWithoutTasks.length) {
+    const missingIds = candidEncountersIdsWithoutTasks.filter(
+      (id) => !encountersWithoutTasks.some((enc) => getCandidEncounterIdFromEncounter(enc) === id)
+    );
+
+    console.warn(`Candid encounter IDs with no matching FHIR encounter: ${JSON.stringify(missingIds)}`);
+  }
+
   return await populateAmountInPackages(candid, result);
 }
 
@@ -221,7 +254,10 @@ export async function populateAmountInPackages(
     const itemization = res.body as InvoiceItemizationResponse;
 
     if (!itemization.claimId) {
-      console.warn(`Itemization response is missing claimId, skipping`);
+      console.warn(
+        `Itemization response is missing claimId, skipping (input claimId: ${packages[idx]?.claim?.claimId})`
+      );
+
       return;
     }
 
@@ -255,10 +291,11 @@ async function getAllCandidClaims(candid: CandidApiClient, sinceDate: DateTime):
     since: sinceDate,
   });
 
-  const claimsFetched = inventoryPages?.claims;
-  console.log('fetched claims: ', claimsFetched?.length);
-  if (claimsFetched?.length && claimsFetched.length > 0) {
-    return claimsFetched;
-  }
-  return [];
+  const claimsFetched = inventoryPages?.claims ?? [];
+
+  console.log(
+    `Candid inventory returned ${claimsFetched.length} invoiceable claims (pages: ${inventoryPages?.pageCount ?? 0})`
+  );
+
+  return claimsFetched;
 }

--- a/packages/zambdas/src/ehr/get-invoices-tasks/index.ts
+++ b/packages/zambdas/src/ehr/get-invoices-tasks/index.ts
@@ -257,7 +257,11 @@ async function getFhirResourcesGrouped(
   });
   const resources = bundle.unbundle() as Resource[];
   const tasks = resources.filter((r) => r.resourceType === 'Task') as FhirTask[];
-  console.log('Tasks found: ', tasks.length);
+
+  console.log(
+    `Tasks found: ${tasks.length} (page: ${page}, status: ${status}, patientId: ${patientId}, hideZeroBalance: ${hideZeroBalance})`
+  );
+
   const resultGroups: TaskGroup[] = [];
 
   tasks.forEach((task) => {
@@ -322,7 +326,14 @@ async function getFhirResourcesGrouped(
     });
   });
 
-  console.log('Tasks groups created: ', resultGroups.length);
+  console.log(
+    `Task groups built: ${resultGroups.length} of ${tasks.length} tasks on this page (bundle.total: ${bundle.total})`
+  );
+
+  if (resultGroups.length < tasks.length) {
+    console.warn(`${tasks.length - resultGroups.length} task(s) dropped due to missing encounter or patient in bundle`);
+  }
+
   return { taskGroups: resultGroups, bundleTotal: bundle.total ?? resultGroups.length };
 }
 


### PR DESCRIPTION
- Fixed parseBundleIntoResources throwing on FHIR searchset bundles with no results
- Added early returns when claims/encounter ID arrays are empty to avoid unnecessary FHIR batch requests
- Fixed async error handling in updateInvoice - errors were silently swallowed while showing a success snackbar
- Improved logging across the invoicing pipeline