### PR TITLE
Add code coverage reporting to CI pipeline with Coveralls integration

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -116,9 +116,41 @@ jobs:
           key: seed-data-${{ steps.env.outputs.environment }}-${{ github.sha }}-${{ github.run_id }}
           fail-on-cache-miss: true
 
+      - name: Spec tests with coverage
+        if: ${{ !cancelled() }}
+        run: cd packages/spec && npx vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text-summary --passWithNoTests
+        env:
+          ENV: ${{ steps.env.outputs.environment }}
+          CI: true
+          NODE_OPTIONS: "--max-old-space-size=8192"
+
+      - name: Upload spec coverage to Coveralls
+        if: ${{ !cancelled() && hashFiles('packages/spec/coverage/lcov.info') != '' }}
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          flag-name: spec
+          parallel: true
+          file: ./packages/spec/coverage/lcov.info
+
+      - name: Test-utils tests with coverage
+        if: ${{ !cancelled() }}
+        run: cd packages/test-utils && npx vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text-summary --passWithNoTests
+        env:
+          ENV: ${{ steps.env.outputs.environment }}
+          CI: true
+          NODE_OPTIONS: "--max-old-space-size=8192"
+
+      - name: Upload test-utils coverage to Coveralls
+        if: ${{ !cancelled() && hashFiles('packages/test-utils/coverage/lcov.info') != '' }}
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          flag-name: test-utils
+          parallel: true
+          file: ./packages/test-utils/coverage/lcov.info
+
       - name: Utils tests with coverage
         if: ${{ !cancelled() }}
-        run: cd packages/utils && npx vitest run --coverage
+        run: cd packages/utils && npx vitest run --coverage --passWithNoTests
         env:
           ENV: ${{ steps.env.outputs.environment }}
           CI: true
@@ -132,25 +164,9 @@ jobs:
           parallel: true
           file: ./packages/utils/coverage/lcov.info
 
-      - name: UI components tests with coverage
-        if: ${{ !cancelled() }}
-        run: cd packages/ui-components && npx vitest run --coverage
-        env:
-          ENV: ${{ steps.env.outputs.environment }}
-          CI: true
-          NODE_OPTIONS: "--max-old-space-size=8192"
-
-      - name: Upload ui-components coverage to Coveralls
-        if: ${{ !cancelled() && hashFiles('packages/ui-components/coverage/lcov.info') != '' }}
-        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
-        with:
-          flag-name: ui-components
-          parallel: true
-          file: ./packages/ui-components/coverage/lcov.info
-
       - name: Zambda unit & integration tests with coverage
         if: ${{ !cancelled() }}
-        run: cd packages/zambdas && npx vitest run --coverage
+        run: cd packages/zambdas && npx vitest run --coverage --passWithNoTests
         env:
           ENV: ${{ steps.env.outputs.environment }}
           CI: true
@@ -166,7 +182,7 @@ jobs:
 
       - name: EHR unit tests with coverage
         if: ${{ !cancelled() }}
-        run: cd apps/ehr && npx vitest run --config ./vitest.config.ts --coverage
+        run: cd apps/ehr && npx vitest run --config ./vitest.config.ts --coverage --passWithNoTests
         env:
           ENV: ${{ steps.env.outputs.environment }}
           CI: true
@@ -182,7 +198,7 @@ jobs:
 
       - name: EHR component tests with coverage
         if: ${{ !cancelled() }}
-        run: cd apps/ehr && npx vitest run --config ./vitest.config.component-tests.ts --coverage
+        run: cd apps/ehr && npx vitest run --config ./vitest.config.component-tests.ts --coverage --passWithNoTests
         env:
           ENV: ${{ steps.env.outputs.environment }}
           CI: true
@@ -198,7 +214,7 @@ jobs:
 
       - name: Intake unit tests with coverage
         if: ${{ !cancelled() }}
-        run: cd apps/intake && npx vitest run --config ./vitest.config.ts --coverage
+        run: cd apps/intake && npx vitest run --config ./vitest.config.ts --coverage --passWithNoTests
         env:
           ENV: ${{ steps.env.outputs.environment }}
           CI: true
@@ -214,7 +230,7 @@ jobs:
 
       - name: Intake component tests with coverage
         if: ${{ !cancelled() }}
