### PR TITLE
fix(tests): Make procedures happy path test config-aware.

### DIFF
--- a/apps/ehr/tests/e2e/page/abstract/BaseProgressNotePage.ts
+++ b/apps/ehr/tests/e2e/page/abstract/BaseProgressNotePage.ts
@@ -39,16 +39,17 @@ export abstract class BaseProgressNotePage {
     const cptPrefix = 'CPT:';
     for (const procedureDetail of procedureDetails) {
       if (procedureDetail.startsWith(cptPrefix)) {
-        // sometimes it's not in order and that flakes the test
-        const [cptCode1, cptCode2] = procedureDetail.replace(cptPrefix, '').split('; ');
-        let regex: string;
-        if (cptCode2 != null) {
-          regex = `${cptPrefix} (${cptCode1 + '; ' + cptCode2}|${cptCode2 + '; ' + cptCode1})`;
-        } else {
-          regex = `${cptPrefix} ${cptCode1}`;
+        // CPT codes render in a '; '-joined list whose order depends on how the procedure was built
+        // (procedure-type CPT may be auto-added before or after user-selected codes, and may vary by config).
+        // Verify the CPT heading and each expected code independently to stay order-agnostic.
+        const cptCodes = procedureDetail
+          .slice(cptPrefix.length)
+          .split('; ')
+          .filter((code) => code.length > 0);
+        await matcher.toContainText(cptPrefix);
+        for (const cptCode of cptCodes) {
+          await matcher.toContainText(cptCode);
         }
-        console.log('>>> this is the regex', regex);
-        await matcher.toContainText(new RegExp(regex));
       } else {
         await matcher.toContainText(procedureDetail);
       }

--- a/apps/ehr/tests/e2e/specs/in-person/orders.spec.ts
+++ b/apps/ehr/tests/e2e/specs/in-person/orders.spec.ts
@@ -879,11 +879,12 @@ async function verifyProcedureRow(procedureInfo: ProcedureInfo, procedureRow: Pr
 function progressNoteProcedureDetails(procedureInfo: ProcedureInfo): string[] {
   const cptInfo: string[] = [];
   for (const cpt of procedureInfo.cptInfo) {
-    const cptPrefix = cpt.procedureTypeCptCode ? cpt.procedureTypeCptCode + ':' : '';
-    cptInfo.push(cptPrefix + cpt.cptCode + ' ' + cpt.cptName);
+    if (cpt.procedureTypeCptCode) {
+      cptInfo.push(cpt.procedureTypeCptCode);
+    }
+    cptInfo.push(cpt.cptCode + ' ' + cpt.cptName);
   }
   return [
-    // colon will be used to split and reorder string so this line is different
     'CPT:' + cptInfo.join('; '),
     'Dx: ' + procedureInfo.diagnosisCode + ' ' + procedureInfo.diagnosisName,
     'Performed by: ' + procedureInfo.performedBy,


### PR DESCRIPTION
Fixes an e2e test flake where the tests do not work for some configurations, it depends on whether their procedures include CPT codes or not.