### PR TITLE
fix ehr e2e test flake for complete encounters report where sometimes…

### DIFF
--- a/apps/ehr/tests/e2e/specs/reports/completeEncounters.spec.ts
+++ b/apps/ehr/tests/e2e/specs/reports/completeEncounters.spec.ts
@@ -40,7 +40,9 @@ test.describe('Complete Encounters Report', () => {
     await page.goto('/reports/complete-encounters');
 
     // Heading
-    await expect(page.getByRole('heading', { name: 'Complete Encounters' })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('heading', { name: 'Complete Encounters', exact: true })).toBeVisible({
+      timeout: 15000,
+    });
 
     // Description text
     await expect(page.getByText(/This report shows encounters that have been completed/i)).toBeVisible();


### PR DESCRIPTION
… text is not matched uniquely