-        run: cd apps/intake && npx vitest run --config ./vitest.config.component-tests.ts --coverage
+        run: cd apps/intake && npx vitest run --config ./vitest.config.component-tests.ts --coverage --passWithNoTests
         env:
           ENV: ${{ steps.env.outputs.environment }}
           CI: true
@@ -233,7 +249,7 @@ jobs:
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           parallel-finished: true
-          carryforward: "utils,ui-components,zambdas,ehr-unit,ehr-component,intake-unit,intake-component"
+          carryforward: "spec,test-utils,utils,zambdas,ehr-unit,ehr-component,intake-unit,intake-component"
 
       - name: Set GitHub Commit Status
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -117,6 +117,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Utils tests with coverage
+        if: ${{ !cancelled() }}
         run: cd packages/utils && npx vitest run --coverage
         env:
           ENV: ${{ steps.env.outputs.environment }}
@@ -124,7 +125,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=8192"
 
       - name: Upload utils coverage to Coveralls
-        if: always()
+        if: ${{ !cancelled() && hashFiles('packages/utils/coverage/lcov.info') != '' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           flag-name: utils
@@ -132,6 +133,7 @@ jobs:
           file: ./packages/utils/coverage/lcov.info
 
       - name: UI components tests with coverage
+        if: ${{ !cancelled() }}
         run: cd packages/ui-components && npx vitest run --coverage
         env:
           ENV: ${{ steps.env.outputs.environment }}
@@ -139,7 +141,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=8192"
 
       - name: Upload ui-components coverage to Coveralls
-        if: always()
+        if: ${{ !cancelled() && hashFiles('packages/ui-components/coverage/lcov.info') != '' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           flag-name: ui-components
@@ -147,6 +149,7 @@ jobs:
           file: ./packages/ui-components/coverage/lcov.info
 
       - name: Zambda unit & integration tests with coverage
+        if: ${{ !cancelled() }}
         run: cd packages/zambdas && npx vitest run --coverage
         env:
           ENV: ${{ steps.env.outputs.environment }}
@@ -154,7 +157,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=8192"
 
       - name: Upload zambdas coverage to Coveralls
-        if: always()
+        if: ${{ !cancelled() && hashFiles('packages/zambdas/coverage/integration/lcov.info') != '' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           flag-name: zambdas
@@ -162,6 +165,7 @@ jobs:
           file: ./packages/zambdas/coverage/integration/lcov.info
 
       - name: EHR unit tests with coverage
+        if: ${{ !cancelled() }}
         run: cd apps/ehr && npx vitest run --config ./vitest.config.ts --coverage
         env:
           ENV: ${{ steps.env.outputs.environment }}
@@ -169,7 +173,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=8192"
 
       - name: Upload EHR unit coverage to Coveralls
-        if: always()
+        if: ${{ !cancelled() && hashFiles('apps/ehr/coverage/unit/lcov.info') != '' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           flag-name: ehr-unit
@@ -177,6 +181,7 @@ jobs:
           file: ./apps/ehr/coverage/unit/lcov.info
 
       - name: EHR component tests with coverage
+        if: ${{ !cancelled() }}
         run: cd apps/ehr && npx vitest run --config ./vitest.config.component-tests.ts --coverage
         env:
           ENV: ${{ steps.env.outputs.environment }}
@@ -184,7 +189,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=8192"
 
       - name: Upload EHR component coverage to Coveralls
-        if: always()
+        if: ${{ !cancelled() && hashFiles('apps/ehr/coverage/component/lcov.info') != '' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           flag-name: ehr-component
@@ -192,6 +197,7 @@ jobs:
           file: ./apps/ehr/coverage/component/lcov.info
 
       - name: Intake unit tests with coverage
+        if: ${{ !cancelled() }}
         run: cd apps/intake && npx vitest run --config ./vitest.config.ts --coverage
         env:
           ENV: ${{ steps.env.outputs.environment }}
@@ -199,7 +205,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=8192"
 
       - name: Upload intake unit coverage to Coveralls
-        if: always()
+        if: ${{ !cancelled() && hashFiles('apps/intake/coverage/unit/lcov.info') != '' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           flag-name: intake-unit
@@ -207,6 +213,7 @@ jobs:
           file: ./apps/intake/coverage/unit/lcov.info
 
       - name: Intake component tests with coverage
+        if: ${{ !cancelled() }}
         run: cd apps/intake && npx vitest run --config ./vitest.config.component-tests.ts --coverage
         env:
           ENV: ${{ steps.env.outputs.environment }}
@@ -214,7 +221,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=8192"
 
       - name: Upload intake component coverage to Coveralls
-        if: always()
+        if: ${{ !cancelled() && hashFiles('apps/intake/coverage/component/lcov.info') != '' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           flag-name: intake-component
@@ -222,7 +229,7 @@ jobs:
           file: ./apps/intake/coverage/component/lcov.info
 
       - name: Coveralls parallel finished
-        if: always()
+        if: ${{ !cancelled() }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           parallel-finished: true

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -116,26 +116,117 @@ jobs:
           key: seed-data-${{ steps.env.outputs.environment }}-${{ github.sha }}-${{ github.run_id }}
           fail-on-cache-miss: true
 
-      - name: Unit tests
-        run: npm run test
+      - name: Utils tests with coverage
+        run: cd packages/utils && npx vitest run --coverage
         env:
           ENV: ${{ steps.env.outputs.environment }}
           CI: true
           NODE_OPTIONS: "--max-old-space-size=8192"
 
-      - name: Patient component tests
-        run: cd apps/intake && npm run component-tests
+      - name: Upload utils coverage to Coveralls
+        if: always()
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          flag-name: utils
+          parallel: true
+          file: ./packages/utils/coverage/lcov.info
+
+      - name: UI components tests with coverage
+        run: cd packages/ui-components && npx vitest run --coverage
         env:
           ENV: ${{ steps.env.outputs.environment }}
           CI: true
           NODE_OPTIONS: "--max-old-space-size=8192"
 
-      - name: EHR component tests
-        run: cd apps/ehr && npm run component-tests
+      - name: Upload ui-components coverage to Coveralls
+        if: always()
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          flag-name: ui-components
+          parallel: true
+          file: ./packages/ui-components/coverage/lcov.info
+
+      - name: Zambda unit & integration tests with coverage
+        run: cd packages/zambdas && npx vitest run --coverage
         env:
           ENV: ${{ steps.env.outputs.environment }}
           CI: true
           NODE_OPTIONS: "--max-old-space-size=8192"
+
+      - name: Upload zambdas coverage to Coveralls
+        if: always()
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          flag-name: zambdas
+          parallel: true
+          file: ./packages/zambdas/coverage/integration/lcov.info
+
+      - name: EHR unit tests with coverage
+        run: cd apps/ehr && npx vitest run --config ./vitest.config.ts --coverage
+        env:
+          ENV: ${{ steps.env.outputs.environment }}
+          CI: true
+          NODE_OPTIONS: "--max-old-space-size=8192"
+
+      - name: Upload EHR unit coverage to Coveralls
+        if: always()
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          flag-name: ehr-unit
+          parallel: true
+          file: ./apps/ehr/coverage/unit/lcov.info
+
+      - name: EHR component tests with coverage
+        run: cd apps/ehr && npx vitest run --config ./vitest.config.component-tests.ts --coverage
+        env:
+          ENV: ${{ steps.env.outputs.environment }}
+          CI: true
+          NODE_OPTIONS: "--max-old-space-size=8192"
+
+      - name: Upload EHR component coverage to Coveralls
+        if: always()
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          flag-name: ehr-component
+          parallel: true
+          file: ./apps/ehr/coverage/component/lcov.info
+
+      - name: Intake unit tests with coverage
+        run: cd apps/intake && npx vitest run --config ./vitest.config.ts --coverage
+        env:
+          ENV: ${{ steps.env.outputs.environment }}
+          CI: true
+          NODE_OPTIONS: "--max-old-space-size=8192"
+
+      - name: Upload intake unit coverage to Coveralls
+        if: always()
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          flag-name: intake-unit
+          parallel: true
+          file: ./apps/intake/coverage/unit/lcov.info
+
+      - name: Intake component tests with coverage
+        run: cd apps/intake && npx vitest run --config ./vitest.config.component-tests.ts --coverage
+        env:
+          ENV: ${{ steps.env.outputs.environment }}
+          CI: true
+          NODE_OPTIONS: "--max-old-space-size=8192"
+
+      - name: Upload intake component coverage to Coveralls
+        if: always()
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          flag-name: intake-component
+          parallel: true
+          file: ./apps/intake/coverage/component/lcov.info
+
+      - name: Coveralls parallel finished
+        if: always()
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          parallel-finished: true
+          carryforward: "utils,ui-components,zambdas,ehr-unit,ehr-component,intake-unit,intake-component"
 
       - name: Set GitHub Commit Status
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -148,6 +148,22 @@ jobs:
           parallel: true
           file: ./packages/test-utils/coverage/lcov.info
 
+      - name: Deploy tests with coverage
+        if: ${{ !cancelled() }}
+        run: cd deploy && npx vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text-summary --passWithNoTests
+        env:
+          ENV: ${{ steps.env.outputs.environment }}
+          CI: true
+          NODE_OPTIONS: "--max-old-space-size=8192"
+
+      - name: Upload deploy coverage to Coveralls
+        if: ${{ !cancelled() && hashFiles('deploy/coverage/lcov.info') != '' }}
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          flag-name: deploy
+          parallel: true
+          file: ./deploy/coverage/lcov.info
+
       - name: Utils tests with coverage
         if: ${{ !cancelled() }}
         run: cd packages/utils && npx vitest run --coverage --passWithNoTests
@@ -164,7 +180,7 @@ jobs:
           parallel: true
           file: ./packages/utils/coverage/lcov.info
 
-      - name: Zambda unit & integration tests with coverage
+      - name: Zambda tests with coverage
         if: ${{ !cancelled() }}
         run: cd packages/zambdas && npx vitest run --coverage --passWithNoTests
         env:
@@ -249,7 +265,7 @@ jobs:
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           parallel-finished: true
-          carryforward: "spec,test-utils,utils,zambdas,ehr-unit,ehr-component,intake-unit,intake-component"
+          carryforward: "spec,test-utils,deploy,utils,zambdas,ehr-unit,ehr-component,intake-unit,intake-component"
 
       - name: Set GitHub Commit Status
         if: github.event_name == 'workflow_dispatch'

--- a/apps/ehr/vitest.config.component-tests.ts
+++ b/apps/ehr/vitest.config.component-tests.ts
@@ -15,6 +15,19 @@ export default defineConfig({
     setupFiles: ['./tests/component/setup.ts'],
     environment: 'jsdom',
     testTimeout: 30_000, // 30 seconds
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov', 'text-summary', 'json'],
+      reportsDirectory: './coverage/component',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.test.{ts,tsx}',
+        'src/**/*.spec.{ts,tsx}',
+        'src/**/*.d.ts',
+        'src/**/types/**',
+        'src/**/__mocks__/**',
+      ],
+    },
   },
   plugins: [tsconfigPaths(), react()],
 });

--- a/apps/ehr/vitest.config.ts
+++ b/apps/ehr/vitest.config.ts
@@ -11,6 +11,19 @@ export default defineConfig({
     // Disable globals to avoid conflicts with Playwright's expect during test execution
     globals: false,
     exclude: ['**/*.spec.ts', '**/*.test.tsx'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov', 'text-summary', 'json'],
+      reportsDirectory: './coverage/unit',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.test.{ts,tsx}',
+        'src/**/*.spec.{ts,tsx}',
+        'src/**/*.d.ts',
+        'src/**/types/**',
+        'src/**/__mocks__/**',
+      ],
+    },
   },
   plugins: [tsconfigPaths()],
 });

--- a/apps/intake/vitest.config.component-tests.ts
+++ b/apps/intake/vitest.config.component-tests.ts
@@ -14,6 +14,19 @@ export default defineConfig({
     include: ['**/*.test.tsx'],
     setupFiles: ['./tests/component/setup.ts'],
     environment: 'happy-dom',
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov', 'text-summary', 'json'],
+      reportsDirectory: './coverage/component',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.test.{ts,tsx}',
+        'src/**/*.spec.{ts,tsx}',
+        'src/**/*.d.ts',
+        'src/**/types/**',
+        'src/**/__mocks__/**',
+      ],
+    },
   },
   plugins: [tsconfigPaths(), react()],
 });

--- a/apps/intake/vitest.config.ts
+++ b/apps/intake/vitest.config.ts
@@ -11,6 +11,19 @@ export default defineConfig({
     // Disable globals to avoid conflicts with Playwright's expect during test execution
     globals: false,
     exclude: ['**/*.spec.ts', '**/*.test.tsx'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov', 'text-summary', 'json'],
+      reportsDirectory: './coverage/unit',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.test.{ts,tsx}',
+        'src/**/*.spec.{ts,tsx}',
+        'src/**/*.d.ts',
+        'src/**/types/**',
+        'src/**/__mocks__/**',
+      ],
+    },
   },
   plugins: [tsconfigPaths()],
 });

--- a/packages/ui-components/vitest.config.ts
+++ b/packages/ui-components/vitest.config.ts
@@ -8,7 +8,11 @@ export default mergeConfig(
     test: {
       environment: 'happy-dom',
       coverage: {
-        reporter: ['text', 'json', 'html'],
+        provider: 'v8',
+        reporter: ['lcov', 'text-summary', 'json'],
+        reportsDirectory: './coverage',
+        include: ['lib/**/*.{ts,tsx}'],
+        exclude: ['lib/**/*.test.{ts,tsx}', 'lib/**/*.spec.{ts,tsx}', 'lib/**/*.d.ts'],
       },
     },
   })

--- a/packages/utils/vitest.config.ts
+++ b/packages/utils/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    silent: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov', 'text-summary', 'json'],
+      reportsDirectory: './coverage',
+      include: ['lib/**/*.{ts,tsx}'],
+      exclude: ['lib/**/*.test.{ts,tsx}', 'lib/**/*.spec.{ts,tsx}', 'lib/**/*.d.ts'],
+    },
+  },
+});

