### PR TITLE
Add template section action selection UI and backend validation

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/templates/ApplyTemplate.tsx
+++ b/apps/ehr/src/features/visits/shared/components/templates/ApplyTemplate.tsx
@@ -113,8 +113,9 @@ export const ApplyTemplate: React.FC = () => {
   };
 
   const handleDialogClose = (): void => {
+    // Leave pendingTemplate in place so the dialog body doesn't change while it
+    // animates out. It gets replaced on the next selection or apply.
     setDialogOpen(false);
-    setPendingTemplate(null);
   };
 
   const handleApplyTemplate = async (sectionActions: TemplateSectionActions): Promise<void> => {
@@ -152,7 +153,8 @@ export const ApplyTemplate: React.FC = () => {
     }
     setSelectedTemplate(pendingTemplate);
     setDialogOpen(false);
-    setPendingTemplate(null);
+    // Keep pendingTemplate while the dialog animates out; the next selection
+    // (or another apply) will overwrite it.
   };
 
   const selectTemplateByName = (templateName: string): void => {

--- a/apps/ehr/src/features/visits/shared/components/templates/ApplyTemplate.tsx
+++ b/apps/ehr/src/features/visits/shared/components/templates/ApplyTemplate.tsx
@@ -24,11 +24,12 @@ import { useApiClients } from 'src/hooks/useAppClients';
 import { useCommandPaletteSource } from 'src/hooks/useCommandPaletteSource';
 import useEvolveUser from 'src/hooks/useEvolveUser';
 import { usePendingQuickPick } from 'src/hooks/usePendingQuickPick';
-import { ExamType, RoleType } from 'utils';
+import { ExamType, RoleType, TemplateSectionActions } from 'utils';
 import { useGetAppointmentAccessibility } from '../../hooks/useGetAppointmentAccessibility';
 import { useAppointmentData } from '../../stores/appointment/appointment.store';
 import { resetExamObservationsStore } from '../../stores/appointment/reset-exam-observations';
 import { resetRosObservationsStore } from '../../stores/appointment/reset-ros-observations';
+import { TemplatePreviewDialog } from './TemplatePreviewDialog';
 import { TemplateOption, useListTemplates } from './useListTemplates';
 
 const ADD_NEW_SENTINEL = '__ADD_NEW__';
@@ -50,7 +51,7 @@ const ADD_OR_UPDATE_LABEL = '+ Add or Update Template From Note';
 export const ApplyTemplate: React.FC = () => {
   const [selectedTemplate, setSelectedTemplate] = useState<TemplateOption | null>(null);
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
-  const [pendingTemplate, setPendingTemplate] = useState<string>('');
+  const [pendingTemplate, setPendingTemplate] = useState<TemplateOption | null>(null);
   const [isApplyingTemplate, setIsApplyingTemplate] = useState<boolean>(false);
   const [createDialogOpen, setCreateDialogOpen] = useState<boolean>(false);
   const [newTemplateName, setNewTemplateName] = useState<string>('');
@@ -103,27 +104,29 @@ export const ApplyTemplate: React.FC = () => {
         setSelectedTemplate(null);
         return;
       }
-      setPendingTemplate(newValue.value);
+      setPendingTemplate(newValue);
       setDialogOpen(true);
     } else {
       setSelectedTemplate(null);
-      setPendingTemplate('');
+      setPendingTemplate(null);
     }
   };
 
   const handleDialogClose = (): void => {
     setDialogOpen(false);
-    setPendingTemplate('');
+    setPendingTemplate(null);
   };
 
