### PR TITLE
Return a user-facing error when en ecounter is consurrently modified during "change-in-person-visit-status" execution 

### DIFF
--- a/packages/utils/lib/fhir/resourcePatch.ts
+++ b/packages/utils/lib/fhir/resourcePatch.ts
@@ -8,6 +8,7 @@ export interface GetPatchBinaryInput {
   resourceId: string;
   resourceType: string;
   patchOperations: Operation[];
+  ifMatch?: string;
 }
 
 export function getPatchBinary(input: GetPatchBinaryInput): BatchInputPatchRequest<FhirResource> {
@@ -21,6 +22,7 @@ export function getPatchBinary(input: GetPatchBinaryInput): BatchInputPatchReque
       data: btoa(unescape(encodeURIComponent(JSON.stringify(patchOperations)))),
       contentType: 'application/json-patch+json',
     },
+    ifMatch: input.ifMatch,
   };
 }
 

--- a/packages/utils/lib/types/errors/index.ts
+++ b/packages/utils/lib/types/errors/index.ts
@@ -26,6 +26,7 @@ export enum APIErrorCode {
   PATIENT_PHONE_NOT_FOUND = 4021,
   RESOURCE_INCOMPLETE_FOR_OPERATION = 4022,
   ALREADY_EXISTS = 4023,
+  CONCURRENT_UPDATE = 4024,
   // 41xx
   QUESTIONNAIRE_RESPONSE_INVALID = 4100,
   QUESTIONNAIRE_NOT_FOUND_FOR_QR = 4101,
@@ -391,6 +392,13 @@ export const RESOURCE_INCOMPLETE_FOR_OPERATION_ERROR = (message: string): APIErr
 export const ALREADY_EXISTS_WITH_MESSAGE = (message: string): APIError => {
   return {
     code: APIErrorCode.ALREADY_EXISTS,
+    message,
+  };
+};
+
+export const CONCURRENT_UPDATE_WITH_MESSAGE = (message: string): APIError => {
+  return {
+    code: APIErrorCode.CONCURRENT_UPDATE,
     message,
   };
 };

--- a/packages/zambdas/src/ehr/change-in-person-visit-status/helpers/helpers.ts
+++ b/packages/zambdas/src/ehr/change-in-person-visit-status/helpers/helpers.ts
@@ -3,6 +3,7 @@ import { captureException } from '@sentry/aws-serverless';
 import { Operation } from 'fast-json-patch';
 import { Appointment, Encounter } from 'fhir/r4b';
 import {
+  CONCURRENT_UPDATE_WITH_MESSAGE,
   getAppointmentMetaTagOpForStatusUpdate,
   getEncounterStatusHistoryUpdateOp,
   getPatchBinary,
@@ -49,6 +50,9 @@ export const changeInPersonVisitStatusIfPossible = async (
               resourceType: 'Encounter',
               resourceId: resourcesToUpdate.encounter.id!,
               patchOperations: updateInPersonEncounterStatusOp,
+              ifMatch: resourcesToUpdate.encounter.meta?.versionId
+                ? `W/"${resourcesToUpdate.encounter.meta.versionId}"`
+                : undefined,
             }),
           ]
         : []),
@@ -67,7 +71,11 @@ export const changeInPersonVisitStatusIfPossible = async (
       await oystehr.fhir.transaction({
         requests,
       });
-    } catch (error) {
+    } catch (error: any) {
+      const is412 = error?.code === 412 || error?.statusCode === 412 || error?.message?.includes('412');
+      if (is412) {
+        throw CONCURRENT_UPDATE_WITH_MESSAGE('The encounter was modified during the operation');
+      }
       captureException(error, {
         tags: {
           encounterId: resourcesToUpdate.encounter.id,


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2491/error-changing-visit-status-for-in-person-visit