### PR TITLE
Fix waiting room behaviour

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/VirtualAppointmentFooter.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/VirtualAppointmentFooter.tsx
@@ -79,7 +79,7 @@ export const VirtualAppointmentFooter: FC = () => {
       });
     } else {
       if (!apiClient || !user || !appointment?.id || !encounter.id) {
-        throw new Error('api client not defined or userId not provided');
+        throw new Error('apiClient or user or appointment.id or encounter.id is undefined');
       }
       const encounterId = encounter.id;
       initTelemedSession.mutate(

--- a/apps/ehr/src/features/visits/in-person/components/VirtualAppointmentFooter.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/VirtualAppointmentFooter.tsx
@@ -8,6 +8,8 @@ import { ConfirmationDialog } from 'src/components/ConfirmationDialog';
 import { dataTestIds } from 'src/constants/data-test-ids';
 import { useGetAppointmentAccessibility } from 'src/features/visits/shared/hooks/useGetAppointmentAccessibility';
 import { useAppointmentData } from 'src/features/visits/shared/stores/appointment/appointment.store';
+import { handleChangeInPersonVisitStatus } from 'src/helpers/inPersonVisitStatusUtils';
+import { useApiClients } from 'src/hooks/useAppClients';
 import useEvolveUser from 'src/hooks/useEvolveUser';
 import {
   diffInMinutes,
@@ -30,7 +32,7 @@ export const VirtualAppointmentFooter: FC = () => {
   const theme = useTheme();
   const [isInviteParticipantOpen, setIsInviteParticipantOpen] = useState(false);
   const appointmentAccessibility = useGetAppointmentAccessibility();
-  const { appointment, encounter, mappedData, questionnaireResponse } = useAppointmentData();
+  const { appointment, encounter, mappedData, questionnaireResponse, appointmentRefetch } = useAppointmentData();
   const { meetingData } = getSelectors(useVideoCallStore, ['meetingData']);
   const appointmentStatus = (appointment && getInPersonVisitStatus(appointment, encounter)) ?? 'unknown';
   const statusHistory = getVisitStatusHistory(encounter);
@@ -68,6 +70,7 @@ export const VirtualAppointmentFooter: FC = () => {
       });
     }
   );
+  const { oystehrZambda } = useApiClients();
   const onConnect = useCallback(async (): Promise<void> => {
     if (appointmentStatus === 'provider') {
       const meetingDataResponse = await getMeetingData.refetch({ throwOnError: true });
@@ -75,9 +78,10 @@ export const VirtualAppointmentFooter: FC = () => {
         meetingData: meetingDataResponse.data,
       });
     } else {
-      if (!apiClient || !user || !appointment?.id) {
+      if (!apiClient || !user || !appointment?.id || !encounter.id) {
         throw new Error('api client not defined or userId not provided');
       }
+      const encounterId = encounter.id;
       initTelemedSession.mutate(
         { apiClient, appointmentId: appointment.id, userId: user?.id },
         {
@@ -85,6 +89,14 @@ export const VirtualAppointmentFooter: FC = () => {
             useVideoCallStore.setState({
               meetingData: response.meetingData,
             });
+            await handleChangeInPersonVisitStatus(
+              {
+                encounterId: encounterId,
+                updatedStatus: 'provider',
+              },
+              oystehrZambda
+            );
+            await appointmentRefetch();
           },
           onError: () => {
             enqueueSnackbar('Error trying to connect to a patient.', {
@@ -94,7 +106,17 @@ export const VirtualAppointmentFooter: FC = () => {
         }
       );
     }
-  }, [apiClient, appointment?.id, appointmentStatus, getMeetingData, initTelemedSession, user]);
+  }, [
+    apiClient,
+    appointment?.id,
+    appointmentRefetch,
+    appointmentStatus,
+    encounter.id,
+    getMeetingData,
+    initTelemedSession,
+    oystehrZambda,
+    user,
+  ]);
 
   const providerAllowedToConnect =
     appointmentAccessibility.isPractitionerLicensedInState &&

--- a/packages/zambdas/src/patient/get-wait-status/index.ts
+++ b/packages/zambdas/src/patient/get-wait-status/index.ts
@@ -6,9 +6,9 @@ import {
   appointmentTypeForAppointment,
   createOystehrClient,
   getAppointmentResourceById,
+  getInPersonVisitStatus,
   getLocationIdFromAppointment,
   getSecret,
-  getTelemedVisitStatus,
   PROJECT_WEBSITE,
   SecretsKeys,
   TelemedAppointmentStatusEnum,
@@ -108,9 +108,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     };
   }
 
-  const telemedStatus = getTelemedVisitStatus(videoEncounter.status, appointment.status);
+  const status = getInPersonVisitStatus(appointment, videoEncounter);
 
-  if (telemedStatus === 'ready' || telemedStatus === 'pre-video' || telemedStatus === 'on-video') {
+  if (['arrived', 'ready', 'intake', 'ready for provider', 'provider'].includes(status)) {
     const appointments = await getAppointmentsForLocation(oystehr, locationId);
 
     const estimatedTime = calculateEstimatedTime(appointments);
@@ -119,10 +119,10 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     const response = {
       statusCode: 200,
       body: JSON.stringify(<WaitingRoomResponse>{
-        status: telemedStatus === 'on-video' ? telemedStatus : TelemedAppointmentStatusEnum.ready,
+        status: status === 'provider' ? TelemedAppointmentStatusEnum['on-video'] : TelemedAppointmentStatusEnum.ready,
         estimatedTime: estimatedTime,
         numberInLine: numberInLine,
-        encounterId: telemedStatus === 'on-video' ? videoEncounter?.id : undefined,
+        encounterId: status === 'provider' ? videoEncounter?.id : undefined,
         appointmentType: appointmentTypeForAppointment(appointment),
       }),
     };
@@ -133,7 +133,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     const response = {
       statusCode: 200,
       body: JSON.stringify({
-        status: telemedStatus === 'cancelled' ? telemedStatus : TelemedAppointmentStatusEnum.complete,
+        status: status === 'cancelled' ? status : TelemedAppointmentStatusEnum.complete,
       }),
     };
     console.log(JSON.stringify(response, null, 4));


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2287/virtual-visits-video-call-waiting-room-is-broken-when-visists-status

Since telemed visits started to use in-person's statuses waiting room breaks when a visit becomes in "intake"(and maybe some else) statuses. Thus some in-person status needs to be used as an indicator of a started call. "provider" status looks like an acceptable indicator of a started video call.