### PR TITLE
Fix error with saving empty summary message in follow-up encounters

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/follow-up-note/FollowUpSummaryCard.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/follow-up-note/FollowUpSummaryCard.tsx
@@ -75,7 +75,7 @@ export const FollowUpSummaryCard: React.FC = () => {
           patientId: patient.id,
           reason: data.reason || undefined,
           otherReason: data.reason === 'Other' ? data.otherReason : undefined,
-          message: data.message,
+          message: data.message.trim(),
           start: encounter.period?.start || new Date().toISOString(),
           location: data.location,
           resolved: false,


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2398/error-while-saving-empty-summary-message-in-follow-up-encounters