### PR TITLE
fix: retry sentry-cli once and continue deploy on persistent failure

### DIFF
--- a/packages/zambdas/bundle.ts
+++ b/packages/zambdas/bundle.ts
@@ -124,6 +124,22 @@ const copyAssets = async (from: string, to: string): Promise<void> => {
 
 const SENTRY_CHUNK_SIZE = 10;
 
+const runSentryCommandWithRetry = async (label: string, runCommand: () => Promise<unknown>): Promise<boolean> => {
+  try {
+    await runCommand();
+    return true;
+  } catch (error) {
+    console.warn(`Sentry CLI command failed (${label}), retrying once...`, error);
+  }
+  try {
+    await runCommand();
+    return true;
+  } catch (error) {
+    console.warn(`Sentry CLI command failed (${label}) after retry; skipping remaining Sentry steps:`, error);
+    return false;
+  }
+};
+
 const injectSourceMaps = async (zambdas: ZambdaSpec[]): Promise<void> => {
   if (!process.env.SENTRY_ORG || !process.env.SENTRY_PROJECT || !process.env.SENTRY_AUTH_TOKEN) {
     console.warn('Sentry environment variables are not set');
@@ -143,7 +159,14 @@ const injectSourceMaps = async (zambdas: ZambdaSpec[]): Promise<void> => {
   };
   const revParse = await $`git rev-parse --verify HEAD`;
   const releaseName = revParse.stdout;
-  await $(shellConfig)`sentry-cli releases new ${releaseName}`;
+  if (
+    !(await runSentryCommandWithRetry(
+      `releases new ${releaseName}`,
+      () => $(shellConfig)`sentry-cli releases new ${releaseName}`
+    ))
+  ) {
+    return;
+  }
 
   const zambdaDirs = zambdas.map((z) => path.dirname(`.dist/${z.src.substring('src/'.length)}.js`));
   const chunks = chunkArray(zambdaDirs, SENTRY_CHUNK_SIZE);
@@ -152,21 +175,36 @@ const injectSourceMaps = async (zambdas: ZambdaSpec[]): Promise<void> => {
   );
 
   for (const chunk of chunks) {
-    await Promise.all(
-      chunk.map((dir) => $(shellConfig)`sentry-cli sourcemaps inject ${dir} --quiet --log-level error`)
+    const results = await Promise.all(
+      chunk.map((dir) =>
+        runSentryCommandWithRetry(
+          `sourcemaps inject ${dir}`,
+          () => $(shellConfig)`sentry-cli sourcemaps inject ${dir} --quiet --log-level error`
+        )
+      )
     );
+    if (results.some((ok) => !ok)) return;
   }
 
   console.log(
     `Uploading source maps for ${zambdas.length} zambdas in ${chunks.length} chunks of up to ${SENTRY_CHUNK_SIZE}...`
   );
   for (const chunk of chunks) {
-    await Promise.all(
-      chunk.map((dir) => $(shellConfig)`sentry-cli sourcemaps upload --strict --release ${releaseName} ${dir}`)
+    const results = await Promise.all(
+      chunk.map((dir) =>
+        runSentryCommandWithRetry(
+          `sourcemaps upload ${dir}`,
+          () => $(shellConfig)`sentry-cli sourcemaps upload --strict --release ${releaseName} ${dir}`
+        )
+      )
     );
+    if (results.some((ok) => !ok)) return;
   }
 
-  await $(shellConfig)`sentry-cli releases finalize ${releaseName}`;
+  await runSentryCommandWithRetry(
+    `releases finalize ${releaseName}`,
+    () => $(shellConfig)`sentry-cli releases finalize ${releaseName}`
+  );
 };
 
 const zipZambda = async (


### PR DESCRIPTION
Code written by Claude Opus 4.7. I have read all of it and understand it. I spent 1 hour on this.

## Summary
- Sentry's CLI has been intermittently failing in recent deploys. Rather than blocking the deploy, each `sentry-cli` call in `packages/zambdas/bundle.ts` now gets one retry.
- If a call still fails after the retry, we log the failure and skip the remaining (dependent) Sentry steps — release create / inject / upload / finalize are chained, so there's no point continuing once one gives up.
- Net effect: bundle/deploy proceeds without sourcemaps rather than failing outright.

## Test plan
- [x] Trigger a deploy and confirm sourcemaps still upload when Sentry is healthy.
- wait and see if we have issues again
- 
🤖 Generated with [Claude Code](https://claude.com/claude-code)