### PR TITLE
fix(tests): fix tests fail because they try to write to screens that …

### DIFF
--- a/apps/ehr/tests/e2e/specs/in-person/inPersonVisit.spec.ts
+++ b/apps/ehr/tests/e2e/specs/in-person/inPersonVisit.spec.ts
@@ -14,6 +14,8 @@ import {
   getPatientDetailsStepAnswers,
   getPaymentOptionInsuranceAnswers,
   getResponsiblePartyStepAnswers,
+  hasAttorneyInformationPage,
+  hasEmployerInformationPage,
   INSURANCE_PLAN_PAYER_META_TAG_CODE,
   isoToDateObject,
 } from 'utils';
@@ -116,9 +118,9 @@ test.describe('In-person visit', async () => {
           insurancePolicyHolderRelationshipToInsured2: PATIENT_INSURANCE_POLICY_HOLDER_2_RELATIONSHIP_TO_INSURED,
         }),
         getResponsiblePartyStepAnswers({}),
-        getEmployerInformationStepAnswers({}),
+        ...(hasEmployerInformationPage() ? [getEmployerInformationStepAnswers({})] : []),
         getEmergencyContactStepAnswers({}),
-        getAttorneyInformationStepAnswers({}),
+        ...(hasAttorneyInformationPage() ? [getAttorneyInformationStepAnswers({})] : []),
         getConsentStepAnswers({}),
       ];
     });
@@ -266,7 +268,7 @@ test.describe('In-person visit', async () => {
           insurancePolicyHolderRelationshipToInsured2: PATIENT_INSURANCE_POLICY_HOLDER_2_RELATIONSHIP_TO_INSURED,
         }),
         getResponsiblePartyStepAnswers({}),
-        getEmployerInformationStepAnswers({}),
+        ...(hasEmployerInformationPage() ? [getEmployerInformationStepAnswers({})] : []),
         getEmergencyContactStepAnswers({}),
         getConsentStepAnswers({}),
       ];


### PR DESCRIPTION
…may not be in the paperwork for the ottehr instance

[HOST-798: EHR e2e create appointment beforeAll failures](https://linear.app/zapehr/issue/HOST-798/ehr-e2e-create-appointment-beforeall-failures)