### PR TITLE
Fix ICD-10 codes padding

### DIFF
--- a/packages/zambdas/src/shared/icd-10-search.ts
+++ b/packages/zambdas/src/shared/icd-10-search.ts
@@ -77,7 +77,7 @@ export async function loadAndParseIcd10Data(): Promise<Icd10Code[]> {
         if (activeSevenChrDef) {
           // Generate billable codes with seventh characters
           activeSevenChrDef.forEach((extension) => {
-            const trimmedCode = code.trim();
+            const trimmedCode = code.trim() + (!code.includes('.') ? '.' : '');
             let finalCode = trimmedCode;
 
             // Pad with "X" so that "seventh" character is in the correct position


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2376/icd-10-search-zambda-can-give-8-character-codes