### PR TITLE
fix(immunization): validate date fields and surface API errors to user

### DIFF
--- a/apps/ehr/src/features/immunization/components/VaccineDetailsCard.tsx
+++ b/apps/ehr/src/features/immunization/components/VaccineDetailsCard.tsx
@@ -45,6 +45,7 @@ import useEvolveUser from 'src/hooks/useEvolveUser';
 import { ROUTE_OPTIONS } from 'src/shared/utils/options';
 import {
   EMERGENCY_CONTACT_RELATIONSHIPS,
+  getApiError,
   ImmunizationOrder,
   REQUIRED_FIELD_ERROR_MESSAGE,
   RoleType,
@@ -126,12 +127,19 @@ export const VaccineDetailsCard: React.FC<Props> = ({ order }) => {
     if (data.otherReason) {
       data.reason = data.otherReason;
     }
-    await administerOrder({
-      orderId: order.id,
-      type: administrationTypeRef.current.type,
-      ...(await cleanupProperties(data)),
-    });
-    navigate(getImmunizationMARUrl(appointmentId!));
+    try {
+      await administerOrder({
+        orderId: order.id,
+        type: administrationTypeRef.current.type,
+        ...(await cleanupProperties(data)),
+      });
+      navigate(getImmunizationMARUrl(appointmentId!));
+    } catch (error) {
+      enqueueSnackbar(getApiError({ error, defaultError: 'An error occurred. Please try again.' }), {
+        variant: 'error',
+      });
+      throw error;
+    }
   };
 
   const onAdministrationActionClick = async (administrationType: AdministrationType): Promise<void> => {

--- a/packages/zambdas/src/ehr/immunization/administer-order/index.ts
+++ b/packages/zambdas/src/ehr/immunization/administer-order/index.ts
@@ -11,6 +11,7 @@ import {
   Reference,
   RelatedPerson,
 } from 'fhir/r4b';
+import { DateTime } from 'luxon';
 import {
   AdministerImmunizationOrderRequest,
   CODE_SYSTEM_CPT,
@@ -23,6 +24,7 @@ import {
   getFullName,
   getMedicationName,
   ImmunizationEmergencyContact,
+  INVALID_INPUT_ERROR,
   mapFhirToOrderStatus,
   mapOrderStatusToFhir,
   MEDICATION_ADMINISTRATION_PERFORMER_TYPE_SYSTEM,
@@ -282,6 +284,23 @@ export function validateRequestParameters(
   }
 
   if (missingFields.length > 0) throw new Error(`Missing required fields [${missingFields.join(', ')}]`);
+
+  function validateDate(value: string, input: string): void {
+    const dt = DateTime.fromISO(value);
+    if (!dt.isValid || dt.year < 1900) {
+      throw INVALID_INPUT_ERROR(`Invalid ${input}, "${value}" is not a valid date`);
+    }
+  }
+
+  if (administrationDetails?.expDate) {
+    validateDate(administrationDetails.expDate, 'expiration date');
+  }
+  if (administrationDetails?.administeredDateTime) {
+    validateDate(administrationDetails.administeredDateTime, 'administered date');
+  }
+  if (administrationDetails?.visGivenDate) {
+    validateDate(administrationDetails.visGivenDate, 'VIS given date');
+  }
 
   if (administrationDetails) {
     if (administrationDetails.mvx) administrationDetails.mvx = administrationDetails.mvx.trim();


### PR DESCRIPTION
- Validate expDate, administeredDateTime, and visGivenDate in administer-immunization-order zambda using Luxon; throws INVALID_INPUT_ERROR for invalid or pre-epoch dates
- Catch and display API error messages as a snackbar in VaccineDetailsCard; re-throw to keep the confirmation modal open