### PR TITLE
Fix "Waiting room" page and "Recent progress note" button

### DIFF
--- a/apps/ehr/src/pages/PatientPage.tsx
+++ b/apps/ehr/src/pages/PatientPage.tsx
@@ -13,7 +13,7 @@ import { FullNameDisplay } from 'src/features/visits/shared/components/patient/i
 import { IdentifiersRow } from 'src/features/visits/shared/components/patient/info/IdentifiersRow';
 import Summary from 'src/features/visits/shared/components/patient/info/Summary';
 import { PatientFollowupEncountersGrid } from 'src/features/visits/shared/components/patient/PatientFollowupEncountersGrid';
-import { getFirstName, getLastName, ServiceMode } from 'utils';
+import { getFirstName, getLastName } from 'utils';
 import CustomBreadcrumbs from '../components/CustomBreadcrumbs';
 import { PatientEncountersGrid } from '../components/PatientEncountersGrid';
 import { PatientLabsTab } from '../components/PatientLabsTab';
@@ -110,11 +110,7 @@ export default function PatientPage(): JSX.Element {
                 <RoundedButton
                   target="_blank"
                   sx={{ width: '100%' }}
-                  to={
-                    latestAppointment.serviceMode === ServiceMode.virtual
-                      ? `/telemed/appointments/${latestAppointment.appointmentId}?tab=sign`
-                      : `/in-person/${latestAppointment.appointmentId}/${ROUTER_PATH.REVIEW_AND_SIGN}`
-                  }
+                  to={`/in-person/${latestAppointment.appointmentId}/${ROUTER_PATH.REVIEW_AND_SIGN}`}
                 >
                   Recent Progress Note
                 </RoundedButton>

--- a/packages/zambdas/src/patient/get-wait-status/index.ts
+++ b/packages/zambdas/src/patient/get-wait-status/index.ts
@@ -110,7 +110,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
   const status = getInPersonVisitStatus(appointment, videoEncounter);
 
-  if (['arrived', 'ready', 'intake', 'ready for provider', 'provider'].includes(status)) {
+  if (['pending', 'arrived', 'ready', 'intake', 'ready for provider', 'provider'].includes(status)) {
     const appointments = await getAppointmentsForLocation(oystehr, locationId);
 
     const estimatedTime = calculateEstimatedTime(appointments);


### PR DESCRIPTION
Patient app. Video call fails with 'The call has ended. Please, request another visit' error message:
https://linear.app/zapehr/issue/OTR-2310/patient-app-video-call-fails-with-the-call-has-ended-please-request

Virtual visits. Video call. Waiting room is broken when visist's status is changed to 'Intake':
https://linear.app/zapehr/issue/OTR-2287/virtual-visits-video-call-waiting-room-is-broken-when-visists-status

EHR. Old progress note is opened if opened from Patient record page:
https://linear.app/zapehr/issue/OTR-2288/ehr-old-progress-note-is-opened-if-opened-from-patient-record-page