### PR TITLE
use userMe instead of oystehr.user.me

### DIFF
--- a/packages/utils/lib/auth/user-me.helper.ts
+++ b/packages/utils/lib/auth/user-me.helper.ts
@@ -36,7 +36,3 @@ export enum M2MClientMockType {
   provider = 'mock-provider',
   patient = 'mock-patient',
 }
-
-export const getCallerUserWithAccessToken = async (token: string, secrets: Secrets): Promise<User> => {
-  return userMe(token, secrets);
-};

--- a/packages/zambdas/src/ehr/assign-practitioner/index.ts
+++ b/packages/zambdas/src/ehr/assign-practitioner/index.ts
@@ -1,7 +1,7 @@
 import Oystehr from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Appointment, Coding, Encounter, PractitionerRole } from 'fhir/r4b';
-import { AssignPractitionerInput, AssignPractitionerResponse } from 'utils';
+import { AssignPractitionerInput, AssignPractitionerResponse, Secrets, userMe } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
 import { createOystehrClient } from '../../shared/helpers';
 import { getVisitResources } from '../../shared/practitioner/helpers';
@@ -17,12 +17,16 @@ export const index = wrapHandler('assign-practitioner', async (input: ZambdaInpu
   const oystehr = createOystehrClient(m2mToken, validatedParameters.secrets);
   console.log('Created Oystehr client');
 
-  const oystehrCurrentUser = createOystehrClient(validatedParameters.userToken, validatedParameters.secrets);
   console.log('Created CurrentUser Oystehr client');
 
   const validatedData = await complexValidation(oystehr, validatedParameters);
 
-  const response = await performEffect(oystehr, oystehrCurrentUser, validatedData);
+  const response = await performEffect(
+    oystehr,
+    validatedParameters.userToken,
+    validatedParameters.secrets,
+    validatedData
+  );
   return {
     statusCode: 200,
     body: JSON.stringify(response),
@@ -61,7 +65,8 @@ export const complexValidation = async (
 
 export const performEffect = async (
   oystehr: Oystehr,
-  oystehrCurrentUser: Oystehr,
+  token: string,
+  secrets: Secrets | null,
   validatedData: {
     encounter: Encounter;
     appointment: Appointment;
@@ -71,7 +76,7 @@ export const performEffect = async (
 ): Promise<AssignPractitionerResponse> => {
   const { encounter, appointment, practitionerId, userRole } = validatedData;
 
-  const user = await oystehrCurrentUser.user.me();
+  const user = await userMe(token, secrets);
   await assignPractitionerIfPossible(oystehr, encounter, appointment, practitionerId, userRole, user);
 
   return {

--- a/packages/zambdas/src/ehr/assign-practitioner/index.ts
+++ b/packages/zambdas/src/ehr/assign-practitioner/index.ts
@@ -17,8 +17,6 @@ export const index = wrapHandler('assign-practitioner', async (input: ZambdaInpu
   const oystehr = createOystehrClient(m2mToken, validatedParameters.secrets);
   console.log('Created Oystehr client');
 
-  console.log('Created CurrentUser Oystehr client');
-
   const validatedData = await complexValidation(oystehr, validatedParameters);
 
   const response = await performEffect(

--- a/packages/zambdas/src/ehr/create-nursing-order/index.ts
+++ b/packages/zambdas/src/ehr/create-nursing-order/index.ts
@@ -85,8 +85,7 @@ export const index = wrapHandler('create-nursing-order', async (input: ZambdaInp
 
   const userPractitionerIdRequest = async (): Promise<string> => {
     try {
-      const oystehrCurrentUser = createOystehrClient(userToken, secrets);
-      return await getMyPractitionerId(oystehrCurrentUser);
+      return await getMyPractitionerId(userToken, secrets);
     } catch {
       throw Error('Resource configuration error - user creating this order must have a Practitioner resource linked');
     }

--- a/packages/zambdas/src/ehr/create-resources-from-audio-recording/index.ts
+++ b/packages/zambdas/src/ehr/create-resources-from-audio-recording/index.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { CreateResourcesFromAudioRecordingInput, Secrets } from 'utils';
+import { CreateResourcesFromAudioRecordingInput, Secrets, userMe } from 'utils';
 import {
   checkOrCreateM2MClientToken,
   createOystehrClient,
@@ -28,8 +28,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, validatedParameters.secrets);
   const oystehr = createOystehrClient(m2mToken, validatedParameters.secrets);
 
-  const oystehrCurrentUser = createOystehrClient(userToken, secrets);
-  const providerUserProfile = (await oystehrCurrentUser.user.me()).profile;
+  const providerUserProfile = (await userMe(userToken, secrets)).profile;
 
   const presignedFileDownloadUrl = await createPresignedUrl(m2mToken, z3URL, 'download');
   console.log(presignedFileDownloadUrl);

--- a/packages/zambdas/src/ehr/create-update-medication-order/helpers.ts
+++ b/packages/zambdas/src/ehr/create-update-medication-order/helpers.ts
@@ -18,8 +18,8 @@ import {
   searchMedicationLocation,
   searchRouteByCode,
   Secrets,
+  userMe,
 } from 'utils';
-import { createOystehrClient } from '../../shared';
 import { createMedicationAdministrationResource } from './fhir-resources-creation';
 
 export function getPerformerId(medicationAdministration: MedicationAdministration): string | undefined {
@@ -57,8 +57,7 @@ export function createMedicationCopy(
 }
 
 export async function practitionerIdFromZambdaInput(userToken: string, secrets: Secrets | null): Promise<string> {
-  const oystehr = createOystehrClient(userToken, secrets);
-  const myPractitionerId = removePrefix('Practitioner/', (await oystehr.user.me()).profile);
+  const myPractitionerId = removePrefix('Practitioner/', (await userMe(userToken, secrets)).profile);
   if (!myPractitionerId) throw FHIR_RESOURCE_NOT_FOUND_CUSTOM('No practitioner id was found for token provided');
   return myPractitionerId;
 }

--- a/packages/zambdas/src/ehr/create-update-medication-order/helpers.ts
+++ b/packages/zambdas/src/ehr/create-update-medication-order/helpers.ts
@@ -14,11 +14,8 @@ import {
   MedicationData,
   MedicationOrderStatuses,
   OrderPackage,
-  removePrefix,
   searchMedicationLocation,
   searchRouteByCode,
-  Secrets,
-  userMe,
 } from 'utils';
 import { createMedicationAdministrationResource } from './fhir-resources-creation';
 
@@ -54,12 +51,6 @@ export function createMedicationCopy(
     resourceCopy.code.coding.push({ system: CODE_SYSTEM_NDC, code: orderData.ndc });
   }
   return resourceCopy;
-}
-
-export async function practitionerIdFromZambdaInput(userToken: string, secrets: Secrets | null): Promise<string> {
-  const myPractitionerId = removePrefix('Practitioner/', (await userMe(userToken, secrets)).profile);
-  if (!myPractitionerId) throw FHIR_RESOURCE_NOT_FOUND_CUSTOM('No practitioner id was found for token provided');
-  return myPractitionerId;
 }
 
 export async function getMedicationByName(oystehr: Oystehr, medicationName: string): Promise<Medication> {

--- a/packages/zambdas/src/ehr/create-update-medication-order/index.ts
+++ b/packages/zambdas/src/ehr/create-update-medication-order/index.ts
@@ -38,7 +38,13 @@ import {
   searchRouteByCode,
   UpdateMedicationOrderInput,
 } from 'utils';
-import { checkOrCreateM2MClientToken, createOystehrClient, wrapHandler, ZambdaInput } from '../../shared';
+import {
+  checkOrCreateM2MClientToken,
+  createOystehrClient,
+  getMyPractitionerId,
+  wrapHandler,
+  ZambdaInput,
+} from '../../shared';
 import {
   createMedicationAdministrationResource,
   createMedicationRequest,
@@ -48,7 +54,6 @@ import {
   createMedicationCopy,
   getEncounterIdFromMA,
   getMedicationById,
-  practitionerIdFromZambdaInput,
   updateMedicationAdministrationData,
   validateProviderAccess,
 } from './helpers';
@@ -65,7 +70,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, validatedParameters.secrets);
   const userToken = input.headers.Authorization.replace('Bearer ', '') as string;
   const oystehr = createOystehrClient(m2mToken, validatedParameters.secrets);
-  const practitionerId = await practitionerIdFromZambdaInput(userToken, validatedParameters.secrets);
+  const practitionerId = await getMyPractitionerId(userToken, validatedParameters.secrets);
   console.log('Created zapToken, fhir and clients.');
 
   const response = await performEffect(oystehr, validatedParameters, practitionerId, userToken);

--- a/packages/zambdas/src/ehr/delete-patient-instruction/index.ts
+++ b/packages/zambdas/src/ehr/delete-patient-instruction/index.ts
@@ -1,6 +1,7 @@
 import Oystehr from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Communication } from 'fhir/r4b';
+import { Secrets, userMe } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
 import { createOystehrClient } from '../../shared/helpers';
 import { validateRequestParameters } from './validateRequestParameters';
@@ -15,7 +16,12 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createOystehrClient(m2mToken, secrets);
   const oystehrCurrentUser = createOystehrClient(userToken, secrets);
-  const isProviderInstruction = await checkIfBelongsToCurrentProvider(oystehrCurrentUser, instructionId);
+  const isProviderInstruction = await checkIfBelongsToCurrentProvider(
+    oystehrCurrentUser,
+    userToken,
+    secrets,
+    instructionId
+  );
   if (!isProviderInstruction) throw new Error('Instruction deletion failed. Instruction does not belongs to provider');
   await deleteCommunication(oystehr, instructionId);
 
@@ -31,10 +37,15 @@ async function deleteCommunication(oystehr: Oystehr, id: string): Promise<void> 
   await oystehr.fhir.delete({ resourceType: 'Communication', id });
 }
 
-async function checkIfBelongsToCurrentProvider(oystehr: Oystehr, resourceId: string): Promise<boolean> {
+async function checkIfBelongsToCurrentProvider(
+  oystehr: Oystehr,
+  token: string,
+  secrets: Secrets | null,
+  resourceId: string
+): Promise<boolean> {
   const [resource, myUser] = await Promise.all([
     oystehr.fhir.get<Communication>({ resourceType: 'Communication', id: resourceId }),
-    oystehr.user.me(),
+    userMe(token, secrets),
   ]);
   return resource.sender?.reference === myUser.profile;
 }

--- a/packages/zambdas/src/ehr/delete-patient-instruction/index.ts
+++ b/packages/zambdas/src/ehr/delete-patient-instruction/index.ts
@@ -15,13 +15,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   const { instructionId, secrets, userToken } = validateRequestParameters(input);
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createOystehrClient(m2mToken, secrets);
-  const oystehrCurrentUser = createOystehrClient(userToken, secrets);
-  const isProviderInstruction = await checkIfBelongsToCurrentProvider(
-    oystehrCurrentUser,
-    userToken,
-    secrets,
-    instructionId
-  );
+  const isProviderInstruction = await checkIfBelongsToCurrentProvider(oystehr, userToken, secrets, instructionId);
   if (!isProviderInstruction) throw new Error('Instruction deletion failed. Instruction does not belongs to provider');
   await deleteCommunication(oystehr, instructionId);
 

--- a/packages/zambdas/src/ehr/delete-user/index.ts
+++ b/packages/zambdas/src/ehr/delete-user/index.ts
@@ -8,6 +8,7 @@ import {
   DeleteUserZambdaOutput,
   RoleType,
   Secrets,
+  userMe,
 } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
 import { createOystehrClient } from '../../shared/helpers';
@@ -26,10 +27,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createOystehrClient(m2mToken, secrets);
-  const callerOystehr = createOystehrClient(userToken, secrets);
 
   console.group('complexValidation');
-  await complexValidation(oystehr, callerOystehr, userId);
+  await complexValidation(oystehr, userToken, secrets, userId);
   console.groupEnd();
   console.debug('complexValidation success');
 
@@ -70,8 +70,13 @@ function validateRequestParameters(
   };
 }
 
-async function complexValidation(oystehr: Oystehr, callerOystehr: Oystehr, userId: string): Promise<void> {
-  const [user, caller] = await Promise.all([oystehr.user.get({ id: userId }), callerOystehr.user.me()]);
+async function complexValidation(
+  oystehr: Oystehr,
+  token: string,
+  secrets: Secrets | null,
+  userId: string
+): Promise<void> {
+  const [user, caller] = await Promise.all([oystehr.user.get({ id: userId }), userMe(token, secrets)]);
   if (!user) {
     throw {
       code: APIErrorCode.INVALID_INPUT,

--- a/packages/zambdas/src/ehr/get-patient-instructions/index.ts
+++ b/packages/zambdas/src/ehr/get-patient-instructions/index.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { getSecret, SecretsKeys, userMe } from 'utils';
-import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
+import { getSecret, SecretsKeys } from 'utils';
+import { checkOrCreateM2MClientToken, getMyPractitionerId, wrapHandler, ZambdaInput } from '../../shared';
 import { makeCommunicationDTO } from '../../shared/chart-data';
 import { createOystehrClient } from '../../shared/helpers';
 import { getCommunicationResources } from './helpers';
@@ -13,7 +13,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     const { type, secrets, userToken } = validateRequestParameters(input);
     m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
     const oystehr = createOystehrClient(m2mToken, secrets);
-    const myPractitionerId = (await userMe(userToken, secrets)).profile;
+    const myPractitionerId = await getMyPractitionerId(userToken, secrets);
     const ORGANIZATION_ID = getSecret(SecretsKeys.ORGANIZATION_ID, secrets);
     const communicationsOwnerId = type === 'organization' ? ORGANIZATION_ID : myPractitionerId;
 

--- a/packages/zambdas/src/ehr/get-patient-instructions/index.ts
+++ b/packages/zambdas/src/ehr/get-patient-instructions/index.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { getSecret, SecretsKeys } from 'utils';
+import { getSecret, SecretsKeys, userMe } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
 import { makeCommunicationDTO } from '../../shared/chart-data';
 import { createOystehrClient } from '../../shared/helpers';
@@ -13,8 +13,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     const { type, secrets, userToken } = validateRequestParameters(input);
     m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
     const oystehr = createOystehrClient(m2mToken, secrets);
-    const oystehrCurrentUser = createOystehrClient(userToken, secrets);
-    const myPractitionerId = (await oystehrCurrentUser.user.me()).profile;
+    const myPractitionerId = (await userMe(userToken, secrets)).profile;
     const ORGANIZATION_ID = getSecret(SecretsKeys.ORGANIZATION_ID, secrets);
     const communicationsOwnerId = type === 'organization' ? ORGANIZATION_ID : myPractitionerId;
 

--- a/packages/zambdas/src/ehr/immunization/administer-order/index.ts
+++ b/packages/zambdas/src/ehr/immunization/administer-order/index.ts
@@ -60,8 +60,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, validatedParameters.secrets);
   const oystehr = createOystehrClient(m2mToken, validatedParameters.secrets);
   const userToken = input.headers.Authorization.replace('Bearer ', '');
-  const oystehrCurrentUser = createOystehrClient(userToken, validatedParameters.secrets);
-  const userPractitionerId = await getMyPractitionerId(oystehrCurrentUser);
+  const userPractitionerId = await getMyPractitionerId(userToken, validatedParameters.secrets);
   const userPractitioner = await oystehr.fhir.get<Practitioner>({
     resourceType: 'Practitioner',
     id: userPractitionerId,

--- a/packages/zambdas/src/ehr/immunization/create-update-order/index.ts
+++ b/packages/zambdas/src/ehr/immunization/create-update-order/index.ts
@@ -29,8 +29,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, validatedParameters.secrets);
   const oystehr = createOystehrClient(m2mToken, validatedParameters.secrets);
   const userToken = input.headers.Authorization.replace('Bearer ', '');
-  const oystehrCurrentUser = createOystehrClient(userToken, validatedParameters.secrets);
-  const userPractitionerId = await getMyPractitionerId(oystehrCurrentUser);
+  const userPractitionerId = await getMyPractitionerId(userToken, validatedParameters.secrets);
   let response;
   if (validatedParameters.orderId) {
     response = await updateImmunizationOrder(oystehr, validatedParameters);

--- a/packages/zambdas/src/ehr/lab/external/create-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/external/create-lab-order/index.ts
@@ -94,8 +94,7 @@ export const index = wrapHandler('create-lab-order', async (input: ZambdaInput):
       'Resource configuration error - user creating this external lab order must have a Practitioner resource linked'
     );
   }
-  const oystehrCurrentUser = createOystehrClient(userToken, secrets);
-  const currentUserPractitioner = await oystehrCurrentUser.fhir.get<Practitioner>({
+  const currentUserPractitioner = await oystehr.fhir.get<Practitioner>({
     resourceType: 'Practitioner',
     id: curUserPractitionerId,
   });

--- a/packages/zambdas/src/ehr/lab/external/create-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/external/create-lab-order/index.ts
@@ -86,15 +86,15 @@ export const index = wrapHandler('create-lab-order', async (input: ZambdaInput):
   const oystehr = createOystehrClient(m2mToken, secrets);
 
   const userToken = input.headers.Authorization.replace('Bearer ', '');
-  const oystehrCurrentUser = createOystehrClient(userToken, secrets);
   let curUserPractitionerId: string | undefined;
   try {
-    curUserPractitionerId = await getMyPractitionerId(oystehrCurrentUser);
+    curUserPractitionerId = await getMyPractitionerId(userToken, secrets);
   } catch {
     throw EXTERNAL_LAB_ERROR(
       'Resource configuration error - user creating this external lab order must have a Practitioner resource linked'
     );
   }
+  const oystehrCurrentUser = createOystehrClient(userToken, secrets);
   const currentUserPractitioner = await oystehrCurrentUser.fhir.get<Practitioner>({
     resourceType: 'Practitioner',
     id: curUserPractitionerId,

--- a/packages/zambdas/src/ehr/lab/external/delete-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/external/delete-lab-order/index.ts
@@ -38,8 +38,10 @@ export const index = wrapHandler('delete-lab-order', async (input: ZambdaInput):
 
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createOystehrClient(m2mToken, secrets);
-  const oystehrCurrentUser = createOystehrClient(validatedParameters.userToken, validatedParameters.secrets);
-  const practitionerIdFromCurrentUser = await getMyPractitionerId(oystehrCurrentUser);
+  const practitionerIdFromCurrentUser = await getMyPractitionerId(
+    validatedParameters.userToken,
+    validatedParameters.secrets
+  );
 
   const { serviceRequest, questionnaireResponse, tasks, communications, documentReferences, diagnosticReports } =
     await getLabOrderRelatedResources(oystehr, validatedParameters);

--- a/packages/zambdas/src/ehr/lab/external/submit-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/external/submit-lab-order/index.ts
@@ -9,6 +9,7 @@ import {
   MANUAL_EXTERNAL_LAB_ORDER_CATEGORY_CODING,
   OYSTEHR_SUBMIT_LAB_API,
   SubmitLabOrderOutput,
+  userMe,
 } from 'utils';
 import { checkOrCreateM2MClientToken, createOystehrClient, wrapHandler, ZambdaInput } from '../../../../shared';
 import {
@@ -37,7 +38,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   const oystehr = createOystehrClient(m2mToken, secrets);
 
   const userToken = input.headers.Authorization.replace('Bearer ', '');
-  const currentUser = await createOystehrClient(userToken, secrets).user.me();
+  const currentUser = await userMe(userToken, secrets);
 
   const now = DateTime.now();
 

--- a/packages/zambdas/src/ehr/lab/external/update-lab-order-resources/index.ts
+++ b/packages/zambdas/src/ehr/lab/external/update-lab-order-resources/index.ts
@@ -93,8 +93,10 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createOystehrClient(m2mToken, secrets);
-  const oystehrCurrentUser = createOystehrClient(validatedParameters.userToken, validatedParameters.secrets);
-  const practitionerIdFromCurrentUser = await getMyPractitionerId(oystehrCurrentUser);
+  const practitionerIdFromCurrentUser = await getMyPractitionerId(
+    validatedParameters.userToken,
+    validatedParameters.secrets
+  );
 
   switch (validatedParameters.event) {
     case 'reviewed': {

--- a/packages/zambdas/src/ehr/lab/in-house/collect-in-house-lab-specimen/index.ts
+++ b/packages/zambdas/src/ehr/lab/in-house/collect-in-house-lab-specimen/index.ts
@@ -47,11 +47,10 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createOystehrClient(m2mToken, secrets);
-  const oystehrCurrentUser = createOystehrClient(validatedParameters.userToken, validatedParameters.secrets);
 
   const { encounterId, serviceRequestId, data } = validatedParameters;
 
-  const userPractitionerId = await getMyPractitionerId(oystehrCurrentUser);
+  const userPractitionerId = await getMyPractitionerId(validatedParameters.userToken, validatedParameters.secrets);
 
   const [serviceRequestResources, tasksCSTResources, userPractitioner, encounter] = await Promise.all([
     oystehr.fhir.get<ServiceRequest>({

--- a/packages/zambdas/src/ehr/lab/in-house/create-in-house-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/in-house/create-in-house-lab-order/index.ts
@@ -372,11 +372,14 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     }
 
     const saveChartDataResponse = diagnosesNew.length
-      ? await oystehr.zambda.execute({
-          id: 'save-chart-data',
-          encounterId,
-          diagnosis: diagnosesNew,
-        })
+      ? await oystehr.zambda.execute(
+          {
+            id: 'save-chart-data',
+            encounterId,
+            diagnosis: diagnosesNew,
+          },
+          { accessToken: validatedParameters.userToken }
+        )
       : {};
 
     const response = {

--- a/packages/zambdas/src/ehr/lab/in-house/create-in-house-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/in-house/create-in-house-lab-order/index.ts
@@ -193,8 +193,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
     const userPractitionerIdRequest = async (): Promise<string> => {
       try {
-        const oystehrCurrentUser = createOystehrClient(validatedParameters.userToken, validatedParameters.secrets);
-        return await getMyPractitionerId(oystehrCurrentUser);
+        return await getMyPractitionerId(validatedParameters.userToken, validatedParameters.secrets);
       } catch {
         throw Error(
           'Resource configuration error - user creating this in-house lab order must have a Practitioner resource linked'

--- a/packages/zambdas/src/ehr/lab/in-house/create-in-house-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/in-house/create-in-house-lab-order/index.ts
@@ -66,7 +66,6 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
     m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
     const oystehr = createOystehrClient(m2mToken, secrets);
-    const oystehrCurrentUser = createOystehrClient(validatedParameters.userToken, validatedParameters.secrets);
 
     const { encounterId, testItems, diagnosesAll, diagnosesNew, notes } = validatedParameters;
     console.log('This is testItems in create-in-house-lab-order', JSON.stringify(testItems, undefined, 2));
@@ -324,11 +323,11 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     if (!attendingPractitionerId) throw Error('Attending practitioner not found');
 
     const { currentUserPractitionerName, attendingPractitionerName } = await Promise.all([
-      oystehrCurrentUser.fhir.get<Practitioner>({
+      oystehr.fhir.get<Practitioner>({
         resourceType: 'Practitioner',
         id: userPractitionerId,
       }),
-      oystehrCurrentUser.fhir.get<Practitioner>({
+      oystehr.fhir.get<Practitioner>({
         resourceType: 'Practitioner',
         id: attendingPractitionerId,
       }),
@@ -373,7 +372,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     }
 
     const saveChartDataResponse = diagnosesNew.length
-      ? await oystehrCurrentUser.zambda.execute({
+      ? await oystehr.zambda.execute({
           id: 'save-chart-data',
           encounterId,
           diagnosis: diagnosesNew,

--- a/packages/zambdas/src/ehr/lab/in-house/create-in-house-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/in-house/create-in-house-lab-order/index.ts
@@ -372,14 +372,11 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     }
 
     const saveChartDataResponse = diagnosesNew.length
-      ? await oystehr.zambda.execute(
-          {
-            id: 'save-chart-data',
-            encounterId,
-            diagnosis: diagnosesNew,
-          },
-          { accessToken: validatedParameters.userToken }
-        )
+      ? await oystehr.zambda.execute({
+          id: 'save-chart-data',
+          encounterId,
+          diagnosis: diagnosesNew,
+        })
       : {};
 
     const response = {

--- a/packages/zambdas/src/ehr/lab/in-house/create-in-house-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/in-house/create-in-house-lab-order/index.ts
@@ -371,8 +371,10 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
       throw Error('Error creating in-house lab order in transaction');
     }
 
+    // save chart data requires user token
+    const oystehrCurrentUser = createOystehrClient(validatedParameters.userToken, validatedParameters.secrets);
     const saveChartDataResponse = diagnosesNew.length
-      ? await oystehr.zambda.execute({
+      ? await oystehrCurrentUser.zambda.execute({
           id: 'save-chart-data',
           encounterId,
           diagnosis: diagnosesNew,

--- a/packages/zambdas/src/ehr/lab/in-house/delete-in-house-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/in-house/delete-in-house-lab-order/index.ts
@@ -173,8 +173,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createOystehrClient(m2mToken, secrets);
 
-  const oystehrCurrentUser = createOystehrClient(userToken, secrets);
-  const currentUserPractitionerId = await getMyPractitionerId(oystehrCurrentUser);
+  const currentUserPractitionerId = await getMyPractitionerId(userToken, secrets);
   console.log(`User initiating delete action is Practitioner/${currentUserPractitionerId}`);
 
   const resources = await getInHouseLabOrderRelatedResources(oystehr, serviceRequestId);

--- a/packages/zambdas/src/ehr/lab/in-house/get-in-house-orders/helpers.ts
+++ b/packages/zambdas/src/ehr/lab/in-house/get-in-house-orders/helpers.ts
@@ -36,7 +36,7 @@ import {
   Pagination,
   TestStatus,
 } from 'utils';
-import { createOystehrClient, getMyPractitionerId, sendErrors } from '../../../../shared';
+import { getMyPractitionerId, sendErrors } from '../../../../shared';
 import { getObservationsForDiagnosticReportResults } from '../../shared/helpers';
 import {
   buildOrderHistory,
@@ -313,8 +313,7 @@ export const getInHouseResources = async (
       activityDefinitions.push(...additionalActivityDefinitions);
     }
 
-    const oystehrCurrentUser = createOystehrClient(userToken, params.secrets);
-    const myPractitionerId = await getMyPractitionerId(oystehrCurrentUser);
+    const myPractitionerId = await getMyPractitionerId(userToken, params.secrets);
 
     if (myPractitionerId) {
       currentPractitioner = await oystehr.fhir.get<Practitioner>({

--- a/packages/zambdas/src/ehr/lab/in-house/handle-in-house-lab-results/index.ts
+++ b/packages/zambdas/src/ehr/lab/in-house/handle-in-house-lab-results/index.ts
@@ -88,8 +88,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   console.log('token', m2mToken);
 
   const oystehr = createOystehrClient(m2mToken, secrets);
-  const oystehrCurrentUser = createOystehrClient(userToken, secrets);
-  const curUserPractitionerId = await getMyPractitionerId(oystehrCurrentUser);
+  const curUserPractitionerId = await getMyPractitionerId(userToken, secrets);
 
   const {
     serviceRequest,

--- a/packages/zambdas/src/ehr/patient-account/remove-coverage/index.ts
+++ b/packages/zambdas/src/ehr/patient-account/remove-coverage/index.ts
@@ -14,6 +14,7 @@ import {
   NOT_AUTHORIZED,
   RemoveCoverageResponse,
   Secrets,
+  userMe,
 } from 'utils';
 import { checkOrCreateM2MClientToken, createOystehrClient, wrapHandler, ZambdaInput } from '../../../shared';
 import { getAccountAndCoverageResourcesForPatient } from '../../shared/harvest';
@@ -147,8 +148,7 @@ const validateRequestParameters = (input: ZambdaInput): Input => {
 
 const complexValidation = async (input: Input, oystehr: Oystehr): Promise<EffectInput> => {
   const { patientId, coverageId, userToken, secrets } = input;
-  const userOystehr = createOystehrClient(userToken, secrets);
-  const user = await userOystehr.user.me();
+  const user = await userMe(userToken, secrets);
   if (!user) {
     throw NOT_AUTHORIZED;
   }

--- a/packages/zambdas/src/ehr/patient-account/update/index.ts
+++ b/packages/zambdas/src/ehr/patient-account/update/index.ts
@@ -21,6 +21,7 @@ import {
   Secrets,
   SecretsKeys,
   UpdatePatientAccountResponse,
+  userMe,
 } from 'utils';
 import { ValidationError } from 'yup';
 import {
@@ -31,11 +32,11 @@ import {
   wrapHandler,
   ZambdaInput,
 } from '../../../shared';
-import { mergeEncounterAccounts } from '../../shared/harvest';
 import {
   createMasterRecordPatchOperations,
   createUpdatePharmacyPatchOps,
   getAccountAndCoverageResourcesForPatient,
+  mergeEncounterAccounts,
   updatePatientAccountFromQuestionnaire,
   updateStripeCustomer,
 } from '../../shared/harvest';
@@ -372,8 +373,7 @@ interface FinishedInput extends BasicInput {
 const complexValidation = async (input: BasicInput): Promise<FinishedInput> => {
   const { secrets, userToken, questionnaireResponse } = input;
   console.log('questionnaireResponse', JSON.stringify(questionnaireResponse));
-  const oystehr = createOystehrClient(userToken, secrets);
-  const user = await oystehr.user.me();
+  const user = await userMe(userToken, secrets);
   if (!user) {
     throw NOT_AUTHORIZED;
   }

--- a/packages/zambdas/src/ehr/radiology/create-order/index.ts
+++ b/packages/zambdas/src/ehr/radiology/create-order/index.ts
@@ -14,7 +14,6 @@ import {
   FHIR_EXTENSION,
   FILLER_ORDER_NUMBER_CODE_SYSTEM,
   getAdvaPACSLocationForAppointmentOrEncounter,
-  getCallerUserWithAccessToken,
   getSecret,
   HL7_IDENTIFIER_TYPE_CODE_SYSTEM,
   HL7_IDENTIFIER_TYPE_CODE_SYSTEM_ACCESSION_NUMBER,
@@ -29,6 +28,7 @@ import {
   SERVICE_REQUEST_ORDER_DETAIL_PARAMETER_PRE_RELEASE_VALUE_STRING_URL,
   SERVICE_REQUEST_ORDER_DETAIL_PRE_RELEASE_URL,
   SERVICE_REQUEST_REQUESTED_TIME_EXTENSION_URL,
+  userMe,
 } from 'utils';
 import {
   checkOrCreateM2MClientToken,
@@ -88,7 +88,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (unsafeInput: ZambdaInput): 
 
   const validatedInput = await validateInput(unsafeInput, oystehr);
 
-  const callerUser = await getCallerUserWithAccessToken(validatedInput.callerAccessToken, secrets);
+  const callerUser = await userMe(validatedInput.callerAccessToken, secrets);
 
   const output = await performEffect(validatedInput, callerUser.profile, secrets, oystehr);
 

--- a/packages/zambdas/src/ehr/save-chart-data/index.ts
+++ b/packages/zambdas/src/ehr/save-chart-data/index.ts
@@ -129,7 +129,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     // ----- !!!DON'T DELETE!!! this is in #2129 scope -----
     // const [allResources, currentPractitioner, chartDataBeforeUpdate] = await Promise.all([
     //   getEncounterAndRelatedResources(oystehr, encounterId),
-    //   getUserPractitioner(oystehr, oystehrCurrentUser),
+    //   getUserPractitioner(oystehr, userToken, secrets),
     //   getChartData(oystehr, encounterId),
     // ]);
 

--- a/packages/zambdas/src/ehr/save-chart-data/index.ts
+++ b/packages/zambdas/src/ehr/save-chart-data/index.ts
@@ -23,7 +23,6 @@ import {
   PATIENT_VITALS_META_SYSTEM,
   SCHOOL_WORK_NOTE,
   Secrets,
-  userMe,
 } from 'utils';
 import {
   checkOrCreateM2MClientToken,
@@ -32,6 +31,7 @@ import {
   createOystehrClient,
   createProcedureServiceRequest,
   followUpToPerformerMap,
+  getMyPractitionerId,
   makeAllergyResource,
   makeBirthHistoryObservationResource,
   makeClinicalImpressionResource,
@@ -626,11 +626,7 @@ async function getUserPractitioner(
   secrets: Secrets | null
 ): Promise<Practitioner> {
   try {
-    const getUserResponse = await userMe(userToken, secrets);
-    const userProfile = getUserResponse.profile;
-    console.log(`User Profile: ${JSON.stringify(userProfile)}`);
-    const userProfileString = userProfile.split('/');
-    const practitionerId = userProfileString[1];
+    const practitionerId = await getMyPractitionerId(userToken, secrets);
     return await oystehr.fhir.get<Practitioner>({
       resourceType: 'Practitioner',
       id: practitionerId,

--- a/packages/zambdas/src/ehr/save-patient-instruction/index.ts
+++ b/packages/zambdas/src/ehr/save-patient-instruction/index.ts
@@ -1,5 +1,6 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Communication } from 'fhir/r4b';
+import { userMe } from 'utils/lib/auth/user-me.helper';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
 import { makeCommunicationDTO } from '../../shared/chart-data';
 import { createOystehrClient } from '../../shared/helpers';
@@ -13,8 +14,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   const { instructionId, text, title, secrets, userToken } = validateRequestParameters(input);
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createOystehrClient(m2mToken, secrets);
-  const oystehrCurrentUser = createOystehrClient(userToken, secrets);
-  const myUserProfile = (await oystehrCurrentUser.user.me()).profile;
+  const myUserProfile = (await userMe(userToken, secrets)).profile;
   let communication: Communication;
 
   if (instructionId) {

--- a/packages/zambdas/src/ehr/save-patient-instruction/index.ts
+++ b/packages/zambdas/src/ehr/save-patient-instruction/index.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Communication } from 'fhir/r4b';
-import { userMe } from 'utils/lib/auth/user-me.helper';
+import { userMe } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
 import { makeCommunicationDTO } from '../../shared/chart-data';
 import { createOystehrClient } from '../../shared/helpers';

--- a/packages/zambdas/src/ehr/sign-appointment/index.ts
+++ b/packages/zambdas/src/ehr/sign-appointment/index.ts
@@ -1,4 +1,4 @@
-import Oystehr, { BatchInputRequest } from '@oystehr/sdk';
+import Oystehr, { BatchInputRequest, User } from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Operation } from 'fast-json-patch';
 import { FhirResource, Provenance, Task } from 'fhir/r4b';
@@ -16,6 +16,7 @@ import {
   SignAppointmentInput,
   SignAppointmentResponse,
   TaskIndicator,
+  userMe,
   visitStatusToFhirAppointmentStatusMap,
   visitStatusToFhirEncounterStatusMap,
 } from 'utils';
@@ -37,10 +38,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, validatedParameters.secrets);
 
   const oystehr = createOystehrClient(m2mToken, validatedParameters.secrets);
-  const oystehrCurrentUser = createOystehrClient(validatedParameters.userToken, validatedParameters.secrets);
   console.log('Created Oystehr client');
 
-  const response = await performEffect(oystehr, oystehrCurrentUser, validatedParameters);
+  const response = await performEffect(oystehr, validatedParameters);
   return {
     statusCode: 200,
     body: JSON.stringify(response),
@@ -49,10 +49,11 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
 export const performEffect = async (
   oystehr: Oystehr,
-  oystehrCurrentUser: Oystehr,
-  params: SignAppointmentInput
+  params: SignAppointmentInput & {
+    userToken: string;
+  }
 ): Promise<SignAppointmentResponse> => {
-  const { appointmentId, encounterId, timezone, supervisorApprovalEnabled } = params;
+  const { appointmentId, encounterId, timezone, supervisorApprovalEnabled, userToken, secrets } = params;
 
   const visitResources = await getAppointmentAndRelatedResources(oystehr, appointmentId, true, encounterId);
   if (!visitResources) {
@@ -77,16 +78,12 @@ export const performEffect = async (
 
   console.log(`appointment and encounter statuses: ${appointment.status}, ${encounter.status}`);
   const currentStatus = getInPersonVisitStatus(appointment, encounter);
+  const user = await userMe(userToken, secrets);
 
   if (isFollowup) {
     // For follow-up encounters: only update encounter status and create PDF (no appointment updates, no email)
     if (currentStatus) {
-      await changeFollowupEncounterStatusToCompleted(
-        oystehr,
-        oystehrCurrentUser,
-        visitResources,
-        supervisorApprovalEnabled
-      );
+      await changeFollowupEncounterStatusToCompleted(oystehr, user, visitResources, supervisorApprovalEnabled);
     }
     console.debug(`Follow-up encounter status has been changed.`);
 
@@ -108,7 +105,7 @@ export const performEffect = async (
   } else {
     // For regular encounters: keep existing behavior
     if (currentStatus) {
-      await changeStatusToCompleted(oystehr, oystehrCurrentUser, visitResources, supervisorApprovalEnabled);
+      await changeStatusToCompleted(oystehr, user, visitResources, supervisorApprovalEnabled);
     }
     console.debug(`Status has been changed.`);
 
@@ -162,7 +159,7 @@ export const performEffect = async (
 
 const changeFollowupEncounterStatusToCompleted = async (
   oystehr: Oystehr,
-  oystehrCurrentUser: Oystehr,
+  user: User,
   resourcesToUpdate: FullAppointmentResourcePackage,
   supervisorApprovalEnabled?: boolean
 ): Promise<void> => {
@@ -179,8 +176,6 @@ const changeFollowupEncounterStatusToCompleted = async (
       value: encounterStatus,
     },
   ];
-
-  const user = await oystehrCurrentUser.user.me();
 
   const encounterStatusHistoryUpdate: Operation = getEncounterStatusHistoryUpdateOp(
     resourcesToUpdate.encounter,
@@ -237,7 +232,7 @@ const changeFollowupEncounterStatusToCompleted = async (
 
 const changeStatusToCompleted = async (
   oystehr: Oystehr,
-  oystehrCurrentUser: Oystehr,
+  user: User,
   resourcesToUpdate: FullAppointmentResourcePackage,
   supervisorApprovalEnabled?: boolean
 ): Promise<void> => {
@@ -258,8 +253,6 @@ const changeStatusToCompleted = async (
       value: appointmentStatus,
     },
   ];
-
-  const user = await oystehrCurrentUser.user.me();
 
   patchOps.push(...getAppointmentMetaTagOpForStatusUpdate(resourcesToUpdate.appointment, 'completed', { user }));
 

--- a/packages/zambdas/src/ehr/sign-appointment/index.ts
+++ b/packages/zambdas/src/ehr/sign-appointment/index.ts
@@ -78,11 +78,11 @@ export const performEffect = async (
 
   console.log(`appointment and encounter statuses: ${appointment.status}, ${encounter.status}`);
   const currentStatus = getInPersonVisitStatus(appointment, encounter);
-  const user = await userMe(userToken, secrets);
 
   if (isFollowup) {
     // For follow-up encounters: only update encounter status and create PDF (no appointment updates, no email)
     if (currentStatus) {
+      const user = await userMe(userToken, secrets);
       await changeFollowupEncounterStatusToCompleted(oystehr, user, visitResources, supervisorApprovalEnabled);
     }
     console.debug(`Follow-up encounter status has been changed.`);
@@ -105,6 +105,7 @@ export const performEffect = async (
   } else {
     // For regular encounters: keep existing behavior
     if (currentStatus) {
+      const user = await userMe(userToken, secrets);
       await changeStatusToCompleted(oystehr, user, visitResources, supervisorApprovalEnabled);
     }
     console.debug(`Status has been changed.`);

--- a/packages/zambdas/src/ehr/sign-appointment/index.ts
+++ b/packages/zambdas/src/ehr/sign-appointment/index.ts
@@ -20,7 +20,7 @@ import {
   visitStatusToFhirAppointmentStatusMap,
   visitStatusToFhirEncounterStatusMap,
 } from 'utils';
-import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
+import { checkOrCreateM2MClientToken, getMyPractitionerId, wrapHandler, ZambdaInput } from '../../shared';
 import { createProvenanceForEncounter } from '../../shared/createProvenanceForEncounter';
 import { createPublishExcuseNotesOps } from '../../shared/createPublishExcuseNotesOps';
 import { createOystehrClient } from '../../shared/helpers';
@@ -82,8 +82,8 @@ export const performEffect = async (
   if (isFollowup) {
     // For follow-up encounters: only update encounter status and create PDF (no appointment updates, no email)
     if (currentStatus) {
-      const user = await userMe(userToken, secrets);
-      await changeFollowupEncounterStatusToCompleted(oystehr, user, visitResources, supervisorApprovalEnabled);
+      const userId = await getMyPractitionerId(userToken, secrets);
+      await changeFollowupEncounterStatusToCompleted(oystehr, userId, visitResources, supervisorApprovalEnabled);
     }
     console.debug(`Follow-up encounter status has been changed.`);
 
@@ -160,7 +160,7 @@ export const performEffect = async (
 
 const changeFollowupEncounterStatusToCompleted = async (
   oystehr: Oystehr,
-  user: User,
+  userId: string,
   resourcesToUpdate: FullAppointmentResourcePackage,
   supervisorApprovalEnabled?: boolean
 ): Promise<void> => {
@@ -204,11 +204,7 @@ const changeFollowupEncounterStatusToCompleted = async (
         provenanceCreate = {
           method: 'POST',
           url: '/Provenance',
-          resource: createProvenanceForEncounter(
-            resourcesToUpdate.encounter.id,
-            user.profile.split('/')[1],
-            'verifier'
-          ),
+          resource: createProvenanceForEncounter(resourcesToUpdate.encounter.id, userId, 'verifier'),
         };
       }
     }

--- a/packages/zambdas/src/ehr/sync-user/index.ts
+++ b/packages/zambdas/src/ehr/sync-user/index.ts
@@ -6,12 +6,11 @@ import {
   allLicensesForPractitioner,
   FHIR_IDENTIFIER_NPI,
   getPractitionerNPIIdentifier,
-  getSecret,
   makeQualificationForPractitioner,
   PractitionerLicense,
   Secrets,
-  SecretsKeys,
   SyncUserResponse,
+  userMe,
 } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
 import { createOystehrClient } from '../../shared/helpers';
@@ -30,9 +29,8 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   const m2mOystehrClient = createOystehrClient(m2mToken, secrets);
 
   const userToken = input.headers.Authorization.replace('Bearer ', '');
-  const userOystehrClient = createOystehrClient(userToken, secrets);
 
-  const response = await performEffect(m2mOystehrClient, userOystehrClient, secrets);
+  const response = await performEffect(m2mOystehrClient, userToken, secrets);
 
   return {
     statusCode: 200,
@@ -42,12 +40,12 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
 async function performEffect(
   m2mOystehrClient: Oystehr,
-  userOystehrClient: Oystehr,
+  token: string,
   secrets: Secrets | null
 ): Promise<SyncUserResponse> {
   const [remotePractitioner, localPractitioner] = await Promise.all([
-    getRemotePractitionerAndCredentials(userOystehrClient, secrets),
-    getLocalEHRPractitioner(userOystehrClient),
+    getRemotePractitionerAndCredentials(token, secrets),
+    getLocalEHRPractitioner(token, secrets),
   ]);
   if (!remotePractitioner) {
     return {
@@ -100,11 +98,11 @@ interface RemotePractitionerData {
 }
 
 async function getRemotePractitionerAndCredentials(
-  oystehr: Oystehr,
+  token: string,
   secrets: Secrets | null
 ): Promise<RemotePractitionerData | undefined> {
   console.log('Preparing search parameters for remote practitioner');
-  const myEhrUser = await oystehr.user.me();
+  const myEhrUser = await userMe(token, secrets);
   const myEmail = myEhrUser.email?.toLocaleLowerCase();
   console.log(`Preparing search for local practitioner email: ${myEmail}`);
 
@@ -149,8 +147,9 @@ async function getRemotePractitionerAndCredentials(
   return undefined;
 }
 
-async function getLocalEHRPractitioner(oystehr: Oystehr): Promise<Practitioner> {
-  const practitionerId = (await oystehr.user.me()).profile.replace('Practitioner/', '');
+async function getLocalEHRPractitioner(token: string, secrets: Secrets | null): Promise<Practitioner> {
+  const practitionerId = (await userMe(token, secrets)).profile.replace('Practitioner/', '');
+  const oystehr = createOystehrClient(token, secrets);
   return await oystehr.fhir.get<Practitioner>({
     resourceType: 'Practitioner',
     id: practitionerId,

--- a/packages/zambdas/src/ehr/sync-user/index.ts
+++ b/packages/zambdas/src/ehr/sync-user/index.ts
@@ -26,11 +26,11 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   console.log('Parameters: ' + JSON.stringify(input));
 
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
-  const m2mOystehrClient = createOystehrClient(m2mToken, secrets);
+  const oystehr = createOystehrClient(m2mToken, secrets);
 
   const userToken = input.headers.Authorization.replace('Bearer ', '');
 
-  const response = await performEffect(m2mOystehrClient, userToken, secrets);
+  const response = await performEffect(oystehr, userToken, secrets);
 
   return {
     statusCode: 200,
@@ -38,14 +38,10 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   };
 });
 
-async function performEffect(
-  m2mOystehrClient: Oystehr,
-  token: string,
-  secrets: Secrets | null
-): Promise<SyncUserResponse> {
+async function performEffect(oystehr: Oystehr, token: string, secrets: Secrets | null): Promise<SyncUserResponse> {
   const [remotePractitioner, localPractitioner] = await Promise.all([
     getRemotePractitionerAndCredentials(token, secrets),
-    getLocalEHRPractitioner(token, secrets),
+    getLocalEHRPractitioner(oystehr, token, secrets),
   ]);
   if (!remotePractitioner) {
     return {
@@ -71,7 +67,7 @@ async function performEffect(
   ehrPractitioner = updatePractitionerQualification(ehrPractitioner, remotePractitioner);
   ehrPractitioner = updatePractitionerCredentials(ehrPractitioner, remotePractitioner);
   ehrPractitioner = updatePractitionerNPI(ehrPractitioner, remotePractitioner);
-  const result = await updatePractitioner(m2mOystehrClient, ehrPractitioner);
+  const result = await updatePractitioner(oystehr, ehrPractitioner);
   console.log(`Practitioner updated successfully:  ${JSON.stringify(result)}`);
   if (result)
     return {
@@ -147,9 +143,12 @@ async function getRemotePractitionerAndCredentials(
   return undefined;
 }
 
-async function getLocalEHRPractitioner(token: string, secrets: Secrets | null): Promise<Practitioner> {
+async function getLocalEHRPractitioner(
+  oystehr: Oystehr,
+  token: string,
+  secrets: Secrets | null
+): Promise<Practitioner> {
   const practitionerId = (await userMe(token, secrets)).profile.replace('Practitioner/', '');
-  const oystehr = createOystehrClient(token, secrets);
   return await oystehr.fhir.get<Practitioner>({
     resourceType: 'Practitioner',
     id: practitionerId,

--- a/packages/zambdas/src/ehr/sync-user/index.ts
+++ b/packages/zambdas/src/ehr/sync-user/index.ts
@@ -12,7 +12,7 @@ import {
   SyncUserResponse,
   userMe,
 } from 'utils';
-import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
+import { checkOrCreateM2MClientToken, getMyPractitionerId, wrapHandler, ZambdaInput } from '../../shared';
 import { createOystehrClient } from '../../shared/helpers';
 import { validateRequestParameters } from './validateRequestParameters';
 
@@ -148,7 +148,7 @@ async function getLocalEHRPractitioner(
   token: string,
   secrets: Secrets | null
 ): Promise<Practitioner> {
-  const practitionerId = (await userMe(token, secrets)).profile.replace('Practitioner/', '');
+  const practitionerId = await getMyPractitionerId(token, secrets);
   return await oystehr.fhir.get<Practitioner>({
     resourceType: 'Practitioner',
     id: practitionerId,

--- a/packages/zambdas/src/ehr/tasks/create-manual-task/index.ts
+++ b/packages/zambdas/src/ehr/tasks/create-manual-task/index.ts
@@ -21,8 +21,8 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, params.secrets);
   const oystehr = createOystehrClient(m2mToken, params.secrets);
   const userToken = input.headers.Authorization.replace('Bearer ', '');
+  const userPractitionerId = await getMyPractitionerId(userToken, params.secrets);
   const oystehrCurrentUser = createOystehrClient(userToken, params.secrets);
-  const userPractitionerId = await getMyPractitionerId(oystehrCurrentUser);
   const currentUserPractitioner = await oystehrCurrentUser.fhir.get<Practitioner>({
     resourceType: 'Practitioner',
     id: userPractitionerId,

--- a/packages/zambdas/src/ehr/tasks/create-manual-task/index.ts
+++ b/packages/zambdas/src/ehr/tasks/create-manual-task/index.ts
@@ -22,8 +22,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   const oystehr = createOystehrClient(m2mToken, params.secrets);
   const userToken = input.headers.Authorization.replace('Bearer ', '');
   const userPractitionerId = await getMyPractitionerId(userToken, params.secrets);
-  const oystehrCurrentUser = createOystehrClient(userToken, params.secrets);
-  const currentUserPractitioner = await oystehrCurrentUser.fhir.get<Practitioner>({
+  const currentUserPractitioner = await oystehr.fhir.get<Practitioner>({
     resourceType: 'Practitioner',
     id: userPractitionerId,
   });

--- a/packages/zambdas/src/ehr/unassign-practitioner/index.ts
+++ b/packages/zambdas/src/ehr/unassign-practitioner/index.ts
@@ -22,10 +22,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, validatedParameters.secrets);
 
   const oystehr = createOystehrClient(m2mToken, validatedParameters.secrets);
-  const oystehrCurrentUser = createOystehrClient(validatedParameters.userToken, validatedParameters.secrets);
   console.log('Created Oystehr client');
 
-  const validatedData = await complexValidation(oystehr, oystehrCurrentUser, validatedParameters);
+  const validatedData = await complexValidation(oystehr, validatedParameters);
 
   const response = await performEffect(oystehr, validatedData);
   return {
@@ -35,7 +34,6 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 });
 export const complexValidation = async (
   oystehr: Oystehr,
-  oystehrCurrentUser: Oystehr,
   params: UnassignPractitionerZambdaInputValidated
 ): Promise<{
   encounter: Encounter;

--- a/packages/zambdas/src/ehr/unlock-appointment/index.ts
+++ b/packages/zambdas/src/ehr/unlock-appointment/index.ts
@@ -7,6 +7,7 @@ import {
   getPatchBinary,
   UnlockAppointmentZambdaInputValidated,
   UnlockAppointmentZambdaOutput,
+  userMe,
 } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
 import { createOystehrClient } from '../../shared/helpers';
@@ -22,10 +23,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, validatedParameters.secrets);
 
   const oystehr = createOystehrClient(m2mToken, validatedParameters.secrets);
-  const oystehrCurrentUser = createOystehrClient(validatedParameters.userToken, validatedParameters.secrets);
   console.log('Created Oystehr client');
 
-  const response = await performEffect(oystehr, oystehrCurrentUser, validatedParameters);
+  const response = await performEffect(oystehr, validatedParameters);
   return {
     statusCode: 200,
     body: JSON.stringify(response),
@@ -34,10 +34,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
 export const performEffect = async (
   oystehr: Oystehr,
-  oystehrCurrentUser: Oystehr,
   params: UnlockAppointmentZambdaInputValidated
 ): Promise<UnlockAppointmentZambdaOutput> => {
-  const { appointmentId } = params;
+  const { appointmentId, userToken, secrets } = params;
 
   const appointment = await oystehr.fhir.get<Appointment>({
     resourceType: 'Appointment',
@@ -49,7 +48,7 @@ export const performEffect = async (
   }
 
   // Get the current user for tracking who unlocked the appointment
-  const user = await oystehrCurrentUser.user.me();
+  const user = await userMe(userToken, secrets);
 
   // Generate unlock operation (removes APPOINTMENT_LOCKED tag and replaces /meta/tag array)
   const [unlockOp] = getAppointmentLockMetaTagOperations(appointment, false);

--- a/packages/zambdas/src/ehr/update-nursing-order/index.ts
+++ b/packages/zambdas/src/ehr/update-nursing-order/index.ts
@@ -34,9 +34,6 @@ export const index = wrapHandler(async (input: ZambdaInput): Promise<APIGatewayP
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createOystehrClient(m2mToken, secrets);
 
-  const oystehrCurrentUser = createOystehrClient(userToken, secrets);
-  const _practitionerIdFromCurrentUser = await getMyPractitionerId(oystehrCurrentUser);
-
   const nursingOrderResourcesRequest = async (): Promise<(ServiceRequest | Task)[]> =>
     (
       await oystehr.fhir.search({
@@ -56,8 +53,7 @@ export const index = wrapHandler(async (input: ZambdaInput): Promise<APIGatewayP
 
   const userPractitionerIdRequest = async (): Promise<string> => {
     try {
-      const oystehrCurrentUser = createOystehrClient(validatedParameters.userToken, validatedParameters.secrets);
-      return await getMyPractitionerId(oystehrCurrentUser);
+      return await getMyPractitionerId(userToken, secrets);
     } catch {
       throw Error('Resource configuration error - user creating this order must have a Practitioner resource linked');
     }

--- a/packages/zambdas/src/shared/practitioners.ts
+++ b/packages/zambdas/src/shared/practitioners.ts
@@ -1,8 +1,7 @@
-import Oystehr from '@oystehr/sdk';
-import { removePrefix } from 'utils';
+import { removePrefix, Secrets, userMe } from 'utils';
 
-export async function getMyPractitionerId(oystehr: Oystehr): Promise<string> {
-  const myPractitionerId = removePrefix('Practitioner/', (await oystehr.user.me()).profile);
+export async function getMyPractitionerId(token: string, secrets: Secrets | null): Promise<string> {
+  const myPractitionerId = removePrefix('Practitioner/', (await userMe(token, secrets)).profile);
   if (!myPractitionerId) throw new Error("Can't receive practitioner resource id attached to current user");
   return myPractitionerId;
 }

--- a/packages/zambdas/test/get-my-practitioner-id.test.ts
+++ b/packages/zambdas/test/get-my-practitioner-id.test.ts
@@ -1,0 +1,51 @@
+import { User } from '@oystehr/sdk';
+import { Secrets, SecretsKeys, userMe } from 'utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getMyPractitionerId } from '../src/shared';
+
+vi.mock('utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('utils')>();
+  return {
+    ...actual,
+    userMe: vi.fn(),
+  };
+});
+
+const secrets: Secrets = {
+  [SecretsKeys.FHIR_API]: 'http://fhir',
+  [SecretsKeys.PROJECT_API]: 'http://project',
+  [SecretsKeys.ENVIRONMENT]: 'local',
+};
+
+const buildUser = (profile: string): User => ({
+  id: 'user-id',
+  name: 'Test User',
+  phoneNumber: null,
+  authenticationMethod: 'email',
+  email: 'test@ottehr.com',
+  profile,
+  roles: [],
+});
+
+describe('getMyPractitionerId — user-token path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the Practitioner id and forwards token + secrets to userMe', async () => {
+    vi.mocked(userMe).mockResolvedValue(buildUser('Practitioner/abc-123'));
+
+    const result = await getMyPractitionerId('user-token-xyz', secrets);
+
+    expect(userMe).toHaveBeenCalledWith('user-token-xyz', secrets);
+    expect(result).toBe('abc-123');
+  });
+
+  it('throws when the User profile is not a Practitioner reference', async () => {
+    vi.mocked(userMe).mockResolvedValue(buildUser('Patient/foo'));
+
+    await expect(getMyPractitionerId('user-token', secrets)).rejects.toThrow(
+      "Can't receive practitioner resource id attached to current user"
+    );
+  });
+});

--- a/packages/zambdas/test/helpers/integration-test-seed-data-setup.ts
+++ b/packages/zambdas/test/helpers/integration-test-seed-data-setup.ts
@@ -47,6 +47,8 @@ export interface InsertFullAppointmentDataBaseResult {
 export interface IntegrationTestSetupResult {
   oystehr: Oystehr;
   oystehrTestUserM2M: Oystehr;
+  testUserM2MToken: string;
+  testUserM2MProfile: string;
   token: string;
   processId: string;
   cleanup: () => Promise<void>;
@@ -328,6 +330,8 @@ export const setupIntegrationTest = async (
   return {
     oystehr: oystehrAdmin,
     oystehrTestUserM2M: oystehrTestUserM2M,
+    testUserM2MToken,
+    testUserM2MProfile: testUserM2M.profile,
     token,
     processId,
     cleanup,

--- a/packages/zambdas/test/integration/get-my-practitioner-id.test.ts
+++ b/packages/zambdas/test/integration/get-my-practitioner-id.test.ts
@@ -1,0 +1,36 @@
+import { M2MClientMockType, Secrets, SecretsKeys } from 'utils';
+import { getMyPractitionerId } from '../../src/shared';
+import { SECRETS } from '../data/secrets';
+import { setupIntegrationTest } from '../helpers/integration-test-seed-data-setup';
+
+describe('getMyPractitionerId — M2M token integration', () => {
+  let testUserM2MToken: string;
+  let testUserM2MProfile: string;
+  let cleanup: () => Promise<void>;
+
+  const secrets: Secrets = {
+    [SecretsKeys.FHIR_API]: SECRETS.FHIR_API,
+    [SecretsKeys.PROJECT_API]: SECRETS.PROJECT_API,
+    [SecretsKeys.ENVIRONMENT]: 'local',
+  };
+
+  beforeAll(async () => {
+    const setup = await setupIntegrationTest('integration/get-my-practitioner-id.test.ts', M2MClientMockType.provider);
+    testUserM2MToken = setup.testUserM2MToken;
+    testUserM2MProfile = setup.testUserM2MProfile;
+    cleanup = setup.cleanup;
+  }, 60_000);
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it('resolves the caller Practitioner id when invoked with an M2M provider token', async () => {
+    expect(testUserM2MProfile).toMatch(/^Practitioner\//);
+    const expectedPractitionerId = testUserM2MProfile.replace('Practitioner/', '');
+
+    const practitionerId = await getMyPractitionerId(testUserM2MToken, secrets);
+
+    expect(practitionerId).toBe(expectedPractitionerId);
+  });
+});


### PR DESCRIPTION
i didn't realize #7349 exists, but i considered its comment of `Where it was used for additional FHIR ops, those ops were moved to the existing M2M oystehr client (same permissions under our access policy).` in my changes and built on it. i believe i've considered all functionality from that pr.