### PR TITLE
Szaccagni/otr 2304 exam update data migration issues

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/exam-tab/ExamMigrationWarning.tsx
+++ b/apps/ehr/src/features/visits/shared/components/exam-tab/ExamMigrationWarning.tsx
@@ -88,6 +88,7 @@ export const ExamMigrationWarning: FC<ExamMigrationWarningProps> = ({ unmatchedF
           </Typography>
           <FormControl>
             <RadioGroup
+              aria-label="Migration options for Normal external genital exam"
               row
               value={genitalExamSex ?? ''}
               onChange={(e) => setGenitalExamSex(e.target.value as 'male' | 'female')}

--- a/apps/ehr/src/features/visits/shared/components/exam-tab/ExamMigrationWarning.tsx
+++ b/apps/ehr/src/features/visits/shared/components/exam-tab/ExamMigrationWarning.tsx
@@ -1,7 +1,7 @@
 import { otherColors } from '@ehrTheme/colors';
 import ErrorOutlineOutlined from '@mui/icons-material/ErrorOutlineOutlined';
 import { LoadingButton } from '@mui/lab';
-import { Typography, useTheme } from '@mui/material';
+import { FormControl, FormControlLabel, Radio, RadioGroup, Typography, useTheme } from '@mui/material';
 import { Stack } from '@mui/system';
 import { useQueryClient } from '@tanstack/react-query';
 import { enqueueSnackbar } from 'notistack';
@@ -11,6 +11,8 @@ import { CHART_DATA_QUERY_KEY } from 'src/constants';
 import { useApiClients } from 'src/hooks/useAppClients';
 import { useAppointmentData } from '../../stores/appointment/appointment.store';
 import { useExamObservationsStore } from '../../stores/appointment/exam-observations.store';
+
+const NORMAL_EXTERNAL_GENITAL_EXAM_FIELD = 'normal-external-genital-exam';
 
 type ExamMigrationWarningProps = {
   unmatchedFields: string[];
@@ -22,13 +24,20 @@ export const ExamMigrationWarning: FC<ExamMigrationWarningProps> = ({ unmatchedF
   const { resources } = useAppointmentData();
   const queryClient = useQueryClient();
   const [isMigrating, setIsMigrating] = useState(false);
+  const [genitalExamSex, setGenitalExamSex] = useState<'male' | 'female' | undefined>(undefined);
+
+  const needsGenitalExamChoice = unmatchedFields.includes(NORMAL_EXTERNAL_GENITAL_EXAM_FIELD);
+  const canMigrate = !needsGenitalExamChoice || genitalExamSex !== undefined;
 
   const handleMigrate = async (): Promise<void> => {
     if (!oystehrZambda || !resources.encounter?.id) return;
 
     setIsMigrating(true);
     try {
-      await migrateExamData(oystehrZambda, { encounterId: resources.encounter.id });
+      await migrateExamData(oystehrZambda, {
+        encounterId: resources.encounter.id,
+        ...(needsGenitalExamChoice && genitalExamSex ? { normalExternalGenitalExamSex: genitalExamSex } : {}),
+      });
       enqueueSnackbar('Exam data migrated successfully', { variant: 'success' });
       // Remove only the unmatched fields from the store without touching hasInitialData
       const currentState = useExamObservationsStore.getState();
@@ -71,11 +80,46 @@ export const ExamMigrationWarning: FC<ExamMigrationWarningProps> = ({ unmatchedF
           )}. You can safely migrate this information to the new exam format by clicking the button below.`}
         </Typography>
       </Stack>
+      {needsGenitalExamChoice && (
+        <Stack gap={0.5} ml="32px">
+          <Typography variant="body2" style={{ color: otherColors.lightErrorText, fontWeight: '500' }}>
+            The &quot;Normal external genital exam&quot; finding has been split into male and female sections. Please
+            select which section applies to this patient:
+          </Typography>
+          <FormControl>
+            <RadioGroup
+              row
+              value={genitalExamSex ?? ''}
+              onChange={(e) => setGenitalExamSex(e.target.value as 'male' | 'female')}
+            >
+              <FormControlLabel
+                value="male"
+                control={<Radio size="small" />}
+                label={
+                  <Typography variant="body2" style={{ color: otherColors.lightErrorText }}>
+                    GU (Male) — Normal external genital/testicular exam
+                  </Typography>
+                }
+              />
+              <FormControlLabel
+                value="female"
+                control={<Radio size="small" />}
+                label={
+                  <Typography variant="body2" style={{ color: otherColors.lightErrorText }}>
+                    GU (Female) — Normal external genital exam
+                  </Typography>
+                }
+              />
+            </RadioGroup>
+          </FormControl>
+        </Stack>
+      )}
       <LoadingButton
         variant="contained"
         size="small"
         onClick={handleMigrate}
         loading={isMigrating}
+        disabled={!canMigrate}
         sx={{ textTransform: 'none', borderRadius: '16px', ml: '32px' }}
       >
         Migrate Exam Data

--- a/packages/utils/lib/ottehr-config/examination/in-person.config.ts
+++ b/packages/utils/lib/ottehr-config/examination/in-person.config.ts
@@ -1280,6 +1280,18 @@ export const InPersonExamConfig: ExamItemConfig = {
         },
       },
       abnormal: {
+        'right-cervical-node-easily-mobile-non-tender-not-erythematous': {
+          label: 'Right cervical node, easily mobile, non-tender, not erythematous',
+          defaultValue: false,
+          type: 'checkbox',
+          legacy: true,
+        },
+        'left-cervical-node-easily-mobile-non-tender-not-erythematous': {
+          label: 'Left cervical node, easily mobile, non-tender, not erythematous',
+          defaultValue: false,
+          type: 'checkbox',
+          legacy: true,
+        },
         'lymph-anterior-cervical': createLymphNodeModalExam('lymph-anterior-cervical', 'Anterior cervical', LR_COLUMNS),
         'lymph-posterior-cervical': createLymphNodeModalExam(
           'lymph-posterior-cervical',
@@ -2496,6 +2508,12 @@ export const InPersonExamConfig: ExamItemConfig = {
     label: 'GU (Male)',
     components: {
       normal: {
+        'normal-testicular-exam': {
+          label: 'Normal testicular exam, no tenderness, no erythema, cremasteric reflexes present',
+          defaultValue: false,
+          type: 'checkbox',
+          legacy: true,
+        },
         'normal-external-genital-testicular-exam': {
           label: 'Normal external genital/testicular exam',
           defaultValue: false,
@@ -2513,6 +2531,12 @@ export const InPersonExamConfig: ExamItemConfig = {
         },
       },
       abnormal: {
+        'scrotal-edema-swelling': {
+          label: 'Scrotal edema / swelling',
+          defaultValue: false,
+          type: 'checkbox',
+          legacy: true,
+        },
         'right-side-scrotal-edema-swelling': {
           label: 'Right side - scrotal edema / swelling',
           defaultValue: false,

--- a/packages/utils/lib/types/api/chart-data/chart-data.types.ts
+++ b/packages/utils/lib/types/api/chart-data/chart-data.types.ts
@@ -552,6 +552,7 @@ export interface AccidentDTO extends SaveableDTO {
 
 export interface MigrateExamDataInput {
   encounterId: string;
+  normalExternalGenitalExamSex?: 'male' | 'female';
 }
 
 export interface MigrateExamDataOutput {

--- a/packages/zambdas/src/ehr/migrate-exam-data/index.ts
+++ b/packages/zambdas/src/ehr/migrate-exam-data/index.ts
@@ -61,6 +61,15 @@ function validateInput(input: ZambdaInput): MigrateExamDataInput & { secrets: Za
   const parsedBody = typeof body === 'string' ? JSON.parse(body) : body;
   const encounterId = parsedBody?.encounterId;
   if (!encounterId) throw new Error('encounterId is required');
-  const normalExternalGenitalExamSex = parsedBody?.normalExternalGenitalExamSex as 'male' | 'female' | undefined;
+
+  let normalExternalGenitalExamSex: 'male' | 'female' | undefined;
+  const normalExternalGenitalExamSexParsed = parsedBody?.normalExternalGenitalExamSex;
+
+  if (normalExternalGenitalExamSexParsed === 'male' || normalExternalGenitalExamSexParsed === 'female') {
+    normalExternalGenitalExamSex = normalExternalGenitalExamSexParsed;
+  } else if (normalExternalGenitalExamSexParsed !== undefined) {
+    throw new Error('normalExternalGenitalExamSex must be either "male" or "female"');
+  }
+
   return { encounterId, normalExternalGenitalExamSex, secrets };
 }

--- a/packages/zambdas/src/ehr/migrate-exam-data/index.ts
+++ b/packages/zambdas/src/ehr/migrate-exam-data/index.ts
@@ -16,7 +16,7 @@ const ZAMBDA_NAME = 'migrate-exam-data';
 
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   try {
-    const { encounterId, secrets } = validateInput(input);
+    const { encounterId, normalExternalGenitalExamSex, secrets } = validateInput(input);
     m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
     const oystehr = createOystehrClient(m2mToken, secrets);
 
@@ -37,7 +37,8 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
       encounter,
       patient.id!,
       encounterId,
-      examObservations
+      examObservations,
+      normalExternalGenitalExamSex
     );
 
     const response: MigrateExamDataOutput = {
@@ -60,5 +61,6 @@ function validateInput(input: ZambdaInput): MigrateExamDataInput & { secrets: Za
   const parsedBody = typeof body === 'string' ? JSON.parse(body) : body;
   const encounterId = parsedBody?.encounterId;
   if (!encounterId) throw new Error('encounterId is required');
-  return { encounterId, secrets };
+  const normalExternalGenitalExamSex = parsedBody?.normalExternalGenitalExamSex as 'male' | 'female' | undefined;
+  return { encounterId, normalExternalGenitalExamSex, secrets };
 }

--- a/packages/zambdas/src/shared/chart-data/migrations/index.ts
+++ b/packages/zambdas/src/shared/chart-data/migrations/index.ts
@@ -112,6 +112,10 @@ const PARENT_FIELD_TO_LABEL_MAP: Record<string, string> = {
   'murmur-grade': 'Murmur',
 };
 
+// this field previously existing under a unified 'GU, Rectal' section which has now been split into male / female
+// we will prompt the user to pick before migrating
+export const NORMAL_EXTERNAL_GENITAL_EXAM_FIELD = 'normal-external-genital-exam';
+
 export interface MigrationResult {
   migrated: boolean;
   observations: ExamObservationDTO[];
@@ -181,6 +185,33 @@ export function migrateV0ToV1(observations: ExamObservationDTO[]): MigrationResu
 }
 
 /**
+ * Migration for the 'normal-external-genital-exam' field, which was split into
+ * sex-specific fields. Requires the user to specify which section applies.
+ */
+export function migrateNormalExternalGenitalExam(
+  observations: ExamObservationDTO[],
+  sex: 'male' | 'female'
+): { migrated: boolean; observations: ExamObservationDTO[]; migratedResourceId?: string } {
+  const targetField =
+    sex === 'male' ? 'normal-external-genital-testicular-exam' : 'normal-external-genital-exam-female';
+  const targetLabel = sex === 'male' ? 'Normal external genital/testicular exam' : 'Normal external genital exam';
+
+  let migrated = false;
+  let migratedResourceId: string | undefined;
+
+  const result = observations.map((obs) => {
+    if (obs.field === NORMAL_EXTERNAL_GENITAL_EXAM_FIELD) {
+      migrated = true;
+      migratedResourceId = obs.resourceId;
+      return { ...obs, field: targetField, label: targetLabel };
+    }
+    return obs;
+  });
+
+  return { migrated, observations: result, migratedResourceId };
+}
+
+/**
  * Run all pending exam migrations for an encounter.
  * Returns the migrated observations and list of old resource IDs to delete.
  */
@@ -189,52 +220,57 @@ export async function runExamMigrations(
   encounter: Encounter,
   patientId: string,
   encounterId: string,
-  examObservations: ExamObservationDTO[]
+  examObservations: ExamObservationDTO[],
+  normalExternalGenitalExamSex?: 'male' | 'female'
 ): Promise<ExamObservationDTO[]> {
   const currentVersion = getExamMigrationVersion(encounter);
+  const needsVersionMigration = currentVersion < CURRENT_EXAM_MIGRATION_VERSION;
+  const needsGenitalMigration =
+    !!normalExternalGenitalExamSex &&
+    examObservations.some((obs) => obs.field === NORMAL_EXTERNAL_GENITAL_EXAM_FIELD && obs.value === true);
 
-  if (currentVersion >= CURRENT_EXAM_MIGRATION_VERSION) {
+  if (!needsVersionMigration && !needsGenitalMigration) {
     return examObservations;
   }
 
   let result = examObservations;
-  let didMigrate = false;
+  let didV1Migration = false;
+  let genitalMigration: ReturnType<typeof migrateNormalExternalGenitalExam> | undefined;
 
   // Run migration 0 → 1
-  if (currentVersion < 1) {
+  if (needsVersionMigration && currentVersion < 1) {
     const migration = migrateV0ToV1(result);
     if (migration.migrated) {
-      didMigrate = true;
+      didV1Migration = true;
       result = migration.observations;
     }
   }
 
-  // Persist if any migration ran
-  if (didMigrate) {
-    console.log(`Running exam migration from version ${currentVersion} to ${CURRENT_EXAM_MIGRATION_VERSION}`);
+  // Run user-directed genital exam migration
+  if (needsGenitalMigration) {
+    genitalMigration = migrateNormalExternalGenitalExam(result, normalExternalGenitalExamSex!);
+    if (genitalMigration.migrated) {
+      result = genitalMigration.observations;
+    }
+  }
 
-    try {
+  const didMigrate = didV1Migration || genitalMigration?.migrated;
+
+  try {
+    const requests: any[] = [];
+
+    if (didV1Migration) {
+      console.log(`Running exam migration from version ${currentVersion} to ${CURRENT_EXAM_MIGRATION_VERSION}`);
+
       // Collect old standalone observation IDs to delete
-      const oldResourceIds: string[] = [];
       for (const obs of examObservations) {
         if (obs.value === true && MIGRATION_V1_FIELD_MAP[obs.field] && obs.resourceId) {
-          oldResourceIds.push(obs.resourceId);
+          requests.push({ method: 'DELETE', url: `/Observation/${obs.resourceId}` });
         }
-      }
-
-      const requests: any[] = [];
-
-      // Delete old standalone observations
-      for (const resourceId of oldResourceIds) {
-        requests.push({
-          method: 'DELETE',
-          url: `/Observation/${resourceId}`,
-        });
       }
 
       // Create/update parent observations with components
       for (const obs of result) {
-        // Only persist observations that were part of migration (have components from migrated data)
         if (obs.components && obs.components.length > 0) {
           console.log('Obs to be migrated', JSON.stringify(obs));
           const fhirObs = makeExamObservationResource(encounterId, patientId, obs, undefined, obs.label || obs.field);
@@ -245,48 +281,55 @@ export async function runExamMigrations(
           }
         }
       }
+    }
 
-      // Update encounter with new migration version
+    if (genitalMigration?.migrated) {
+      const targetField =
+        normalExternalGenitalExamSex === 'male'
+          ? 'normal-external-genital-testicular-exam'
+          : 'normal-external-genital-exam-female';
+      const migratedObs = result.find((obs) => obs.field === targetField);
+      if (migratedObs) {
+        console.log('Migrating normal-external-genital-exam to', targetField, JSON.stringify(migratedObs));
+        const fhirObs = makeExamObservationResource(
+          encounterId,
+          patientId,
+          migratedObs,
+          undefined,
+          migratedObs.label || migratedObs.field
+        );
+        if (genitalMigration.migratedResourceId) {
+          requests.push({
+            method: 'PUT',
+            url: `/Observation/${genitalMigration.migratedResourceId}`,
+            resource: fhirObs,
+          });
+        } else {
+          requests.push({ method: 'POST', url: '/Observation', resource: fhirObs });
+        }
+      }
+    }
+
+    // Update encounter migration version if version-based migration was pending
+    if (needsVersionMigration) {
       const updatedExtensions = (encounter.extension ?? []).filter((e) => e.url !== EXAM_MIGRATION_VERSION_URL);
-      updatedExtensions.push({
-        url: EXAM_MIGRATION_VERSION_URL,
-        valueInteger: CURRENT_EXAM_MIGRATION_VERSION,
-      });
-
+      updatedExtensions.push({ url: EXAM_MIGRATION_VERSION_URL, valueInteger: CURRENT_EXAM_MIGRATION_VERSION });
       requests.push({
         method: 'PUT',
         url: `/Encounter/${encounterId}`,
-        resource: {
-          ...encounter,
-          extension: updatedExtensions,
-        },
+        resource: { ...encounter, extension: updatedExtensions },
       });
+    }
 
-      if (requests.length > 0) {
-        await oystehr.fhir.transaction({ requests });
-        console.log(
-          `Exam migration complete: deleted ${oldResourceIds.length} old observations, updated encounter version to ${CURRENT_EXAM_MIGRATION_VERSION}`
-        );
+    if (requests.length > 0) {
+      await oystehr.fhir.transaction({ requests });
+      if (didMigrate) {
+        console.log(`Exam migration complete, updated encounter version to ${CURRENT_EXAM_MIGRATION_VERSION}`);
       }
-    } catch (error) {
-      console.error('Exam migration failed, returning unmigrated data:', error);
-      return examObservations;
     }
-  } else {
-    // No data needed migration but version needs updating
-    try {
-      const updatedExtensions = (encounter.extension ?? []).filter((e) => e.url !== EXAM_MIGRATION_VERSION_URL);
-      updatedExtensions.push({
-        url: EXAM_MIGRATION_VERSION_URL,
-        valueInteger: CURRENT_EXAM_MIGRATION_VERSION,
-      });
-      await oystehr.fhir.update({
-        ...encounter,
-        extension: updatedExtensions,
-      } as Encounter);
-    } catch (error) {
-      console.error('Failed to update encounter migration version:', error);
-    }
+  } catch (error) {
+    console.error('Exam migration failed, returning un-migrated data:', error);
+    return examObservations;
   }
 
   return result;

--- a/packages/zambdas/src/shared/chart-data/migrations/index.ts
+++ b/packages/zambdas/src/shared/chart-data/migrations/index.ts
@@ -112,8 +112,8 @@ const PARENT_FIELD_TO_LABEL_MAP: Record<string, string> = {
   'murmur-grade': 'Murmur',
 };
 
-// this field previously existing under a unified 'GU, Rectal' section which has now been split into male / female
-// we will prompt the user to pick before migrating
+// This field previously existed under a unified 'GU, Rectal' section, which has now been split into male/female sections.
+// We will prompt the user to choose before migrating.
 export const NORMAL_EXTERNAL_GENITAL_EXAM_FIELD = 'normal-external-genital-exam';
 
 export interface MigrationResult {
@@ -187,6 +187,7 @@ export function migrateV0ToV1(observations: ExamObservationDTO[]): MigrationResu
 /**
  * Migration for the 'normal-external-genital-exam' field, which was split into
  * sex-specific fields. Requires the user to specify which section applies.
+ * Also operates under the assumption that there will ever only be one of these in an exam to be migrated
  */
 export function migrateNormalExternalGenitalExam(
   observations: ExamObservationDTO[],
@@ -253,8 +254,6 @@ export async function runExamMigrations(
       result = genitalMigration.observations;
     }
   }
-
-  const didMigrate = didV1Migration || genitalMigration?.migrated;
 
   try {
     const requests: any[] = [];
@@ -323,8 +322,11 @@ export async function runExamMigrations(
 
     if (requests.length > 0) {
       await oystehr.fhir.transaction({ requests });
-      if (didMigrate) {
+      if (didV1Migration) {
         console.log(`Exam migration complete, updated encounter version to ${CURRENT_EXAM_MIGRATION_VERSION}`);
+      }
+      if (genitalMigration && genitalMigration.migrated) {
+        console.log(`Genital exam migration complete, updated applied observation-only migration changes`);
       }
     }
   } catch (error) {

--- a/packages/zambdas/test/unit/exam-migration.test.ts
+++ b/packages/zambdas/test/unit/exam-migration.test.ts
@@ -1,6 +1,13 @@
+import { Observation } from 'fhir/r4b';
 import { ExamObservationDTO } from 'utils';
 import { describe, expect, it } from 'vitest';
-import { migrateV0ToV1, MIGRATION_V1_FIELD_MAP } from '../../src/shared/chart-data/migrations/index';
+import { makeExamObservationDTO } from '../../src/shared';
+import {
+  migrateNormalExternalGenitalExam,
+  migrateV0ToV1,
+  MIGRATION_V1_FIELD_MAP,
+  NORMAL_EXTERNAL_GENITAL_EXAM_FIELD,
+} from '../../src/shared/chart-data/migrations/index';
 
 describe('Exam migration V0 to V1', () => {
   describe('MIGRATION_V1_FIELD_MAP', () => {
@@ -250,5 +257,103 @@ describe('Exam migration V0 to V1', () => {
       expect(codes).toContain('subcostal');
       expect(codes).toContain('intercostal');
     });
+  });
+});
+
+describe('migrateNormalExternalGenitalExam', () => {
+  const legacyObs: Observation = {
+    resourceType: 'Observation',
+    subject: {
+      reference: 'Patient/patient-id',
+    },
+    encounter: {
+      reference: 'Encounter/encounter-id',
+    },
+    status: 'final',
+    valueBoolean: true,
+    code: {
+      text: 'Normal external genital exam, no lesions / redness / discharge',
+    },
+    meta: {
+      tag: [
+        {
+          code: 'normal-external-genital-exam',
+          system: 'https://fhir.zapehr.com/r4/StructureDefinitions/exam-observation-field',
+        },
+      ],
+      versionId: '123',
+      lastUpdated: '2026-04-20T16:00:49.994Z',
+    },
+    id: 'obs-genital-1',
+  };
+
+  const legacyExamDTO = makeExamObservationDTO(legacyObs);
+
+  it('renames the field to the male target when sex is male', () => {
+    const result = migrateNormalExternalGenitalExam([legacyExamDTO], 'male');
+
+    expect(result.migrated).toBe(true);
+    expect(result.observations).toHaveLength(1);
+    expect(result.observations[0].field).toBe('normal-external-genital-testicular-exam');
+    expect(result.observations[0].label).toBe('Normal external genital/testicular exam');
+  });
+
+  it('renames the field to the female target when sex is female', () => {
+    const result = migrateNormalExternalGenitalExam([legacyExamDTO], 'female');
+
+    expect(result.migrated).toBe(true);
+    expect(result.observations).toHaveLength(1);
+    expect(result.observations[0].field).toBe('normal-external-genital-exam-female');
+    expect(result.observations[0].label).toBe('Normal external genital exam');
+  });
+
+  it('returns the resourceId of the migrated observation', () => {
+    const result = migrateNormalExternalGenitalExam([legacyExamDTO], 'male');
+
+    expect(result.migratedResourceId).toBe('obs-genital-1');
+  });
+
+  it('returns migratedResourceId as undefined when the observation has no resourceId', () => {
+    const obs: ExamObservationDTO = { field: NORMAL_EXTERNAL_GENITAL_EXAM_FIELD, value: true };
+    const result = migrateNormalExternalGenitalExam([obs], 'female');
+
+    expect(result.migrated).toBe(true);
+    expect(result.migratedResourceId).toBeUndefined();
+  });
+
+  it('preserves all other properties on the migrated observation', () => {
+    const result = migrateNormalExternalGenitalExam([legacyExamDTO], 'male');
+
+    expect(result.observations[0]).toMatchObject({ value: true, resourceId: 'obs-genital-1' });
+  });
+
+  it('leaves unrelated observations unchanged', () => {
+    const other: ExamObservationDTO = { field: 'some-other-field', value: false };
+    const result = migrateNormalExternalGenitalExam([legacyExamDTO, other], 'female');
+
+    expect(result.observations).toHaveLength(2);
+    const unchanged = result.observations.find((o) => o.field === 'some-other-field');
+    expect(unchanged).toEqual(other);
+  });
+
+  it('returns migrated=false and observations unchanged when the legacy field is absent', () => {
+    const observations: ExamObservationDTO[] = [
+      { field: 'normal-external-genital-testicular-exam', value: true },
+      { field: 'some-other-field', value: false },
+    ];
+
+    const result = migrateNormalExternalGenitalExam(observations, 'male');
+
+    expect(result.migrated).toBe(false);
+    expect(result.migratedResourceId).toBeUndefined();
+    expect(result.observations).toEqual(observations);
+  });
+
+  it('handles an empty observations array without error', () => {
+    const result = migrateNormalExternalGenitalExam([], 'female');
+
+    expect(result.migrated).toBe(false);
+    expect(result.observations).toEqual([]);
+    expect(result.migratedResourceId).toBeUndefined();
   });
 });


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2304/exam-update-data-migration-issues#comment-14dc34b9

I've added the following as legacy checkbox fields: 
- normal-testicular-exam
- scrotal-edema-swelling
- right-cervical-node-easily-mobile-non-tender-not-erythematous
- left-cervical-node-easily-mobile-non-tender-not-erythematous

I've also added specific logic to handle migrating 'normal-external-genital-exam' which now exists under both GU (male) and GU (female). Since the longterm plan is to build versioning into the exam config I didn't want to add logic to handle rendering legacy sections, seemed more practical to just include it in the exam migration logic which will presumably be removed once the versioning is built out more. Discussed with Daniel in slack. 