### PR TITLE
Fix progress note button

### DIFF
--- a/apps/ehr/src/components/PatientEncountersGrid.tsx
+++ b/apps/ehr/src/components/PatientEncountersGrid.tsx
@@ -316,13 +316,7 @@ export const PatientEncountersGrid: FC<PatientEncountersGridProps> = (props) => 
       }
       case 'note':
         return (
-          <RoundedButton
-            to={
-              row.serviceMode === ServiceMode.virtual
-                ? `/telemed/appointments/${row.appointmentId}?tab=sign`
-                : `/in-person/${row.appointmentId}/${ROUTER_PATH.REVIEW_AND_SIGN}`
-            }
-          >
+          <RoundedButton to={`/in-person/${row.appointmentId}/${ROUTER_PATH.REVIEW_AND_SIGN}`}>
             Progress Note
           </RoundedButton>
         );


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2288/ehr-old-progress-note-is-opened-if-opened-from-patient-record-page#comment-879b56e9