--- a/packages/zambdas/vitest.config.ts
+++ b/packages/zambdas/vitest.config.ts
@@ -20,13 +20,7 @@ export default defineConfig({
       reporter: ['lcov', 'text-summary', 'json'],
       reportsDirectory: './coverage/integration',
       include: ['src/**/*.ts'],
-      exclude: [
-        'src/**/*.test.ts',
-        'src/**/*.spec.ts',
-        'src/**/*.d.ts',
-        'src/scripts/**',
-        'src/local-server/**',
-      ],
+      exclude: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/**/*.d.ts', 'src/scripts/**', 'src/local-server/**'],
     },
   },
 });

--- a/packages/zambdas/vitest.config.ts
+++ b/packages/zambdas/vitest.config.ts
@@ -15,5 +15,18 @@ export default defineConfig({
         inline: [/@sentry/, /utils/],
       },
     },
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov', 'text-summary', 'json'],
+      reportsDirectory: './coverage/integration',
+      include: ['src/**/*.ts'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/**/*.spec.ts',
+        'src/**/*.d.ts',
+        'src/scripts/**',
+        'src/local-server/**',
+      ],
+    },
   },
 });

--- a/packages/zambdas/vitest.config.unit.ts
+++ b/packages/zambdas/vitest.config.unit.ts
@@ -18,13 +18,7 @@ export default defineConfig({
       reporter: ['lcov', 'text-summary', 'json'],
       reportsDirectory: './coverage/unit',
       include: ['src/**/*.ts'],
-      exclude: [
-        'src/**/*.test.ts',
-        'src/**/*.spec.ts',
-        'src/**/*.d.ts',
-        'src/scripts/**',
-        'src/local-server/**',
-      ],
+      exclude: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/**/*.d.ts', 'src/scripts/**', 'src/local-server/**'],
     },
   },
 });

--- a/packages/zambdas/vitest.config.unit.ts
+++ b/packages/zambdas/vitest.config.unit.ts
@@ -13,5 +13,18 @@ export default defineConfig({
         inline: [/@sentry/, /utils/],
       },
     },
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov', 'text-summary', 'json'],
+      reportsDirectory: './coverage/unit',
+      include: ['src/**/*.ts'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/**/*.spec.ts',
+        'src/**/*.d.ts',
+        'src/scripts/**',
+        'src/local-server/**',
+      ],
+    },
   },
 });

