### PR TITLE
fix several requirements for command palette

### DIFF
--- a/apps/ehr/src/components/CommandPaletteRegistrations.tsx
+++ b/apps/ehr/src/components/CommandPaletteRegistrations.tsx
@@ -3,8 +3,13 @@ import { useGlobalQuickPicks } from '../hooks/useGlobalQuickPicks';
 import { useNavigationQuickPicks } from '../hooks/useNavigationQuickPicks';
 
 export const CommandPaletteRegistrations: FC = () => {
-  useGlobalQuickPicks();
   useNavigationQuickPicks();
+
+  return null;
+};
+
+export const CommandPaletteInPersonRegistrations: FC = () => {
+  useGlobalQuickPicks();
 
   return null;
 };

--- a/apps/ehr/src/features/immunization/pages/ImmunizationOrderCreateEdit.tsx
+++ b/apps/ehr/src/features/immunization/pages/ImmunizationOrderCreateEdit.tsx
@@ -27,6 +27,7 @@ import { ButtonRounded } from 'src/features/visits/in-person/components/RoundedB
 import { WarningBlock } from 'src/features/visits/in-person/components/WarningBlock';
 import { getImmunizationMARUrl } from 'src/features/visits/in-person/routing/helpers';
 import { QuickPicksButton } from 'src/features/visits/shared/components/QuickPicksButton';
+import { useGetAppointmentAccessibility } from 'src/features/visits/shared/hooks/useGetAppointmentAccessibility';
 import { useAppointmentData } from 'src/features/visits/shared/stores/appointment/appointment.store';
 import { cleanupProperties } from 'src/helpers/misc.helper';
 import { useCommandPaletteSource } from 'src/hooks/useCommandPaletteSource';
@@ -50,6 +51,7 @@ export const ImmunizationOrderCreateEdit: React.FC = () => {
     resources: { encounter, patient },
   } = useAppointmentData(appointmentId);
 