-  const handleApplyTemplate = async (): Promise<void> => {
+  const handleApplyTemplate = async (sectionActions: TemplateSectionActions): Promise<void> => {
+    if (!pendingTemplate) return;
     if (oystehrZambda && encounter.id) {
       setIsApplyingTemplate(true);
       try {
         await applyTemplate(oystehrZambda, {
           encounterId: encounter.id,
-          templateName: pendingTemplate,
+          templateName: pendingTemplate.value,
           examType: ExamType.IN_PERSON,
+          sectionActions,
         });
 
         // Reset exam observations store to force reload from server
@@ -147,19 +150,15 @@ export const ApplyTemplate: React.FC = () => {
         setIsApplyingTemplate(false);
       }
     }
-    // Find the template option that matches the pendingTemplate value
-    const selectedTemplateOption = templates.find((template) => template.value === pendingTemplate) || null;
-    setSelectedTemplate(selectedTemplateOption);
+    setSelectedTemplate(pendingTemplate);
     setDialogOpen(false);
-    setPendingTemplate('');
-  };
-
-  const getTemplateName = (value: string): string => {
-    return templates.find((option) => option.value === value)?.label || '';
+    setPendingTemplate(null);
   };
 
   const selectTemplateByName = (templateName: string): void => {
-    setPendingTemplate(templateName);
+    const option = templates.find((t) => t.value === templateName);
+    if (!option) return;
+    setPendingTemplate(option);
     setDialogOpen(true);
   };
 
@@ -305,55 +304,15 @@ export const ApplyTemplate: React.FC = () => {
         </Box>
       )}
 
-      {/* Apply Template Confirmation Dialog */}
-      <Dialog
+      <TemplatePreviewDialog
         open={dialogOpen}
-        onClose={handleDialogClose}
-        disableScrollLock
-        sx={{
-          '.MuiPaper-root': {
-            padding: 2,
-          },
-        }}
-      >
-        <DialogTitle variant="h4" color="primary.dark" sx={{ width: '80%' }}>
-          Apply Template
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText
-            sx={{
-              color: theme.palette.text.primary,
-            }}
-          >
-            Are you sure you want to apply the <strong>{getTemplateName(pendingTemplate)}</strong> template?
-            <br />
-            <br />
-            <strong>Overwritten:</strong> ROS, Exam, MDM, Patient Instructions, E&amp;M Code
-            <br />
-            <strong>Appended:</strong> HPI, MOI, ICD-10 Diagnoses, CPT Codes
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions sx={{ justifyContent: 'space-between', px: 3 }}>
-          <Button
-            variant="outlined"
-            onClick={handleDialogClose}
-            size="medium"
-            sx={buttonSx}
-            disabled={isApplyingTemplate}
-          >
-            Cancel
-          </Button>
-          <LoadingButton
-            variant="contained"
-            onClick={handleApplyTemplate}
-            size="medium"
-            sx={buttonSx}
-            loading={isApplyingTemplate}
-          >
-            Apply Template
-          </LoadingButton>
-        </DialogActions>
-      </Dialog>
+        templateId={pendingTemplate?.id ?? null}
+        templateName={pendingTemplate?.label ?? ''}
+        examType={ExamType.IN_PERSON}
+        isApplying={isApplyingTemplate}
+        onCancel={handleDialogClose}
+        onApply={handleApplyTemplate}
+      />
 
       {/* Create/Update Template Dialog */}
       <Dialog open={createDialogOpen} onClose={handleCreateDialogClose} disableScrollLock maxWidth="sm" fullWidth>

--- a/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
+++ b/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
@@ -13,7 +13,6 @@ import {
   IconButton,
   Skeleton,
   Stack,
-  ToggleButton,
   ToggleButtonGroup,
   Typography,
   useTheme,
@@ -21,6 +20,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import React, { useEffect, useMemo, useState } from 'react';
 import { getTemplateDetail } from 'src/api/api';
+import { ContainedPrimaryToggleButton } from 'src/components/ContainedPrimaryToggleButton';
 import { useApiClients } from 'src/hooks/useAppClients';
 import {
   AdminGetTemplateDetailOutput,
@@ -386,7 +386,7 @@ const SectionCard: React.FC<{
           <ExpandMoreIcon fontSize="small" />
         </IconButton>
         <Box sx={{ flex: 1, minWidth: 0 }}>
-          <Typography variant="subtitle2" sx={{ fontWeight: 600, lineHeight: 1.3 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 600, lineHeight: 1.3, color: 'primary.dark' }}>
             {descriptor.label}
           </Typography>
           {summary ? (
@@ -414,19 +414,18 @@ const SectionCard: React.FC<{
             }}
             disabled={disabled}
             aria-label={`Action for ${descriptor.label}`}
-            sx={{ '& .MuiToggleButton-root': { textTransform: 'none' } }}
           >
-            <ToggleButton value="skip" title={ACTION_TOOLTIPS.skip}>
+            <ContainedPrimaryToggleButton value="skip" title={ACTION_TOOLTIPS.skip}>
               {ACTION_LABELS.skip}
-            </ToggleButton>
+            </ContainedPrimaryToggleButton>
             {noAppend ? null : (
-              <ToggleButton value="append" title={ACTION_TOOLTIPS.append}>
+              <ContainedPrimaryToggleButton value="append" title={ACTION_TOOLTIPS.append}>
                 {ACTION_LABELS.append}
-              </ToggleButton>
+              </ContainedPrimaryToggleButton>
             )}
-            <ToggleButton value="overwrite" title={ACTION_TOOLTIPS.overwrite}>
+            <ContainedPrimaryToggleButton value="overwrite" title={ACTION_TOOLTIPS.overwrite}>
               {ACTION_LABELS.overwrite}
-            </ToggleButton>
+            </ContainedPrimaryToggleButton>
           </ToggleButtonGroup>
         </Box>
       </Box>

--- a/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
+++ b/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
@@ -390,7 +390,10 @@ const SectionCard: React.FC<{
           <ExpandMoreIcon fontSize="small" />
         </IconButton>
         <Box sx={{ flex: 1, minWidth: 0 }}>
-          <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.3, color: 'primary.dark' }}>
+          <Typography
+            variant="subtitle1"
+            sx={{ fontWeight: 600, fontSize: '0.9375rem', lineHeight: 1.3, color: 'primary.dark' }}
+          >
             {descriptor.label}
           </Typography>
           {summary ? (
@@ -436,7 +439,7 @@ const SectionCard: React.FC<{
       <Collapse in={expanded} unmountOnExit>
         <Box
           id={`template-section-${descriptor.key}-body`}
-          sx={{ px: 2, pb: 2, pt: 0.5, borderTop: `1px solid ${theme.palette.divider}`, ...previewSx }}
+          sx={{ px: 2, pb: 2, pt: 2, borderTop: `1px solid ${theme.palette.divider}`, ...previewSx }}
         >
           <SectionPreview sectionKey={descriptor.key} sections={sections} />
         </Box>

--- a/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
+++ b/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
@@ -10,7 +10,6 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Divider,
   IconButton,
   Skeleton,
   Stack,
@@ -415,6 +414,7 @@ const SectionCard: React.FC<{
             }}
             disabled={disabled}
             aria-label={`Action for ${descriptor.label}`}
+            sx={{ '& .MuiToggleButton-root': { textTransform: 'none' } }}
           >
             <ToggleButton value="skip" title={ACTION_TOOLTIPS.skip}>
               {ACTION_LABELS.skip}
@@ -531,7 +531,7 @@ export const TemplatePreviewDialog: React.FC<TemplatePreviewDialogProps> = ({
         ) : sectionsWithContent.length === 0 ? (
           <Alert severity="info">This template is empty — nothing to apply.</Alert>
         ) : (
-          <Stack spacing={2} divider={<Divider flexItem />}>
+          <Stack spacing={1}>
             {sectionsWithContent.map((section) => (
               <SectionCard
                 key={section.key}

--- a/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
+++ b/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
@@ -1,14 +1,17 @@
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { LoadingButton } from '@mui/lab';
 import {
   Alert,
   Box,
   Button,
   Chip,
+  Collapse,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   Divider,
+  IconButton,
   Skeleton,
   Stack,
   ToggleButton,
@@ -70,6 +73,69 @@ const ACTION_TOOLTIPS: Record<TemplateSectionAction, string> = {
   skip: "Don't apply this section.",
   append: 'Keep existing content and add the template content.',
   overwrite: 'Replace existing content with the template content.',
+};
+
+const truncate = (s: string, n = 80): string => {
+  const collapsed = s.replace(/\s+/g, ' ').trim();
+  return collapsed.length <= n ? collapsed : `${collapsed.slice(0, n).trim()}…`;
+};
+
+const pluralize = (n: number, singular: string, plural = `${singular}s`): string =>
+  `${n} ${n === 1 ? singular : plural}`;
+
+const getSectionSummary = (sections: AdminGetTemplateDetailOutput['sections'], key: TemplateSectionKey): string => {
+  switch (key) {
+    case 'hpi':
+      return sections.hpiNote ? truncate(sections.hpiNote) : '';
+    case 'moi':
+      return sections.moiNote ? truncate(sections.moiNote) : '';
+    case 'ros': {
+      const parts: string[] = [];
+      if (sections.rosNote) parts.push(`note: "${truncate(sections.rosNote, 40)}"`);
+      if (sections.rosFindings.length > 0) parts.push(pluralize(sections.rosFindings.length, 'finding'));
+      return parts.join(' · ');
+    }
+    case 'examFindings': {
+      const abnormal = sections.examFindings.filter((f) => f.isAbnormal).length;
+      const normal = sections.examFindings.length - abnormal;
+      const parts: string[] = [];
+      if (abnormal) parts.push(`${abnormal} abnormal`);
+      if (normal) parts.push(`${normal} normal`);
+      return parts.join(', ');
+    }
+    case 'mdm':
+      return sections.mdm ? truncate(sections.mdm) : '';
+    case 'diagnoses': {
+      const codes = sections.diagnoses
+        .slice(0, 2)
+        .map((d) => d.code)
+        .join(', ');
+      const extra = sections.diagnoses.length - 2;
+      return extra > 0 ? `${codes} +${extra} more` : codes;
+    }
+    case 'patientInstructions':
+      return pluralize(sections.patientInstructions.length, 'instruction');
+    case 'cptCodes': {
+      const codes = sections.cptCodes
+        .slice(0, 2)
+        .map((c) => c.code)
+        .join(', ');
+      const extra = sections.cptCodes.length - 2;
+      return extra > 0 ? `${codes} +${extra} more` : codes;
+    }
+    case 'emCode':
+      return sections.emCode ? sections.emCode.code : '';
+    case 'accident': {
+      if (!sections.accident) return '';
+      const flags: string[] = [];
+      if (sections.accident.autoAccident) flags.push('Auto');
+      if (sections.accident.employment) flags.push('Employment');
+      if (sections.accident.otherAccident) flags.push('Other');
+      return flags.length > 0 ? flags.join(', ') : 'Yes';
+    }
+    default:
+      return '';
+  }
 };
 
 const sectionHasContent = (sections: AdminGetTemplateDetailOutput['sections'], key: TemplateSectionKey): boolean => {
@@ -268,7 +334,9 @@ const SectionCard: React.FC<{
   disabled: boolean;
 }> = ({ descriptor, sections, action, onActionChange, disabled }) => {
   const theme = useTheme();
+  const [expanded, setExpanded] = useState(false);
   const noAppend = TEMPLATE_SECTIONS_NO_APPEND.has(descriptor.key);
+  const summary = getSectionSummary(sections, descriptor.key);
 
   const previewSx = {
     opacity: action === 'skip' ? 0.5 : 1,
@@ -280,40 +348,96 @@ const SectionCard: React.FC<{
       sx={{
         border: `1px solid ${theme.palette.divider}`,
         borderRadius: 1,
-        p: 2,
+        overflow: 'hidden',
       }}
       data-testid={`template-section-${descriptor.key}`}
     >
-      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.5 }}>
-        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-          {descriptor.label}
-        </Typography>
-        <ToggleButtonGroup
-          value={action}
-          exclusive
+      <Box
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        aria-controls={`template-section-${descriptor.key}-body`}
+        onClick={() => setExpanded((v) => !v)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setExpanded((v) => !v);
+          }
+        }}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          px: 1.5,
+          py: 1,
+          cursor: 'pointer',
+          userSelect: 'none',
+          '&:hover': { backgroundColor: theme.palette.action.hover },
+        }}
+      >
+        <IconButton
           size="small"
-          onChange={(_, next: TemplateSectionAction | null) => {
-            if (next) onActionChange(next);
+          aria-label={expanded ? 'Collapse section' : 'Expand section'}
+          sx={{
+            transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+            transition: 'transform 150ms ease-in-out',
           }}
-          disabled={disabled}
-          aria-label={`Action for ${descriptor.label}`}
+          tabIndex={-1}
         >
-          <ToggleButton value="skip" title={ACTION_TOOLTIPS.skip}>
-            {ACTION_LABELS.skip}
-          </ToggleButton>
-          {noAppend ? null : (
-            <ToggleButton value="append" title={ACTION_TOOLTIPS.append}>
-              {ACTION_LABELS.append}
+          <ExpandMoreIcon fontSize="small" />
+        </IconButton>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 600, lineHeight: 1.3 }}>
+            {descriptor.label}
+          </Typography>
+          {summary ? (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                lineHeight: 1.3,
+              }}
+            >
+              {summary}
+            </Typography>
+          ) : null}
+        </Box>
+        <Box onClick={(e) => e.stopPropagation()} sx={{ flexShrink: 0 }}>
+          <ToggleButtonGroup
+            value={action}
+            exclusive
+            size="small"
+            onChange={(_, next: TemplateSectionAction | null) => {
+              if (next) onActionChange(next);
+            }}
+            disabled={disabled}
+            aria-label={`Action for ${descriptor.label}`}
+          >
+            <ToggleButton value="skip" title={ACTION_TOOLTIPS.skip}>
+              {ACTION_LABELS.skip}
             </ToggleButton>
-          )}
-          <ToggleButton value="overwrite" title={ACTION_TOOLTIPS.overwrite}>
-            {ACTION_LABELS.overwrite}
-          </ToggleButton>
-        </ToggleButtonGroup>
-      </Stack>
-      <Box sx={previewSx}>
-        <SectionPreview sectionKey={descriptor.key} sections={sections} />
+            {noAppend ? null : (
+              <ToggleButton value="append" title={ACTION_TOOLTIPS.append}>
+                {ACTION_LABELS.append}
+              </ToggleButton>
+            )}
+            <ToggleButton value="overwrite" title={ACTION_TOOLTIPS.overwrite}>
+              {ACTION_LABELS.overwrite}
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
       </Box>
+      <Collapse in={expanded} unmountOnExit>
+        <Box
+          id={`template-section-${descriptor.key}-body`}
+          sx={{ px: 2, pb: 2, pt: 0.5, borderTop: `1px solid ${theme.palette.divider}`, ...previewSx }}
+        >
+          <SectionPreview sectionKey={descriptor.key} sections={sections} />
+        </Box>
+      </Collapse>
     </Box>
   );
 };

--- a/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
+++ b/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
@@ -24,7 +24,9 @@ import { ContainedPrimaryToggleButton } from 'src/components/ContainedPrimaryTog
 import { useApiClients } from 'src/hooks/useAppClients';
 import {
   AdminGetTemplateDetailOutput,
+  buildExamFieldToSectionMap,
   ExamType,
+  InPersonExamConfig,
   RosFindingState,
   RosFindingStateLabel,
   TEMPLATE_SECTION_DEFAULT_ACTIONS,
@@ -33,6 +35,13 @@ import {
   TemplateSectionActions,
   TemplateSectionKey,
 } from 'utils';
+
+// Static once-per-module: maps every exam field name to the body-system section it
+// belongs to (e.g. "abdomen-soft" -> { sectionLabel: "Abdomen" }). Used to render
+// exam-finding chips under their owning section so they're meaningful on their own.
+const EXAM_FIELD_TO_SECTION = buildExamFieldToSectionMap(InPersonExamConfig);
+const EXAM_SECTION_KEYS_IN_ORDER = Object.keys(InPersonExamConfig);
+const EXAM_OTHER_SECTION_KEY = '__other__';
 
 interface TemplatePreviewDialogProps {
   open: boolean;
@@ -238,37 +247,50 @@ const SectionPreview: React.FC<{
       );
     }
     case 'examFindings': {
-      const abnormal = sections.examFindings.filter((f) => f.isAbnormal);
-      const normal = sections.examFindings.filter((f) => !f.isAbnormal);
+      // Group findings by body-system section so each chip is anchored under a
+      // header like "Abdomen". Anything whose fieldName isn't in the exam config
+      // (e.g. comment fields with custom keys) falls into an "Other" bucket.
+      const groupedByKey = new Map<string, typeof sections.examFindings>();
+      for (const finding of sections.examFindings) {
+        const info = EXAM_FIELD_TO_SECTION.get(finding.fieldName);
+        const key = info?.sectionKey ?? EXAM_OTHER_SECTION_KEY;
+        const existing = groupedByKey.get(key);
+        if (existing) existing.push(finding);
+        else groupedByKey.set(key, [finding]);
+      }
+
+      const orderedKeys = [
+        ...EXAM_SECTION_KEYS_IN_ORDER.filter((k) => groupedByKey.has(k)),
+        ...(groupedByKey.has(EXAM_OTHER_SECTION_KEY) ? [EXAM_OTHER_SECTION_KEY] : []),
+      ];
+
       return (
-        <Stack spacing={1}>
-          {abnormal.length > 0 ? (
-            <Box>
-              <Typography variant="caption" sx={{ color: 'text.secondary', textTransform: 'uppercase' }}>
-                Abnormal
-              </Typography>
-              <Stack spacing={0.5} sx={{ mt: 0.5 }}>
-                {abnormal.map((f) => (
-                  <Typography key={f.fieldName} variant="body2">
-                    <strong>{f.label}</strong>
-                    {f.note ? `: ${f.note}` : ''}
-                  </Typography>
-                ))}
-              </Stack>
-            </Box>
-          ) : null}
-          {normal.length > 0 ? (
-            <Box>
-              <Typography variant="caption" sx={{ color: 'text.secondary', textTransform: 'uppercase' }}>
-                Normal
-              </Typography>
-              <Stack direction="row" flexWrap="wrap" gap={0.5} sx={{ mt: 0.5 }}>
-                {normal.map((f) => (
-                  <Chip key={f.fieldName} label={f.label} size="small" variant="outlined" />
-                ))}
-              </Stack>
-            </Box>
-          ) : null}
+        <Stack spacing={1.5}>
+          {orderedKeys.map((key) => {
+            const findings = groupedByKey.get(key)!;
+            const label =
+              key === EXAM_OTHER_SECTION_KEY
+                ? 'Other'
+                : EXAM_FIELD_TO_SECTION.get(findings[0].fieldName)?.sectionLabel ?? key;
+            return (
+              <Box key={key}>
+                <Typography variant="caption" sx={{ color: 'text.secondary', textTransform: 'uppercase' }}>
+                  {label}
+                </Typography>
+                <Stack direction="row" flexWrap="wrap" gap={0.5} sx={{ mt: 0.5 }}>
+                  {findings.map((f) => (
+                    <Chip
+                      key={f.fieldName}
+                      label={f.note ? `${f.label}: ${f.note}` : f.label}
+                      size="small"
+                      color={f.isAbnormal ? 'warning' : undefined}
+                      variant={f.isAbnormal ? 'filled' : 'outlined'}
+                    />
+                  ))}
+                </Stack>
+              </Box>
+            );
+          })}
         </Stack>
       );
     }

--- a/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
+++ b/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
@@ -164,11 +164,15 @@ const sectionHasContent = (sections: AdminGetTemplateDetailOutput['sections'], k
   }
 };
 
+// Strip leading/trailing whitespace so section bodies render flush with the top of
+// the collapse area regardless of how a provider entered the template text.
+const stripOuterWhitespace = (s: string): string => s.replace(/^\s+|\s+$/g, '');
+
 const TextBlock: React.FC<{ value: string | null | undefined }> = ({ value }) => {
   if (!value) return null;
   return (
     <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', color: 'text.primary' }}>
-      {value}
+      {stripOuterWhitespace(value)}
     </Typography>
   );
 };
@@ -283,7 +287,7 @@ const SectionPreview: React.FC<{
                 </Typography>
               ) : null}
               <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', color: 'text.primary' }}>
-                {item.text}
+                {stripOuterWhitespace(item.text)}
               </Typography>
             </Box>
           ))}
@@ -386,7 +390,7 @@ const SectionCard: React.FC<{
           <ExpandMoreIcon fontSize="small" />
         </IconButton>
         <Box sx={{ flex: 1, minWidth: 0 }}>
-          <Typography variant="subtitle2" sx={{ fontWeight: 600, lineHeight: 1.3, color: 'primary.dark' }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.3, color: 'primary.dark' }}>
             {descriptor.label}
           </Typography>
           {summary ? (
@@ -450,7 +454,6 @@ export const TemplatePreviewDialog: React.FC<TemplatePreviewDialogProps> = ({
   onApply,
 }) => {
   const { oystehrZambda } = useApiClients();
-  const theme = useTheme();
   const [actions, setActions] = useState<Record<TemplateSectionKey, TemplateSectionAction>>({
     ...TEMPLATE_SECTION_DEFAULT_ACTIONS,
   });
@@ -514,7 +517,7 @@ export const TemplatePreviewDialog: React.FC<TemplatePreviewDialogProps> = ({
         Apply Template: {templateName}
       </DialogTitle>
       <DialogContent>
-        <Typography variant="body2" sx={{ color: theme.palette.text.secondary, mb: 2 }}>
+        <Typography variant="body1" sx={{ color: 'text.primary', mb: 2 }}>
           Review what will be applied and choose how each section should be merged with the current note.
         </Typography>
         {detailQuery.isLoading ? (

--- a/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
+++ b/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
@@ -1,0 +1,441 @@
+import { LoadingButton } from '@mui/lab';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  Skeleton,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
+import React, { useEffect, useMemo, useState } from 'react';
+import { getTemplateDetail } from 'src/api/api';
+import { useApiClients } from 'src/hooks/useAppClients';
+import {
+  AdminGetTemplateDetailOutput,
+  ExamType,
+  RosFindingState,
+  RosFindingStateLabel,
+  TEMPLATE_SECTION_DEFAULT_ACTIONS,
+  TEMPLATE_SECTIONS_NO_APPEND,
+  TemplateSectionAction,
+  TemplateSectionActions,
+  TemplateSectionKey,
+} from 'utils';
+
+interface TemplatePreviewDialogProps {
+  open: boolean;
+  templateId: string | null;
+  templateName: string;
+  examType: ExamType;
+  isApplying: boolean;
+  onCancel: () => void;
+  onApply: (actions: TemplateSectionActions) => void;
+}
+
+interface SectionDescriptor {
+  key: TemplateSectionKey;
+  label: string;
+}
+
+const SECTIONS_IN_ORDER: readonly SectionDescriptor[] = [
+  { key: 'hpi', label: 'HPI (History of Present Illness)' },
+  { key: 'moi', label: 'MOI (Mechanism of Injury)' },
+  { key: 'ros', label: 'Review of Systems (ROS)' },
+  { key: 'examFindings', label: 'Exam Findings' },
+  { key: 'mdm', label: 'Medical Decision Making (MDM)' },
+  { key: 'diagnoses', label: 'Assessment / ICD-10 Diagnoses' },
+  { key: 'patientInstructions', label: 'Patient Instructions' },
+  { key: 'cptCodes', label: 'CPT Codes' },
+  { key: 'emCode', label: 'E&M Code' },
+  { key: 'accident', label: 'Accident' },
+];
+
+const ACTION_LABELS: Record<TemplateSectionAction, string> = {
+  skip: 'Skip',
+  append: 'Append',
+  overwrite: 'Overwrite',
+};
+
+const ACTION_TOOLTIPS: Record<TemplateSectionAction, string> = {
+  skip: "Don't apply this section.",
+  append: 'Keep existing content and add the template content.',
+  overwrite: 'Replace existing content with the template content.',
+};
+
+const sectionHasContent = (sections: AdminGetTemplateDetailOutput['sections'], key: TemplateSectionKey): boolean => {
+  switch (key) {
+    case 'hpi':
+      return Boolean(sections.hpiNote);
+    case 'moi':
+      return Boolean(sections.moiNote);
+    case 'ros':
+      return Boolean(sections.rosNote) || sections.rosFindings.length > 0;
+    case 'examFindings':
+      return sections.examFindings.length > 0;
+    case 'mdm':
+      return Boolean(sections.mdm);
+    case 'diagnoses':
+      return sections.diagnoses.length > 0;
+    case 'patientInstructions':
+      return sections.patientInstructions.length > 0;
+    case 'cptCodes':
+      return sections.cptCodes.length > 0;
+    case 'emCode':
+      return Boolean(sections.emCode);
+    case 'accident':
+      return Boolean(sections.accident);
+    default:
+      return false;
+  }
+};
+
+const TextBlock: React.FC<{ value: string | null | undefined }> = ({ value }) => {
+  if (!value) return null;
+  return (
+    <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', color: 'text.primary' }}>
+      {value}
+    </Typography>
+  );
+};
+
+const CodeList: React.FC<{ items: { code: string; display: string }[] }> = ({ items }) => (
+  <Stack spacing={0.5}>
+    {items.map((item, idx) => (
+      <Typography key={`${item.code}-${idx}`} variant="body2" sx={{ color: 'text.primary' }}>
+        <strong>{item.code}</strong>
+        {item.display ? ` — ${item.display}` : ''}
+      </Typography>
+    ))}
+  </Stack>
+);
+
+const SectionPreview: React.FC<{
+  sectionKey: TemplateSectionKey;
+  sections: AdminGetTemplateDetailOutput['sections'];
+}> = ({ sectionKey, sections }) => {
+  switch (sectionKey) {
+    case 'hpi':
+      return <TextBlock value={sections.hpiNote} />;
+    case 'moi':
+      return <TextBlock value={sections.moiNote} />;
+    case 'ros': {
+      const reported = sections.rosFindings.filter((f) => f.findingState === RosFindingState.Reports);
+      const denied = sections.rosFindings.filter((f) => f.findingState === RosFindingState.Denies);
+      return (
+        <Stack spacing={1}>
+          {sections.rosNote ? (
+            <Box>
+              <Typography variant="caption" sx={{ color: 'text.secondary', textTransform: 'uppercase' }}>
+                Note
+              </Typography>
+              <TextBlock value={sections.rosNote} />
+            </Box>
+          ) : null}
+          {reported.length > 0 ? (
+            <Box>
+              <Typography variant="caption" sx={{ color: 'text.secondary', textTransform: 'uppercase' }}>
+                {RosFindingStateLabel[RosFindingState.Reports]}
+              </Typography>
+              <Stack direction="row" flexWrap="wrap" gap={0.5} sx={{ mt: 0.5 }}>
+                {reported.map((f) => (
+                  <Chip key={f.fieldName} label={f.label} size="small" color="warning" />
+                ))}
+              </Stack>
+            </Box>
+          ) : null}
+          {denied.length > 0 ? (
+            <Box>
+              <Typography variant="caption" sx={{ color: 'text.secondary', textTransform: 'uppercase' }}>
+                {RosFindingStateLabel[RosFindingState.Denies]}
+              </Typography>
+              <Stack direction="row" flexWrap="wrap" gap={0.5} sx={{ mt: 0.5 }}>
+                {denied.map((f) => (
+                  <Chip key={f.fieldName} label={f.label} size="small" variant="outlined" />
+                ))}
+              </Stack>
+            </Box>
+          ) : null}
+        </Stack>
+      );
+    }
+    case 'examFindings': {
+      const abnormal = sections.examFindings.filter((f) => f.isAbnormal);
+      const normal = sections.examFindings.filter((f) => !f.isAbnormal);
+      return (
+        <Stack spacing={1}>
+          {abnormal.length > 0 ? (
+            <Box>
+              <Typography variant="caption" sx={{ color: 'text.secondary', textTransform: 'uppercase' }}>
+                Abnormal
+              </Typography>
+              <Stack spacing={0.5} sx={{ mt: 0.5 }}>
+                {abnormal.map((f) => (
+                  <Typography key={f.fieldName} variant="body2">
+                    <strong>{f.label}</strong>
+                    {f.note ? `: ${f.note}` : ''}
+                  </Typography>
+                ))}
+              </Stack>
+            </Box>
+          ) : null}
+          {normal.length > 0 ? (
+            <Box>
+              <Typography variant="caption" sx={{ color: 'text.secondary', textTransform: 'uppercase' }}>
+                Normal
+              </Typography>
+              <Stack direction="row" flexWrap="wrap" gap={0.5} sx={{ mt: 0.5 }}>
+                {normal.map((f) => (
+                  <Chip key={f.fieldName} label={f.label} size="small" variant="outlined" />
+                ))}
+              </Stack>
+            </Box>
+          ) : null}
+        </Stack>
+      );
+    }
+    case 'mdm':
+      return <TextBlock value={sections.mdm} />;
+    case 'diagnoses':
+      return <CodeList items={sections.diagnoses} />;
+    case 'patientInstructions':
+      return (
+        <Stack spacing={1.5}>
+          {sections.patientInstructions.map((item, idx) => (
+            <Box key={idx}>
+              {item.title ? (
+                <Typography variant="subtitle2" sx={{ color: 'text.primary' }}>
+                  {item.title}
+                </Typography>
+              ) : null}
+              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', color: 'text.primary' }}>
+                {item.text}
+              </Typography>
+            </Box>
+          ))}
+        </Stack>
+      );
+    case 'cptCodes':
+      return <CodeList items={sections.cptCodes} />;
+    case 'emCode':
+      return sections.emCode ? <CodeList items={[sections.emCode]} /> : null;
+    case 'accident': {
+      const accident = sections.accident;
+      if (!accident) return null;
+      const flags: string[] = [];
+      if (accident.autoAccident) flags.push('Auto accident');
+      if (accident.employment) flags.push('Employment');
+      if (accident.otherAccident) flags.push('Other accident');
+      return (
+        <Stack spacing={0.5}>
+          {flags.length > 0 ? (
+            <Typography variant="body2" sx={{ color: 'text.primary' }}>
+              <strong>Type:</strong> {flags.join(', ')}
+            </Typography>
+          ) : null}
+          {accident.date ? (
+            <Typography variant="body2" sx={{ color: 'text.primary' }}>
+              <strong>Date:</strong> {accident.date}
+            </Typography>
+          ) : null}
+          {accident.state ? (
+            <Typography variant="body2" sx={{ color: 'text.primary' }}>
+              <strong>State:</strong> {accident.state}
+            </Typography>
+          ) : null}
+        </Stack>
+      );
+    }
+    default:
+      return null;
+  }
+};
+
+const SectionCard: React.FC<{
+  descriptor: SectionDescriptor;
+  sections: AdminGetTemplateDetailOutput['sections'];
+  action: TemplateSectionAction;
+  onActionChange: (action: TemplateSectionAction) => void;
+  disabled: boolean;
+}> = ({ descriptor, sections, action, onActionChange, disabled }) => {
+  const theme = useTheme();
+  const noAppend = TEMPLATE_SECTIONS_NO_APPEND.has(descriptor.key);
+
+  const previewSx = {
+    opacity: action === 'skip' ? 0.5 : 1,
+    transition: 'opacity 120ms ease-in-out',
+  };
+
+  return (
+    <Box
+      sx={{
+        border: `1px solid ${theme.palette.divider}`,
+        borderRadius: 1,
+        p: 2,
+      }}
+      data-testid={`template-section-${descriptor.key}`}
+    >
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.5 }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+          {descriptor.label}
+        </Typography>
+        <ToggleButtonGroup
+          value={action}
+          exclusive
+          size="small"
+          onChange={(_, next: TemplateSectionAction | null) => {
+            if (next) onActionChange(next);
+          }}
+          disabled={disabled}
+          aria-label={`Action for ${descriptor.label}`}
+        >
+          <ToggleButton value="skip" title={ACTION_TOOLTIPS.skip}>
+            {ACTION_LABELS.skip}
+          </ToggleButton>
+          {noAppend ? null : (
+            <ToggleButton value="append" title={ACTION_TOOLTIPS.append}>
+              {ACTION_LABELS.append}
+            </ToggleButton>
+          )}
+          <ToggleButton value="overwrite" title={ACTION_TOOLTIPS.overwrite}>
+            {ACTION_LABELS.overwrite}
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Stack>
+      <Box sx={previewSx}>
+        <SectionPreview sectionKey={descriptor.key} sections={sections} />
+      </Box>
+    </Box>
+  );
+};
+
+export const TemplatePreviewDialog: React.FC<TemplatePreviewDialogProps> = ({
+  open,
+  templateId,
+  templateName,
+  isApplying,
+  onCancel,
+  onApply,
+}) => {
+  const { oystehrZambda } = useApiClients();
+  const theme = useTheme();
+  const [actions, setActions] = useState<Record<TemplateSectionKey, TemplateSectionAction>>({
+    ...TEMPLATE_SECTION_DEFAULT_ACTIONS,
+  });
+
+  const detailQuery = useQuery({
+    queryKey: ['admin-get-template-detail', templateId],
+    enabled: open && !!templateId && !!oystehrZambda,
+    queryFn: async () => {
+      if (!oystehrZambda || !templateId) throw new Error('API client or templateId not available');
+      return getTemplateDetail(oystehrZambda, { templateId });
+    },
+  });
+
+  useEffect(() => {
+    if (open) {
+      setActions({ ...TEMPLATE_SECTION_DEFAULT_ACTIONS });
+    }
+  }, [open, templateId]);
+
+  const sectionsWithContent = useMemo(() => {
+    if (!detailQuery.data) return [];
+    return SECTIONS_IN_ORDER.filter((s) => sectionHasContent(detailQuery.data.sections, s.key));
+  }, [detailQuery.data]);
+
+  const handleActionChange = (key: TemplateSectionKey, action: TemplateSectionAction): void => {
+    setActions((prev) => ({ ...prev, [key]: action }));
+  };
+
+  const handleApply = (): void => {
+    // Only send actions for sections the template actually has content for.
+    // Skipping a section the template doesn't carry is a no-op and would clutter the payload.
+    const payload: TemplateSectionActions = {};
+    for (const section of sectionsWithContent) {
+      payload[section.key] = actions[section.key];
+    }
+    onApply(payload);
+  };
+
+  const buttonSx = {
+    fontWeight: 500,
+    textTransform: 'none',
+    borderRadius: 6,
+  };
+
+  const allSkipped = sectionsWithContent.length > 0 && sectionsWithContent.every((s) => actions[s.key] === 'skip');
+
+  return (
+    <Dialog
+      open={open}
+      onClose={isApplying ? undefined : onCancel}
+      disableScrollLock
+      maxWidth="md"
+      fullWidth
+      sx={{
+        '.MuiPaper-root': {
+          padding: 2,
+        },
+      }}
+    >
+      <DialogTitle variant="h4" color="primary.dark">
+        Apply Template: {templateName}
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" sx={{ color: theme.palette.text.secondary, mb: 2 }}>
+          Review what will be applied and choose how each section should be merged with the current note.
+        </Typography>
+        {detailQuery.isLoading ? (
+          <Stack spacing={2}>
+            {[0, 1, 2].map((i) => (
+              <Skeleton key={i} variant="rectangular" height={120} />
+            ))}
+          </Stack>
+        ) : detailQuery.error ? (
+          <Alert severity="error">
+            Failed to load template preview: {(detailQuery.error as Error).message ?? 'Unknown error'}
+          </Alert>
+        ) : sectionsWithContent.length === 0 ? (
+          <Alert severity="info">This template is empty — nothing to apply.</Alert>
+        ) : (
+          <Stack spacing={2} divider={<Divider flexItem />}>
+            {sectionsWithContent.map((section) => (
+              <SectionCard
+                key={section.key}
+                descriptor={section}
+                sections={detailQuery.data!.sections}
+                action={actions[section.key]}
+                onActionChange={(next) => handleActionChange(section.key, next)}
+                disabled={isApplying}
+              />
+            ))}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ justifyContent: 'space-between', px: 3 }}>
+        <Button variant="outlined" onClick={onCancel} size="medium" sx={buttonSx} disabled={isApplying}>
+          Cancel
+        </Button>
+        <LoadingButton
+          variant="contained"
+          onClick={handleApply}
+          size="medium"
+          sx={buttonSx}
+          loading={isApplying}
+          disabled={detailQuery.isLoading || !!detailQuery.error || sectionsWithContent.length === 0 || allSkipped}
+        >
+          Apply Template
+        </LoadingButton>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
+++ b/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
@@ -5,13 +5,13 @@ import {
   Box,
   Button,
   Chip,
+  CircularProgress,
   Collapse,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   IconButton,
-  Skeleton,
   Stack,
   ToggleButtonGroup,
   Typography,
@@ -518,11 +518,9 @@ export const TemplatePreviewDialog: React.FC<TemplatePreviewDialogProps> = ({
           Review what will be applied and choose how each section should be merged with the current note.
         </Typography>
         {detailQuery.isLoading ? (
-          <Stack spacing={2}>
-            {[0, 1, 2].map((i) => (
-              <Skeleton key={i} variant="rectangular" height={120} />
-            ))}
-          </Stack>
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 6 }}>
+            <CircularProgress size={32} />
+          </Box>
         ) : detailQuery.error ? (
           <Alert severity="error">
             Failed to load template preview: {(detailQuery.error as Error).message ?? 'Unknown error'}

--- a/apps/ehr/tests/component/ApplyTemplate.test.tsx
+++ b/apps/ehr/tests/component/ApplyTemplate.test.tsx
@@ -112,8 +112,8 @@ const mockTemplateDetail = {
     rosNote: 'Negative except as documented.',
     rosFindings: [],
     examFindings: [
-      { fieldName: 'throat-erythema', label: 'Throat erythema', isAbnormal: true, note: 'Marked redness' },
-      { fieldName: 'lungs-clear', label: 'Lungs clear', isAbnormal: false, note: '' },
+      { fieldName: 'tender', label: 'Tender', isAbnormal: true, note: 'RLQ' },
+      { fieldName: 'soft', label: 'Soft', isAbnormal: false, note: '' },
     ],
     mdm: 'Streptococcal pharyngitis suspected.',
     diagnoses: [{ code: 'J02.9', display: 'Acute pharyngitis, unspecified' }],
@@ -488,14 +488,18 @@ describe('ApplyTemplate', () => {
     // Summary is rendered in the header
     expect(within(examCard).getByText('1 abnormal, 1 normal')).toBeInTheDocument();
     // Body contents are NOT in the DOM while collapsed (Collapse uses unmountOnExit)
-    expect(within(examCard).queryByText('Throat erythema')).toBeNull();
+    expect(within(examCard).queryByText('Abdomen')).toBeNull();
 
     // Click the section label to expand
     await user.click(within(examCard).getByText('Exam Findings'));
 
     await waitFor(() => {
-      expect(within(examCard).getByText('Throat erythema')).toBeInTheDocument();
+      // Body-system grouping renders the section header
+      expect(within(examCard).getByText('Abdomen')).toBeInTheDocument();
     });
+    // And the chips appear underneath the header
+    expect(within(examCard).getByText('Tender: RLQ')).toBeInTheDocument();
+    expect(within(examCard).getByText('Soft')).toBeInTheDocument();
   });
 
   it('should disable Apply when every section is set to Skip', async () => {

--- a/apps/ehr/tests/component/ApplyTemplate.test.tsx
+++ b/apps/ehr/tests/component/ApplyTemplate.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReactNode } from 'react';
 import { BrowserRouter } from 'react-router-dom';
@@ -21,12 +21,14 @@ const mockCreateTemplate = vi.fn();
 const mockDeleteTemplate = vi.fn();
 const mockApplyTemplate = vi.fn();
 const mockListTemplates = vi.fn();
+const mockGetTemplateDetail = vi.fn();
 
 vi.mock('src/api/api', () => ({
   createTemplate: (...args: any[]) => mockCreateTemplate(...args),
   deleteTemplate: (...args: any[]) => mockDeleteTemplate(...args),
   applyTemplate: (...args: any[]) => mockApplyTemplate(...args),
   listTemplates: (...args: any[]) => mockListTemplates(...args),
+  getTemplateDetail: (...args: any[]) => mockGetTemplateDetail(...args),
 }));
 
 const mockOystehrZambda = { zambda: { execute: vi.fn() } };
@@ -75,6 +77,12 @@ vi.mock('src/hooks/useEvolveUser', () => ({
   }),
 }));
 
+const mockResetRosObservationsStore = vi.fn();
+
+vi.mock('../../src/features/visits/shared/stores/appointment/reset-ros-observations', () => ({
+  resetRosObservationsStore: (...args: any[]) => mockResetRosObservationsStore(...args),
+}));
+
 // ============================================================================
 // IMPORTS (must come after vi.mock calls)
 // ============================================================================
@@ -91,6 +99,29 @@ const mockTemplatesData = {
     { title: 'Ear Infection', id: 'template-2' },
     { title: 'Well Child Visit', id: 'template-3' },
   ],
+};
+
+const mockTemplateDetail = {
+  templateName: 'Sore Throat',
+  templateId: 'template-1',
+  examVersion: '2025-09-25',
+  isCurrentVersion: true,
+  sections: {
+    hpiNote: 'Patient reports sore throat for 3 days.',
+    moiNote: null,
+    rosNote: 'Negative except as documented.',
+    rosFindings: [],
+    examFindings: [
+      { fieldName: 'throat-erythema', label: 'Throat erythema', isAbnormal: true, note: 'Marked redness' },
+      { fieldName: 'lungs-clear', label: 'Lungs clear', isAbnormal: false, note: '' },
+    ],
+    mdm: 'Streptococcal pharyngitis suspected.',
+    diagnoses: [{ code: 'J02.9', display: 'Acute pharyngitis, unspecified' }],
+    patientInstructions: [{ title: 'Hydration', text: 'Drink plenty of fluids.' }],
+    cptCodes: [{ code: '99213', display: 'Office visit' }],
+    emCode: { code: '99213', display: 'Office visit' },
+    accident: null,
+  },
 };
 
 const createWrapper = () => {
@@ -120,6 +151,7 @@ describe('ApplyTemplate', () => {
     mockCreateTemplate.mockResolvedValue({ templateName: 'New Template', templateId: 'new-id' });
     mockDeleteTemplate.mockResolvedValue({ message: 'Deleted' });
     mockApplyTemplate.mockResolvedValue({ message: 'Applied' });
+    mockGetTemplateDetail.mockResolvedValue(mockTemplateDetail);
   });
 
   it('should render the template select autocomplete', async () => {
@@ -326,7 +358,7 @@ describe('ApplyTemplate', () => {
     });
   });
 
-  it('should show apply confirmation dialog when selecting a regular template', async () => {
+  it('should open the preview dialog with section cards when selecting a regular template', async () => {
     const user = userEvent.setup();
     render(<ApplyTemplate />, { wrapper: createWrapper() });
 
@@ -344,13 +376,21 @@ describe('ApplyTemplate', () => {
     await user.click(screen.getByText('Sore Throat'));
 
     await waitFor(() => {
-      expect(screen.getByText(/Are you sure you want to apply/)).toBeInTheDocument();
-      // Dialog title and confirm button both say "Apply Template"
-      expect(screen.getAllByText('Apply Template').length).toBeGreaterThanOrEqual(2);
+      expect(screen.getByText('Apply Template: Sore Throat')).toBeInTheDocument();
+      expect(screen.getByText(/Review what will be applied/)).toBeInTheDocument();
     });
+
+    // Only sections with content in the fixture should render. moiNote is null, accident is null.
+    await waitFor(() => {
+      expect(screen.getByTestId('template-section-hpi')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('template-section-mdm')).toBeInTheDocument();
+    expect(screen.getByTestId('template-section-examFindings')).toBeInTheDocument();
+    expect(screen.queryByTestId('template-section-moi')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('template-section-accident')).not.toBeInTheDocument();
   });
 
-  it('should call applyTemplate when confirming apply', async () => {
+  it('should send default actions to applyTemplate when applied without changes', async () => {
     const user = userEvent.setup();
     render(<ApplyTemplate />, { wrapper: createWrapper() });
 
@@ -358,23 +398,18 @@ describe('ApplyTemplate', () => {
       expect(screen.getByLabelText('Select condition')).toBeInTheDocument();
     });
 
-    const autocomplete = screen.getByLabelText('Select condition');
-    await user.click(autocomplete);
-
+    await user.click(screen.getByLabelText('Select condition'));
     await waitFor(() => {
       expect(screen.getByText('Sore Throat')).toBeInTheDocument();
     });
-
     await user.click(screen.getByText('Sore Throat'));
 
     await waitFor(() => {
-      expect(screen.getByText(/Are you sure you want to apply/)).toBeInTheDocument();
+      expect(screen.getByTestId('template-section-hpi')).toBeInTheDocument();
     });
 
-    // Click the "Apply Template" button in the dialog (the second one, in DialogActions)
-    const applyButtons = screen.getAllByText('Apply Template');
-    const confirmButton = applyButtons[applyButtons.length - 1];
-    await user.click(confirmButton);
+    const applyButton = screen.getByRole('button', { name: 'Apply Template' });
+    await user.click(applyButton);
 
     await waitFor(() => {
       expect(mockApplyTemplate).toHaveBeenCalledWith(
@@ -383,9 +418,91 @@ describe('ApplyTemplate', () => {
           encounterId: 'test-encounter-id',
           templateName: 'Sore Throat',
           examType: 'inPerson',
+          sectionActions: {
+            hpi: 'append',
+            ros: 'append',
+            examFindings: 'overwrite',
+            mdm: 'overwrite',
+            diagnoses: 'append',
+            patientInstructions: 'overwrite',
+            cptCodes: 'append',
+            emCode: 'overwrite',
+          },
         })
       );
     });
+  });
+
+  it('should not render an Append button for sections that disallow it', async () => {
+    const user = userEvent.setup();
+    render(<ApplyTemplate />, { wrapper: createWrapper() });
+
+    await user.click(await screen.findByLabelText('Select condition'));
+    await user.click(await screen.findByText('Sore Throat'));
+
+    const examCard = await screen.findByTestId('template-section-examFindings');
+    expect(within(examCard).queryByRole('button', { name: 'Append' })).toBeNull();
+    expect(within(examCard).getByRole('button', { name: 'Skip' })).toBeInTheDocument();
+    expect(within(examCard).getByRole('button', { name: 'Overwrite' })).toBeInTheDocument();
+
+    const emCard = screen.getByTestId('template-section-emCode');
+    expect(within(emCard).queryByRole('button', { name: 'Append' })).toBeNull();
+  });
+
+  it('should forward the user-selected per-section actions to applyTemplate', async () => {
+    const user = userEvent.setup();
+    render(<ApplyTemplate />, { wrapper: createWrapper() });
+
+    await user.click(await screen.findByLabelText('Select condition'));
+    await user.click(await screen.findByText('Sore Throat'));
+
+    const mdmCard = await screen.findByTestId('template-section-mdm');
+    await user.click(within(mdmCard).getByRole('button', { name: 'Skip' }));
+
+    const hpiCard = screen.getByTestId('template-section-hpi');
+    await user.click(within(hpiCard).getByRole('button', { name: 'Overwrite' }));
+
+    await user.click(screen.getByRole('button', { name: 'Apply Template' }));
+
+    await waitFor(() => {
+      expect(mockApplyTemplate).toHaveBeenCalledWith(
+        mockOystehrZambda,
+        expect.objectContaining({
+          sectionActions: expect.objectContaining({
+            mdm: 'skip',
+            hpi: 'overwrite',
+          }),
+        })
+      );
+    });
+  });
+
+  it('should disable Apply when every section is set to Skip', async () => {
+    const user = userEvent.setup();
+    mockGetTemplateDetail.mockResolvedValue({
+      ...mockTemplateDetail,
+      sections: {
+        ...mockTemplateDetail.sections,
+        rosNote: null,
+        examFindings: [],
+        diagnoses: [],
+        patientInstructions: [],
+        cptCodes: [],
+        emCode: null,
+        mdm: null,
+        // Only HPI has content.
+      },
+    });
+    render(<ApplyTemplate />, { wrapper: createWrapper() });
+
+    await user.click(await screen.findByLabelText('Select condition'));
+    await user.click(await screen.findByText('Sore Throat'));
+
+    const hpiCard = await screen.findByTestId('template-section-hpi');
+    await user.click(within(hpiCard).getByRole('button', { name: 'Skip' }));
+
+    const applyButton = screen.getByRole('button', { name: 'Apply Template' });
+    expect(applyButton).toBeDisabled();
   });
 
   it('should disable autocomplete when in read-only mode', async () => {

--- a/apps/ehr/tests/component/ApplyTemplate.test.tsx
+++ b/apps/ehr/tests/component/ApplyTemplate.test.tsx
@@ -477,6 +477,27 @@ describe('ApplyTemplate', () => {
     });
   });
 
+  it('should render sections collapsed by default with a summary, expanding on click', async () => {
+    const user = userEvent.setup();
+    render(<ApplyTemplate />, { wrapper: createWrapper() });
+
+    await user.click(await screen.findByLabelText('Select condition'));
+    await user.click(await screen.findByText('Sore Throat'));
+
+    const examCard = await screen.findByTestId('template-section-examFindings');
+    // Summary is rendered in the header
+    expect(within(examCard).getByText('1 abnormal, 1 normal')).toBeInTheDocument();
+    // Body contents are NOT in the DOM while collapsed (Collapse uses unmountOnExit)
+    expect(within(examCard).queryByText('Throat erythema')).toBeNull();
+
+    // Click the section label to expand
+    await user.click(within(examCard).getByText('Exam Findings'));
+
+    await waitFor(() => {
+      expect(within(examCard).getByText('Throat erythema')).toBeInTheDocument();
+    });
+  });
+
   it('should disable Apply when every section is set to Skip', async () => {
     const user = userEvent.setup();
     mockGetTemplateDetail.mockResolvedValue({

--- a/packages/utils/lib/config-helpers/exam-observations.ts
+++ b/packages/utils/lib/config-helpers/exam-observations.ts
@@ -196,6 +196,49 @@ export function collectKnownExamFields(examConfig: ExamItemConfig): Set<string> 
   return knownFields;
 }
 
+export interface ExamFieldSectionInfo {
+  sectionKey: string;
+  sectionLabel: string;
+}
+
+// Walks the exam config and produces a map from every component field name (the keys
+// stored in chart data) to the section it belongs to. The preview UI uses this to
+// group exam findings under their body-system header so a chip like "Soft" is
+// rendered under "Abdomen" instead of floating without context.
+export function buildExamFieldToSectionMap(examConfig: ExamItemConfig): Map<string, ExamFieldSectionInfo> {
+  const map = new Map<string, ExamFieldSectionInfo>();
+
+  const walk = (components: Record<string, ExamCardComponent>, sectionKey: string, sectionLabel: string): void => {
+    Object.entries(components).forEach(([key, component]) => {
+      if (component.type === 'checkbox' || component.type === 'checkbox-with-modal' || component.type === 'text') {
+        map.set(key, { sectionKey, sectionLabel });
+      } else if (component.type === 'dropdown') {
+        map.set(key, { sectionKey, sectionLabel });
+        if (isDropdownComponent(component)) {
+          Object.keys(component.components).forEach((k) => map.set(k, { sectionKey, sectionLabel }));
+        }
+      } else if (component.type === 'column') {
+        walk(component.components, sectionKey, sectionLabel);
+      } else if (component.type === 'multi-select') {
+        map.set(key, { sectionKey, sectionLabel });
+        if (isMultiSelectComponent(component)) {
+          Object.keys(component.options).forEach((k) => map.set(k, { sectionKey, sectionLabel }));
+        }
+      } else if (component.type === 'form') {
+        Object.keys(component.components).forEach((k) => map.set(k, { sectionKey, sectionLabel }));
+      }
+    });
+  };
+
+  Object.entries(examConfig).forEach(([sectionKey, section]) => {
+    walk(section.components.normal, sectionKey, section.label);
+    walk(section.components.abnormal, sectionKey, section.label);
+    Object.keys(section.components.comment).forEach((k) => map.set(k, { sectionKey, sectionLabel: section.label }));
+  });
+
+  return map;
+}
+
 // helpers for formatting labels for checkbox-with-modal
 function groupComponents(
   components: ExamObservationComponentDTO[],

--- a/packages/utils/lib/ottehr-config/examination/index.ts
+++ b/packages/utils/lib/ottehr-config/examination/index.ts
@@ -2,6 +2,8 @@ import { createSimpleHash, validateExamConfig } from '../../config-helpers/exami
 import { InPersonExamConfig, NORMAL_LABELS } from './in-person.config';
 import { TelemedExamConfig } from './telemed.config';
 
+export { InPersonExamConfig, NORMAL_LABELS, TelemedExamConfig };
+
 export const ExamConfig = {
   telemed: {
     default: {

--- a/packages/utils/lib/types/data/apply-template.types.ts
+++ b/packages/utils/lib/types/data/apply-template.types.ts
@@ -1,9 +1,45 @@
 import { ExamType } from '../../ottehr-config/examination';
 
+export type TemplateSectionAction = 'skip' | 'overwrite' | 'append';
+
+export type TemplateSectionKey =
+  | 'hpi'
+  | 'moi'
+  | 'ros'
+  | 'examFindings'
+  | 'mdm'
+  | 'diagnoses'
+  | 'patientInstructions'
+  | 'cptCodes'
+  | 'emCode'
+  | 'accident';
+
+export type TemplateSectionActions = Partial<Record<TemplateSectionKey, TemplateSectionAction>>;
+
+export const TEMPLATE_SECTION_DEFAULT_ACTIONS: Record<TemplateSectionKey, TemplateSectionAction> = {
+  hpi: 'append',
+  moi: 'append',
+  ros: 'append',
+  examFindings: 'overwrite',
+  mdm: 'overwrite',
+  diagnoses: 'append',
+  patientInstructions: 'overwrite',
+  cptCodes: 'append',
+  emCode: 'overwrite',
+  accident: 'overwrite',
+};
+
+export const TEMPLATE_SECTIONS_NO_APPEND: ReadonlySet<TemplateSectionKey> = new Set<TemplateSectionKey>([
+  'examFindings',
+  'emCode',
+  'accident',
+]);
+
 export interface ApplyTemplateZambdaInput {
   encounterId: string;
   examType: ExamType;
   templateName: string;
+  sectionActions?: TemplateSectionActions;
 }
 
 export type ApplyTemplateZambdaOutput = void;

--- a/packages/zambdas/src/ehr/apply-template/index.ts
+++ b/packages/zambdas/src/ehr/apply-template/index.ts
@@ -13,6 +13,10 @@ import {
   chunkThings,
   GLOBAL_TEMPLATE_META_TAG_CODE_SYSTEM,
   ICD_10_CODE_SYSTEM,
+  TEMPLATE_SECTION_DEFAULT_ACTIONS,
+  TemplateSectionAction,
+  TemplateSectionActions,
+  TemplateSectionKey,
 } from 'utils';
 import { v4 as uuidV4 } from 'uuid';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
@@ -23,6 +27,8 @@ interface ComplexValidationOutput {
   templateList: List;
   encounter: Encounter;
 }
+
+type ResolvedSectionActions = Record<TemplateSectionKey, TemplateSectionAction>;
 
 // Lifting up value to outside of the handler allows it to stay in memory across warm lambda invocations
 let m2mToken: string;
@@ -95,13 +101,43 @@ const complexValidation = async (
   return { templateList: templateLists[0], encounter };
 };
 
+const resolveSectionActions = (input?: TemplateSectionActions): ResolvedSectionActions => {
+  return { ...TEMPLATE_SECTION_DEFAULT_ACTIONS, ...(input ?? {}) };
+};
+
+const hasTagSystem = (resource: FhirResource, system: string): boolean =>
+  resource.meta?.tag?.some((t) => t.system === system) ?? false;
+
+// Maps an existing chart-data resource on the encounter (or a contained template resource)
+// to the template section it belongs to. Returns null if it doesn't map to a managed section.
+const getSectionForResource = (resource: FhirResource): TemplateSectionKey | null => {
+  if (hasTagSystem(resource, chartDataTagSystem('chief-complaint'))) return 'hpi';
+  if (hasTagSystem(resource, chartDataTagSystem('mechanism-of-injury'))) return 'moi';
+  if (hasTagSystem(resource, chartDataTagSystem('ros'))) return 'ros';
+  if (hasTagSystem(resource, chartDataTagSystem('ros-observation-field'))) return 'ros';
+  if (hasTagSystem(resource, chartDataTagSystem('exam-observation-field'))) return 'examFindings';
+  if (hasTagSystem(resource, chartDataTagSystem('medical-decision'))) return 'mdm';
+  if (hasTagSystem(resource, chartDataTagSystem('patient-instruction'))) return 'patientInstructions';
+  if (hasTagSystem(resource, chartDataTagSystem('em-code'))) return 'emCode';
+  if (hasTagSystem(resource, chartDataTagSystem('cpt-code'))) return 'cptCodes';
+  if (hasTagSystem(resource, chartDataTagSystem('accident'))) return 'accident';
+  if (
+    resource.resourceType === 'Condition' &&
+    (resource as Condition).code?.coding?.some((c) => c.system === ICD_10_CODE_SYSTEM)
+  ) {
+    return 'diagnoses';
+  }
+  return null;
+};
+
 const performEffect = async (
   validatedInput: ApplyTemplateZambdaInput & Pick<ZambdaInput, 'secrets'>,
   templateList: List,
   encounter: Encounter,
   oystehr: Oystehr
 ): Promise<void> => {
-  const { encounterId } = validatedInput;
+  const { encounterId, sectionActions } = validatedInput;
+  const actions = resolveSectionActions(sectionActions);
 
   const encounterBundle = (
     await oystehr.fhir.search({
@@ -117,14 +153,14 @@ const performEffect = async (
     })
   ).unbundle();
   // Make 1 transaction to delete old resources that are being replaced and write the new ones
-  const deleteRequests = await makeDeleteRequests(encounterBundle);
+  const deleteRequests = makeDeleteRequests(encounterBundle, actions);
   const deleteBatches = chunkThings(deleteRequests, 5).map((chunk) =>
     oystehr.fhir.batch({
       requests: chunk,
     })
   );
 
-  const createRequests = makeCreateRequests(encounter, templateList, encounterBundle);
+  const createRequests = makeCreateRequests(encounter, templateList, encounterBundle, actions);
 
   const miniTransactionRequests = createRequests.filter((request) => {
     if (request.method === 'POST') {
@@ -171,38 +207,51 @@ const performEffect = async (
   ]);
 
   console.log('Outcome bundles, ', JSON.stringify(bundles));
-
-  // TODO when we can do it all in one transaction, then do it all in one transaction.
-  // const transactionBundle = await oystehr.fhir.transaction({
-  //   requests: [...deleteRequests, ...createRequests],
-  // });
-
-  // console.log('Transaction Bundle:', transactionBundle);
 };
 
-const makeDeleteRequests = async (encounterBundle: FhirResource[]): Promise<BatchInputDeleteRequest[]> => {
-  const deleteResourcesRequests: BatchInputDeleteRequest[] = [];
+// Decide whether an existing chart-data resource on the encounter should be deleted
+// based on the action the user picked for its section.
+//
+// Section actions and their delete semantics:
+// - skip:      never delete
+// - overwrite: always delete existing
+// - append (text-only sections HPI/ROS-note/MDM): do NOT delete; we PATCH the text instead
+// - append (MOI): DO delete; we recreate with the concatenated text
+// - append (ROS findings observations): DO delete; ROS append overwrites the structured findings
+// - append (list-style sections: diagnoses, patient instructions, CPT codes): do NOT delete; new items are added
+const shouldDeleteExistingResource = (resource: FhirResource, action: TemplateSectionAction): boolean => {
+  if (action === 'skip') return false;
+  if (action === 'overwrite') return true;
 
-  const resourcesToDelete = encounterBundle.filter(
-    (resource) =>
-      resource.meta?.tag?.some(
-        (tag) =>
-          tag.system === chartDataTagSystem('exam-observation-field') ||
-          tag.system === chartDataTagSystem('ros-observation-field') ||
-          tag.system === chartDataTagSystem('medical-decision') ||
-          tag.system === chartDataTagSystem('patient-instruction') ||
-          // E&M code is replaced (one per visit); CPT codes are additive (like ICD diagnoses)
-          tag.system === chartDataTagSystem('em-code') ||
-          tag.system === chartDataTagSystem('mechanism-of-injury')
-        // tag.system === chartDataTagSystem('chief-complaint')
-      )
-  );
+  // action === 'append'
+  if (hasTagSystem(resource, chartDataTagSystem('chief-complaint'))) return false;
+  if (hasTagSystem(resource, chartDataTagSystem('ros')) && resource.resourceType === 'Condition') return false;
+  if (hasTagSystem(resource, chartDataTagSystem('medical-decision'))) return false;
 
-  deleteResourcesRequests.push(
-    ...resourcesToDelete.map((resource) => makeDeleteResourceRequest(resource.resourceType, resource.id!)) // we just fetched these so they definitely have id
-  );
+  const section = getSectionForResource(resource);
+  if (section === 'diagnoses' || section === 'patientInstructions' || section === 'cptCodes') return false;
 
-  return deleteResourcesRequests;
+  // Fall-through (MOI Condition, ROS observations): delete and recreate.
+  return true;
+};
+
+const makeDeleteRequests = (
+  encounterBundle: FhirResource[],
+  actions: ResolvedSectionActions
+): BatchInputDeleteRequest[] => {
+  const deleteRequests: BatchInputDeleteRequest[] = [];
+
+  for (const resource of encounterBundle) {
+    if (!resource.id) continue;
+    const section = getSectionForResource(resource);
+    if (!section) continue;
+    const action = actions[section];
+    if (shouldDeleteExistingResource(resource, action)) {
+      deleteRequests.push(makeDeleteResourceRequest(resource.resourceType, resource.id));
+    }
+  }
+
+  return deleteRequests;
 };
 
 const makeDeleteResourceRequest = (resourceType: string, id: string): BatchInputDeleteRequest => ({
@@ -213,7 +262,8 @@ const makeDeleteResourceRequest = (resourceType: string, id: string): BatchInput
 const makeCreateRequests = (
   encounter: Encounter,
   templateList: List,
-  encounterBundle: FhirResource[]
+  encounterBundle: FhirResource[],
+  actions: ResolvedSectionActions
 ): Array<
   | BatchInputPostRequest<Observation | ClinicalImpression | Condition | Communication | Procedure>
   | BatchInputJSONPatchRequest
@@ -228,30 +278,45 @@ const makeCreateRequests = (
     return createResourcesRequests;
   }
 
-  const encounterDiagnoses = encounter.diagnosis ?? [];
-  // If there's a 'rank' on the diagnosis, remove it. We use rank: 1 to indicate the 'primary diagnosis'.
-  encounterDiagnoses.forEach((d) => {
-    if (d.rank) {
-      delete d.rank;
+  // Decide what to do with encounter.diagnosis based on the diagnoses action.
+  // - skip:      leave it untouched (encounterDiagnoses stays null)
+  // - append:    start from existing (drop primary-diagnosis ranks), template entries get pushed in
+  // - overwrite: start from empty
+  let encounterDiagnoses: NonNullable<Encounter['diagnosis']> | null = null;
+  if (actions.diagnoses !== 'skip') {
+    if (actions.diagnoses === 'overwrite') {
+      encounterDiagnoses = [];
+    } else {
+      encounterDiagnoses = (encounter.diagnosis ?? []).map((d) => {
+        const { rank: _rank, ...rest } = d;
+        return rest;
+      });
     }
-  });
+  }
 
-  // We will patch the HPI to append content if it already exists.
-  const existingHpiCondition = encounterBundle.find(
-    (resource) => resource.meta?.tag?.some((tag) => tag.system === chartDataTagSystem('chief-complaint'))
-  );
+  // Existing resources we may patch instead of recreate (HPI, ROS note, MDM).
+  const existingHpiCondition = encounterBundle.find((r) => hasTagSystem(r, chartDataTagSystem('chief-complaint'))) as
+    | Condition
+    | undefined;
 
-  const existingMoiCondition = encounterBundle.find(
-    (resource) => resource.meta?.tag?.some((tag) => tag.system === chartDataTagSystem('mechanism-of-injury'))
-  );
+  const existingMoiCondition = encounterBundle.find((r) =>
+    hasTagSystem(r, chartDataTagSystem('mechanism-of-injury'))
+  ) as Condition | undefined;
 
   const existingRosCondition = encounterBundle.find(
-    (resource) => resource.meta?.tag?.some((tag) => tag.system === chartDataTagSystem('ros'))
-  );
+    (r) => hasTagSystem(r, chartDataTagSystem('ros')) && r.resourceType === 'Condition'
+  ) as Condition | undefined;
 
-  const templateEncounter = templateList.contained?.find((r) => r.resourceType === 'Encounter');
+  const existingMdm = encounterBundle.find((r) => hasTagSystem(r, chartDataTagSystem('medical-decision'))) as
+    | ClinicalImpression
+    | undefined;
+
+  const templateEncounter = templateList.contained?.find((r) => r.resourceType === 'Encounter') as
+    | Encounter
+    | undefined;
   const templateEncounterDiagnoses = templateEncounter?.diagnosis;
   const templateEncounterExtensions = templateEncounter?.extension ?? [];
+
   let templateHpiCondition: Condition | undefined;
   let templateRosCondition: Condition | undefined;
   let moiHandled = false;
@@ -264,25 +329,50 @@ const makeCreateRequests = (
       continue;
     }
 
-    // For Chief Complaint, if there is an existing HPI Condition, instead of creating, we will patch so skip.
+    const section = getSectionForResource(containedResource);
+    if (!section) {
+      // Unknown contained resource — not managed by any section, skip.
+      continue;
+    }
+    const action = actions[section];
+    if (action === 'skip') continue;
+
+    // For Chief Complaint on append: if an existing HPI Condition exists, patch it instead of creating.
     if (
-      containedResource.meta?.tag?.some((tag) => tag.system === chartDataTagSystem('chief-complaint')) &&
+      action === 'append' &&
+      hasTagSystem(containedResource, chartDataTagSystem('chief-complaint')) &&
       existingHpiCondition
     ) {
       templateHpiCondition = containedResource as Condition;
       continue;
     }
 
-    if (containedResource.meta?.tag?.some((tag) => tag.system === chartDataTagSystem('ros')) && existingRosCondition) {
+    // For ROS Condition on append: if an existing ROS Condition exists, patch it instead of creating.
+    if (
+      action === 'append' &&
+      hasTagSystem(containedResource, chartDataTagSystem('ros')) &&
+      containedResource.resourceType === 'Condition' &&
+      existingRosCondition
+    ) {
       templateRosCondition = containedResource as Condition;
       continue;
     }
 
     // Skip duplicate MOI Conditions from the template (only the first one is used)
-    if (
-      containedResource.meta?.tag?.some((tag) => tag.system === chartDataTagSystem('mechanism-of-injury')) &&
-      moiHandled
-    ) {
+    if (hasTagSystem(containedResource, chartDataTagSystem('mechanism-of-injury')) && moiHandled) {
+      continue;
+    }
+
+    // For MDM on append: if an existing MDM ClinicalImpression exists, patch its summary instead of creating.
+    if (action === 'append' && hasTagSystem(containedResource, chartDataTagSystem('medical-decision')) && existingMdm) {
+      const existingSummary = existingMdm.summary ?? '';
+      const templateSummary = (containedResource as ClinicalImpression).summary ?? '';
+      const combined = existingSummary ? `${existingSummary}\n\n${templateSummary}` : templateSummary;
+      createResourcesRequests.push({
+        method: 'PATCH',
+        url: `ClinicalImpression/${existingMdm.id}`,
+        operations: [{ op: 'replace', path: '/summary', value: combined }],
+      });
       continue;
     }
 
@@ -311,7 +401,8 @@ const makeCreateRequests = (
     // For Condition resources that are ICD-10 codes, we need to update the Encounter.diagnosis references
     if (
       resourceToCreate.resourceType === 'Condition' &&
-      resourceToCreate.code?.coding?.find((c) => c.system === ICD_10_CODE_SYSTEM)
+      resourceToCreate.code?.coding?.find((c) => c.system === ICD_10_CODE_SYSTEM) &&
+      encounterDiagnoses !== null
     ) {
       const diagnosisToAdd = templateEncounterDiagnoses?.find((d) => {
         return d.condition.reference?.split('/')[1] === containedResource.id;
@@ -322,19 +413,23 @@ const makeCreateRequests = (
       });
     }
 
-    // For MOI, append existing text to the template text (existing MOI Conditions are deleted separately)
+    // For MOI on append: concatenate existing text into the template text before creating.
+    // (The existing MOI Condition is deleted separately by makeDeleteRequests.)
     if (
+      action === 'append' &&
       resourceToCreate.resourceType === 'Condition' &&
-      resourceToCreate.meta?.tag?.some((t) => t.system === chartDataTagSystem('mechanism-of-injury'))
+      hasTagSystem(resourceToCreate, chartDataTagSystem('mechanism-of-injury'))
     ) {
       moiHandled = true;
       if (existingMoiCondition) {
-        const existingText = (existingMoiCondition as Condition).note?.[0]?.text;
+        const existingText = existingMoiCondition.note?.[0]?.text;
         const templateText = (containedResource as Condition).note?.[0]?.text;
         if (existingText) {
           resourceToCreate.note = [{ text: `${existingText}\n\n${templateText || ''}` }];
         }
       }
+    } else if (hasTagSystem(resourceToCreate, chartDataTagSystem('mechanism-of-injury'))) {
+      moiHandled = true;
     }
 
     createResourcesRequests.push({
@@ -347,15 +442,24 @@ const makeCreateRequests = (
 
   const encounterPatchOperations: Operation[] = [];
 
-  // Patch the encounter.diagnoses with our new diagnosis references.
-  if (encounterDiagnoses.length > 0) {
-    encounterPatchOperations.push({
-      op: encounter.diagnosis ? 'replace' : 'add',
-      path: '/diagnosis',
-      value: encounterDiagnoses,
-    });
+  // Patch encounter.diagnosis only if the diagnoses section wasn't skipped.
+  if (encounterDiagnoses !== null) {
+    if (encounterDiagnoses.length > 0) {
+      encounterPatchOperations.push({
+        op: encounter.diagnosis ? 'replace' : 'add',
+        path: '/diagnosis',
+        value: encounterDiagnoses,
+      });
+    } else if (encounter.diagnosis && actions.diagnoses === 'overwrite') {
+      encounterPatchOperations.push({
+        op: 'remove',
+        path: '/diagnosis',
+      });
+    }
   }
 
+  // Encounter.extension merging is a cross-cutting concern not tied to a user-facing section.
+  // Carry it through as before so visit metadata extensions on the template still apply.
   if (templateEncounterExtensions.length > 0) {
     const newExtensions = (encounter.extension ?? []).filter(
       (extension) =>
@@ -377,9 +481,9 @@ const makeCreateRequests = (
     });
   }
 
-  // Patch HPI Condition note if it already exists
-  if (existingHpiCondition) {
-    const condition = existingHpiCondition as Condition;
+  // Patch HPI Condition note when appending and existing exists
+  if (existingHpiCondition && actions.hpi === 'append' && templateHpiCondition) {
+    const condition = existingHpiCondition;
     const encounterDiagnosisPatch: BatchInputJSONPatchRequest = {
       method: 'PATCH',
       url: `Condition/${condition.id}`,
@@ -387,16 +491,16 @@ const makeCreateRequests = (
         {
           op: 'replace',
           path: '/note/0/text',
-          value: `${condition.note?.[0]?.text}\n\n${templateHpiCondition?.note?.[0]?.text}`,
+          value: `${condition.note?.[0]?.text}\n\n${templateHpiCondition.note?.[0]?.text}`,
         },
       ],
     };
     createResourcesRequests.push(encounterDiagnosisPatch);
   }
 
-  // Patch ROS note if it already exists
-  if (existingRosCondition) {
-    const condition = existingRosCondition as Condition;
+  // Patch ROS note when appending and existing exists
+  if (existingRosCondition && actions.ros === 'append' && templateRosCondition) {
+    const condition = existingRosCondition;
     const encounterDiagnosisPatch: BatchInputJSONPatchRequest = {
       method: 'PATCH',
       url: `Condition/${condition.id}`,
@@ -404,7 +508,7 @@ const makeCreateRequests = (
         {
           op: 'replace',
           path: '/note/0/text',
-          value: `${condition.note?.[0]?.text}\n\n${templateRosCondition?.note?.[0]?.text}`,
+          value: `${condition.note?.[0]?.text}\n\n${templateRosCondition.note?.[0]?.text}`,
         },
       ],
     };

--- a/packages/zambdas/src/ehr/apply-template/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/apply-template/validateRequestParameters.ts
@@ -1,5 +1,45 @@
-import { ApplyTemplateZambdaInput, ExamType, INVALID_INPUT_ERROR, MISSING_REQUIRED_PARAMETERS } from 'utils';
+import {
+  ApplyTemplateZambdaInput,
+  ExamType,
+  INVALID_INPUT_ERROR,
+  MISSING_REQUIRED_PARAMETERS,
+  TEMPLATE_SECTION_DEFAULT_ACTIONS,
+  TEMPLATE_SECTIONS_NO_APPEND,
+  TemplateSectionAction,
+  TemplateSectionActions,
+  TemplateSectionKey,
+} from 'utils';
 import { ZambdaInput } from '../../shared';
+
+const VALID_ACTIONS: readonly TemplateSectionAction[] = ['skip', 'overwrite', 'append'];
+
+const VALID_SECTION_KEYS: ReadonlySet<TemplateSectionKey> = new Set(
+  Object.keys(TEMPLATE_SECTION_DEFAULT_ACTIONS) as TemplateSectionKey[]
+);
+
+const parseSectionActions = (raw: unknown): TemplateSectionActions => {
+  if (raw === undefined) return {};
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw INVALID_INPUT_ERROR('sectionActions must be an object');
+  }
+
+  const result: TemplateSectionActions = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (!VALID_SECTION_KEYS.has(key as TemplateSectionKey)) {
+      throw INVALID_INPUT_ERROR(`Unknown template section: ${key}`);
+    }
+    if (typeof value !== 'string' || !VALID_ACTIONS.includes(value as TemplateSectionAction)) {
+      throw INVALID_INPUT_ERROR(
+        `Invalid action for section ${key}: ${String(value)}. Must be one of: ${VALID_ACTIONS.join(', ')}`
+      );
+    }
+    if (value === 'append' && TEMPLATE_SECTIONS_NO_APPEND.has(key as TemplateSectionKey)) {
+      throw INVALID_INPUT_ERROR(`Section ${key} does not support the 'append' action`);
+    }
+    result[key as TemplateSectionKey] = value as TemplateSectionAction;
+  }
+  return result;
+};
 
 export function validateRequestParameters(input: ZambdaInput): ApplyTemplateZambdaInput & Pick<ZambdaInput, 'secrets'> {
   if (!input.body) {
@@ -13,7 +53,7 @@ export function validateRequestParameters(input: ZambdaInput): ApplyTemplateZamb
     throw INVALID_INPUT_ERROR('Request body must be a valid JSON object');
   }
 
-  const { examType, templateName, encounterId } = parsedInput as Record<string, unknown>;
+  const { examType, templateName, encounterId, sectionActions } = parsedInput as Record<string, unknown>;
 
   // Validate required parameters
   const missingFields = [];
@@ -49,10 +89,13 @@ export function validateRequestParameters(input: ZambdaInput): ApplyTemplateZamb
     throw new Error('No secrets provided in input');
   }
 
+  const validatedSectionActions = parseSectionActions(sectionActions);
+
   return {
     examType: examType as ExamType,
     templateName,
     encounterId,
+    sectionActions: validatedSectionActions,
     secrets: input.secrets,
   };
 }

--- a/packages/zambdas/test/unit/apply-template-validation.test.ts
+++ b/packages/zambdas/test/unit/apply-template-validation.test.ts
@@ -1,0 +1,75 @@
+import { ExamType } from 'utils';
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../src/ehr/apply-template/validateRequestParameters';
+import { ZambdaInput } from '../../src/shared';
+
+const createInput = (body: Record<string, unknown>): ZambdaInput => ({
+  body: JSON.stringify(body),
+  headers: { Authorization: 'Bearer test-token' },
+  secrets: { AUTH0_SECRET: 'test-secret' },
+});
+
+const baseBody = {
+  encounterId: 'encounter-1',
+  templateName: 'My Template',
+  examType: ExamType.IN_PERSON,
+};
+
+describe('Apply Template - validateRequestParameters', () => {
+  test('accepts a request without sectionActions and defaults to an empty object', () => {
+    const result = validateRequestParameters(createInput(baseBody));
+    expect(result.sectionActions).toEqual({});
+  });
+
+  test('accepts valid sectionActions for every supported section', () => {
+    const sectionActions = {
+      hpi: 'append',
+      moi: 'overwrite',
+      ros: 'skip',
+      examFindings: 'overwrite',
+      mdm: 'append',
+      diagnoses: 'append',
+      patientInstructions: 'skip',
+      cptCodes: 'overwrite',
+      emCode: 'skip',
+      accident: 'overwrite',
+    };
+    const result = validateRequestParameters(createInput({ ...baseBody, sectionActions }));
+    expect(result.sectionActions).toEqual(sectionActions);
+  });
+
+  test('rejects an unknown section key', () => {
+    const input = createInput({ ...baseBody, sectionActions: { totallyMadeUp: 'append' } });
+    expect(() => validateRequestParameters(input)).toThrow(/Unknown template section/);
+  });
+
+  test('rejects an invalid action value', () => {
+    const input = createInput({ ...baseBody, sectionActions: { hpi: 'merge' } });
+    expect(() => validateRequestParameters(input)).toThrow(/Invalid action/);
+  });
+
+  test("rejects 'append' for examFindings", () => {
+    const input = createInput({ ...baseBody, sectionActions: { examFindings: 'append' } });
+    expect(() => validateRequestParameters(input)).toThrow(/does not support the 'append' action/);
+  });
+
+  test("rejects 'append' for emCode", () => {
+    const input = createInput({ ...baseBody, sectionActions: { emCode: 'append' } });
+    expect(() => validateRequestParameters(input)).toThrow(/does not support the 'append' action/);
+  });
+
+  test("rejects 'append' for accident", () => {
+    const input = createInput({ ...baseBody, sectionActions: { accident: 'append' } });
+    expect(() => validateRequestParameters(input)).toThrow(/does not support the 'append' action/);
+  });
+
+  test('rejects sectionActions that is not an object', () => {
+    const input = createInput({ ...baseBody, sectionActions: 'not-an-object' });
+    expect(() => validateRequestParameters(input)).toThrow(/must be an object/);
+  });
+
+  test('still throws when required fields are missing', () => {
+    const input = createInput({ templateName: 'foo', examType: ExamType.IN_PERSON });
+    expect(() => validateRequestParameters(input)).toThrow(/encounterId/);
+  });
+});


### PR DESCRIPTION
Code and description below generated by Claude Opus 4.7 Max. I have not read this code. I've spent 1.5 hours on this.

## Summary

This PR adds a preview dialog that lets users choose how each template section should be merged into the current note (skip, append, or overwrite) before applying a template. The backend now validates and respects these user choices when applying templates.

## Key Changes

**Frontend (EHR)**
- New `TemplatePreviewDialog` component that displays template content organized by section with expandable cards
- Each section card shows a summary and allows users to select an action (skip/append/overwrite) via toggle buttons
- Actions respect section constraints (e.g., examFindings, emCode, and accident sections don't support append)
- Dialog prevents applying if all sections are skipped or if template is empty
- Updated `ApplyTemplate` component to open the preview dialog and pass selected actions to the backend

**Backend (Zambdas)**
- New `validateRequestParameters` validation for `sectionActions` input with comprehensive error checking
- `resolveSectionActions` function merges user-provided actions with defaults
- `getSectionForResource` maps existing FHIR resources to their template sections
- `shouldDeleteExistingResource` determines whether to delete existing content based on the action and section type:
  - `skip`: never delete
  - `overwrite`: always delete
  - `append`: delete for MOI and ROS observations; preserve for text-only sections (HPI, ROS note, MDM) and list-style sections (diagnoses, patient instructions, CPT codes)
- Updated `makeDeleteRequests` and `makeCreateRequests` to respect user-selected actions
- Encounter diagnoses handling now respects the diagnoses action (skip/append/overwrite)

**Shared Types (utils)**
- New types: `TemplateSectionAction`, `TemplateSectionKey`, `TemplateSectionActions`
- `TEMPLATE_SECTION_DEFAULT_ACTIONS` constant with sensible defaults (append for text/lists, overwrite for structured data)
- `TEMPLATE_SECTIONS_NO_APPEND` set identifying sections that don't support append

**Tests**
- New unit test file for `validateRequestParameters` covering valid inputs, invalid actions, section constraints, and error cases
- Updated component tests to verify preview dialog rendering, section cards, and action payload sent to backend

## Notable Implementation Details

- Section summaries are intelligently truncated and pluralized (e.g., "3 findings" vs "1 finding")
- ROS findings are visually separated into "Reports" (warning chips) and "Denies" (outlined chips)
- Exam findings are grouped by abnormal/normal status with notes displayed for abnormal findings
- The dialog uses `data-testid` attributes for reliable test selection
- Delete logic is centralized in `shouldDeleteExistingResource` for maintainability
- Only sections with actual content are included in the preview and payload to reduce noise

https://claude.ai/code/session_017njhT12aAtAnDry4npECbQ