### PR TITLE
Add AI quality test suite with LLM-as-judge evaluation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6588,6 +6588,15 @@
       "version": "2.8.1",
       "license": "0BSD"
     },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@hapi/address": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
@@ -8304,6 +8313,35 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@langchain/google-genai": {
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-0.2.18.tgz",
+      "integrity": "sha512-m9EiN3VKC01A7/625YQ6Q1Lqq8zueewADX4W5Tcme4RImN75zkg2Z7FYbD1Fo6Zwolc4wBNO6LUtbg3no4rv1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@google/generative-ai": "^0.24.0",
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.3.58 <0.4.0"
+      }
+    },
+    "node_modules/@langchain/google-genai/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@langchain/langgraph": {
       "version": "0.2.57",
       "license": "MIT",
@@ -8386,6 +8424,67 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/openai": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.5.18.tgz",
+      "integrity": "sha512-CX1kOTbT5xVFNdtLjnM0GIYNf+P7oMSu+dGCFxxWRa3dZwWiuyuBXCm+dToUGxDLnsHuV1bKBtIzrY1mLq/A1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tiktoken": "^1.0.12",
+        "openai": "^5.3.0",
+        "zod": "^3.25.32"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.3.58 <0.4.0"
+      }
+    },
+    "node_modules/@langchain/openai/node_modules/openai": {
+      "version": "5.23.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.2.tgz",
+      "integrity": "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/openai/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@lhncbc/ucum-lhc": {
@@ -12126,9 +12225,9 @@
       "license": "0BSD"
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@streamparser/json": {
@@ -14292,6 +14391,10 @@
       "engines": {
         "node": ">= 6.0.0"
       }
+    },
+    "node_modules/ai-quality-tests": {
+      "resolved": "packages/ai-quality-tests",
+      "link": true
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -20290,6 +20393,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-node-process": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
@@ -24917,6 +25032,286 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openevals": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/openevals/-/openevals-0.1.5.tgz",
+      "integrity": "sha512-CS1pHXMxpG58FpR0OkizaBTD2Tzye3pVrqdiCFOIDZpsTZhKJQdOldkP0FICK9TVwFcT6h7ShLIpLFYxoxWtbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/openai": ">=0.4.4",
+        "langchain": ">=1.2.27",
+        "langsmith": ">=0.4.6",
+        "uuid": "^11.1.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.3.73",
+        "typescript": "*",
+        "zod": ">=3.24.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openevals/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/openevals/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/openevals/node_modules/langchain": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.3.0.tgz",
+      "integrity": "sha512-1JiqaoljBHyY3mHg58CbKskIgHrGvDp4XidlQ0sSd8LaPhIjMLhGGGBPihy2uuVPn6TvyUv9d381jFYTGSyrWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph": "^1.2.6",
+        "@langchain/langgraph-checkpoint": "^1.0.1",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.39"
+      }
+    },
+    "node_modules/openevals/node_modules/langchain/node_modules/@langchain/langgraph": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.7.tgz",
+      "integrity": "sha512-Oh3MY/q4YS3xY79JQDOz5r+48KcWDDYfTb8hQ/Y2mD4rCrJ/W4FJDKqbZHvYS4/ohd/YjuCZrcCoeLiJy4d3pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph-checkpoint": "^1.0.1",
+        "@langchain/langgraph-sdk": "~1.8.5",
+        "@standard-schema/spec": "1.1.0",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.16",
+        "zod": "^3.25.32 || ^4.2.0",
+        "zod-to-json-schema": "^3.x"
+      },
+      "peerDependenciesMeta": {
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openevals/node_modules/langchain/node_modules/@langchain/langgraph-checkpoint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
+      "integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.1"
+      }
+    },
+    "node_modules/openevals/node_modules/langchain/node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/openevals/node_modules/langchain/node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.7.tgz",
+      "integrity": "sha512-RXo7LBV+l03GrQn++QpBbpeCaBxpuDun8jo9t9s6uSR0WEBsQodV4f5kXYMeVtlAZNOv5HEiuEqf5S7d1QL7iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1",
+        "uuid": "^13.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.16",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openevals/node_modules/langchain/node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/openevals/node_modules/langchain/node_modules/@langchain/langgraph/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/openevals/node_modules/langchain/node_modules/p-queue": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.1.tgz",
+      "integrity": "sha512-yQS1vV2V7Q14MQrgD8jMNY5owPuGgVHVdSK8NqmKpOVajnjbaeMa6uLOzTALPtvJ7Vo4bw0BGsw7qfUT8z24Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openevals/node_modules/langsmith": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.16.tgz",
+      "integrity": "sha512-nSsSnTo3gjg1dnb48vb8i582zyjvtPbn+EpR6P1pNELb+4Hb4R3nt7LDy+Tl1ltw73vPGfJQtUWOl28irI1b5w==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "console-table-printer": "^2.12.1",
+        "p-queue": "^6.6.2",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openevals/node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/openevals/node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openevals/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openevals/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "dev": true,
@@ -28915,7 +29310,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -30295,7 +30690,7 @@
     },
     "node_modules/ws": {
       "version": "7.5.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -30557,6 +30952,21 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "packages/ai-quality-tests": {
+      "version": "0.1.0",
+      "dependencies": {
+        "@langchain/anthropic": "^0.3.32",
+        "@langchain/core": "^0.3.78",
+        "@langchain/google-genai": "^0.2.0",
+        "@langchain/openai": "^0.5.0",
+        "dotenv": "^16.4.0",
+        "openevals": "^0.1.5"
+      },
+      "devDependencies": {
+        "typescript": "5.8.3",
+        "vitest": "^3.2.4"
       }
     },
     "packages/config-types": {

--- a/packages/ai-quality-tests/.env.example
+++ b/packages/ai-quality-tests/.env.example
@@ -1,12 +1,24 @@
-# Judge model API key (defaults to OpenAI)
-OPENAI_API_KEY=sk-...
+# ── Model under test ─────────────────────────────────────────────────────────
+# Format: provider:model-name
+# Examples:
+#   gemini:gemini-3.1-flash-lite-preview   (production default)
+#   claude:claude-haiku-4-5-20251001
+#   claude:claude-opus-4-20250514
+#   claude:claude-sonnet-4-20250514
+EXTRACTION_MODEL=gemini:gemini-3.1-flash-lite-preview
 
-# Gemini via Vertex AI (production default)
+# ── API keys for models under test ──────────────────────────────────────────
+# Only the keys for your chosen provider are required.
+
+# Gemini via Vertex AI
 GOOGLE_CLOUD_PROJECT_ID=your-gcp-project-id
 GOOGLE_CLOUD_API_KEY=...
 
-# Claude (alternative model under test)
+# Claude via Anthropic API
 ANTHROPIC_API_KEY=sk-ant-...
+
+# ── Judge model (evaluates outputs) ─────────────────────────────────────────
+OPENAI_API_KEY=sk-...
 
 # Override the judge model (default: openai:o3-mini)
 # JUDGE_MODEL=anthropic:claude-sonnet-4-20250514

--- a/packages/ai-quality-tests/.env.example
+++ b/packages/ai-quality-tests/.env.example
@@ -1,0 +1,9 @@
+# Judge model API key (defaults to OpenAI)
+OPENAI_API_KEY=sk-...
+
+# Models under test
+ANTHROPIC_API_KEY=sk-ant-...
+GOOGLE_API_KEY=...
+
+# Override the judge model (default: openai:o3-mini)
+# JUDGE_MODEL=anthropic:claude-sonnet-4-20250514

--- a/packages/ai-quality-tests/.env.example
+++ b/packages/ai-quality-tests/.env.example
@@ -1,9 +1,12 @@
 # Judge model API key (defaults to OpenAI)
 OPENAI_API_KEY=sk-...
 
-# Models under test
+# Gemini via Vertex AI (production default)
+GOOGLE_CLOUD_PROJECT_ID=your-gcp-project-id
+GOOGLE_CLOUD_API_KEY=...
+
+# Claude (alternative model under test)
 ANTHROPIC_API_KEY=sk-ant-...
-GOOGLE_API_KEY=...
 
 # Override the judge model (default: openai:o3-mini)
 # JUDGE_MODEL=anthropic:claude-sonnet-4-20250514

--- a/packages/ai-quality-tests/README.md
+++ b/packages/ai-quality-tests/README.md
@@ -35,7 +35,8 @@ cp packages/ai-quality-tests/.env.example packages/ai-quality-tests/.env
 | Key | Purpose |
 |-----|---------|
 | `OPENAI_API_KEY` | Judge model (evaluates outputs) |
-| `GOOGLE_API_KEY` | Gemini model under test (production default) |
+| `GOOGLE_CLOUD_PROJECT_ID` | GCP project for Vertex AI (Gemini) |
+| `GOOGLE_CLOUD_API_KEY` | Gemini model under test via Vertex AI (production default) |
 | `ANTHROPIC_API_KEY` | Claude model under test (alternative) |
 
 ## Running Tests

--- a/packages/ai-quality-tests/README.md
+++ b/packages/ai-quality-tests/README.md
@@ -1,0 +1,101 @@
+# AI Quality Tests
+
+LLM-as-judge quality tests for Ottehr's AI features, using [openevals](https://github.com/langchain-ai/openevals).
+
+## Features Tested
+
+### HPI Chatbot
+- **HPI narrative extraction** — evaluates clinical accuracy, completeness, and writing style of extracted History of Present Illness
+- **Structured data extraction** — evaluates accuracy of medications, allergies, PMH, surgical history, etc.
+- **HPI completeness suggestions** — evaluates the "missing HPI elements" detection feature
+- **JSON format compliance** — validates response structure matches expected schema
+
+### Ambient Scribe
+- **HPI narrative extraction** — same criteria as chatbot, applied to audio transcripts
+- **Structured data extraction** — includes labs, prescriptions, and procedures (scribe-specific fields)
+- **Mechanism of injury** — evaluates MOI narrative for workers' comp cases
+- **JSON format compliance** — validates response structure
+
+### Model Comparison
+- Side-by-side quality comparison across different models (Gemini vs Claude)
+
+## Setup
+
+```bash
+# From repo root
+npm install
+
+# Configure API keys
+cp packages/ai-quality-tests/.env.example packages/ai-quality-tests/.env
+# Edit .env with your API keys
+```
+
+### Required API Keys
+
+| Key | Purpose |
+|-----|---------|
+| `OPENAI_API_KEY` | Judge model (evaluates outputs) |
+| `GOOGLE_API_KEY` | Gemini model under test (production default) |
+| `ANTHROPIC_API_KEY` | Claude model under test (alternative) |
+
+## Running Tests
+
+```bash
+cd packages/ai-quality-tests
+
+# Run all quality tests
+npx vitest run
+
+# Run only HPI chatbot tests
+npx vitest run tests/hpi-chatbot
+
+# Run only ambient scribe tests
+npx vitest run tests/ambient-scribe
+
+# Run model comparison
+npx vitest run tests/model-comparison.test.ts
+
+# Watch mode (re-runs on file changes)
+npx vitest
+```
+
+## Changing Prompts or Models
+
+### Testing a prompt change
+1. Edit the prompt in `src/prompts.ts` (mirrors production prompts from `packages/zambdas/src/shared/ai.ts`)
+2. Run the tests to see if quality improves or regresses
+3. If satisfied, apply the same change to the production code
+
+### Testing a different model
+1. Edit `src/models.ts` to change the model name
+2. Or use the model comparison test to compare models side-by-side
+
+### Changing the judge model
+Set `JUDGE_MODEL` in your `.env` file:
+```
+JUDGE_MODEL=anthropic:claude-sonnet-4-20250514
+```
+
+## Adding Test Cases
+
+Add new cases to:
+- `src/test-data/hpi-chatbot-cases.ts` — HPI chatbot scenarios
+- `src/test-data/ambient-scribe-cases.ts` — ambient scribe scenarios
+
+Each case needs:
+- A realistic transcript
+- Clinically accurate expected output (used as reference for the judge)
+
+## Architecture
+
+```
+src/
+  prompts.ts              # Production prompts (mirrored from zambdas)
+  evaluation-prompts.ts   # LLM-as-judge rubrics
+  models.ts               # Model invocation helpers
+  test-data/              # Test cases with expected outputs
+tests/
+  hpi-chatbot/            # HPI chatbot quality tests
+  ambient-scribe/         # Ambient scribe quality tests
+  model-comparison.test.ts # Cross-model comparison
+```

--- a/packages/ai-quality-tests/README.md
+++ b/packages/ai-quality-tests/README.md
@@ -17,7 +17,7 @@ LLM-as-judge quality tests for Ottehr's AI features, using [openevals](https://g
 - **JSON format compliance** — validates response structure
 
 ### Model Comparison
-- Side-by-side quality comparison across different models (Gemini vs Claude)
+- Side-by-side quality comparison across any set of models
 
 ## Setup
 
@@ -25,26 +25,41 @@ LLM-as-judge quality tests for Ottehr's AI features, using [openevals](https://g
 # From repo root
 npm install
 
-# Configure API keys
+# Configure environment
 cp packages/ai-quality-tests/.env.example packages/ai-quality-tests/.env
-# Edit .env with your API keys
+# Edit .env with your API keys and model choice
 ```
 
-### Required API Keys
+### Environment Variables
 
-| Key | Purpose |
-|-----|---------|
-| `OPENAI_API_KEY` | Judge model (evaluates outputs) |
-| `GOOGLE_CLOUD_PROJECT_ID` | GCP project for Vertex AI (Gemini) |
-| `GOOGLE_CLOUD_API_KEY` | Gemini model under test via Vertex AI (production default) |
-| `ANTHROPIC_API_KEY` | Claude model under test (alternative) |
+| Variable | Purpose |
+|----------|---------|
+| `EXTRACTION_MODEL` | Model under test. Format: `provider:model-name` (see examples below) |
+| `GOOGLE_CLOUD_PROJECT_ID` | GCP project for Vertex AI (required for Gemini models) |
+| `GOOGLE_CLOUD_API_KEY` | API key for Vertex AI (required for Gemini models) |
+| `ANTHROPIC_API_KEY` | API key for Anthropic (required for Claude models) |
+| `OPENAI_API_KEY` | API key for the judge model that evaluates outputs |
+| `JUDGE_MODEL` | Override judge model (default: `openai:o3-mini`) |
+| `COMPARISON_MODELS` | Comma-separated list for model comparison test |
+
+### EXTRACTION_MODEL examples
+
+```bash
+# Production default (Gemini via Vertex AI)
+EXTRACTION_MODEL=gemini:gemini-3.1-flash-lite-preview
+
+# Claude models
+EXTRACTION_MODEL=claude:claude-haiku-4-5-20251001
+EXTRACTION_MODEL=claude:claude-opus-4-20250514
+EXTRACTION_MODEL=claude:claude-sonnet-4-20250514
+```
 
 ## Running Tests
 
 ```bash
 cd packages/ai-quality-tests
 
-# Run all quality tests
+# Run all quality tests with the configured EXTRACTION_MODEL
 npx vitest run
 
 # Run only HPI chatbot tests
@@ -53,8 +68,9 @@ npx vitest run tests/hpi-chatbot
 # Run only ambient scribe tests
 npx vitest run tests/ambient-scribe
 
-# Run model comparison
-npx vitest run tests/model-comparison.test.ts
+# Run model comparison (requires COMPARISON_MODELS env var)
+COMPARISON_MODELS=gemini:gemini-3.1-flash-lite-preview,claude:claude-opus-4-20250514 \
+  npx vitest run tests/model-comparison.test.ts
 
 # Watch mode (re-runs on file changes)
 npx vitest
@@ -62,19 +78,21 @@ npx vitest
 
 ## Changing Prompts or Models
 
+### Testing a different model
+Set `EXTRACTION_MODEL` in your `.env` and re-run the tests:
+```bash
+EXTRACTION_MODEL=claude:claude-opus-4-20250514 npx vitest run
+```
+
 ### Testing a prompt change
 1. Edit the prompt in `src/prompts.ts` (mirrors production prompts from `packages/zambdas/src/shared/ai.ts`)
 2. Run the tests to see if quality improves or regresses
 3. If satisfied, apply the same change to the production code
 
-### Testing a different model
-1. Edit `src/models.ts` to change the model name
-2. Or use the model comparison test to compare models side-by-side
-
-### Changing the judge model
-Set `JUDGE_MODEL` in your `.env` file:
-```
-JUDGE_MODEL=anthropic:claude-sonnet-4-20250514
+### Comparing models side-by-side
+```bash
+COMPARISON_MODELS=gemini:gemini-3.1-flash-lite-preview,claude:claude-opus-4-20250514 \
+  npx vitest run tests/model-comparison.test.ts
 ```
 
 ## Adding Test Cases

--- a/packages/ai-quality-tests/package.json
+++ b/packages/ai-quality-tests/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "ai-quality-tests",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:hpi-chatbot": "vitest run tests/hpi-chatbot",
+    "test:ambient-scribe": "vitest run tests/ambient-scribe",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "openevals": "^0.1.5",
+    "@langchain/core": "^0.3.78",
+    "@langchain/anthropic": "^0.3.32",
+    "@langchain/google-genai": "^0.2.0",
+    "@langchain/openai": "^0.5.0",
+    "dotenv": "^16.4.0"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4",
+    "typescript": "5.8.3"
+  }
+}

--- a/packages/ai-quality-tests/package.json
+++ b/packages/ai-quality-tests/package.json
@@ -13,7 +13,6 @@
     "openevals": "^0.1.5",
     "@langchain/core": "^0.3.78",
     "@langchain/anthropic": "^0.3.32",
-    "@langchain/google-genai": "^0.2.0",
     "@langchain/openai": "^0.5.0",
     "dotenv": "^16.4.0"
   },

--- a/packages/ai-quality-tests/src/evaluation-prompts.ts
+++ b/packages/ai-quality-tests/src/evaluation-prompts.ts
@@ -1,0 +1,154 @@
+/**
+ * Custom LLM-as-judge evaluation prompts for clinical AI quality assessment.
+ *
+ * Each prompt is a template consumed by openevals' createLLMAsJudge().
+ * Variables in {braces} are automatically interpolated from the evaluator call.
+ */
+
+/**
+ * Evaluates whether the HPI (History of Present Illness) narrative is
+ * clinically accurate, complete, and well-written.
+ */
+export const HPI_NARRATIVE_QUALITY_PROMPT = `You are a board-certified emergency medicine physician reviewing an AI-generated
+History of Present Illness (HPI) narrative extracted from a patient interview transcript.
+
+<transcript>
+{inputs}
+</transcript>
+
+<ai_generated_hpi>
+{outputs}
+</ai_generated_hpi>
+
+<reference_hpi>
+{reference_outputs}
+</reference_hpi>
+
+Evaluate the AI-generated HPI on these criteria:
+1. **Clinical Accuracy**: Does it accurately represent what the patient reported? No hallucinated or fabricated details?
+2. **Completeness**: Does it capture all clinically relevant information from the transcript (chief complaint, onset, duration, quality, severity, modifying factors, associated symptoms)?
+3. **Appropriate Negatives**: Does it correctly note relevant negatives the patient denied, without including conditions the patient denies having (as positive findings)?
+4. **Clinical Writing Style**: Is it written in proper third-person clinical prose ("The patient presents with...")?
+5. **No Fabrication**: Does it avoid adding information not present in the transcript?
+
+Return a score of true if the HPI meets professional clinical documentation standards
+(accurate, reasonably complete, no fabrications), or false if it has significant
+clinical errors, fabrications, or critical omissions.
+
+Provide a brief explanation for your score.`;
+
+/**
+ * Evaluates whether structured data fields (medications, allergies, PMH, etc.)
+ * are accurately extracted from the transcript.
+ */
+export const STRUCTURED_EXTRACTION_QUALITY_PROMPT = `You are a clinical informaticist reviewing AI-extracted structured medical data
+from a patient interview transcript.
+
+<transcript>
+{inputs}
+</transcript>
+
+<ai_extracted_data>
+{outputs}
+</ai_extracted_data>
+
+<reference_data>
+{reference_outputs}
+</reference_data>
+
+Evaluate the AI extraction on these criteria:
+1. **Accuracy**: Are all extracted items actually mentioned in the transcript?
+2. **Completeness**: Are there any items mentioned in the transcript that were missed?
+3. **Correct Categorization**: Are items placed in the correct fields (e.g., medications in medicationsHistory, not in allergies)?
+4. **Negation Handling**: Items the patient denies should NOT appear (e.g., if patient says "I don't smoke", smoking should not appear in socialHistory as a positive finding).
+5. **Format Compliance**: Are medications formatted with dose and timing when available? Are allergies formatted with reactions?
+
+Return a score of true if the extraction is clinically acceptable (no major errors,
+no dangerous omissions like missed allergies, no hallucinated items), or false if
+there are significant errors.
+
+Provide a brief explanation for your score.`;
+
+/**
+ * Evaluates the overall JSON response format compliance.
+ */
+export const FORMAT_COMPLIANCE_PROMPT = `You are reviewing an AI-generated JSON response for format compliance.
+
+<ai_response>
+{outputs}
+</ai_response>
+
+Check these format requirements:
+1. The response must be valid JSON (it has been parsed, so just verify structure).
+2. "historyOfPresentIllness" and "mechanismOfInjury" (if present) must be strings (clinical prose), NOT arrays.
+3. All other fields must be JSON arrays of strings.
+4. Keys must be camelCase.
+5. Sections with no relevant information should be omitted entirely (not present as empty arrays).
+6. No markdown formatting in the response.
+
+Return true if the format is correct, false if there are format violations.
+
+Provide a brief explanation for your score.`;
+
+/**
+ * Evaluates the mechanism of injury extraction for workers' comp cases.
+ */
+export const MECHANISM_OF_INJURY_PROMPT = `You are a board-certified occupational medicine physician reviewing an AI-generated
+Mechanism of Injury (MOI) narrative extracted from a workers' compensation visit transcript.
+
+<transcript>
+{inputs}
+</transcript>
+
+<ai_generated_moi>
+{outputs}
+</ai_generated_moi>
+
+<reference_moi>
+{reference_outputs}
+</reference_moi>
+
+Evaluate the MOI on these criteria:
+1. **Accuracy**: Does it accurately describe how the injury occurred based on the transcript?
+2. **Key Details**: Does it include the activity at time of injury, body mechanics involved, forces/weights, and timing?
+3. **Work-Relatedness**: Does it clearly establish the injury occurred in a work context?
+4. **Clinical Prose**: Is it written as a proper clinical narrative, not a list?
+5. **No Fabrication**: Does it avoid adding details not present in the transcript?
+
+Return true if the MOI meets occupational medicine documentation standards,
+false if it has significant errors or omissions.
+
+Provide a brief explanation for your score.`;
+
+/**
+ * Evaluates HPI suggestion quality (missing elements detection).
+ */
+export const HPI_SUGGESTION_QUALITY_PROMPT = `You are a clinical documentation specialist reviewing an AI system's assessment
+of potentially missing elements in an HPI (History of Present Illness).
+
+The standard HPI elements for an urgent care visit are:
+Onset, Location, Duration, Characteristic, Aggravating, Relieving, Timing, Severity, Associated Symptoms
+
+<hpi_text>
+{inputs}
+</hpi_text>
+
+<ai_suggestions>
+{outputs}
+</ai_suggestions>
+
+<reference_suggestions>
+{reference_outputs}
+</reference_suggestions>
+
+Evaluate the AI's suggestions:
+1. **Accuracy**: Are the identified missing elements actually missing from the HPI?
+2. **No False Positives**: Does it avoid flagging elements that ARE adequately covered?
+3. **Completeness**: Does it catch the important missing elements?
+4. **Format**: Is the response a single sentence starting with "HPI may not have covered"?
+5. **Appropriate Empty Response**: If the HPI is thorough, is the suggestions array empty?
+
+Return true if the suggestions are clinically helpful and accurate, false if they
+contain significant errors (flagging covered elements or missing obviously absent ones).
+
+Provide a brief explanation for your score.`;

--- a/packages/ai-quality-tests/src/models.ts
+++ b/packages/ai-quality-tests/src/models.ts
@@ -1,0 +1,131 @@
+/**
+ * Model invocation helpers that mirror the production AI pipeline.
+ *
+ * These call the same models with the same prompts as the production code,
+ * so we can evaluate output quality end-to-end.
+ */
+
+import { ChatAnthropic } from '@langchain/anthropic';
+import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
+import { getHpiExtractionPrompt, HPI_SUGGESTION_PROMPT } from './prompts.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface ExtractionResult {
+  raw: string;
+  parsed: Record<string, unknown>;
+}
+
+export interface HpiSuggestionResult {
+  raw: string;
+  parsed: { suggestions: string[] };
+}
+
+// ── Gemini (production default for extraction) ──────────────────────────────
+
+let geminiClient: ChatGoogleGenerativeAI | null = null;
+
+function getGeminiClient(): ChatGoogleGenerativeAI {
+  if (!geminiClient) {
+    const apiKey = process.env.GOOGLE_API_KEY;
+    if (!apiKey) throw new Error('GOOGLE_API_KEY is required to run extraction tests');
+    geminiClient = new ChatGoogleGenerativeAI({
+      model: 'gemini-2.0-flash-lite',
+      apiKey,
+      temperature: 0,
+    });
+  }
+  return geminiClient;
+}
+
+// ── Claude (alternative model for extraction) ───────────────────────────────
+
+let claudeClient: ChatAnthropic | null = null;
+
+function getClaudeClient(): ChatAnthropic {
+  if (!claudeClient) {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) throw new Error('ANTHROPIC_API_KEY is required to run Claude extraction tests');
+    claudeClient = new ChatAnthropic({
+      model: 'claude-haiku-4-5-20251001',
+      anthropicApiKey: apiKey,
+      temperature: 0,
+    });
+  }
+  return claudeClient;
+}
+
+// ── Extraction (HPI chatbot + ambient scribe) ───────────────────────────────
+
+/**
+ * Calls the extraction model with the production prompt and a transcript.
+ * Returns both the raw string response and the parsed JSON.
+ */
+export async function runExtraction(
+  transcript: string,
+  patientInfo: string,
+  fields: string,
+  model: 'gemini' | 'claude' = 'gemini'
+): Promise<ExtractionResult> {
+  const prompt = getHpiExtractionPrompt(patientInfo, fields) + '\n' + transcript;
+
+  let raw: string;
+  if (model === 'gemini') {
+    const response = await getGeminiClient().invoke([{ role: 'user', content: prompt }]);
+    raw = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+  } else {
+    const response = await getClaudeClient().invoke([{ role: 'user', content: prompt }]);
+    raw = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Try to extract JSON from markdown code blocks
+    const match = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (match) {
+      parsed = JSON.parse(match[1].trim());
+    } else {
+      throw new Error(`Failed to parse AI response as JSON: ${raw.slice(0, 200)}...`);
+    }
+  }
+
+  return { raw, parsed };
+}
+
+// ── HPI suggestion ──────────────────────────────────────────────────────────
+
+/**
+ * Calls the AI model with the HPI suggestion prompt, mirroring the
+ * ai-suggestion-notes zambda for the 'missing-hpi' type.
+ */
+export async function runHpiSuggestion(
+  hpiText: string,
+  model: 'gemini' | 'claude' = 'gemini'
+): Promise<HpiSuggestionResult> {
+  const prompt = HPI_SUGGESTION_PROMPT + `\nHPI: ${hpiText}`;
+
+  let raw: string;
+  if (model === 'gemini') {
+    const response = await getGeminiClient().invoke([{ role: 'user', content: prompt }]);
+    raw = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+  } else {
+    const response = await getClaudeClient().invoke([{ role: 'user', content: prompt }]);
+    raw = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+  }
+
+  let parsed: { suggestions: string[] };
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    const match = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (match) {
+      parsed = JSON.parse(match[1].trim());
+    } else {
+      throw new Error(`Failed to parse HPI suggestion response as JSON: ${raw.slice(0, 200)}...`);
+    }
+  }
+
+  return { raw, parsed };
+}

--- a/packages/ai-quality-tests/src/models.ts
+++ b/packages/ai-quality-tests/src/models.ts
@@ -3,10 +3,12 @@
  *
  * These call the same models with the same prompts as the production code,
  * so we can evaluate output quality end-to-end.
+ *
+ * The Gemini path uses the Vertex AI REST endpoint directly, matching
+ * the production invokeChatbotVertexAI() in packages/zambdas/src/shared/ai.ts.
  */
 
 import { ChatAnthropic } from '@langchain/anthropic';
-import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 import { getHpiExtractionPrompt, HPI_SUGGESTION_PROMPT } from './prompts.js';
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -21,21 +23,38 @@ export interface HpiSuggestionResult {
   parsed: { suggestions: string[] };
 }
 
-// ── Gemini (production default for extraction) ──────────────────────────────
+// ── Gemini via Vertex AI (production default for extraction) ─────────────────
 
-let geminiClient: ChatGoogleGenerativeAI | null = null;
+/**
+ * Calls Gemini via the Vertex AI REST endpoint, mirroring invokeChatbotVertexAI()
+ * from packages/zambdas/src/shared/ai.ts.
+ */
+async function invokeGeminiVertexAI(text: string): Promise<string> {
+  const projectId = process.env.GOOGLE_CLOUD_PROJECT_ID;
+  const apiKey = process.env.GOOGLE_CLOUD_API_KEY;
+  if (!projectId) throw new Error('GOOGLE_CLOUD_PROJECT_ID is required to run Gemini extraction tests');
+  if (!apiKey) throw new Error('GOOGLE_CLOUD_API_KEY is required to run Gemini extraction tests');
 
-function getGeminiClient(): ChatGoogleGenerativeAI {
-  if (!geminiClient) {
-    const apiKey = process.env.GOOGLE_API_KEY;
-    if (!apiKey) throw new Error('GOOGLE_API_KEY is required to run extraction tests');
-    geminiClient = new ChatGoogleGenerativeAI({
-      model: 'gemini-2.0-flash-lite',
-      apiKey,
-      temperature: 0,
-    });
+  const response = await fetch(
+    `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/global/publishers/google/models/gemini-3.1-flash-lite-preview:generateContent?key=${apiKey}`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        contents: [{ role: 'user', parts: [{ text }] }],
+        generationConfig: {
+          temperature: 0,
+        },
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Vertex AI request failed (${response.status}): ${body}`);
   }
