### PR TITLE
fix(ehr): change timeout for create-invoices-tasks

### DIFF
--- a/config/oystehr-core/zambdas.json
+++ b/config/oystehr-core/zambdas.json
@@ -1451,6 +1451,7 @@
       "name": "create-invoices-tasks",
       "type": "cron",
       "runtime": "nodejs22.x",
+      "timeout": "300",
       "src": "src/cron/create-invoices-tasks/index",
       "zip": ".dist/zips/create-invoices-tasks.zip",
       "schedule": {


### PR DESCRIPTION
We have some other crons that are allowed 5 mins so that's what i picked. 