### PR TITLE
feat: tracking board - update visit components to green when visit de…

### DIFF
--- a/packages/utils/lib/fhir/patient.isPatientDemographicsComplete.test.ts
+++ b/packages/utils/lib/fhir/patient.isPatientDemographicsComplete.test.ts
@@ -1,0 +1,104 @@
+import { Patient } from 'fhir/r4b';
+import { describe, expect, it } from 'vitest';
+import { isPatientDemographicsComplete } from './patient';
+
+const completePatient = (): Patient => ({
+  resourceType: 'Patient',
+  name: [{ given: ['John'], family: 'Doe' }],
+  birthDate: '1990-01-01',
+  gender: 'male',
+  telecom: [{ system: 'phone', value: '+15555550100' }],
+  address: [{ line: ['1 Main St'], city: 'Anywhere', state: 'NY', postalCode: '10001' }],
+});
+
+describe('isPatientDemographicsComplete', () => {
+  it('returns true for a fully populated patient', () => {
+    expect(isPatientDemographicsComplete(completePatient())).toBe(true);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isPatientDemographicsComplete(undefined)).toBe(false);
+  });
+
+  it('returns false when name has no given', () => {
+    const patient = completePatient();
+    patient.name = [{ given: [], family: 'Doe' }];
+    expect(isPatientDemographicsComplete(patient)).toBe(false);
+  });
+
+  it('returns false when name has no family', () => {
+    const patient = completePatient();
+    patient.name = [{ given: ['John'] }];
+    expect(isPatientDemographicsComplete(patient)).toBe(false);
+  });
+
+  it('returns false when name has only whitespace', () => {
+    const patient = completePatient();
+    patient.name = [{ given: ['   '], family: 'Doe' }];
+    expect(isPatientDemographicsComplete(patient)).toBe(false);
+  });
+
+  it('returns false when birthDate is missing', () => {
+    const patient = completePatient();
+    patient.birthDate = undefined;
+    expect(isPatientDemographicsComplete(patient)).toBe(false);
+  });
+
+  it('returns false when gender is missing', () => {
+    const patient = completePatient();
+    patient.gender = undefined;
+    expect(isPatientDemographicsComplete(patient)).toBe(false);
+  });
+
+  it('accepts gender "unknown"', () => {
+    const patient = completePatient();
+    patient.gender = 'unknown';
+    expect(isPatientDemographicsComplete(patient)).toBe(true);
+  });
+
+  it('returns false when no reachable telecom anywhere', () => {
+    const patient = completePatient();
+    patient.telecom = [];
+    expect(isPatientDemographicsComplete(patient)).toBe(false);
+  });
+
+  it('accepts email-only telecom (no phone)', () => {
+    const patient = completePatient();
+    patient.telecom = [{ system: 'email', value: 'patient@example.com' }];
+    expect(isPatientDemographicsComplete(patient)).toBe(true);
+  });
+
+  it('ignores non-phone/email telecom systems (e.g. sms, fax)', () => {
+    const patient = completePatient();
+    patient.telecom = [{ system: 'sms', value: '+15555550100' }];
+    expect(isPatientDemographicsComplete(patient)).toBe(false);
+  });
+
+  it('accepts guardian telecom on Patient.contact (pediatric)', () => {
+    const patient = completePatient();
+    patient.telecom = [];
+    patient.contact = [{ telecom: [{ system: 'phone', value: '+15555550100' }] }];
+    expect(isPatientDemographicsComplete(patient)).toBe(true);
+  });
+
+  it('returns false when address is missing postalCode', () => {
+    const patient = completePatient();
+    patient.address = [{ line: ['1 Main St'], city: 'Anywhere', state: 'NY' }];
+    expect(isPatientDemographicsComplete(patient)).toBe(false);
+  });
+
+  it('returns false when address has empty line', () => {
+    const patient = completePatient();
+    patient.address = [{ line: [''], city: 'Anywhere', state: 'NY', postalCode: '10001' }];
+    expect(isPatientDemographicsComplete(patient)).toBe(false);
+  });
+
+  it('passes when at least one of multiple addresses is complete', () => {
+    const patient = completePatient();
+    patient.address = [
+      { line: [''], city: 'Anywhere', state: 'NY', postalCode: '10001' },
+      { line: ['1 Main St'], city: 'Anywhere', state: 'NY', postalCode: '10001' },
+    ];
+    expect(isPatientDemographicsComplete(patient)).toBe(true);
+  });
+});

--- a/packages/utils/lib/fhir/patient.ts
+++ b/packages/utils/lib/fhir/patient.ts
@@ -460,6 +460,45 @@ export function getPatientContactEmail(patient: Patient): string | undefined {
   }
 }
 
