### PR TITLE
Disable wrapping of header elements on Progress Note

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/Header.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/Header.tsx
@@ -417,9 +417,9 @@ export const Header = (): JSX.Element => {
         </Box>
         <Grid container spacing={2} sx={{ padding: '0 18px 0 4px' }}>
           <Grid item xs={12}>
-            <Grid container alignItems="center" justifyContent="space-between">
+            <Grid container alignItems="center" justifyContent="space-between" wrap="nowrap">
               <Grid item>
-                <Grid container alignItems="center" spacing={2}>
+                <Grid container alignItems="center" spacing={2} wrap="nowrap">
                   <Grid item>
                     {isFollowup ? (
                       getFollowupStatusChip(getAnnotationFollowupStatusLabel(encounter?.status))


### PR DESCRIPTION
https://linear.app/zapehr/issue/OYST-3186/uk-align-header-on-progress-note