-  return geminiClient;
+
+  const json = await response.json();
+  return json.candidates[0].content.parts[0].text;
 }
 
 // ── Claude (alternative model for extraction) ───────────────────────────────
@@ -71,8 +90,7 @@ export async function runExtraction(
 
   let raw: string;
   if (model === 'gemini') {
-    const response = await getGeminiClient().invoke([{ role: 'user', content: prompt }]);
-    raw = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+    raw = await invokeGeminiVertexAI(prompt);
   } else {
     const response = await getClaudeClient().invoke([{ role: 'user', content: prompt }]);
     raw = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
@@ -108,8 +126,7 @@ export async function runHpiSuggestion(
 
   let raw: string;
   if (model === 'gemini') {
-    const response = await getGeminiClient().invoke([{ role: 'user', content: prompt }]);
-    raw = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+    raw = await invokeGeminiVertexAI(prompt);
   } else {
     const response = await getClaudeClient().invoke([{ role: 'user', content: prompt }]);
     raw = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);

--- a/packages/ai-quality-tests/src/models.ts
+++ b/packages/ai-quality-tests/src/models.ts
@@ -1,11 +1,15 @@
 /**
  * Model invocation helpers that mirror the production AI pipeline.
  *
- * These call the same models with the same prompts as the production code,
- * so we can evaluate output quality end-to-end.
+ * The model under test is configured via the EXTRACTION_MODEL env var.
+ * Format: "provider:model-name"
+ *   - gemini:gemini-3.1-flash-lite-preview  (production default)
+ *   - claude:claude-haiku-4-5-20251001
+ *   - claude:claude-opus-4-20250514
  *
- * The Gemini path uses the Vertex AI REST endpoint directly, matching
- * the production invokeChatbotVertexAI() in packages/zambdas/src/shared/ai.ts.
+ * Gemini models use the Vertex AI REST endpoint (requires GOOGLE_CLOUD_PROJECT_ID
+ * and GOOGLE_CLOUD_API_KEY), matching production invokeChatbotVertexAI().
+ * Claude models use the Anthropic API (requires ANTHROPIC_API_KEY).
  */
 
 import { ChatAnthropic } from '@langchain/anthropic';
@@ -23,20 +27,44 @@ export interface HpiSuggestionResult {
   parsed: { suggestions: string[] };
 }
 
-// ── Gemini via Vertex AI (production default for extraction) ─────────────────
+// ── Model config from env ───────────────────────────────────────────────────
 
-/**
- * Calls Gemini via the Vertex AI REST endpoint, mirroring invokeChatbotVertexAI()
- * from packages/zambdas/src/shared/ai.ts.
- */
-async function invokeGeminiVertexAI(text: string): Promise<string> {
+const DEFAULT_MODEL = 'gemini:gemini-3.1-flash-lite-preview';
+
+interface ModelConfig {
+  provider: 'gemini' | 'claude';
+  modelName: string;
+}
+
+export function getModelConfig(envOverride?: string): ModelConfig {
+  const raw = envOverride ?? process.env.EXTRACTION_MODEL ?? DEFAULT_MODEL;
+  const colonIdx = raw.indexOf(':');
+  if (colonIdx === -1) {
+    throw new Error(
+      `Invalid EXTRACTION_MODEL format "${raw}". Expected "provider:model-name" ` +
+        '(e.g. "gemini:gemini-3.1-flash-lite-preview" or "claude:claude-opus-4-20250514")'
+    );
+  }
+  const provider = raw.slice(0, colonIdx) as ModelConfig['provider'];
+  const modelName = raw.slice(colonIdx + 1);
+
+  if (provider !== 'gemini' && provider !== 'claude') {
+    throw new Error(`Unknown provider "${provider}". Supported: gemini, claude`);
+  }
+
+  return { provider, modelName };
+}
+
+// ── Gemini via Vertex AI ────────────────────────────────────────────────────
+
+async function invokeGeminiVertexAI(text: string, modelName: string): Promise<string> {
   const projectId = process.env.GOOGLE_CLOUD_PROJECT_ID;
   const apiKey = process.env.GOOGLE_CLOUD_API_KEY;
-  if (!projectId) throw new Error('GOOGLE_CLOUD_PROJECT_ID is required to run Gemini extraction tests');
-  if (!apiKey) throw new Error('GOOGLE_CLOUD_API_KEY is required to run Gemini extraction tests');
+  if (!projectId) throw new Error('GOOGLE_CLOUD_PROJECT_ID is required for Gemini models');
+  if (!apiKey) throw new Error('GOOGLE_CLOUD_API_KEY is required for Gemini models');
 
   const response = await fetch(
-    `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/global/publishers/google/models/gemini-3.1-flash-lite-preview:generateContent?key=${apiKey}`,
+    `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/global/publishers/google/models/${modelName}:generateContent?key=${apiKey}`,
     {
       method: 'POST',
       body: JSON.stringify({
@@ -57,92 +85,78 @@ async function invokeGeminiVertexAI(text: string): Promise<string> {
   return json.candidates[0].content.parts[0].text;
 }
 
-// ── Claude (alternative model for extraction) ───────────────────────────────
+// ── Claude via Anthropic API ────────────────────────────────────────────────
 
-let claudeClient: ChatAnthropic | null = null;
+const claudeClients = new Map<string, ChatAnthropic>();
 
-function getClaudeClient(): ChatAnthropic {
-  if (!claudeClient) {
+function getClaudeClient(modelName: string): ChatAnthropic {
+  let client = claudeClients.get(modelName);
+  if (!client) {
     const apiKey = process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) throw new Error('ANTHROPIC_API_KEY is required to run Claude extraction tests');
-    claudeClient = new ChatAnthropic({
-      model: 'claude-haiku-4-5-20251001',
+    if (!apiKey) throw new Error('ANTHROPIC_API_KEY is required for Claude models');
+    client = new ChatAnthropic({
+      model: modelName,
       anthropicApiKey: apiKey,
       temperature: 0,
     });
+    claudeClients.set(modelName, client);
   }
-  return claudeClient;
+  return client;
+}
+
+// ── Invoke any model ────────────────────────────────────────────────────────
+
+async function invokeModel(text: string, config: ModelConfig): Promise<string> {
+  if (config.provider === 'gemini') {
+    return invokeGeminiVertexAI(text, config.modelName);
+  }
+
+  const response = await getClaudeClient(config.modelName).invoke([{ role: 'user', content: text }]);
+  return typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+}
+
+function parseJsonResponse(raw: string): Record<string, unknown> {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // Try to extract JSON from markdown code blocks
+    const match = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (match) {
+      return JSON.parse(match[1].trim());
+    }
+    throw new Error(`Failed to parse AI response as JSON: ${raw.slice(0, 200)}...`);
+  }
 }
 
 // ── Extraction (HPI chatbot + ambient scribe) ───────────────────────────────
 
 /**
  * Calls the extraction model with the production prompt and a transcript.
- * Returns both the raw string response and the parsed JSON.
+ * Uses EXTRACTION_MODEL env var to determine the model, or accepts an override.
  */
 export async function runExtraction(
   transcript: string,
   patientInfo: string,
   fields: string,
-  model: 'gemini' | 'claude' = 'gemini'
+  modelOverride?: string
 ): Promise<ExtractionResult> {
+  const config = getModelConfig(modelOverride);
   const prompt = getHpiExtractionPrompt(patientInfo, fields) + '\n' + transcript;
-
-  let raw: string;
-  if (model === 'gemini') {
-    raw = await invokeGeminiVertexAI(prompt);
-  } else {
-    const response = await getClaudeClient().invoke([{ role: 'user', content: prompt }]);
-    raw = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
-  }
-
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    // Try to extract JSON from markdown code blocks
-    const match = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
-    if (match) {
-      parsed = JSON.parse(match[1].trim());
-    } else {
-      throw new Error(`Failed to parse AI response as JSON: ${raw.slice(0, 200)}...`);
-    }
-  }
-
+  const raw = await invokeModel(prompt, config);
+  const parsed = parseJsonResponse(raw);
   return { raw, parsed };
 }
 
 // ── HPI suggestion ──────────────────────────────────────────────────────────
 
 /**
- * Calls the AI model with the HPI suggestion prompt, mirroring the
- * ai-suggestion-notes zambda for the 'missing-hpi' type.
+ * Calls the AI model with the HPI suggestion prompt.
+ * Uses EXTRACTION_MODEL env var to determine the model, or accepts an override.
  */
-export async function runHpiSuggestion(
-  hpiText: string,
-  model: 'gemini' | 'claude' = 'gemini'
-): Promise<HpiSuggestionResult> {
+export async function runHpiSuggestion(hpiText: string, modelOverride?: string): Promise<HpiSuggestionResult> {
+  const config = getModelConfig(modelOverride);
   const prompt = HPI_SUGGESTION_PROMPT + `\nHPI: ${hpiText}`;
-
-  let raw: string;
-  if (model === 'gemini') {
-    raw = await invokeGeminiVertexAI(prompt);
-  } else {
-    const response = await getClaudeClient().invoke([{ role: 'user', content: prompt }]);
-    raw = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
-  }
-
-  let parsed: { suggestions: string[] };
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    const match = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
-    if (match) {
-      parsed = JSON.parse(match[1].trim());
-    } else {
-      throw new Error(`Failed to parse HPI suggestion response as JSON: ${raw.slice(0, 200)}...`);
-    }
-  }
-
+  const raw = await invokeModel(prompt, config);
+  const parsed = parseJsonResponse(raw) as { suggestions: string[] };
   return { raw, parsed };
 }

--- a/packages/ai-quality-tests/src/prompts.ts
+++ b/packages/ai-quality-tests/src/prompts.ts
@@ -1,0 +1,84 @@
+/**
+ * Production prompts mirrored from the Ottehr TypeScript codebase.
+ *
+ * Kept in sync with:
+ *   - packages/zambdas/src/shared/ai.ts          → getPrompt()
+ *   - packages/utils/lib/ottehr-config/prompts/   → HPI_SUGGESTION
+ */
+
+/**
+ * Mirrors getPrompt() from packages/zambdas/src/shared/ai.ts.
+ * Used by both the HPI chatbot and ambient scribe features to extract
+ * structured clinical data from a conversation transcript.
+ */
+export function getHpiExtractionPrompt(patientInfo: string, fields: string): string {
+  return `I'll give you a transcript of a chat between a healthcare provider and a patient.
+Patient details: ${patientInfo}
+Please generate ${fields} based on the transcript.
+Return JSON. No markdown. Use camelCase keys.
+
+FORMAT RULES:
+- "historyOfPresentIllness" and "mechanismOfInjury" must be well-written clinical prose paragraphs (free text). Write in third person ("The patient presents with...").
+- All other sections must be JSON arrays of individual items (one item per array element).
+- For medications: each item should include the medication name, dose if mentioned, and last taken date/time if mentioned (e.g. "Lisinopril 10mg, last taken 03/15/2025 14:00").
+- For allergies: include the reaction if mentioned (e.g. "Penicillin - rash").
+- For conditions, surgical history, and hospitalizations: use short clinical phrases (e.g. "hypertension", "appendectomy 2019").
+- Do NOT include items the patient denies or negates.
+- Omit sections with no relevant information entirely.
+
+Example response:
+{
+  "historyOfPresentIllness": "The patient presents with chest pain for 2 days, worsening with exertion. No associated shortness of breath or diaphoresis.",
+  "pastMedicalHistory": ["hypertension", "type 2 diabetes"],
+  "pastSurgicalHistory": ["appendectomy 2019"],
+  "medicationsHistory": ["Lisinopril 10mg, last taken 03/28/2025 08:00", "Metformin 500mg", "Aspirin 81mg"],
+  "allergies": ["Penicillin - rash", "Sulfa drugs"],
+  "socialHistory": ["non-smoker", "occasional alcohol"],
+  "familyHistory": ["father - coronary artery disease", "mother - breast cancer"],
+  "hospitalizationsHistory": ["pneumonia January 2023"],
+  "labs": ["CBC", "BMP"],
+  "erx": ["Amoxicillin 500mg"],
+  "procedures": ["wound closure"]
+}
+The transcript: `;
+}
+
+/**
+ * Mirrors HPI_SUGGESTION from packages/utils/lib/ottehr-config/prompts/index.ts.
+ * Used by the ai-suggestion-notes zambda to identify missing HPI elements.
+ */
+export const HPI_SUGGESTION_PROMPT = `For each of these clinic data points gathered in HPI for an urgent care visit:
+    Onset,
+    Location,
+    Duration,
+    Characteristic,
+    Aggravating,
+    Relieving,
+    Timing,
+    Severity,
+    Associated Symptoms
+
+    Identify any the provider did not address sufficiently in the following HPI with a simple concise list within a single sentence of possibly missing items.
+    Start the single sentence with "HPI may not have covered"
+    Return a JSON object with a single field "suggestions" that is empty if there are no suggestions, or a list of one string of potentially missing items.
+    Do not respond with more than one sentence.
+    The response should be formatted like:
+    {
+      "suggestions": ["HPI may not have covered Onset, Location, Duration, Characteristic, Aggravating, Relieving, Timing, Severity, Associated Symptoms"]
+    }`;
+
+// ── Field sets (mirrored from createResourcesFromAiInterview in ai.ts) ──────
+
+/** Default fields requested for chat-based interviews (HPI chatbot). */
+export const CHAT_INTERVIEW_FIELDS =
+  'history of present illness, past medical history, past surgical history, ' +
+  'medications history, allergies, social history, family history, hospitalizations history';
+
+/** Fields for audio-recording-based interviews (ambient scribe). */
+export const AUDIO_INTERVIEW_FIELDS =
+  'labs, erx, procedures, history of present illness, past medical history, ' +
+  'past surgical history, medications history, allergies, social history, ' +
+  'family history, hospitalizations history';
+
+/** Prepended when the appointment is workers' comp. */
+export const WORKERS_COMP_PREFIX = 'mechanism of injury, ';

--- a/packages/ai-quality-tests/src/setup.ts
+++ b/packages/ai-quality-tests/src/setup.ts
@@ -1,0 +1,8 @@
+import { config } from 'dotenv';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Load .env from the package root
+config({ path: resolve(__dirname, '../.env') });

--- a/packages/ai-quality-tests/src/test-data/ambient-scribe-cases.ts
+++ b/packages/ai-quality-tests/src/test-data/ambient-scribe-cases.ts
@@ -1,0 +1,231 @@
+/**
+ * Test cases for the ambient scribe feature.
+ *
+ * Each case simulates a provider-patient conversation transcript as would be
+ * generated from an audio recording. These are more natural/conversational
+ * than the chatbot cases and include provider clinical observations and
+ * treatment plans (labs, erx, procedures).
+ */
+
+export interface AmbientScribeCase {
+  id: string;
+  description: string;
+  patientInfo: string;
+  isWorkersComp?: boolean;
+  transcript: string;
+  expected: Record<string, unknown>;
+}
+
+export const AMBIENT_SCRIBE_CASES: AmbientScribeCase[] = [
+  {
+    id: 'ankle_sprain_visit',
+    description: 'In-person visit for ankle sprain with exam findings and treatment',
+    patientInfo: 'Age: 28 year old, Sex: female',
+    transcript: [
+      "Provider: Hi, I'm Dr. Smith. What happened to your ankle?",
+      "Patient: I was playing basketball last night and landed on someone's foot. My right ankle just rolled under me.",
+      'Provider: When exactly did this happen?',
+      'Patient: Around 8pm last night, so about 14 hours ago.',
+      "Provider: How's the pain? Scale of 1 to 10?",
+      "Patient: It's about a 7 right now. It's really swollen.",
+      'Provider: Can you put weight on it?',
+      "Patient: I can a little bit but it really hurts. I've been using crutches my roommate had.",
+      'Provider: Have you iced it or taken anything for the pain?',
+      'Patient: I iced it last night and took some ibuprofen 400mg about 4 hours ago.',
+      'Provider: Any previous ankle injuries?',
+      'Patient: I sprained the same ankle about 2 years ago playing soccer.',
+      'Provider: Any medical conditions, medications, allergies?',
+      'Patient: I take birth control pills. No allergies. No other medical problems.',
+      'Provider: OK, let me examine your ankle. I see significant swelling and ecchymosis over the lateral malleolus. Tender over the ATFL. Negative squeeze test. Anterior drawer is mildly positive. Let\'s get an X-ray to rule out a fracture.',
+      'Patient: OK.',
+      "Provider: X-ray is back and it's negative for fracture. This looks like a grade 2 lateral ankle sprain. I'm going to put you in an air stirrup brace. I want you to follow RICE protocol. I'll prescribe naproxen 500mg twice a day for pain.",
+      'Patient: How long until I can play basketball again?',
+      'Provider: Typically 4-6 weeks. Follow up with orthopedics in one week.',
+    ].join('\n'),
+    expected: {
+      historyOfPresentIllness:
+        'The patient is a 28-year-old female presenting with right ankle pain after an ' +
+        'inversion injury sustained while playing basketball approximately 14 hours ago. ' +
+        'She reports pain of 7/10 with significant swelling. She is able to bear weight ' +
+        'minimally. She has been using ice and took ibuprofen 400mg approximately 4 hours ' +
+        'prior to presentation. She has a history of a right ankle sprain 2 years ago.',
+      pastMedicalHistory: ['prior right ankle sprain 2 years ago'],
+      medicationsHistory: ['oral contraceptive pills', 'Ibuprofen 400mg, last taken 4 hours ago'],
+      erx: ['Naproxen 500mg'],
+      procedures: ['air stirrup brace application'],
+      labs: ['X-ray right ankle'],
+    },
+  },
+  {
+    id: 'uti_visit',
+    description: 'UTI visit with labs ordered and prescription',
+    patientInfo: 'Age: 35 year old, Sex: female',
+    transcript: [
+      "Provider: What's going on today?",
+      "Patient: I've been having burning when I pee for the past two days. I also feel like I have to go all the time but only a little comes out.",
+      'Provider: Any blood in your urine?',
+      'Patient: I noticed a little bit of pink yesterday.',
+      'Provider: Any fever, back pain, or nausea?',
+      'Patient: No fever. No back pain. Just uncomfortable.',
+      'Provider: Have you had UTIs before?',
+      'Patient: Yes, I had one about a year ago. They gave me Bactrim and it worked.',
+      'Provider: Any medical conditions?',
+      'Patient: Just seasonal allergies.',
+      'Provider: Medications?',
+      'Patient: Cetirizine 10mg daily and a multivitamin.',
+      'Provider: Any drug allergies?',
+      'Patient: Amoxicillin gives me a rash.',
+      "Provider: OK let's get a urinalysis and a urine culture. I'm going to start you on trimethoprim-sulfamethoxazole 160/800mg twice daily for 3 days. We'll adjust if the culture shows resistance.",
+    ].join('\n'),
+    expected: {
+      historyOfPresentIllness:
+        'The patient is a 35-year-old female presenting with dysuria and urinary frequency ' +
+        'for 2 days. She reports mild hematuria noticed yesterday. She denies fever, flank ' +
+        'pain, and nausea. She has a history of a prior UTI approximately 1 year ago that ' +
+        'responded to trimethoprim-sulfamethoxazole.',
+      pastMedicalHistory: ['seasonal allergies', 'prior UTI'],
+      medicationsHistory: ['Cetirizine 10mg', 'multivitamin'],
+      allergies: ['Amoxicillin - rash'],
+      labs: ['urinalysis', 'urine culture'],
+      erx: ['trimethoprim-sulfamethoxazole 160/800mg'],
+    },
+  },
+  {
+    id: 'elderly_fall',
+    description: 'Elderly patient fall with multiple comorbidities and polypharmacy',
+    patientInfo: 'Age: 78 year old, Sex: male',
+    transcript: [
+      'Provider: Hi Mr. Johnson, I understand you had a fall today?',
+      'Patient: Yes, I was getting up from my chair and felt dizzy. Next thing I know I was on the floor.',
+      'Provider: Did you hit your head?',
+      "Patient: I don't think so. I landed on my right hip and my right wrist.",
+      'Provider: Did you lose consciousness?',
+      'Patient: No, I was awake the whole time. My wife helped me up.',
+      "Provider: How's the pain?",
+      'Patient: My hip is sore, maybe a 5 out of 10. My wrist hurts too, about a 4.',
+      'Provider: Have you fallen before?',
+      'Patient: I fell once about 3 months ago but I was fine then.',
+      'Provider: Any dizziness or lightheadedness regularly?',
+      'Patient: Sometimes when I stand up too fast.',
+      'Provider: Tell me about your medical history.',
+      'Patient: I have atrial fibrillation, hypertension, type 2 diabetes, and chronic kidney disease. I also had a knee replacement on my left side in 2020.',
+      'Provider: And your medications?',
+      'Patient: Let me look at my list... Apixaban 5mg twice a day, metoprolol 50mg twice a day, lisinopril 20mg once a day, amlodipine 5mg once a day, metformin 1000mg twice a day, and insulin glargine 20 units at bedtime.',
+      'Provider: Allergies?',
+      'Patient: ACE inhibitors make me cough. And iodine contrast dye.',
+      'Provider: Family history?',
+      'Patient: My father had a stroke. My mother had diabetes.',
+      'Provider: Do you smoke or drink?',
+      'Patient: Never smoked. I stopped drinking years ago.',
+      'Provider: Any hospitalizations?',
+      'Patient: I was in the hospital last year for my afib, they did a cardioversion. And the knee surgery in 2020.',
+      "Provider: OK, let me examine you. Let's get X-rays of the right hip and right wrist. We'll also do a CBC and BMP to check your blood counts and electrolytes given the dizziness.",
+    ].join('\n'),
+    expected: {
+      historyOfPresentIllness:
+        'The patient is a 78-year-old male presenting after a fall from standing. He reports ' +
+        'feeling dizzy while rising from a chair and fell onto his right hip and right wrist. ' +
+        'He denies loss of consciousness and head strike. He reports right hip pain of 5/10 ' +
+        'and right wrist pain of 4/10. He has a history of a prior fall approximately 3 months ' +
+        'ago without injury. He reports intermittent orthostatic dizziness.',
+      pastMedicalHistory: ['atrial fibrillation', 'hypertension', 'type 2 diabetes', 'chronic kidney disease'],
+      pastSurgicalHistory: ['left total knee replacement 2020'],
+      medicationsHistory: [
+        'Apixaban 5mg',
+        'Metoprolol 50mg',
+        'Lisinopril 20mg',
+        'Amlodipine 5mg',
+        'Metformin 1000mg',
+        'Insulin glargine 20 units',
+      ],
+      allergies: ['ACE inhibitors - cough', 'iodine contrast dye'],
+      socialHistory: ['never smoker', 'no alcohol use'],
+      familyHistory: ['father - stroke', 'mother - diabetes'],
+      hospitalizationsHistory: ['atrial fibrillation cardioversion last year', 'left knee replacement 2020'],
+      labs: ['CBC', 'BMP', 'X-ray right hip', 'X-ray right wrist'],
+    },
+  },
+  {
+    id: 'workers_comp_back_injury',
+    description: "Workers' comp visit with mechanism of injury",
+    patientInfo: 'Age: 42 year old, Sex: male',
+    isWorkersComp: true,
+    transcript: [
+      'Provider: I understand you were injured at work today?',
+      'Patient: Yeah, I was lifting a heavy box at the warehouse - probably 60 or 70 pounds - and I felt a sharp pain in my lower back. It was sudden.',
+      'Provider: What time did this happen?',
+      'Patient: Around 10am this morning, about 3 hours ago.',
+      'Provider: Were you twisting when you lifted?',
+      'Patient: Yeah, I was turning to put it on the shelf while lifting.',
+      'Provider: Where exactly is the pain?',
+      'Patient: Lower back, mostly on the left side. It shoots down my left leg too.',
+      'Provider: Rate the pain?',
+      "Patient: 8 out of 10. It's really bad when I try to bend forward.",
+      'Provider: Any numbness or weakness in your legs?',
+      'Patient: A little tingling in my left foot.',
+      'Provider: Any prior back injuries?',
+      "Patient: I strained my back about 5 years ago doing the same kind of work but it wasn't this bad.",
+      'Provider: Medical conditions or medications?',
+      "Patient: I take lisinopril for blood pressure. That's it.",
+      'Provider: Allergies?',
+      'Patient: None.',
+      "Provider: I'm going to order an X-ray of your lumbar spine. I'll prescribe cyclobenzaprine 10mg three times a day and ibuprofen 800mg three times a day. No heavy lifting. Follow up in one week.",
+    ].join('\n'),
+    expected: {
+      mechanismOfInjury:
+        'The patient sustained a lower back injury while lifting a heavy box weighing ' +
+        'approximately 60-70 pounds at a warehouse. The injury occurred while simultaneously ' +
+        'lifting and twisting to place the box on a shelf. The onset of pain was sudden and ' +
+        'immediate at the time of the lift.',
+      historyOfPresentIllness:
+        'The patient is a 42-year-old male presenting with acute lower back pain with left-sided ' +
+        'radiculopathy after a workplace lifting injury approximately 3 hours ago. He reports ' +
+        'pain of 8/10, worst with forward flexion, with radiation down the left leg and tingling ' +
+        'in the left foot. He has a history of a prior back strain 5 years ago.',
+      pastMedicalHistory: ['hypertension', 'prior back strain 5 years ago'],
+      medicationsHistory: ['Lisinopril'],
+      erx: ['Cyclobenzaprine 10mg', 'Ibuprofen 800mg'],
+      labs: ['X-ray lumbar spine'],
+    },
+  },
+  {
+    id: 'pediatric_asthma_exacerbation',
+    description: 'Child with asthma exacerbation, parent present',
+    patientInfo: 'Age: 7 year old, Sex: male',
+    transcript: [
+      "Provider: Hi, what's happening with your son today?",
+      "Parent: He's been wheezing really bad since last night. He woke up coughing at 3am and couldn't stop. His breathing sounds really tight.",
+      'Provider: Has he had any recent cold symptoms or been sick?',
+      "Parent: He had a runny nose starting about 4 days ago. A few kids at school have been sick.",
+      'Provider: Did you give him his rescue inhaler?',
+      'Parent: Yes, I gave him 2 puffs of albuterol at 3am and again at 7am. It helped a little but not as much as usual.',
+      'Provider: Is he on any controller medications?',
+      'Parent: He takes fluticasone 44mcg, 2 puffs twice a day. And montelukast at bedtime.',
+      'Provider: Has he been hospitalized for asthma before?',
+      'Parent: He was in the hospital once when he was 4 for a bad attack. He needed a breathing treatment.',
+      'Provider: Any allergies?',
+      'Parent: He\'s allergic to cats and dust mites. No drug allergies.',
+      'Provider: Any other medical conditions?',
+      'Parent: Just the asthma and eczema.',
+      'Provider: Family history of asthma?',
+      'Parent: I have asthma too, and his grandmother has COPD.',
+      "Provider: I can hear bilateral wheezing. He's using accessory muscles a little. O2 sat is 94%. Let's start a nebulized albuterol treatment now and recheck in 20 minutes. We'll also do a chest X-ray. I'm going to start him on prednisolone 30mg daily for 5 days.",
+    ].join('\n'),
+    expected: {
+      historyOfPresentIllness:
+        'The patient is a 7-year-old male with a history of asthma presenting with acute ' +
+        'wheezing and cough since last night, waking from sleep at 3am. He has had URI symptoms ' +
+        'for 4 days. He received albuterol rescue inhaler at 3am and 7am with partial relief. ' +
+        'He is on fluticasone and montelukast as controller medications. He has a history of ' +
+        'a prior asthma hospitalization at age 4.',
+      pastMedicalHistory: ['asthma', 'eczema'],
+      medicationsHistory: ['Fluticasone 44mcg inhaler', 'Montelukast', 'Albuterol rescue inhaler, last taken 7am'],
+      allergies: ['cats', 'dust mites'],
+      familyHistory: ['mother - asthma', 'grandmother - COPD'],
+      hospitalizationsHistory: ['asthma exacerbation at age 4'],
+      labs: ['chest X-ray'],
+      erx: ['Prednisolone 30mg'],
+      procedures: ['nebulized albuterol treatment'],
+    },
+  },
+];

--- a/packages/ai-quality-tests/src/test-data/hpi-chatbot-cases.ts
+++ b/packages/ai-quality-tests/src/test-data/hpi-chatbot-cases.ts
@@ -1,0 +1,183 @@
+/**
+ * Test cases for the HPI chatbot feature.
+ *
+ * Each case represents a patient chat transcript and the clinically expected
+ * extraction. The `expected` field is used as reference_outputs by the
+ * LLM-as-judge evaluator.
+ */
+
+export interface HpiChatbotCase {
+  id: string;
+  description: string;
+  patientInfo: string;
+  transcript: string;
+  expected: Record<string, unknown>;
+}
+
+export const HPI_CHATBOT_CASES: HpiChatbotCase[] = [
+  {
+    id: 'chest_pain_adult',
+    description: 'Adult with chest pain, multiple comorbidities',
+    patientInfo: 'Age: 58 year old, Sex: male',
+    transcript: [
+      'Provider: What brings you in today?',
+      "Patient: I've been having chest pain for the last two days.",
+      'Provider: Can you describe the pain?',
+      "Patient: It's a pressure-like feeling in the center of my chest. It gets worse when I walk up stairs or exert myself.",
+      'Provider: Does anything make it better?',
+      'Patient: Resting helps. It usually goes away after about 10 minutes of sitting down.',
+      'Provider: Any shortness of breath, nausea, or sweating?',
+      'Patient: No shortness of breath. No nausea or sweating either.',
+      'Provider: Do you have any medical conditions?',
+      'Patient: I have high blood pressure and type 2 diabetes. I also had my gallbladder removed in 2018.',
+      'Provider: What medications are you taking?',
+      'Patient: Lisinopril 10mg, I took it this morning around 8am. Also Metformin 500mg twice a day and baby aspirin.',
+      'Provider: Any allergies?',
+      'Patient: Penicillin gives me a rash. And I\'m allergic to sulfa drugs too.',
+      'Provider: Any family history of heart disease?',
+      'Patient: My father had a heart attack at 62. My mother had breast cancer.',
+      'Provider: Do you smoke or drink?',
+      'Patient: I quit smoking 5 years ago. I have a beer occasionally on weekends.',
+      'Provider: Any hospitalizations?',
+      'Patient: I was hospitalized for pneumonia in January 2023.',
+    ].join('\n'),
+    expected: {
+      historyOfPresentIllness:
+        'The patient is a 58-year-old male presenting with chest pain for 2 days. ' +
+        'He describes a pressure-like sensation in the center of his chest that worsens ' +
+        'with exertion such as climbing stairs and improves with rest, typically resolving ' +
+        'after about 10 minutes. He denies shortness of breath, nausea, or diaphoresis.',
+      pastMedicalHistory: ['hypertension', 'type 2 diabetes'],
+      pastSurgicalHistory: ['cholecystectomy 2018'],
+      medicationsHistory: ['Lisinopril 10mg, last taken today 08:00', 'Metformin 500mg', 'Aspirin 81mg'],
+      allergies: ['Penicillin - rash', 'Sulfa drugs'],
+      socialHistory: ['former smoker, quit 5 years ago', 'occasional alcohol'],
+      familyHistory: ['father - heart attack at age 62', 'mother - breast cancer'],
+      hospitalizationsHistory: ['pneumonia January 2023'],
+    },
+  },
+  {
+    id: 'pediatric_ear_pain',
+    description: 'Pediatric patient with ear pain, parent reporting',
+    patientInfo: 'Age: 4 year old, Sex: female',
+    transcript: [
+      "Provider: What's going on with your daughter today?",
+      "Parent: She's been pulling at her right ear and crying since yesterday. She had a fever of 101.5 this morning.",
+      'Provider: Has she had any cold symptoms?',
+      "Parent: Yes, she's had a runny nose for about a week now.",
+      'Provider: Any ear infections before?',
+      'Parent: She had one about 6 months ago. They gave her amoxicillin and it cleared up.',
+      'Provider: Is she taking any medications right now?',
+      "Parent: Just Children's Tylenol for the fever. I gave her some about two hours ago.",
+      'Provider: Any allergies?',
+      'Parent: No allergies that we know of.',
+      'Provider: Any other medical conditions or surgeries?',
+      "Parent: No, she's been healthy otherwise.",
+      'Provider: Any family history of ear problems?',
+      'Parent: Her older brother had tubes put in when he was 3.',
+    ].join('\n'),
+    expected: {
+      historyOfPresentIllness:
+        'The patient is a 4-year-old female presenting with right ear pain since yesterday. ' +
+        'She has been pulling at her right ear and crying. She had a fever of 101.5°F this morning. ' +
+        'She has had rhinorrhea for approximately one week. She has a history of a prior ear ' +
+        'infection approximately 6 months ago that was treated with amoxicillin.',
+      pastMedicalHistory: ['prior ear infection'],
+      medicationsHistory: ["Children's Tylenol (acetaminophen), last taken 2 hours ago"],
+      familyHistory: ['brother - ear tubes (tympanostomy)'],
+    },
+  },
+  {
+    id: 'laceration_simple',
+    description: 'Simple laceration, minimal medical history',
+    patientInfo: 'Age: 32 year old, Sex: male',
+    transcript: [
+      'Provider: What happened?',
+      'Patient: I was cutting vegetables and the knife slipped. I cut my left index finger.',
+      'Provider: When did this happen?',
+      'Patient: About an hour ago.',
+      'Provider: Is there any numbness or tingling in the finger?',
+      "Patient: No, it just hurts. I can move it fine.",
+      'Provider: How would you rate the pain, 1 to 10?',
+      'Patient: About a 6.',
+      'Provider: Any medical conditions or medications?',
+      "Patient: None. I'm healthy.",
+      'Provider: Any allergies?',
+      'Patient: No allergies.',
+      'Provider: When was your last tetanus shot?',
+      'Patient: I think about 3 years ago.',
+    ].join('\n'),
+    expected: {
+      historyOfPresentIllness:
+        'The patient is a 32-year-old male presenting with a laceration to the left index ' +
+        'finger sustained approximately one hour ago while cutting vegetables. He reports ' +
+        'pain rated 6 out of 10. He denies numbness or tingling and has full range of motion ' +
+        'in the affected finger.',
+    },
+  },
+  {
+    id: 'abdominal_pain_complex',
+    description: 'Complex abdominal pain with extensive history',
+    patientInfo: 'Age: 45 year old, Sex: female',
+    transcript: [
+      'Provider: What brings you in today?',
+      "Patient: I've had really bad stomach pain for the last three days. It's in the right lower part of my belly.",
+      'Provider: Can you describe the pain? Is it sharp, dull, crampy?',
+      "Patient: It started as a dull ache around my belly button but now it's sharp and it's moved to the right lower side.",
+      'Provider: Any nausea or vomiting?',
+      "Patient: Yes, I've thrown up twice today. I also haven't had much appetite.",
+      'Provider: Any fever?',
+      'Patient: I checked this morning and it was 100.8.',
+      'Provider: Any diarrhea or constipation?',
+      "Patient: I haven't had a bowel movement in two days.",
+      'Provider: Any medical history?',
+      'Patient: I have hypothyroidism and GERD. I had a C-section in 2015.',
+      'Provider: What medications do you take?',
+      'Patient: Levothyroxine 75mcg every morning, and omeprazole 20mg.',
+      'Provider: Allergies?',
+      'Patient: Codeine makes me really nauseous. And latex gives me hives.',
+      "Provider: Anyone in the family with GI issues?",
+      'Patient: My mother had colon cancer at 60.',
+      'Provider: Do you smoke or drink alcohol?',
+      "Patient: I don't smoke. I have wine with dinner a few times a week.",
+      'Provider: Any recent hospitalizations?',
+      'Patient: No.',
+    ].join('\n'),
+    expected: {
+      historyOfPresentIllness:
+        'The patient is a 45-year-old female presenting with abdominal pain for 3 days. ' +
+        'The pain initially started as a dull ache periumbilically and has since migrated ' +
+        'to the right lower quadrant, where it is now sharp in character. Associated symptoms ' +
+        'include nausea with two episodes of vomiting today, decreased appetite, constipation ' +
+        'for 2 days, and a low-grade fever of 100.8°F.',
+      pastMedicalHistory: ['hypothyroidism', 'GERD'],
+      pastSurgicalHistory: ['cesarean section 2015'],
+      medicationsHistory: ['Levothyroxine 75mcg', 'Omeprazole 20mg'],
+      allergies: ['Codeine - nausea', 'Latex - hives'],
+      socialHistory: ['non-smoker', 'occasional alcohol'],
+      familyHistory: ['mother - colon cancer at age 60'],
+    },
+  },
+  {
+    id: 'minimal_info',
+    description: 'Patient provides very little information',
+    patientInfo: 'Age: 22 year old, Sex: male',
+    transcript: [
+      'Provider: What brings you in today?',
+      'Patient: I have a sore throat.',
+      'Provider: How long have you had it?',
+      'Patient: Since yesterday.',
+      'Provider: Any fever?',
+      "Patient: I don't think so.",
+      'Provider: Any other symptoms? Cough, runny nose?',
+      'Patient: No.',
+      'Provider: Any medical conditions, medications, or allergies?',
+      'Patient: No, nothing.',
+    ].join('\n'),
+    expected: {
+      historyOfPresentIllness:
+        'The patient is a 22-year-old male presenting with sore throat since yesterday. ' +
+        'He denies fever, cough, and rhinorrhea.',
+    },
+  },
+];

--- a/packages/ai-quality-tests/tests/ambient-scribe/scribe-extraction.test.ts
+++ b/packages/ai-quality-tests/tests/ambient-scribe/scribe-extraction.test.ts
@@ -8,6 +8,7 @@
  * Run: npx vitest run tests/ambient-scribe/scribe-extraction.test.ts
  */
 
+import { beforeAll, describe, expect, it } from 'vitest';
 import { createLLMAsJudge } from 'openevals';
 import {
   FORMAT_COMPLIANCE_PROMPT,

--- a/packages/ai-quality-tests/tests/ambient-scribe/scribe-extraction.test.ts
+++ b/packages/ai-quality-tests/tests/ambient-scribe/scribe-extraction.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Ambient Scribe — clinical data extraction quality tests.
+ *
+ * Tests the quality of AI-extracted clinical data from provider-patient
+ * audio transcripts. The ambient scribe extracts the same fields as the
+ * HPI chatbot, plus labs, erx, and procedures.
+ *
+ * Run: npx vitest run tests/ambient-scribe/scribe-extraction.test.ts
+ */
+
+import { createLLMAsJudge } from 'openevals';
+import {
+  FORMAT_COMPLIANCE_PROMPT,
+  HPI_NARRATIVE_QUALITY_PROMPT,
+  MECHANISM_OF_INJURY_PROMPT,
+  STRUCTURED_EXTRACTION_QUALITY_PROMPT,
+} from '../../src/evaluation-prompts.js';
+import { runExtraction } from '../../src/models.js';
+import { AUDIO_INTERVIEW_FIELDS, WORKERS_COMP_PREFIX } from '../../src/prompts.js';
+import { AMBIENT_SCRIBE_CASES } from '../../src/test-data/ambient-scribe-cases.js';
+
+const judgeModel = process.env.JUDGE_MODEL ?? 'openai:o3-mini';
+
+// ── Evaluators ──────────────────────────────────────────────────────────────
+
+const hpiNarrativeJudge = createLLMAsJudge({
+  prompt: HPI_NARRATIVE_QUALITY_PROMPT,
+  model: judgeModel,
+});
+
+const structuredExtractionJudge = createLLMAsJudge({
+  prompt: STRUCTURED_EXTRACTION_QUALITY_PROMPT,
+  model: judgeModel,
+});
+
+const formatJudge = createLLMAsJudge({
+  prompt: FORMAT_COMPLIANCE_PROMPT,
+  model: judgeModel,
+});
+
+const moiJudge = createLLMAsJudge({
+  prompt: MECHANISM_OF_INJURY_PROMPT,
+  model: judgeModel,
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Ambient Scribe — Extraction Quality', () => {
+  const results = new Map<string, Awaited<ReturnType<typeof runExtraction>>>();
+
+  beforeAll(async () => {
+    const extractions = AMBIENT_SCRIBE_CASES.map(async (tc) => {
+      const fields = tc.isWorkersComp ? WORKERS_COMP_PREFIX + AUDIO_INTERVIEW_FIELDS : AUDIO_INTERVIEW_FIELDS;
+      const result = await runExtraction(tc.transcript, tc.patientInfo, fields);
+      results.set(tc.id, result);
+    });
+    await Promise.all(extractions);
+  });
+
+  describe('HPI narrative quality', () => {
+    for (const tc of AMBIENT_SCRIBE_CASES) {
+      it(`${tc.id}: ${tc.description}`, async () => {
+        const result = results.get(tc.id)!;
+        const hpi = result.parsed.historyOfPresentIllness as string | undefined;
+        expect(hpi).toBeDefined();
+
+        const evalResult = await hpiNarrativeJudge({
+          inputs: tc.transcript,
+          outputs: hpi!,
+          referenceOutputs: tc.expected.historyOfPresentIllness as string,
+        });
+
+        console.log(`[${tc.id}] HPI narrative score: ${evalResult.score}`);
+        console.log(`[${tc.id}] Comment: ${evalResult.comment}`);
+
+        expect(evalResult.score).toBe(true);
+      });
+    }
+  });
+
+  describe('Structured data extraction quality', () => {
+    for (const tc of AMBIENT_SCRIBE_CASES) {
+      it(`${tc.id}: ${tc.description}`, async () => {
+        const result = results.get(tc.id)!;
+
+        // Extract only the structured fields (exclude prose narratives)
+        const { historyOfPresentIllness: _hpi, mechanismOfInjury: _moi, ...structuredOutput } = result.parsed as Record<string, unknown>;
+        const { historyOfPresentIllness: _refHpi, mechanismOfInjury: _refMoi, ...structuredExpected } = tc.expected;
+
+        // Skip if no structured fields expected
+        if (Object.keys(structuredExpected).length === 0) return;
+
+        const evalResult = await structuredExtractionJudge({
+          inputs: tc.transcript,
+          outputs: JSON.stringify(structuredOutput, null, 2),
+          referenceOutputs: JSON.stringify(structuredExpected, null, 2),
+        });
+
+        console.log(`[${tc.id}] Structured extraction score: ${evalResult.score}`);
+        console.log(`[${tc.id}] Comment: ${evalResult.comment}`);
+
+        expect(evalResult.score).toBe(true);
+      });
+    }
+  });
+
+  describe('Mechanism of injury (workers comp cases)', () => {
+    const workersCompCases = AMBIENT_SCRIBE_CASES.filter((tc) => tc.isWorkersComp);
+
+    for (const tc of workersCompCases) {
+      it(`${tc.id}: ${tc.description}`, async () => {
+        const result = results.get(tc.id)!;
+        const moi = result.parsed.mechanismOfInjury as string | undefined;
+        expect(moi).toBeDefined();
+
+        const evalResult = await moiJudge({
+          inputs: tc.transcript,
+          outputs: moi!,
+          referenceOutputs: tc.expected.mechanismOfInjury as string,
+        });
+
+        console.log(`[${tc.id}] MOI score: ${evalResult.score}`);
+        console.log(`[${tc.id}] Comment: ${evalResult.comment}`);
+
+        expect(evalResult.score).toBe(true);
+      });
+    }
+  });
+
+  describe('Labs, eRx, and procedures extraction (scribe-specific)', () => {
+    const casesWithTreatment = AMBIENT_SCRIBE_CASES.filter(
+      (tc) => tc.expected.labs || tc.expected.erx || tc.expected.procedures
+    );
+
+    for (const tc of casesWithTreatment) {
+      it(`${tc.id}: ${tc.description}`, async () => {
+        const result = results.get(tc.id)!;
+
+        // Check that treatment-related fields were extracted
+        const treatmentOutput: Record<string, unknown> = {};
+        const treatmentExpected: Record<string, unknown> = {};
+
+        for (const field of ['labs', 'erx', 'procedures'] as const) {
+          if (tc.expected[field]) {
+            treatmentExpected[field] = tc.expected[field];
+            treatmentOutput[field] = result.parsed[field] ?? [];
+          }
+        }
+
+        const evalResult = await structuredExtractionJudge({
+          inputs: tc.transcript,
+          outputs: JSON.stringify(treatmentOutput, null, 2),
+          referenceOutputs: JSON.stringify(treatmentExpected, null, 2),
+        });
+
+        console.log(`[${tc.id}] Treatment extraction score: ${evalResult.score}`);
+        console.log(`[${tc.id}] Comment: ${evalResult.comment}`);
+
+        expect(evalResult.score).toBe(true);
+      });
+    }
+  });
+
+  describe('JSON format compliance', () => {
+    for (const tc of AMBIENT_SCRIBE_CASES) {
+      it(`${tc.id}: ${tc.description}`, async () => {
+        const result = results.get(tc.id)!;
+
+        const evalResult = await formatJudge({
+          inputs: tc.transcript,
+          outputs: JSON.stringify(result.parsed, null, 2),
+        });
+
+        console.log(`[${tc.id}] Format compliance score: ${evalResult.score}`);
+        console.log(`[${tc.id}] Comment: ${evalResult.comment}`);
+
+        expect(evalResult.score).toBe(true);
+      });
+    }
+  });
+});

--- a/packages/ai-quality-tests/tests/hpi-chatbot/hpi-extraction.test.ts
+++ b/packages/ai-quality-tests/tests/hpi-chatbot/hpi-extraction.test.ts
@@ -7,6 +7,7 @@
  * Run: npx vitest run tests/hpi-chatbot/hpi-extraction.test.ts
  */
 
+import { beforeAll, describe, expect, it } from 'vitest';
 import { createLLMAsJudge } from 'openevals';
 import {
   FORMAT_COMPLIANCE_PROMPT,

--- a/packages/ai-quality-tests/tests/hpi-chatbot/hpi-extraction.test.ts
+++ b/packages/ai-quality-tests/tests/hpi-chatbot/hpi-extraction.test.ts
@@ -1,0 +1,120 @@
+/**
+ * HPI Chatbot — clinical data extraction quality tests.
+ *
+ * Uses openevals LLM-as-judge to evaluate the quality of AI-extracted
+ * clinical data from patient chat transcripts.
+ *
+ * Run: npx vitest run tests/hpi-chatbot/hpi-extraction.test.ts
+ */
+
+import { createLLMAsJudge } from 'openevals';
+import {
+  FORMAT_COMPLIANCE_PROMPT,
+  HPI_NARRATIVE_QUALITY_PROMPT,
+  STRUCTURED_EXTRACTION_QUALITY_PROMPT,
+} from '../../src/evaluation-prompts.js';
+import { runExtraction } from '../../src/models.js';
+import { CHAT_INTERVIEW_FIELDS } from '../../src/prompts.js';
+import { HPI_CHATBOT_CASES } from '../../src/test-data/hpi-chatbot-cases.js';
+
+const judgeModel = process.env.JUDGE_MODEL ?? 'openai:o3-mini';
+
+// ── Evaluators ──────────────────────────────────────────────────────────────
+
+const hpiNarrativeJudge = createLLMAsJudge({
+  prompt: HPI_NARRATIVE_QUALITY_PROMPT,
+  model: judgeModel,
+});
+
+const structuredExtractionJudge = createLLMAsJudge({
+  prompt: STRUCTURED_EXTRACTION_QUALITY_PROMPT,
+  model: judgeModel,
+});
+
+const formatJudge = createLLMAsJudge({
+  prompt: FORMAT_COMPLIANCE_PROMPT,
+  model: judgeModel,
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('HPI Chatbot — Extraction Quality', () => {
+  // Cache extraction results so we don't call the model multiple times per case
+  const results = new Map<string, Awaited<ReturnType<typeof runExtraction>>>();
+
+  beforeAll(async () => {
+    // Run all extractions in parallel
+    const extractions = HPI_CHATBOT_CASES.map(async (tc) => {
+      const result = await runExtraction(tc.transcript, tc.patientInfo, CHAT_INTERVIEW_FIELDS);
+      results.set(tc.id, result);
+    });
+    await Promise.all(extractions);
+  });
+
+  describe('HPI narrative quality', () => {
+    for (const tc of HPI_CHATBOT_CASES) {
+      it(`${tc.id}: ${tc.description}`, async () => {
+        const result = results.get(tc.id)!;
+        const hpi = result.parsed.historyOfPresentIllness as string | undefined;
+        expect(hpi).toBeDefined();
+
+        const evalResult = await hpiNarrativeJudge({
+          inputs: tc.transcript,
+          outputs: hpi!,
+          referenceOutputs: tc.expected.historyOfPresentIllness as string,
+        });
+
+        console.log(`[${tc.id}] HPI narrative score: ${evalResult.score}`);
+        console.log(`[${tc.id}] Comment: ${evalResult.comment}`);
+
+        expect(evalResult.score).toBe(true);
+      });
+    }
+  });
+
+  describe('Structured data extraction quality', () => {
+    // Only run for cases that have structured expected data beyond HPI
+    const casesWithStructuredData = HPI_CHATBOT_CASES.filter(
+      (tc) => Object.keys(tc.expected).length > 1
+    );
+
+    for (const tc of casesWithStructuredData) {
+      it(`${tc.id}: ${tc.description}`, async () => {
+        const result = results.get(tc.id)!;
+
+        // Extract only the structured fields (exclude HPI narrative)
+        const { historyOfPresentIllness: _hpi, ...structuredOutput } = result.parsed as Record<string, unknown>;
+        const { historyOfPresentIllness: _refHpi, ...structuredExpected } = tc.expected;
+
+        const evalResult = await structuredExtractionJudge({
+          inputs: tc.transcript,
+          outputs: JSON.stringify(structuredOutput, null, 2),
+          referenceOutputs: JSON.stringify(structuredExpected, null, 2),
+        });
+
+        console.log(`[${tc.id}] Structured extraction score: ${evalResult.score}`);
+        console.log(`[${tc.id}] Comment: ${evalResult.comment}`);
+
+        expect(evalResult.score).toBe(true);
+      });
+    }
+  });
+
+  describe('JSON format compliance', () => {
+    for (const tc of HPI_CHATBOT_CASES) {
+      it(`${tc.id}: ${tc.description}`, async () => {
+        const result = results.get(tc.id)!;
+
+        const evalResult = await formatJudge({
+          inputs: tc.transcript,
+          outputs: JSON.stringify(result.parsed, null, 2),
+        });
+
+        console.log(`[${tc.id}] Format compliance score: ${evalResult.score}`);
+        console.log(`[${tc.id}] Comment: ${evalResult.comment}`);
+
+        expect(evalResult.score).toBe(true);
+      });
+    }
+  });
+});

--- a/packages/ai-quality-tests/tests/hpi-chatbot/hpi-suggestions.test.ts
+++ b/packages/ai-quality-tests/tests/hpi-chatbot/hpi-suggestions.test.ts
@@ -7,6 +7,7 @@
  * Run: npx vitest run tests/hpi-chatbot/hpi-suggestions.test.ts
  */
 
+import { describe, expect, it } from 'vitest';
 import { createLLMAsJudge } from 'openevals';
 import { HPI_SUGGESTION_QUALITY_PROMPT } from '../../src/evaluation-prompts.js';
 import { runHpiSuggestion } from '../../src/models.js';

--- a/packages/ai-quality-tests/tests/hpi-chatbot/hpi-suggestions.test.ts
+++ b/packages/ai-quality-tests/tests/hpi-chatbot/hpi-suggestions.test.ts
@@ -1,0 +1,120 @@
+/**
+ * HPI Chatbot — HPI completeness suggestion quality tests.
+ *
+ * Tests the "missing HPI elements" suggestion feature that identifies
+ * gaps in the provider's HPI documentation.
+ *
+ * Run: npx vitest run tests/hpi-chatbot/hpi-suggestions.test.ts
+ */
+
+import { createLLMAsJudge } from 'openevals';
+import { HPI_SUGGESTION_QUALITY_PROMPT } from '../../src/evaluation-prompts.js';
+import { runHpiSuggestion } from '../../src/models.js';
+
+const judgeModel = process.env.JUDGE_MODEL ?? 'openai:o3-mini';
+
+const hpiSuggestionJudge = createLLMAsJudge({
+  prompt: HPI_SUGGESTION_QUALITY_PROMPT,
+  model: judgeModel,
+});
+
+// ── Test cases ──────────────────────────────────────────────────────────────
+
+interface SuggestionTestCase {
+  id: string;
+  description: string;
+  hpiText: string;
+  /** Elements we expect to be flagged as missing (empty = HPI is complete). */
+  expectedMissing: string[];
+}
+
+const SUGGESTION_CASES: SuggestionTestCase[] = [
+  {
+    id: 'incomplete_hpi',
+    description: 'HPI missing several key elements',
+    hpiText:
+      'The patient presents with a cough that started 3 days ago. The cough is productive with yellow sputum.',
+    expectedMissing: ['Aggravating', 'Relieving', 'Severity', 'Associated Symptoms'],
+  },
+  {
+    id: 'thorough_hpi',
+    description: 'Thorough HPI covering most elements',
+    hpiText:
+      'The patient is a 45-year-old female presenting with sharp right lower quadrant abdominal pain ' +
+      'that started 3 days ago (Onset). The pain is localized to the RLQ (Location) and has been ' +
+      'constant for the past 72 hours (Duration). The pain is sharp in character (Characteristic), ' +
+      'worsened by movement and palpation (Aggravating), and slightly improved by lying still ' +
+      '(Relieving). The pain is constant without fluctuation (Timing). She rates the pain 8/10 ' +
+      '(Severity). Associated symptoms include nausea, vomiting twice today, fever of 100.8°F, ' +
+      'and constipation for 2 days (Associated Symptoms).',
+    expectedMissing: [],
+  },
+  {
+    id: 'partially_complete_hpi',
+    description: 'HPI with some elements covered, some missing',
+    hpiText:
+      'The patient presents with a headache that started this morning. It is located in the ' +
+      'frontal region and described as a throbbing pain rated 7/10. She denies nausea, vomiting, ' +
+      'visual changes, or neck stiffness.',
+    expectedMissing: ['Aggravating', 'Relieving', 'Timing'],
+  },
+  {
+    id: 'very_minimal_hpi',
+    description: 'Extremely brief HPI missing almost everything',
+    hpiText: 'Patient has knee pain.',
+    expectedMissing: [
+      'Onset',
+      'Location',
+      'Duration',
+      'Characteristic',
+      'Aggravating',
+      'Relieving',
+      'Timing',
+      'Severity',
+      'Associated Symptoms',
+    ],
+  },
+];
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('HPI Chatbot — Suggestion Quality', () => {
+  for (const tc of SUGGESTION_CASES) {
+    it(`${tc.id}: ${tc.description}`, async () => {
+      const result = await runHpiSuggestion(tc.hpiText);
+
+      console.log(`[${tc.id}] Raw response: ${result.raw}`);
+      console.log(`[${tc.id}] Suggestions: ${JSON.stringify(result.parsed.suggestions)}`);
+
+      // Basic format checks
+      expect(result.parsed).toHaveProperty('suggestions');
+      expect(Array.isArray(result.parsed.suggestions)).toBe(true);
+
+      if (tc.expectedMissing.length === 0) {
+        // Should return empty suggestions for thorough HPI
+        expect(result.parsed.suggestions.length).toBe(0);
+      } else {
+        // Should have exactly one suggestion string
+        expect(result.parsed.suggestions.length).toBe(1);
+        expect(result.parsed.suggestions[0]).toMatch(/^HPI may not have covered/);
+      }
+
+      // LLM-as-judge evaluation
+      const referenceOutput =
+        tc.expectedMissing.length === 0
+          ? '{"suggestions": []}'
+          : `{"suggestions": ["HPI may not have covered ${tc.expectedMissing.join(', ')}"]}`;
+
+      const evalResult = await hpiSuggestionJudge({
+        inputs: tc.hpiText,
+        outputs: JSON.stringify(result.parsed),
+        referenceOutputs: referenceOutput,
+      });
+
+      console.log(`[${tc.id}] Suggestion quality score: ${evalResult.score}`);
+      console.log(`[${tc.id}] Comment: ${evalResult.comment}`);
+
+      expect(evalResult.score).toBe(true);
+    });
+  }
+});

--- a/packages/ai-quality-tests/tests/model-comparison.test.ts
+++ b/packages/ai-quality-tests/tests/model-comparison.test.ts
@@ -8,6 +8,7 @@
  * Run: npx vitest run tests/model-comparison.test.ts
  */
 
+import { beforeAll, describe, expect, it } from 'vitest';
 import { createLLMAsJudge } from 'openevals';
 import { HPI_NARRATIVE_QUALITY_PROMPT, STRUCTURED_EXTRACTION_QUALITY_PROMPT } from '../src/evaluation-prompts.js';
 import { runExtraction } from '../src/models.js';
@@ -40,12 +41,12 @@ describe('Model Comparison', () => {
 
   // Only test models for which we have API keys
   beforeAll(() => {
-    if (process.env.GOOGLE_API_KEY) models.push('gemini');
+    if (process.env.GOOGLE_CLOUD_PROJECT_ID && process.env.GOOGLE_CLOUD_API_KEY) models.push('gemini');
     if (process.env.ANTHROPIC_API_KEY) models.push('claude');
 
     if (models.length < 2) {
       console.warn(
-        'Model comparison requires both GOOGLE_API_KEY and ANTHROPIC_API_KEY. ' +
+        'Model comparison requires GOOGLE_CLOUD_PROJECT_ID + GOOGLE_CLOUD_API_KEY and ANTHROPIC_API_KEY. ' +
           `Only ${models.length} model(s) available. Set both keys to compare.`
       );
     }

--- a/packages/ai-quality-tests/tests/model-comparison.test.ts
+++ b/packages/ai-quality-tests/tests/model-comparison.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Model comparison test — run the same cases through different models
+ * and compare quality scores side-by-side.
+ *
+ * This test is useful for evaluating whether switching models (e.g., from
+ * Gemini to Claude, or upgrading model versions) improves output quality.
+ *
+ * Run: npx vitest run tests/model-comparison.test.ts
+ */
+
+import { createLLMAsJudge } from 'openevals';
+import { HPI_NARRATIVE_QUALITY_PROMPT, STRUCTURED_EXTRACTION_QUALITY_PROMPT } from '../src/evaluation-prompts.js';
+import { runExtraction } from '../src/models.js';
+import { CHAT_INTERVIEW_FIELDS } from '../src/prompts.js';
+import { HPI_CHATBOT_CASES } from '../src/test-data/hpi-chatbot-cases.js';
+
+const judgeModel = process.env.JUDGE_MODEL ?? 'openai:o3-mini';
+
+const hpiJudge = createLLMAsJudge({
+  prompt: HPI_NARRATIVE_QUALITY_PROMPT,
+  model: judgeModel,
+});
+
+const structuredJudge = createLLMAsJudge({
+  prompt: STRUCTURED_EXTRACTION_QUALITY_PROMPT,
+  model: judgeModel,
+});
+
+interface ModelScore {
+  model: string;
+  caseId: string;
+  hpiScore: boolean;
+  structuredScore: boolean | null;
+  hpiComment: string;
+  structuredComment: string | null;
+}
+
+describe('Model Comparison', () => {
+  const models: Array<'gemini' | 'claude'> = [];
+
+  // Only test models for which we have API keys
+  beforeAll(() => {
+    if (process.env.GOOGLE_API_KEY) models.push('gemini');
+    if (process.env.ANTHROPIC_API_KEY) models.push('claude');
+
+    if (models.length < 2) {
+      console.warn(
+        'Model comparison requires both GOOGLE_API_KEY and ANTHROPIC_API_KEY. ' +
+          `Only ${models.length} model(s) available. Set both keys to compare.`
+      );
+    }
+  });
+
+  it('compares extraction quality across models', async () => {
+    if (models.length === 0) {
+      console.log('Skipping: no model API keys configured');
+      return;
+    }
+
+    // Use a subset of cases to keep runtime manageable
+    const testCases = HPI_CHATBOT_CASES.slice(0, 3);
+    const scores: ModelScore[] = [];
+
+    for (const model of models) {
+      for (const tc of testCases) {
+        try {
+          const result = await runExtraction(tc.transcript, tc.patientInfo, CHAT_INTERVIEW_FIELDS, model);
+
+          const hpi = result.parsed.historyOfPresentIllness as string;
+          const hpiEval = await hpiJudge({
+            inputs: tc.transcript,
+            outputs: hpi ?? '',
+            referenceOutputs: tc.expected.historyOfPresentIllness as string,
+          });
+
+          let structuredEval = null;
+          if (Object.keys(tc.expected).length > 1) {
+            const { historyOfPresentIllness: _, ...structuredOutput } = result.parsed as Record<string, unknown>;
+            const { historyOfPresentIllness: _2, ...structuredExpected } = tc.expected;
+            structuredEval = await structuredJudge({
+              inputs: tc.transcript,
+              outputs: JSON.stringify(structuredOutput, null, 2),
+              referenceOutputs: JSON.stringify(structuredExpected, null, 2),
+            });
+          }
+
+          scores.push({
+            model,
+            caseId: tc.id,
+            hpiScore: hpiEval.score as boolean,
+            structuredScore: structuredEval ? (structuredEval.score as boolean) : null,
+            hpiComment: hpiEval.comment ?? '',
+            structuredComment: structuredEval?.comment ?? null,
+          });
+        } catch (error) {
+          console.error(`Error testing ${model} on ${tc.id}:`, error);
+          scores.push({
+            model,
+            caseId: tc.id,
+            hpiScore: false,
+            structuredScore: false,
+            hpiComment: `Error: ${error}`,
+            structuredComment: null,
+          });
+        }
+      }
+    }
+
+    // Print comparison table
+    console.log('\n╔══════════════════════════════════════════════════════════╗');
+    console.log('║              MODEL COMPARISON RESULTS                    ║');
+    console.log('╚══════════════════════════════════════════════════════════╝\n');
+
+    for (const model of models) {
+      const modelScores = scores.filter((s) => s.model === model);
+      const hpiPass = modelScores.filter((s) => s.hpiScore).length;
+      const structuredPass = modelScores.filter((s) => s.structuredScore === true).length;
+      const structuredTotal = modelScores.filter((s) => s.structuredScore !== null).length;
+
+      console.log(`📊 ${model.toUpperCase()}`);
+      console.log(`   HPI Narrative:       ${hpiPass}/${modelScores.length} passed`);
+      console.log(`   Structured Extract:  ${structuredPass}/${structuredTotal} passed`);
+      console.log('');
+
+      for (const s of modelScores) {
+        console.log(`   [${s.caseId}] HPI: ${s.hpiScore ? 'PASS' : 'FAIL'} | Structured: ${s.structuredScore === null ? 'N/A' : s.structuredScore ? 'PASS' : 'FAIL'}`);
+        if (!s.hpiScore) console.log(`     HPI comment: ${s.hpiComment}`);
+        if (s.structuredScore === false) console.log(`     Structured comment: ${s.structuredComment}`);
+      }
+      console.log('');
+    }
+
+    // At least one model should pass
+    const anyPass = scores.some((s) => s.hpiScore);
+    expect(anyPass).toBe(true);
+  });
+});

--- a/packages/ai-quality-tests/tests/model-comparison.test.ts
+++ b/packages/ai-quality-tests/tests/model-comparison.test.ts
@@ -2,13 +2,15 @@
  * Model comparison test — run the same cases through different models
  * and compare quality scores side-by-side.
  *
- * This test is useful for evaluating whether switching models (e.g., from
- * Gemini to Claude, or upgrading model versions) improves output quality.
+ * Configure via COMPARISON_MODELS env var (comma-separated list):
+ *   COMPARISON_MODELS=gemini:gemini-3.1-flash-lite-preview,claude:claude-opus-4-20250514
+ *
+ * Each model needs its corresponding API keys set.
  *
  * Run: npx vitest run tests/model-comparison.test.ts
  */
 
-import { beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { createLLMAsJudge } from 'openevals';
 import { HPI_NARRATIVE_QUALITY_PROMPT, STRUCTURED_EXTRACTION_QUALITY_PROMPT } from '../src/evaluation-prompts.js';
 import { runExtraction } from '../src/models.js';
@@ -36,25 +38,23 @@ interface ModelScore {
   structuredComment: string | null;
 }
 
+function getComparisonModels(): string[] {
+  const raw = process.env.COMPARISON_MODELS;
+  if (!raw) {
+    console.warn(
+      'COMPARISON_MODELS not set. Set it to a comma-separated list of models to compare, e.g.:\n' +
+        '  COMPARISON_MODELS=gemini:gemini-3.1-flash-lite-preview,claude:claude-opus-4-20250514'
+    );
+    return [];
+  }
+  return raw.split(',').map((m) => m.trim()).filter(Boolean);
+}
+
 describe('Model Comparison', () => {
-  const models: Array<'gemini' | 'claude'> = [];
-
-  // Only test models for which we have API keys
-  beforeAll(() => {
-    if (process.env.GOOGLE_CLOUD_PROJECT_ID && process.env.GOOGLE_CLOUD_API_KEY) models.push('gemini');
-    if (process.env.ANTHROPIC_API_KEY) models.push('claude');
-
-    if (models.length < 2) {
-      console.warn(
-        'Model comparison requires GOOGLE_CLOUD_PROJECT_ID + GOOGLE_CLOUD_API_KEY and ANTHROPIC_API_KEY. ' +
-          `Only ${models.length} model(s) available. Set both keys to compare.`
-      );
-    }
-  });
-
   it('compares extraction quality across models', async () => {
+    const models = getComparisonModels();
     if (models.length === 0) {
-      console.log('Skipping: no model API keys configured');
+      console.log('Skipping: COMPARISON_MODELS not configured');
       return;
     }
 
@@ -108,9 +108,9 @@ describe('Model Comparison', () => {
     }
 
     // Print comparison table
-    console.log('\n╔══════════════════════════════════════════════════════════╗');
-    console.log('║              MODEL COMPARISON RESULTS                    ║');
-    console.log('╚══════════════════════════════════════════════════════════╝\n');
+    console.log('\n' + '='.length);
+    console.log('MODEL COMPARISON RESULTS');
+    console.log('='.repeat(60) + '\n');
 
     for (const model of models) {
       const modelScores = scores.filter((s) => s.model === model);
@@ -118,7 +118,7 @@ describe('Model Comparison', () => {
       const structuredPass = modelScores.filter((s) => s.structuredScore === true).length;
       const structuredTotal = modelScores.filter((s) => s.structuredScore !== null).length;
 
-      console.log(`📊 ${model.toUpperCase()}`);
+      console.log(`--- ${model} ---`);
       console.log(`   HPI Narrative:       ${hpiPass}/${modelScores.length} passed`);
       console.log(`   Structured Extract:  ${structuredPass}/${structuredTotal} passed`);
       console.log('');

--- a/packages/ai-quality-tests/tsconfig.json
+++ b/packages/ai-quality-tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/ai-quality-tests/vitest.config.ts
+++ b/packages/ai-quality-tests/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    testTimeout: 120_000, // 2 minutes — LLM calls can be slow
+    hookTimeout: 30_000,
+    setupFiles: ['./src/setup.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

Introduces a comprehensive quality testing framework for Ottehr's AI features (HPI chatbot and ambient scribe) using LLM-as-judge evaluation via openevals. This enables automated assessment of clinical data extraction quality against reference outputs.

## Key Changes

- **Test Data**: Added realistic clinical test cases for both HPI chatbot (chat-based) and ambient scribe (audio transcript) scenarios with expected outputs
  - `hpi-chatbot-cases.ts`: 3 cases covering chest pain, pediatric ear pain, and laceration scenarios
  - `ambient-scribe-cases.ts`: 3 cases covering ankle sprain, UTI, and elderly fall with labs/procedures

- **Evaluation Framework**: Created custom LLM-as-judge prompts for clinical quality assessment
  - HPI narrative quality (accuracy, completeness, clinical writing style)
  - Structured data extraction (medications, allergies, PMH, etc.)
  - Format compliance (JSON schema validation)
  - Mechanism of injury (workers' comp specific)
  - HPI completeness suggestions

- **Test Suites**: Implemented three test modules
  - `hpi-extraction.test.ts`: Evaluates HPI narrative and structured data extraction from chat transcripts
  - `hpi-suggestions.test.ts`: Tests the "missing HPI elements" detection feature
  - `scribe-extraction.test.ts`: Evaluates extraction from audio transcripts including labs, prescriptions, and procedures
  - `model-comparison.test.ts`: Side-by-side quality comparison across different models (Gemini vs Claude)

- **Model Integration**: Added helpers to invoke Gemini and Claude models with production prompts
  - `models.ts`: Wraps LangChain clients for extraction and suggestion endpoints
  - Mirrors production prompt structure from zambdas codebase

- **Production Prompt Mirroring**: Created `prompts.ts` to keep test prompts synchronized with production code
  - Extraction prompt from `packages/zambdas/src/shared/ai.ts`
  - HPI suggestion prompt from `packages/utils/lib/ottehr-config/prompts/`

- **Configuration**: Added project setup files
  - `package.json` with vitest and LangChain dependencies
  - `vitest.config.ts` with 2-minute timeout for LLM calls
  - `.env.example` documenting required API keys
  - `tsconfig.json` extending base configuration
  - `setup.ts` for environment variable loading

- **Documentation**: Added comprehensive README with setup instructions, test execution commands, and architecture overview

## Implementation Details

- Tests use openevals' `createLLMAsJudge()` to evaluate outputs against reference clinical documentation
- Judge model defaults to OpenAI o3-mini but is configurable via `JUDGE_MODEL` environment variable
- Extraction results are cached per test case to avoid redundant model calls
- Tests validate both prose narratives (HPI, MOI) and structured arrays (medications, allergies, etc.)
- Format compliance checks ensure JSON structure matches expected schema with proper camelCase keys
- Model comparison test enables evaluating whether model upgrades improve quality

https://claude.ai/code/session_01KgmPu3s5xqsbWLY3B6Z3SQ