+const hasNonEmptyName = (patient: Patient): boolean =>
+  !!patient.name?.some((name) => (name.given?.[0]?.trim().length ?? 0) > 0 && (name.family?.trim().length ?? 0) > 0);
+
+const hasNonEmptyBirthDate = (patient: Patient): boolean => !!patient.birthDate?.trim();
+
+const hasNonEmptyGender = (patient: Patient): boolean => !!patient.gender?.trim();
+
+const hasNonEmptyAddress = (patient: Patient): boolean =>
+  !!patient.address?.some(
+    (address) =>
+      (address.line?.[0]?.trim().length ?? 0) > 0 &&
+      (address.city?.trim().length ?? 0) > 0 &&
+      (address.state?.trim().length ?? 0) > 0 &&
+      (address.postalCode?.trim().length ?? 0) > 0
+  );
+
+const isReachableTelecom = (telecoms?: ContactPoint[]): boolean =>
+  !!telecoms?.some(
+    (telecom) => (telecom.system === 'phone' || telecom.system === 'email') && (telecom.value?.trim().length ?? 0) > 0
+  );
+
+const hasReachableGuardianContact = (patient: Patient): boolean =>
+  !!patient.contact?.some((contact) => isReachableTelecom(contact.telecom));
+
+const hasReachableContact = (patient: Patient): boolean =>
+  isReachableTelecom(patient.telecom) || hasReachableGuardianContact(patient);
+
+export const isPatientDemographicsComplete = (patient: Patient | undefined): boolean => {
+  if (!patient) return false;
+
+  return (
+    hasNonEmptyName(patient) &&
+    hasNonEmptyBirthDate(patient) &&
+    hasNonEmptyGender(patient) &&
+    hasReachableContact(patient) &&
+    hasNonEmptyAddress(patient)
+  );
+};
+
 type MightHaveTelecom = RelatedPerson | Patient | Person | Practitioner;
 export const getSMSNumberForIndividual = (individual: MightHaveTelecom): string | undefined => {
   const { telecom } = individual;

--- a/packages/zambdas/src/ehr/get-appointments/index.ts
+++ b/packages/zambdas/src/ehr/get-appointments/index.ts
@@ -25,6 +25,7 @@ import {
   flattenItems,
   GetAppointmentsZambdaInput,
   getAttendingPractitionerId,
+  getAttestedConsentFromEncounter,
   getChatContainsUnreadMessages,
   getCoding,
   getInPersonVisitStatus,
@@ -38,6 +39,7 @@ import {
   isAnnotationFollowupEncounter,
   isInPersonAppointment,
   isNonPaperworkQuestionnaireResponse,
+  isPatientDemographicsComplete,
   isTruthy,
   PHOTO_ID_CARD_CODE,
   PRIVATE_EXTENSION_BASE_URL,
@@ -748,7 +750,11 @@ const makeAppointmentInformation = (
   }
 
   // if the QR has been updated at least once, this tag will not be present
-  const paperworkHasBeenSubmitted = !!questionnaireResponse?.authored;
+  const demographicsByPaperworkSubmission = !!questionnaireResponse?.authored;
+
+  const demographicsByPatientResource = isPatientDemographicsComplete(patient);
+  const consentByPaperworkSignatures = !!consentComplete;
+  const consentByStaffAttestation = !!(encounter && getAttestedConsentFromEncounter(encounter));
 
   const participants = parseEncounterParticipants(encounter, practitionerIdToResourceMap);
   const attenderProviderType = parseAttenderProviderType(encounter, practitionerIdToResourceMap);
@@ -789,10 +795,10 @@ const makeAppointmentInformation = (
     group: group ? group.name : undefined,
     room: room,
     paperwork: {
-      demographics: paperworkHasBeenSubmitted,
+      demographics: demographicsByPaperworkSubmission || demographicsByPatientResource,
       photoID: idCard,
       insuranceCard: insuranceCard,
-      consent: consentComplete ? true : false,
+      consent: consentByPaperworkSignatures || consentByStaffAttestation,
       ovrpInterest: Boolean(ovrpInterest && ovrpInterest.startsWith('Yes')),
     },
     participants,


### PR DESCRIPTION
# Tracking Board icons reflect staff completion

Icons only lit up on patient paperwork submission. Now they also reflect data filled by staff on Visit Details.

| Icon | Green when |
|---|---|
| Demographics | `QR.authored` OR Patient has name, birthDate, gender, address, reachable telecom |
| Consent | consent forms signed in QR OR `Encounter.attestedConsent` extension set |
| INS Card / ID | DocumentReference exists (unchanged — covers both flows) |

Telecom check falls back to `Patient.contact[*].telecom` for pediatric guardians.
