### PR TITLE
fix(ehr): show Loading item in procedure Quick Picks menu + sort alphabetically

### DIFF
--- a/apps/ehr/src/features/visits/in-person/pages/ProceduresNew.tsx
+++ b/apps/ehr/src/features/visits/in-person/pages/ProceduresNew.tsx
@@ -237,7 +237,16 @@ export default function ProceduresNew(): ReactElement {
   const [quickPickName, setQuickPickName] = useState('');
   const [existingQuickPicks, setExistingQuickPicks] = useState<ProcedureQuickPickData[]>([]);
   const [quickPickSaving, setQuickPickSaving] = useState(false);
-  const { quickPicks: mergedQuickPicks } = useMergedProcedureQuickPicks();
+  // The quick-picks fetch is triggered by mounting this page (useMergedProcedureQuickPicks
+  // calls the zambda from a useEffect on mount), so picks start loading as soon as the
+  // user navigates to /procedures/new — not when they open the Quick Picks menu. We
+  // surface the loading flag below so the menu shows a "Loading…" item while in-flight,
+  // instead of appearing empty on a fast first click.
+  const { quickPicks: mergedQuickPicks, loading: mergedQuickPicksLoading } = useMergedProcedureQuickPicks();
+  const sortedMergedQuickPicks = useMemo(
+    () => [...mergedQuickPicks].sort((a, b) => a.name.localeCompare(b.name)),
+    [mergedQuickPicks]
+  );
 
   const updateState = (stateMutator: (draft: PageState) => void): void => {
     setState((prev) => {
@@ -876,7 +885,8 @@ export default function ProceduresNew(): ReactElement {
             </Box>
 
             <QuickPicksButton
-              quickPicks={!procedureId ? mergedQuickPicks : []}
+              quickPicks={!procedureId ? sortedMergedQuickPicks : []}
+              loading={!procedureId && mergedQuickPicksLoading}
               getLabel={(quickPick) => quickPick.name}
               onSelect={onQuickPickSelect}
               showAddOption

--- a/apps/ehr/src/features/visits/shared/components/QuickPicksButton.tsx
+++ b/apps/ehr/src/features/visits/shared/components/QuickPicksButton.tsx
@@ -9,6 +9,7 @@ interface QuickPicksButtonProps<T> {
   getLabel: (item: T) => string;
   onSelect: (item: T) => void;
   disabled?: boolean;
+  loading?: boolean;
   showAddOption?: boolean;
   isAdmin?: boolean;
   onAddOrUpdate?: () => void;
@@ -20,6 +21,7 @@ export const QuickPicksButton = <T,>({
   getLabel,
   onSelect,
   disabled = false,
+  loading = false,
   showAddOption = false,
   isAdmin = false,
   onAddOrUpdate,
@@ -31,7 +33,7 @@ export const QuickPicksButton = <T,>({
   const searchInputRef = useRef<HTMLInputElement>(null);
   const open = Boolean(anchorEl);
 
-  if (quickPicks.length === 0 && !showAddOption) {
+  if (quickPicks.length === 0 && !showAddOption && !loading) {
     return null;
   }
 
@@ -154,7 +156,12 @@ export const QuickPicksButton = <T,>({
             />
           </MenuItem>
         )}
-        {(showAddOption || searchable) && filteredQuickPicks.length > 0 && <Divider />}
+        {(showAddOption || searchable) && (filteredQuickPicks.length > 0 || loading) && <Divider />}
+        {loading && quickPicks.length === 0 && (
+          <MenuItem disabled sx={{ fontStyle: 'italic', color: 'text.disabled' }}>
+            Loading…
+          </MenuItem>
+        )}
         {filteredQuickPicks.map((item, index) => (
           <MenuItem
             key={getLabel(item)}
@@ -164,7 +171,7 @@ export const QuickPicksButton = <T,>({
             {getLabel(item)}
           </MenuItem>
         ))}
-        {searchable && searchText && filteredQuickPicks.length === 0 && (
+        {searchable && searchText && filteredQuickPicks.length === 0 && !loading && (
           <MenuItem disabled sx={{ fontStyle: 'italic' }}>
             No matches
           </MenuItem>


### PR DESCRIPTION
## Summary

- The Quick Picks button on `/in-person/<id>/procedures/new` could open with an empty menu on the first click after page load. The picks fetch (`useMergedProcedureQuickPicks`) fires from a `useEffect` on mount, but the menu didn't gate on its loading state — a fast click before the response landed showed nothing.
- `QuickPicksButton` now accepts a `loading` prop and renders a disabled "Loading…" `MenuItem` when the picks array is still empty and the fetch is in flight. The button stays mounted instead of early-returning `null`, divider/no-matches rendering both gate on loading.
- `ProceduresNew` threads the hook's `loading` flag through, and sorts picks alphabetically by `name` with `useMemo` so menu order is predictable as the list grows.
- Inline comment confirms the fetch was already triggered on tab navigation (page mount), not on menu open — moving it into the click handler would be a regression, so the comment makes the timing intentional for the next reader.

## Test plan

- [ ] Navigate to `/in-person/<id>/procedures/new` on a project that has procedure Quick Picks configured. Click the **Quick Picks** button immediately on page load (before the network round-trip resolves) — menu should open with a "Loading…" item, then re-render with the picks once the response lands. (Repro before this PR: empty menu on first click; picks appear on second click.)
- [ ] On the same page after picks have loaded, confirm the menu lists picks in alphabetical order by `name`.
- [ ] Confirm the menu still works on a project with **zero** Quick Picks: the "+ Add or Update Quick Pick" entry remains visible (button doesn't disappear), no "Loading…" or "No matches" item shows once the fetch completes.
- [ ] Confirm the search box still filters and that "No matches" still appears for non-empty queries with no hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)