--- a/packages/zambdas/vitest.config.unit.ts
+++ b/packages/zambdas/vitest.config.unit.ts
@@ -13,12 +13,5 @@ export default defineConfig({
         inline: [/@sentry/, /utils/],
       },
     },
-    coverage: {
-      provider: 'v8',
-      reporter: ['lcov', 'text-summary', 'json'],
-      reportsDirectory: './coverage/unit',
-      include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/**/*.d.ts', 'src/scripts/**', 'src/local-server/**'],
-    },
   },
 });


### PR DESCRIPTION
⚠️ 🤖 Code was generated by claude opus 4.7.  I have read and think that I understand all of it, it helps that I have worked on code coverage features just like this on in other projects. I have spent 1 hour working on this so far.

## Summary
This PR adds code coverage tracking to the automated test pipeline by integrating Coveralls and configuring coverage reporting across the workspaces that have tests.

## Key Changes

- **CI Workflow Updates** (`automated-tests.yml`):
  - Replaced the prior `npm run test` + duplicate component runs with explicit per-workspace `vitest run --coverage` invocations
  - Added a Coveralls upload step for each suite with a unique `flag-name` and `parallel: true`
  - Final `parallel-finished` step consolidates all uploads into a single PR comment
  - Each test step uses `if: ${{ !cancelled() }}` so a failure in one phase doesn't cascade
  - Each upload guards on `hashFiles(...) != ''` so a missing lcov silently skips instead of failing the job
  - `--passWithNoTests` is passed to every vitest run as defense against future empty packages

- **Workspaces covered** (each with its own Coveralls flag):
  - `packages/spec` → `spec`
  - `packages/test-utils` → `test-utils`
  - `deploy` → `deploy`
  - `packages/utils` → `utils`
  - `packages/zambdas` → `zambdas` (default config runs both `test/unit/**` and `test/integration/**`, producing one combined report)
  - `apps/ehr` → `ehr-unit` and `ehr-component`
  - `apps/intake` → `intake-unit` and `intake-component`
  - (`packages/ui-components` has no test files and is intentionally not included)

- **Vitest Configuration Updates**:
  - Added `packages/utils/vitest.config.ts` with v8 coverage + lcov reporter
  - Updated `packages/ui-components/vitest.config.ts` to use the v8 provider and standardized lcov reporting (no-op until tests are added there)
  - Updated `packages/zambdas/vitest.config.ts` with coverage settings writing to `coverage/integration`
  - Updated `apps/ehr/vitest.config.ts` and `vitest.config.component-tests.ts` with coverage configs writing to `coverage/unit` and `coverage/component` respectively
  - Updated `apps/intake/vitest.config.ts` and `vitest.config.component-tests.ts` similarly
  - For `spec`, `test-utils`, and `deploy` (no vitest config files), the lcov reporter is passed via CLI flags

- **Coverage Configuration Details**:
  - All configs use v8 as the coverage provider
  - Reports are generated in lcov format for Coveralls integration
  - Each test suite reports to a dedicated directory (e.g., `./coverage/unit`, `./coverage/component`) so unit and component runs in the same workspace don't clobber each other
  - Consistent exclusion patterns across all configs (test files, type definitions, mocks, scripts, local-server)

## Implementation Details

- Coverage reports are uploaded in parallel to Coveralls with unique flag names for each test suite
- The `carryforward` parameter ensures coverage data from all suites is combined in the final report
- Each vitest config specifies appropriate `include` and `exclude` patterns for accurate coverage measurement
- The workflow uses Coveralls action v2.3.6 consistently across all upload steps

## Required follow-up (one-time, on Coveralls)

For the action to actually post comments on PRs:
1. Enable the `masslight/ottehr` repo at https://coveralls.io/repos/new
2. Install the Coveralls GitHub App on the repo so it can comment on PRs

The workflow uses `${{ github.token }}` (auto-provided), so no extra repo secret is required unless Coveralls' integration prompts you to add `COVERALLS_REPO_TOKEN`.

https://claude.ai/code/session_017dvXTH8KfGmYQ5HWLm2jwU