### PR TITLE
fix: handle non-JSON AI responses gracefully in ai-suggestion-notes

### DIFF
--- a/packages/zambdas/src/ehr/ai-suggestion-notes/index.ts
+++ b/packages/zambdas/src/ehr/ai-suggestion-notes/index.ts
@@ -54,8 +54,11 @@ export const index = wrapHandler('ai-suggestion-notes', async (input: ZambdaInpu
         try {
           suggestions = fixAndParseJsonObjectFromString(aiResponseString);
         } catch (fixError) {
-          console.warn('Failed to fix JSON format, returning empty suggestions:', fixError);
-          suggestions = { suggestions: [] };
+          console.error('Failed to fix JSON format from AI response:', fixError);
+          return {
+            statusCode: 500,
+            body: JSON.stringify({ message: 'AI returned invalid JSON response' }),
+          };
         }
       }
     }

--- a/packages/zambdas/src/ehr/ai-suggestion-notes/index.ts
+++ b/packages/zambdas/src/ehr/ai-suggestion-notes/index.ts
@@ -51,7 +51,12 @@ export const index = wrapHandler('ai-suggestion-notes', async (input: ZambdaInpu
         suggestions = JSON.parse(aiResponseString);
       } catch (parseError) {
         console.warn('Failed to parse AI recommendations response, attempting to fix JSON format:', parseError);
-        suggestions = fixAndParseJsonObjectFromString(aiResponseString);
+        try {
+          suggestions = fixAndParseJsonObjectFromString(aiResponseString);
+        } catch (fixError) {
+          console.warn('Failed to fix JSON format, returning empty suggestions:', fixError);
+          suggestions = { suggestions: [] };
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- When the AI returns a response without valid JSON, `fixAndParseJsonObjectFromString` throws an error that hits Sentry
- Added a nested try-catch to return a **500 error** instead of letting the exception propagate
- This provides a clear error response when the AI gives unexpected output

## Test plan
- [ ] Call ai-suggestion-notes with input that causes non-JSON AI response
- [ ] Verify endpoint returns 500 with error message `"AI returned invalid JSON response"`

Slack thread: https://masslight.slack.com/archives/C0AAK8SAT61/p1776457202614769?thread_ts=1776454949.564059&cid=C0AAK8SAT61

https://claude.ai/code/session_01Sago85zoPBvjZEEQbugd5d