### PR TITLE
EHR. Fix "Visit ended. Duration: {time}" counter doesn't stop

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/VirtualAppointmentFooter.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/VirtualAppointmentFooter.tsx
@@ -18,7 +18,6 @@ import {
   getSelectors,
   getVisitStatusHistory,
   INTERPRETER_PHONE_NUMBER,
-  NON_LOS_STATUSES,
   VisitStatusHistoryEntry,
 } from 'utils';
 import { useOystehrAPIClient } from '../../shared/hooks/useOystehrAPIClient';
@@ -51,7 +50,7 @@ export const VirtualAppointmentFooter: FC = () => {
 
   const visitDuration = Duration.fromMillis(
     statusHistory
-      .filter((status) => !NON_LOS_STATUSES.includes(status.status))
+      .filter((status) => status.status === 'provider')
       .reduce((accumulator, statusTemp) => {
         return accumulator + statusDurationMillis(statusTemp);
       }, 0)


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2372/ehr-virtual-visit-visit-ended-duration-time-counter-didnt-stop

Consider time in "provider" status as visit's duration as only in this status a provider can connect to a patient.