### PR TITLE
bump oystehr tf provider to 0.0.21

### DIFF
--- a/deploy/.terraform.lock.hcl
+++ b/deploy/.terraform.lock.hcl
@@ -114,25 +114,23 @@ provider "registry.terraform.io/hashicorp/null" {
 }
 
 provider "registry.terraform.io/masslight/oystehr" {
-  version     = "0.0.20"
-  constraints = "0.0.20"
+  version     = "0.0.21"
+  constraints = "0.0.21"
   hashes = [
-    "h1:T61R6OR28gfAH+DDub6aVhjBvsH9OisASgEgw06SVao=",
-    "h1:clVuCN66uHQaGqpo6MU4CeTsXlXGia2+XBLCeqAPUPI=",
+    "h1:RmBXa95pjv2kuT7yGQoTG6hM9/LmzLrEpRrF9kM/jdc=",
+    "zh:0236aac8cb53d20332134495ff5d69a56b0fbb75458ff21ce5bb5eaccdd2afcd",
+    "zh:03eae39113cdd84a108605503bdb84c5c6a1b611996fd7c061e8c67f00ca7509",
+    "zh:041b56beec90e5663df8ac4f23014591c06f15d9ee1dfc17ae271488c3820c5c",
     "zh:0dde99e7b343fa01f8eefc378171fb8621bedb20f59157d6cc8e3d46c738105f",
-    "zh:11d808389270ab2376a379c51afe6db59bb2d4297d9bba4a815482fbd4af4c0a",
-    "zh:122a791e9d4b4be380eb915891ea2722e35563d7481306febdbfbfccef625468",
-    "zh:1ff47bdf6f4bfb9476fbe66861d4fd28d83e125870197bc3ef2e09dec73abccc",
-    "zh:22cb79e894c1b23f83dadecd88f6d0430c1d62966bbfc1541259b601eb5d6bbe",
-    "zh:2cd5870880d416b155b4b853ce47f19b8c02a5c3d2b88111d59185a78a822f16",
-    "zh:3e8d8c200ad17682875989f5aef77cab6f2ce2772d8aaf452b8fd2d159ddcc3a",
-    "zh:4127aaba665168a12d520b89a2be13f9c83228fbd7429d7d3793a612bc51c420",
-    "zh:6321467a41a33b7a3175465612c62d93033d9daaffc14b4c2404e35afd1de5fa",
-    "zh:6d15fb7061ea6d8aebf8b3eb35664fd11fc1097fd6a0c6ac9a718c858324f4a6",
-    "zh:7563abbfdb727f92ccd15825491240fee0141f38b23d74443c44c94e57b03d51",
-    "zh:9f2971bd052e3db41eb8b4c22d25bdbbed80ff3e39884963a20b6a99b3ca56cf",
-    "zh:ecd42cac74766d1c7016774b48798b635b8446b70aa3de084f5f9c6255e2de6a",
-    "zh:f6da6dbdb003e2d8bf140ba22592cdf9e3408fe4711f0c63569bba43c2ae5bc3",
-    "zh:fad1fbbcc5afe704dde28f1374ca860abdcd72c42df93ad2742b7f3beb9ac791",
+    "zh:2a04a1a6aa2c3e13b4f23305c725cdfb659fc7e3d21b9a7dbc6cb5eb7cdc6a73",
+    "zh:3a8182b9a83a43706594a6c2dd8c2ea58f164cb458dbb77ec29b0ca414dd92ab",
+    "zh:3bc8487645afd1db2ec8aa009cb067fa2e5199000dcc75f866a63f1f5a397ca4",
+    "zh:4dc3dae586789790f5adb96d3c53a4f1e212674e6bf0a7fe5050a0f67ccd1614",
+    "zh:7a052683247bde5725aaf5e7a73096768360557f34e39badd75b3b44b4dc781a",
+    "zh:8335a0d59828b167616210333b15b209f45642db788406698f6f3a8ace6d241b",
+    "zh:9162128524365ccb0fc6a11ca10c678c760d55df9b4fb85f66c84d481cc3d9b7",
+    "zh:9a2bb81a22204b78000a7828b06e18db8216f2d66acb75947a82ff64b0bea0f1",
+    "zh:bf491967e839f28954624dadfe99d140a086ffd0dccfa49a9b301f5bc7db81aa",
+    "zh:d675ee62b6f53a6504481abaa6f5555d4f277a1c1d9ea77889cfa9f909198a4e",
   ]
 }

--- a/deploy/oystehr/main.tf
+++ b/deploy/oystehr/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     oystehr = {
       source  = "registry.terraform.io/masslight/oystehr"
-      version = "0.0.20"
+      version = "0.0.21"
     }
   }
 }


### PR DESCRIPTION
The new version may help with the z3 buckets falling out of tf state bug.