### PR TITLE
fix: visit pdf should be accessible in the EHR

### DIFF
--- a/packages/zambdas/src/ehr/change-telemed-appointment-status/index.ts
+++ b/packages/zambdas/src/ehr/change-telemed-appointment-status/index.ts
@@ -167,19 +167,7 @@ export const performEffect = async (
       }
     };
 
-    // Check if we should skip making visit note available to patient portal
-    const skipSendingVisitNoteToPatientPortal = isFeatureFlagEnabled(
-      'SKIP_SENDING_VISIT_NOTE_TO_PATIENT_PORTAL_WHEN_THE_NOTE_IS_SIGNED_FEATURE_FLAG',
-      secrets
-    );
-
-    let visitNoteCreatedSuccessfully = false;
-
-    if (!skipSendingVisitNoteToPatientPortal) {
-      visitNoteCreatedSuccessfully = await createVisitNoteForPatientPortal();
-    } else {
-      console.log('Skipping visit note creation and email to patient portal - feature flag is enabled');
-    }
+    const visitNoteCreatedSuccessfully = await createVisitNoteForPatientPortal();
 
     let candidEncounterId: string | undefined;
     try {
@@ -279,8 +267,14 @@ export const performEffect = async (
         });
       }
     }
-    // Send email notification only if visit note was created successfully
-    if (visitNoteCreatedSuccessfully) {
+
+    const skipVisitNoteInPatientPortal = isFeatureFlagEnabled(
+      'SKIP_SENDING_VISIT_NOTE_TO_PATIENT_PORTAL_WHEN_THE_NOTE_IS_SIGNED_FEATURE_FLAG',
+      secrets
+    );
+
+    // Send email notification only if visit note was created successfully and not suppressed
+    if (visitNoteCreatedSuccessfully && !skipVisitNoteInPatientPortal) {
       const emailClient = getEmailClient(secrets);
       const emailEnabled = emailClient.getFeatureFlag();
       const patientEmail = getPatientContactEmail(patient);

--- a/packages/zambdas/src/patient/appointment/get-visit-details/helpers.ts
+++ b/packages/zambdas/src/patient/appointment/get-visit-details/helpers.ts
@@ -4,10 +4,12 @@ import {
   FileURLInfo,
   FileURLs,
   getPresignedURL,
+  isFeatureFlagEnabled,
   LAB_DOC_REF_DETAIL_TAGS,
   LAB_RESULT_DOC_REF_CODING_CODE,
   MEDICATION_DISPENSABLE_DRUG_ID,
   PrescribedMedication,
+  Secrets,
 } from 'utils';
 import { getLabDocRefDescriptionFromMetaTags } from '../../../shared/pdf/lab-pdf-utils';
 
@@ -204,4 +206,17 @@ export async function getPresignedURLs(
   );
 
   return { presignedUrls: presignedUrlObj, reviewedLabResultsUrls };
+}
+
+export async function getPatientPortalPresignedURLs(
+  oystehr: Oystehr,
+  oystehrToken: string,
+  encounterId: string | undefined,
+  secrets: Secrets | null
+): Promise<{ presignedUrls: FileURLs; reviewedLabResultsUrls: FileURLInfo[] }> {
+  const result = await getPresignedURLs(oystehr, oystehrToken, encounterId);
+  if (isFeatureFlagEnabled('SKIP_SENDING_VISIT_NOTE_TO_PATIENT_PORTAL_WHEN_THE_NOTE_IS_SIGNED_FEATURE_FLAG', secrets)) {
+    delete result.presignedUrls['visit-note'];
+  }
+  return result;
 }

--- a/packages/zambdas/src/patient/appointment/get-visit-details/index.ts
+++ b/packages/zambdas/src/patient/appointment/get-visit-details/index.ts
@@ -10,7 +10,7 @@ import {
   SecretsKeys,
 } from 'utils';
 import { checkOrCreateM2MClientToken, topLevelCatch, wrapHandler, ZambdaInput } from '../../../shared';
-import { getMedications, getPresignedURLs } from './helpers';
+import { getMedications, getPatientPortalPresignedURLs } from './helpers';
 import { validateRequestParameters } from './validateRequestParameters';
 
 // Lifting up value to outside of the handler allows it to stay in memory across warm lambda invocations
@@ -72,7 +72,12 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
     try {
       console.log(`getting presigned urls for document references files at ${appointmentId}`);
-      const { presignedUrls, reviewedLabResultsUrls } = await getPresignedURLs(oystehr, oystehrToken, encounter?.id);
+      const { presignedUrls, reviewedLabResultsUrls } = await getPatientPortalPresignedURLs(
+        oystehr,
+        oystehrToken,
+        encounter?.id,
+        secrets
+      );
       documents = presignedUrls;
       reviewedLabResults = reviewedLabResultsUrls;
     } catch (error) {
@@ -107,7 +112,12 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
             let followupDocuments = {};
             try {
               if (followupEncounter.id) {
-                const { presignedUrls } = await getPresignedURLs(oystehr, oystehrToken, followupEncounter.id);
+                const { presignedUrls } = await getPatientPortalPresignedURLs(
+                  oystehr,
+                  oystehrToken,
+                  followupEncounter.id,
+                  secrets
+                );
                 followupDocuments = presignedUrls;
               }
             } catch (error) {

--- a/packages/zambdas/src/subscriptions/task/sub-visit-note-pdf-and-email/index.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-visit-note-pdf-and-email/index.ts
@@ -148,9 +148,13 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
   console.log('Chart data received');
   try {
-    let statusMessage: string;
+    // Check if we should skip making visit note visible in patient portal
+    const skipVisitNoteInPatientPortal = isFeatureFlagEnabled(
+      'SKIP_SENDING_VISIT_NOTE_TO_PATIENT_PORTAL_WHEN_THE_NOTE_IS_SIGNED_FEATURE_FLAG',
+      secrets
+    );
 
-    const createAndSendVisitNoteToPatientPortal = async (): Promise<void> => {
+    const createVisitNotePdfAndSendEmail = async (): Promise<void> => {
       const { pdfInfo } = await createProgressNotePdf(
         {
           patient,
@@ -182,79 +186,76 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
       const emailEnabled = emailClient.getFeatureFlag();
 
       if (emailEnabled && !isPDFOnlyTask) {
-        const patientEmail = getPatientContactEmail(patient);
-        let prettyStartTime = '';
-        let locationName = '';
-        let address = '';
-        if (appointment.start && visitResources.timezone) {
-          prettyStartTime = DateTime.fromISO(appointment.start)
-            .setZone(visitResources.timezone)
-            .toFormat(DATETIME_FULL_NO_YEAR);
-        }
-        if (location) {
-          locationName = getNameForOwner(location);
-          address = getAddressStringForScheduleResource(location) ?? '';
-        }
-        const { presignedUrls } = await getPresignedURLs(oystehr, oystehrToken, visitResources.encounter.id!);
-        const visitNoteUrl = presignedUrls['visit-note']?.presignedUrl;
-
-        if (isInPersonAppointment) {
-          const missingData: string[] = [];
-          if (!patientEmail) missingData.push('patient email');
-          if (!appointment.id) missingData.push('appointment ID');
-          if (!locationName) missingData.push('location name');
-          if (!address) missingData.push('address');
-          if (!prettyStartTime) missingData.push('appointment time');
-          if (!visitNoteUrl) missingData.push('visit note URL');
-          if (missingData.length === 0 && location && visitNoteUrl && patientEmail) {
-            // note: it's assumed that location is the schedule owner here, which is incorrect for Provider schedules
-            const templateData: InPersonCompletionTemplateData = {
-              location: getNameForOwner(location),
-              time: prettyStartTime,
-              address,
-              'address-url': makeAddressUrl(address),
-              'visit-note-url': visitNoteUrl,
-            };
-            await emailClient.sendInPersonCompletionEmail(patientEmail, templateData);
-          } else {
-            console.error(
-              `Not sending in-person completion email, missing the following data: ${missingData.join(', ')}`
-            );
-          }
+        if (skipVisitNoteInPatientPortal) {
+          console.log('Skipping completion email to patient - visit note patient portal feature flag is enabled');
         } else {
-          const missingData: string[] = [];
-          if (!patientEmail) missingData.push('patient email');
-          if (!appointment.id) missingData.push('appointment ID');
-          if (!locationName) missingData.push('location name');
-          if (!visitNoteUrl) missingData.push('visit note URL');
-          if (missingData.length === 0 && location && visitNoteUrl && patientEmail) {
-            const templateData: TelemedCompletionTemplateData = {
-              location: getNameForOwner(location),
-              'visit-note-url': visitNoteUrl,
-            };
-            await emailClient.sendVirtualCompletionEmail(patientEmail, templateData);
+          const patientEmail = getPatientContactEmail(patient);
+          let prettyStartTime = '';
+          let locationName = '';
+          let address = '';
+          if (appointment.start && visitResources.timezone) {
+            prettyStartTime = DateTime.fromISO(appointment.start)
+              .setZone(visitResources.timezone)
+              .toFormat(DATETIME_FULL_NO_YEAR);
+          }
+          if (location) {
+            locationName = getNameForOwner(location);
+            address = getAddressStringForScheduleResource(location) ?? '';
+          }
+          const { presignedUrls } = await getPresignedURLs(oystehr, oystehrToken, visitResources.encounter.id!);
+          const visitNoteUrl = presignedUrls['visit-note']?.presignedUrl;
+
+          if (isInPersonAppointment) {
+            const missingData: string[] = [];
+            if (!patientEmail) missingData.push('patient email');
+            if (!appointment.id) missingData.push('appointment ID');
+            if (!locationName) missingData.push('location name');
+            if (!address) missingData.push('address');
+            if (!prettyStartTime) missingData.push('appointment time');
+            if (!visitNoteUrl) missingData.push('visit note URL');
+            if (missingData.length === 0 && location && visitNoteUrl && patientEmail) {
+              // note: it's assumed that location is the schedule owner here, which is incorrect for Provider schedules
+              const templateData: InPersonCompletionTemplateData = {
+                location: getNameForOwner(location),
+                time: prettyStartTime,
+                address,
+                'address-url': makeAddressUrl(address),
+                'visit-note-url': visitNoteUrl,
+              };
+              await emailClient.sendInPersonCompletionEmail(patientEmail, templateData);
+            } else {
+              console.error(
+                `Not sending in-person completion email, missing the following data: ${missingData.join(', ')}`
+              );
+            }
           } else {
-            console.error(
-              `Not sending virtual completion email, missing the following data: ${missingData.join(', ')}`
-            );
+            const missingData: string[] = [];
+            if (!patientEmail) missingData.push('patient email');
+            if (!appointment.id) missingData.push('appointment ID');
+            if (!locationName) missingData.push('location name');
+            if (!visitNoteUrl) missingData.push('visit note URL');
+            if (missingData.length === 0 && location && visitNoteUrl && patientEmail) {
+              const templateData: TelemedCompletionTemplateData = {
+                location: getNameForOwner(location),
+                'visit-note-url': visitNoteUrl,
+              };
+              await emailClient.sendVirtualCompletionEmail(patientEmail, templateData);
+            } else {
+              console.error(
+                `Not sending virtual completion email, missing the following data: ${missingData.join(', ')}`
+              );
+            }
           }
         }
       }
     };
 
-    // Check if we should skip making visit note available to patient portal
-    const skipSendingVisitNoteToPatientPortal = isFeatureFlagEnabled(
-      'SKIP_SENDING_VISIT_NOTE_TO_PATIENT_PORTAL_WHEN_THE_NOTE_IS_SIGNED_FEATURE_FLAG',
-      secrets
-    );
+    await createVisitNotePdfAndSendEmail();
 
-    if (skipSendingVisitNoteToPatientPortal) {
-      console.log('Skipping visit note creation and email to patient portal - feature flag is enabled');
-      statusMessage = 'PDF creation and email sending were skipped due to app settings';
-    } else {
-      await createAndSendVisitNoteToPatientPortal();
-      statusMessage = isPDFOnlyTask ? 'PDF created successfully' : 'PDF created and emailed successfully';
-    }
+    const statusMessage =
+      isPDFOnlyTask || skipVisitNoteInPatientPortal
+        ? 'PDF created successfully'
+        : 'PDF created and emailed successfully';
 
     // update task status and status reason
     console.log('making patch request to update task status');


### PR DESCRIPTION
Previously, when SKIP_SENDING_VISIT_NOTE_TO_PATIENT_PORTAL_WHEN_THE_NOTE_IS_SIGNED_FEATURE_FLAG was enabled, visit note PDF generation was skipped entirely — making it unavailable in the EHR as well.

The fix narrows the scope: the PDF and its DocumentReference are always created (EHR access preserved), but when the flag is enabled, the completion email is not sent and the visit note URL is excluded from the get-visit-details patient portal response. 