+  const { isAppointmentReadOnly: isReadOnly } = useGetAppointmentAccessibility();
   const [isImmunizationHistoryCollapsed, setIsImmunizationHistoryCollapsed] = useState(false);
   const [isOrderSaved, setIsOrderSaved] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -130,7 +132,7 @@ export const ImmunizationOrderCreateEdit: React.FC = () => {
 
   const commandPaletteItems = useMemo(
     () =>
-      orderId
+      orderId || isReadOnly
         ? []
         : mergedQuickPicks.map((quickPick) => {
             const doseAndUnits = quickPick.dose && quickPick.units ? `${quickPick.dose} ${quickPick.units}` : undefined;
@@ -142,13 +144,19 @@ export const ImmunizationOrderCreateEdit: React.FC = () => {
               onSelect: () => onQuickPickSelectRef.current(quickPick),
             };
           }),
-    [mergedQuickPicks, orderId]
+    [isReadOnly, mergedQuickPicks, orderId]
   );
   useCommandPaletteSource('immunization-quick-picks', commandPaletteItems);
 
-  const handlePendingQuickPick = useCallback((payload: ImmunizationQuickPickData) => {
-    onQuickPickSelectRef.current(payload);
-  }, []);
+  const handlePendingQuickPick = useCallback(
+    (payload: ImmunizationQuickPickData) => {
+      if (isReadOnly) {
+        return;
+      }
+      onQuickPickSelectRef.current(payload);
+    },
+    [isReadOnly]
+  );
   usePendingQuickPick('immunizations', handlePendingQuickPick, !isOrderLoading);
 
   return (

--- a/apps/ehr/src/features/radiology/pages/CreateRadiologyOrder.tsx
+++ b/apps/ehr/src/features/radiology/pages/CreateRadiologyOrder.tsx
@@ -33,6 +33,7 @@ import { dataTestIds } from 'src/constants/data-test-ids';
 import DetailPageContainer from 'src/features/common/DetailPageContainer';
 import { getRadiologyUrl } from 'src/features/visits/in-person/routing/helpers';
 import { QuickPicksButton } from 'src/features/visits/shared/components/QuickPicksButton';
+import { useGetAppointmentAccessibility } from 'src/features/visits/shared/hooks/useGetAppointmentAccessibility';
 import {
   useGetCPTHCPCSSearch,
   useICD10SearchNew,
@@ -79,6 +80,7 @@ export const CreateRadiologyOrder: React.FC<CreateRadiologyOrdersProps> = () => 
   const [submitting, setSubmitting] = useState<boolean>(false);
   const { mutate: saveChartData } = useSaveChartData();
   const { encounter } = useAppointmentData();
+  const { isAppointmentReadOnly: isReadOnly } = useGetAppointmentAccessibility();
   const { chartData, setPartialChartData } = useChartData();
   const { diagnosis } = chartData || {};
   const primaryDiagnosis = diagnosis?.find((d) => d.isPrimary);
@@ -149,19 +151,27 @@ export const CreateRadiologyOrder: React.FC<CreateRadiologyOrdersProps> = () => 
 
   const commandPaletteItems = useMemo(
     () =>
-      mergedQuickPicks.map((quickPick) => ({
-        id: `radiology-${quickPick.id ?? quickPick.name}`,
-        label: quickPick.name,
-        category: 'Order Radiology',
-        onSelect: () => onQuickPickSelectRef.current(quickPick),
-      })),
-    [mergedQuickPicks]
+      isReadOnly
+        ? []
+        : mergedQuickPicks.map((quickPick) => ({
+            id: `radiology-${quickPick.id ?? quickPick.name}`,
+            label: quickPick.name,
+            category: 'Order Radiology',
+            onSelect: () => onQuickPickSelectRef.current(quickPick),
+          })),
+    [isReadOnly, mergedQuickPicks]
   );
   useCommandPaletteSource('radiology-quick-picks', commandPaletteItems);
 
-  const handlePendingQuickPick = useCallback((payload: RadiologyQuickPickData) => {
-    onQuickPickSelectRef.current(payload);
-  }, []);
+  const handlePendingQuickPick = useCallback(
+    (payload: RadiologyQuickPickData) => {
+      if (isReadOnly) {
+        return;
+      }
+      onQuickPickSelectRef.current(payload);
+    },
+    [isReadOnly]
+  );
   usePendingQuickPick('radiology', handlePendingQuickPick);
 
   const openQuickPickDialog = async (): Promise<void> => {

--- a/apps/ehr/src/features/visits/in-person/layout/InPersonLayout.tsx
+++ b/apps/ehr/src/features/visits/in-person/layout/InPersonLayout.tsx
@@ -3,6 +3,7 @@ import { Container, Fab, Paper } from '@mui/material';
 import { GlobalStyles, lightTheme, MeetingProvider } from 'amazon-chime-sdk-component-library-react';
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import { CommandPaletteInPersonRegistrations } from 'src/components/CommandPaletteRegistrations';
 import { ThemeProvider } from 'styled-components';
 import { getAdmitterPractitionerId, getAttendingPractitionerId, getSelectors, isTelemedAppointment } from 'utils';
 import { Sidebar } from '../../shared/components/Sidebar';
@@ -55,6 +56,7 @@ export const InPersonLayout: React.FC = () => {
 
   return (
     <div style={layoutStyle}>
+      <CommandPaletteInPersonRegistrations />
       <Header />
       <div style={mainBlocksStyle}>
         <Sidebar />

--- a/apps/ehr/src/hooks/useGlobalQuickPicks.ts
+++ b/apps/ehr/src/hooks/useGlobalQuickPicks.ts
@@ -1,7 +1,9 @@
 import { useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ExamType } from 'utils';
+import { ExamType, getAdmitterPractitionerId, getAttendingPractitionerId } from 'utils';
 import { useListTemplates } from '../features/visits/shared/components/templates/useListTemplates';
+import { useGetAppointmentAccessibility } from '../features/visits/shared/hooks/useGetAppointmentAccessibility';
+import { useAppointmentData } from '../features/visits/shared/stores/appointment/appointment.store';
 import { CommandPaletteItem, useCommandPaletteStore } from '../state/command-palette.store';
 import { useCommandPaletteSource } from './useCommandPaletteSource';
 import {
@@ -17,6 +19,8 @@ import {
 export function useGlobalQuickPicks(): void {
   const location = useLocation();
   const navigate = useNavigate();
+  const { encounter } = useAppointmentData();
+  const { visitType, isAppointmentReadOnly } = useGetAppointmentAccessibility();
   const setPendingQuickPick = useCommandPaletteStore((state) => state.setPendingQuickPick);
 
   const inPersonBasePath = useMemo(() => {
@@ -25,26 +29,34 @@ export function useGlobalQuickPicks(): void {
   }, [location.pathname]);
 
   const isInPersonVisit = Boolean(inPersonBasePath);
+  const assignedIntakePerformerId = encounter ? getAdmitterPractitionerId(encounter) : undefined;
+  const assignedProviderId = encounter ? getAttendingPractitionerId(encounter) : undefined;
+  const isChartingAvailable = Boolean(
+    isInPersonVisit &&
+      (visitType === 'follow-up' || assignedIntakePerformerId) &&
+      assignedProviderId &&
+      !isAppointmentReadOnly
+  );
   const { quickPicks: allergyQuickPicks } = useMergedAllergyQuickPicks({
-    enabled: isInPersonVisit,
+    enabled: isChartingAvailable,
   });
   const { quickPicks: conditionQuickPicks } = useMergedMedicalConditionQuickPicks({
-    enabled: isInPersonVisit,
+    enabled: isChartingAvailable,
   });
   const { quickPicks: medicationQuickPicks } = useMergedMedicationHistoryQuickPicks({
-    enabled: isInPersonVisit,
+    enabled: isChartingAvailable,
   });
   const { quickPicks: inHouseMedicationQuickPicks } = useMergedInHouseMedicationQuickPicks({
-    enabled: isInPersonVisit,
+    enabled: isChartingAvailable,
   });
   const { quickPicks: procedureQuickPicks } = useMergedProcedureQuickPicks({
-    enabled: isInPersonVisit,
+    enabled: isChartingAvailable,
   });
   const { quickPicks: immunizationQuickPicks } = useMergedImmunizationQuickPicks({
-    enabled: isInPersonVisit,
+    enabled: isChartingAvailable,
   });
   const { quickPicks: radiologyQuickPicks } = useMergedRadiologyQuickPicks({
-    enabled: isInPersonVisit,
+    enabled: isChartingAvailable,
   });
 
   const currentSubPath = useMemo(() => {
@@ -55,7 +67,7 @@ export function useGlobalQuickPicks(): void {
     return location.pathname.slice(inPersonBasePath.length + 1);
   }, [inPersonBasePath, location.pathname]);
 
-  const { templates } = useListTemplates(ExamType.IN_PERSON, { enabled: isInPersonVisit });
+  const { templates } = useListTemplates(ExamType.IN_PERSON, { enabled: isChartingAvailable });
 
   const navigateAndDefer = useCallback(
     (targetPath: string, pendingCategory: string, itemId: string, payload: unknown) => {
@@ -83,7 +95,7 @@ export function useGlobalQuickPicks(): void {
   const isOnTemplatesPage = currentSubPath === 'history-of-present-illness-and-templates';
 
   const items = useMemo<CommandPaletteItem[]>(() => {
-    if (!inPersonBasePath) {
+    if (!inPersonBasePath || !isChartingAvailable) {
       return [];
     }
 
@@ -212,6 +224,7 @@ export function useGlobalQuickPicks(): void {
     inHouseMedicationQuickPicks,
     inPersonBasePath,
     immunizationQuickPicks,
+    isChartingAvailable,
     isOnAllergiesPage,
     isOnImmunizationsPage,
     isOnInHouseMedicationPage,


### PR DESCRIPTION
- Palette no longer offers or applies quick picks. Locked follow-ups remain editable, matching existing app behavior.
- Palette no longer offers quick picks while tabs are hidden behind the "Select an intake performer and a provider" alert.
- Verified existing checks correctly suppress global items on their target pages; no duplication.