### PR TITLE
feat: get test coverage on develop and release branches for 'push', n…

### DIFF
--- a/.github/workflows/terraform-apply-and-test-pipeline.yml
+++ b/.github/workflows/terraform-apply-and-test-pipeline.yml
@@ -37,7 +37,7 @@ on:
         type: boolean
         default: false
   push:
-    branches: [main]
+    branches: [main, develop, "release/**"]
     paths:
       - "apps/ehr/**"
       - "apps/intake/**"
@@ -79,6 +79,7 @@ jobs:
     outputs:
       environment: ${{ steps.finalize-env.outputs.environment }}
       should-run-apply: ${{ steps.check.outputs.should-run-apply }}
+      coverage-only: ${{ steps.check.outputs.coverage-only }}
       concurrency-group: ${{ steps.concurrency.outputs.group }}
     steps:
       - name: Determine Environment
@@ -220,6 +221,17 @@ jobs:
               echo "Workflow dispatch without skip flag - running Terraform Apply"
               echo "should-run-apply=true" >> $GITHUB_OUTPUT
             fi
+            echo "coverage-only=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Push to non-main branches (develop, release/**): coverage-only run.
+          # Keeps Coveralls baselines fresh on PR target branches without doing a
+          # full deploy + E2E on every merge. See docs.coveralls.io/build-types.
+          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "Push to non-main branch - coverage-only run (skip terraform apply and E2E)"
+            echo "should-run-apply=false" >> $GITHUB_OUTPUT
+            echo "coverage-only=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -227,12 +239,14 @@ jobs:
           if [ "${{ contains(github.event.pull_request.body || '', '/skip-terraform-apply') }}" == "true" ]; then
             echo "Skipping Terraform Apply via PR command /skip-terraform-apply"
             echo "should-run-apply=false" >> $GITHUB_OUTPUT
+            echo "coverage-only=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           # Default: run Terraform Apply for all push/pull_request events
           echo "Running Terraform Apply by default"
           echo "should-run-apply=true" >> $GITHUB_OUTPUT
+          echo "coverage-only=false" >> $GITHUB_OUTPUT
 
       - name: Determine Concurrency Group
         id: concurrency
@@ -315,8 +329,8 @@ jobs:
       aws_deploy_role: ${{ inputs.aws_deploy_role || vars.AWS_DEPLOY_ROLE }}
       secrets_repository: ${{ inputs.secrets_repository || vars.SECRETS_REPOSITORY }}
       run_automated_tests: ${{ github.event.inputs.run_automated_tests != 'false' || github.event_name != 'workflow_dispatch' }}
-      run_ehr_e2e: ${{ github.event.inputs.run_ehr_e2e != 'false' || github.event_name != 'workflow_dispatch' }}
-      run_intake_e2e: ${{ github.event.inputs.run_intake_e2e != 'false' || github.event_name != 'workflow_dispatch' }}
+      run_ehr_e2e: ${{ needs.determine-environment.outputs.coverage-only != 'true' && (github.event.inputs.run_ehr_e2e != 'false' || github.event_name != 'workflow_dispatch') }}
+      run_intake_e2e: ${{ needs.determine-environment.outputs.coverage-only != 'true' && (github.event.inputs.run_intake_e2e != 'false' || github.event_name != 'workflow_dispatch') }}
       pr_body: ${{ github.event.pull_request.body || '' }}
       github_ref: ${{ github.ref }}
       is_pull_request: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Code was generated with Claude Opus 4.7. I have reviewed and understand all of this code. I have spent 10 minutes on this.

<img width="1688" height="498" alt="image" src="https://github.com/user-attachments/assets/7a2e4811-515c-4af2-8d57-eff6298837d7" />

> 
>  The new "coverage-only" branch in the Check if Terraform Apply is needed step fires for any push that isn't on main. It sets should-run-apply=false and a new coverage-only=true output, which the
>   run-pipeline step ANDs into the run_ehr_e2e / run_intake_e2e flags to skip the E2E jobs. generate-seed-data + automated-tests still run, so Coveralls gets a fresh baseline build for develop/release/**
>   after every merge — which is what the doc recommends to clear the "Target branch is out-of-sync" drift warning.
>   
>   Two caveats worth flagging:
> 
>   1. generate-seed-data will run against the already-deployed environment (e2e/e2e2/e2e3 via load balancer) without a fresh terraform apply. If the freshly-merged commit on develop introduces a schema/IaC
>   change that needs an apply, seed generation could fail. The fallback there is to either land the IaC change via main (which still does the full pipeline) or temporarily re-run the workflow via
>   workflow_dispatch.
>   2. The path filter on push is unchanged, so it still triggers on apps/**, packages/**, etc. It does not include deploy/** (only pull_request does). I left that asymmetry alone since it predates this
>   change — flag it if you want me to align them.

I didn't want to run terraform apply after every merge just to get test coverage reports. It will be OK if it fails and the test coverage is a little bit stale.