### PR TITLE
Restore video room status history removal.

### DIFF
--- a/packages/zambdas/src/ehr/init-telemed-session/video-room-creation.ts
+++ b/packages/zambdas/src/ehr/init-telemed-session/video-room-creation.ts
@@ -1,6 +1,5 @@
 import Oystehr from '@oystehr/sdk';
 import { Appointment, Encounter, RelatedPerson } from 'fhir/r4b';
-import { DateTime } from 'luxon';
 import { getRelatedPersonsForPatient, getSecret, Secrets, SecretsKeys } from 'utils';
 import { getAuth0Token } from '../../shared';
 import { getPatientFromAppointment } from '../../shared/appointment/helpers';
@@ -44,31 +43,7 @@ const execCreateVideoRoomRequest = async (
   return responseData.encounter;
 };
 
-const updateVideoRoomEncounter = (
-  encounter: Encounter,
-  relatedPersons: RelatedPerson[],
-  startTime: DateTime = DateTime.now()
-): Encounter => {
-  encounter.status = 'in-progress';
-  const startTimeIso = startTime.toUTC().toISO()!;
-
-  encounter.statusHistory ??= [];
-
-  const previousStatus = encounter.statusHistory?.[encounter.statusHistory?.length - 1];
-  if (previousStatus) {
-    previousStatus.period = {
-      ...previousStatus.period,
-      end: startTimeIso!,
-    };
-  }
-
-  encounter.statusHistory?.push({
-    status: encounter.status,
-    period: {
-      start: startTimeIso!,
-    },
-  });
-
+const updateVideoRoomEncounter = (encounter: Encounter, relatedPersons: RelatedPerson[]): Encounter => {
   encounter.participant ??= [];
 
   const existingRefs = new Set(


### PR DESCRIPTION
This PR restores changes that were unintentionally lost during a previous merge. While resolving merge conflicts, part of the code from commit c5f8c783d8880162c1c3e3af27d93f6260a0244c (from an already merged PR) was mistakenly overwritten.