### PR TITLE
OTR-2328: Add Insurance Carrier Quick Picks

### DIFF
--- a/apps/ehr/src/api/api.ts
+++ b/apps/ehr/src/api/api.ts
@@ -59,6 +59,8 @@ import {
   CreateInHouseMedicationInput,
   CreateInHouseMedicationQuickPickInput,
   CreateInHouseMedicationQuickPickResponse,
+  CreateInsuranceQuickPickInput,
+  CreateInsuranceQuickPickResponse,
   CreateLabOrderParameters,
   CreateLabOrderZambdaOutput,
   CreateMedicalConditionQuickPickInput,
@@ -110,6 +112,7 @@ import {
   GetImmunizationQuickPicksResponse,
   GetInHouseMedicationQuickPicksResponse,
   GetInHouseOrdersParameters,
+  GetInsuranceQuickPicksResponse,
   GetLabelPrintingConfigInput,
   GetLabelPrintingConfigOutput,
   GetLabOrdersParameters,
@@ -146,6 +149,7 @@ import {
   IncompleteEncountersReportZambdaOutput,
   InHouseGetOrdersResponseDTO,
   InHouseMedicationQuickPickData,
+  InsuranceQuickPickData,
   InviteParticipantRequestParameters,
   LabelPdf,
   ListScheduleOwnersParams,
@@ -177,6 +181,7 @@ import {
   RemoveAllergyQuickPickResponse,
   RemoveImmunizationQuickPickResponse,
   RemoveInHouseMedicationQuickPickResponse,
+  RemoveInsuranceQuickPickResponse,
   RemoveMedicalConditionQuickPickResponse,
   RemoveMedicationHistoryQuickPickResponse,
   RemovePatientInstructionQuickPickResponse,
@@ -204,6 +209,7 @@ import {
   UpdateImmunizationQuickPickResponse,
   UpdateInHouseMedicationInput,
   UpdateInHouseMedicationQuickPickResponse,
+  UpdateInsuranceQuickPickResponse,
   UpdateInvoiceTaskZambdaInput,
   UpdateLabOrderResourcesInput,
   UpdateMedicalConditionQuickPickResponse,
@@ -314,6 +320,10 @@ const ADMIN_GET_MEDICATION_HISTORY_QUICK_PICKS_ZAMBDA_ID = 'admin-get-medication
 const ADMIN_CREATE_MEDICATION_HISTORY_QUICK_PICK_ZAMBDA_ID = 'admin-create-medication-history-quick-pick';
 const ADMIN_UPDATE_MEDICATION_HISTORY_QUICK_PICK_ZAMBDA_ID = 'admin-update-medication-history-quick-pick';
 const ADMIN_REMOVE_MEDICATION_HISTORY_QUICK_PICK_ZAMBDA_ID = 'admin-remove-medication-history-quick-pick';
+const ADMIN_GET_INSURANCE_QUICK_PICKS_ZAMBDA_ID = 'admin-get-insurance-quick-picks';
+const ADMIN_CREATE_INSURANCE_QUICK_PICK_ZAMBDA_ID = 'admin-create-insurance-quick-pick';
+const ADMIN_UPDATE_INSURANCE_QUICK_PICK_ZAMBDA_ID = 'admin-update-insurance-quick-pick';
+const ADMIN_REMOVE_INSURANCE_QUICK_PICK_ZAMBDA_ID = 'admin-remove-insurance-quick-pick';
 const ADMIN_GET_IMMUNIZATION_QUICK_PICKS_ZAMBDA_ID = 'admin-get-immunization-quick-picks';
 const ADMIN_CREATE_IMMUNIZATION_QUICK_PICK_ZAMBDA_ID = 'admin-create-immunization-quick-pick';
 const ADMIN_UPDATE_IMMUNIZATION_QUICK_PICK_ZAMBDA_ID = 'admin-update-immunization-quick-pick';
@@ -2502,6 +2512,68 @@ export const removeMedicationHistoryQuickPick = async (
   try {
     const response = await oystehr.zambda.execute({
       id: ADMIN_REMOVE_MEDICATION_HISTORY_QUICK_PICK_ZAMBDA_ID,
+      quickPickId,
+    } as any);
+    return chooseJson(response);
+  } catch (error: unknown) {
+    console.log(error);
+    throw error;
+  }
+};
+
+// ── Insurance Quick Picks ──
+
+export const getInsuranceQuickPicks = async (oystehr: Oystehr): Promise<GetInsuranceQuickPicksResponse> => {
+  try {
+    const response = await oystehr.zambda.execute({ id: ADMIN_GET_INSURANCE_QUICK_PICKS_ZAMBDA_ID });
+    return chooseJson(response);
+  } catch (error: unknown) {
+    console.log(error);
+    throw error;
+  }
+};
+
+export const createInsuranceQuickPick = async (
+  oystehr: Oystehr,
+  parameters: CreateInsuranceQuickPickInput
+): Promise<CreateInsuranceQuickPickResponse> => {
+  try {
+    const response = await oystehr.zambda.execute({
+      id: ADMIN_CREATE_INSURANCE_QUICK_PICK_ZAMBDA_ID,
+      ...parameters,
+    });
+    return chooseJson(response);
+  } catch (error: unknown) {
+    console.log(error);
+    throw error;
+  }
+};
+
+export const updateInsuranceQuickPick = async (
+  oystehr: Oystehr,
+  quickPickId: string,
+  quickPick: Omit<InsuranceQuickPickData, 'id'>
+): Promise<UpdateInsuranceQuickPickResponse> => {
+  try {
+    const response = await oystehr.zambda.execute({
+      id: ADMIN_UPDATE_INSURANCE_QUICK_PICK_ZAMBDA_ID,
+      quickPickId,
+      quickPick,
+    } as any);
+    return chooseJson(response);
+  } catch (error: unknown) {
+    console.log(error);
+    throw error;
+  }
+};
+
+export const removeInsuranceQuickPick = async (
+  oystehr: Oystehr,
+  quickPickId: string
+): Promise<RemoveInsuranceQuickPickResponse> => {
+  try {
+    const response = await oystehr.zambda.execute({
+      id: ADMIN_REMOVE_INSURANCE_QUICK_PICK_ZAMBDA_ID,
       quickPickId,
     } as any);
     return chooseJson(response);

--- a/apps/ehr/src/features/visits/shared/components/QuickPicksButton.tsx
+++ b/apps/ehr/src/features/visits/shared/components/QuickPicksButton.tsx
@@ -13,6 +13,7 @@ interface QuickPicksButtonProps<T> {
   isAdmin?: boolean;
   onAddOrUpdate?: () => void;
   searchable?: boolean;
+  label?: string;
 }
 
 export const QuickPicksButton = <T,>({
@@ -24,6 +25,7 @@ export const QuickPicksButton = <T,>({
   isAdmin = false,
   onAddOrUpdate,
   searchable = false,
+  label = 'Quick Picks',
 }: QuickPicksButtonProps<T>): JSX.Element | null => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [searchText, setSearchText] = useState('');
@@ -84,7 +86,7 @@ export const QuickPicksButton = <T,>({
           mb: 0.5,
         }}
       >
-        Quick Picks
+        {label}
       </Button>
       <Menu
         anchorEl={anchorEl}

--- a/apps/ehr/src/features/visits/shared/components/patient/InsuranceCarrierQuickPicks.tsx
+++ b/apps/ehr/src/features/visits/shared/components/patient/InsuranceCarrierQuickPicks.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useMergedInsuranceQuickPicks } from 'src/hooks/useMergedQuickPicks';
+import { InsuranceQuickPickData } from 'utils';
+import { QuickPicksButton } from '../QuickPicksButton';
+
+interface InsuranceCarrierQuickPicksProps {
+  fieldKey: string;
+}
+
+export const InsuranceCarrierQuickPicks: FC<InsuranceCarrierQuickPicksProps> = ({ fieldKey }) => {
+  const { setValue } = useFormContext();
+  const { quickPicks } = useMergedInsuranceQuickPicks();
+
+  const handleSelect = (pick: InsuranceQuickPickData): void => {
+    setValue(fieldKey, { reference: pick.organizationReference, display: pick.name }, { shouldDirty: true });
+  };
+
+  return (
+    <QuickPicksButton<InsuranceQuickPickData>
+      quickPicks={quickPicks}
+      getLabel={(pick) => pick.name}
+      onSelect={handleSelect}
+      searchable
+    />
+  );
+};

--- a/apps/ehr/src/features/visits/shared/components/patient/InsuranceCarrierQuickPicks.tsx
+++ b/apps/ehr/src/features/visits/shared/components/patient/InsuranceCarrierQuickPicks.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@mui/material';
 import { FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useMergedInsuranceQuickPicks } from 'src/hooks/useMergedQuickPicks';
@@ -17,12 +18,15 @@ export const InsuranceCarrierQuickPicks: FC<InsuranceCarrierQuickPicksProps> = (
   };
 
   return (
-    <QuickPicksButton<InsuranceQuickPickData>
-      quickPicks={quickPicks}
-      getLabel={(pick) => pick.name}
-      onSelect={handleSelect}
-      searchable
-      label="Insurance Carrier Quick Picks"
-    />
+    // Pull the button visually closer to the Insurance carrier field it controls.
+    <Box sx={{ mb: -1.5 }}>
+      <QuickPicksButton<InsuranceQuickPickData>
+        quickPicks={quickPicks}
+        getLabel={(pick) => pick.name}
+        onSelect={handleSelect}
+        searchable
+        label="Insurance Carrier Quick Picks"
+      />
+    </Box>
   );
 };

--- a/apps/ehr/src/features/visits/shared/components/patient/InsuranceCarrierQuickPicks.tsx
+++ b/apps/ehr/src/features/visits/shared/components/patient/InsuranceCarrierQuickPicks.tsx
@@ -22,6 +22,7 @@ export const InsuranceCarrierQuickPicks: FC<InsuranceCarrierQuickPicksProps> = (
       getLabel={(pick) => pick.name}
       onSelect={handleSelect}
       searchable
+      label="Insurance Carrier Quick Picks"
     />
   );
 };

--- a/apps/ehr/src/features/visits/shared/components/patient/InsuranceCarrierQuickPicks.tsx
+++ b/apps/ehr/src/features/visits/shared/components/patient/InsuranceCarrierQuickPicks.tsx
@@ -18,15 +18,19 @@ export const InsuranceCarrierQuickPicks: FC<InsuranceCarrierQuickPicksProps> = (
   };
 
   return (
-    // Pull the button visually closer to the Insurance carrier field it controls.
-    <Box sx={{ mb: -1.5 }}>
-      <QuickPicksButton<InsuranceQuickPickData>
-        quickPicks={quickPicks}
-        getLabel={(pick) => pick.name}
-        onSelect={handleSelect}
-        searchable
-        label="Insurance Carrier Quick Picks"
-      />
+    // Mirror the form's Row layout (30% label / 70% input + 5px gap) so the
+    // button aligns with the Insurance carrier input column it controls.
+    <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: '5px', mb: -1.5 }}>
+      <Box sx={{ flex: '0 1 30%' }} />
+      <Box sx={{ flex: '1 1 70%' }}>
+        <QuickPicksButton<InsuranceQuickPickData>
+          quickPicks={quickPicks}
+          getLabel={(pick) => pick.name}
+          onSelect={handleSelect}
+          searchable
+          label="Insurance Carrier Quick Picks"
+        />
+      </Box>
     </Box>
   );
 };

--- a/apps/ehr/src/features/visits/shared/components/patient/InsuranceContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/patient/InsuranceContainer.tsx
@@ -31,6 +31,7 @@ import {
 } from 'utils';
 import { CopayWidget } from './CopayWidget';
 import { EligibilityDetailsDialog } from './EligibilityDetailsDialog';
+import { InsuranceCarrierQuickPicks } from './InsuranceCarrierQuickPicks';
 import PatientRecordFormField from './PatientRecordFormField';
 import PatientRecordFormSection, { usePatientRecordFormSection } from './PatientRecordFormSection';
 
@@ -476,6 +477,7 @@ export const InsuranceContainer: FC<InsuranceContainerProps> = ({
         requiredFormFields={requiredFields}
         hiddenFormFields={hiddenFields}
       />
+      <InsuranceCarrierQuickPicks fieldKey={FormFields.insuranceCarrier.key} />
       <PatientRecordFormField
         item={FormFields.insuranceCarrier}
         isLoading={false}

--- a/apps/ehr/src/features/visits/telemed/components/admin/InsuranceQuickPickPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/InsuranceQuickPickPage.tsx
@@ -1,0 +1,60 @@
+import { ReactElement, useCallback } from 'react';
+import { createInsuranceQuickPick, getInsuranceQuickPicks, removeInsuranceQuickPick } from 'src/api/api';
+import { useApiClients } from 'src/hooks/useAppClients';
+import { InsuranceQuickPickData } from 'utils';
+import { InsuranceSearchField } from './InsuranceSearchField';
+import QuickPickEditor from './QuickPickEditor';
+
+export default function InsuranceQuickPickPage(): ReactElement {
+  const { oystehrZambda } = useApiClients();
+
+  const fetchInsurance = useCallback(async () => {
+    if (!oystehrZambda) return [];
+    const response = await getInsuranceQuickPicks(oystehrZambda);
+    return response.quickPicks;
+  }, [oystehrZambda]);
+
+  const createInsurance = useCallback(
+    async (data: Omit<InsuranceQuickPickData, 'id'>) => {
+      if (!oystehrZambda) throw new Error('oystehrZambda was null');
+      const response = await createInsuranceQuickPick(oystehrZambda, { quickPick: data });
+      return response.quickPick;
+    },
+    [oystehrZambda]
+  );
+
+  const removeInsurance = useCallback(
+    async (id: string) => {
+      if (!oystehrZambda) throw new Error('oystehrZambda was null');
+      await removeInsuranceQuickPick(oystehrZambda, id);
+    },
+    [oystehrZambda]
+  );
+
+  return (
+    <QuickPickEditor<InsuranceQuickPickData>
+      title="Insurance Quick Picks"
+      description="Manage common insurance carriers that appear as quick picks when selecting a patient's insurance."
+      columns={[{ label: 'Insurance Name', getValue: (item) => item.name }]}
+      fields={[
+        {
+          key: 'name',
+          label: 'Insurance',
+          required: true,
+          renderField: (value, onValueChange, onExtraData) => (
+            <InsuranceSearchField value={value} onChange={onValueChange} onExtraData={onExtraData} />
+          ),
+        },
+      ]}
+      editable={false}
+      fetchItems={fetchInsurance}
+      createItem={createInsurance}
+      removeItem={removeInsurance}
+      buildItemFromFields={(values) => ({
+        name: values.name.trim(),
+        payerId: values.payerId ?? '',
+        organizationReference: values.organizationReference ?? '',
+      })}
+    />
+  );
+}

--- a/apps/ehr/src/features/visits/telemed/components/admin/InsuranceSearchField.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/InsuranceSearchField.tsx
@@ -1,0 +1,80 @@
+import { Autocomplete, TextField } from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
+import { QuestionnaireItemAnswerOption, Reference } from 'fhir/r4b';
+import { useMemo, useState } from 'react';
+import { useApiClients } from 'src/hooks/useAppClients';
+import { useMergedInsuranceQuickPicks } from 'src/hooks/useMergedQuickPicks';
+
+export const InsuranceSearchField: React.FC<{
+  value: string;
+  onChange: (value: string) => void;
+  onExtraData?: (data: Record<string, string>) => void;
+}> = ({ value, onChange, onExtraData }) => {
+  const { oystehrZambda } = useApiClients();
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const { data: payers, isFetching } = useQuery({
+    queryKey: ['admin-insurance-quick-pick-payers'],
+    queryFn: async (): Promise<Reference[]> => {
+      if (!oystehrZambda) return [];
+      const res = await oystehrZambda.zambda.execute({
+        id: 'get-all-insurance-payers',
+        answerSource: { zambdaId: 'get-all-insurance-payers', prependIdentifier: true },
+      });
+      const output = (res.output as Partial<QuestionnaireItemAnswerOption>[]) ?? [];
+      return output
+        .map((option) => option.valueReference)
+        .filter((ref): ref is Reference => !!ref?.reference && !!ref?.display);
+    },
+    enabled: !!oystehrZambda,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const { quickPicks: existingPicks, loading: existingLoading } = useMergedInsuranceQuickPicks();
+  const existingReferences = useMemo(() => new Set(existingPicks.map((p) => p.organizationReference)), [existingPicks]);
+
+  const options = useMemo(
+    () => (existingLoading ? [] : (payers ?? []).filter((p) => !existingReferences.has(p.reference ?? ''))),
+    [existingLoading, payers, existingReferences]
+  );
+  const selectedOption = value
+    ? options.find((opt) => opt.display === value) ?? ({ display: value } as Reference)
+    : null;
+
+  return (
+    <Autocomplete
+      value={selectedOption}
+      inputValue={searchTerm || value}
+      onInputChange={(_e, newInputValue, reason) => {
+        if (reason === 'input') setSearchTerm(newInputValue);
+      }}
+      onChange={(_e, selected) => {
+        if (selected?.display && selected.reference) {
+          onChange(selected.display);
+          // Display format is "<payerId> - <name>" when prependIdentifier=true.
+          const payerId = selected.display.includes(' - ') ? selected.display.split(' - ')[0] : '';
+          onExtraData?.({ payerId, organizationReference: selected.reference });
+          setSearchTerm('');
+        } else {
+          onChange('');
+          onExtraData?.({ payerId: '', organizationReference: '' });
+        }
+      }}
+      getOptionLabel={(option) => option.display ?? ''}
+      isOptionEqualToValue={(option, val) => option.reference === val.reference}
+      options={options}
+      loading={isFetching || existingLoading}
+      fullWidth
+      noOptionsText={isFetching || existingLoading ? 'Loading payers…' : 'No matching payers'}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label="Insurance"
+          placeholder="Search insurance carriers..."
+          required
+          InputLabelProps={{ shrink: true }}
+        />
+      )}
+    />
+  );
+};

--- a/apps/ehr/src/features/visits/telemed/components/admin/QuickPicksAdminPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/QuickPicksAdminPage.tsx
@@ -34,6 +34,7 @@ import {
   useICD10SearchNew,
 } from 'src/features/visits/shared/stores/appointment/appointment.queries';
 import { useApiClients } from 'src/hooks/useAppClients';
+import { useMergedInsuranceQuickPicks } from 'src/hooks/useMergedQuickPicks';
 import {
   AllergyQuickPickData,
   InsuranceQuickPickData,
@@ -285,7 +286,13 @@ const InsuranceSearchField: React.FC<{
     staleTime: 5 * 60 * 1000,
   });
 
-  const options = payers ?? [];
+  const { quickPicks: existingPicks, loading: existingLoading } = useMergedInsuranceQuickPicks();
+  const existingReferences = useMemo(() => new Set(existingPicks.map((p) => p.organizationReference)), [existingPicks]);
+
+  const options = useMemo(
+    () => (payers ?? []).filter((p) => !existingReferences.has(p.reference ?? '')),
+    [payers, existingReferences]
+  );
   const selectedOption = value
     ? options.find((opt) => opt.display === value) ?? ({ display: value } as Reference)
     : null;
@@ -312,9 +319,9 @@ const InsuranceSearchField: React.FC<{
       getOptionLabel={(option) => option.display ?? ''}
       isOptionEqualToValue={(option, val) => option.reference === val.reference}
       options={options}
-      loading={isFetching}
+      loading={isFetching || existingLoading}
       fullWidth
-      noOptionsText={isFetching ? 'Loading payers…' : 'No matching payers'}
+      noOptionsText={isFetching || existingLoading ? 'Loading payers…' : 'No matching payers'}
       renderInput={(params) => (
         <TextField
           {...params}

--- a/apps/ehr/src/features/visits/telemed/components/admin/QuickPicksAdminPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/QuickPicksAdminPage.tsx
@@ -5,19 +5,16 @@ import React, { ReactElement, useCallback, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   createAllergyQuickPick,
-  createInsuranceQuickPick,
   createMedicalConditionQuickPick,
   createMedicationHistoryQuickPick,
   createPatientInstructionQuickPick,
   createQuickTextQuickPick,
   getAllergyQuickPicks,
-  getInsuranceQuickPicks,
   getMedicalConditionQuickPicks,
   getMedicationHistoryQuickPicks,
   getPatientInstructionQuickPicks,
   getQuickTextQuickPicks,
   removeAllergyQuickPick,
-  removeInsuranceQuickPick,
   removeMedicalConditionQuickPick,
   removeMedicationHistoryQuickPick,
   removePatientInstructionQuickPick,
@@ -34,7 +31,6 @@ import {
 import { useApiClients } from 'src/hooks/useAppClients';
 import {
   AllergyQuickPickData,
-  InsuranceQuickPickData,
   MedicalConditionQuickPickData,
   MedicationHistoryQuickPickData,
   PatientInstructionQuickPickData,
@@ -42,7 +38,7 @@ import {
 } from 'utils';
 import ImmunizationQuickPicksPage from './ImmunizationQuickPicksPage';
 import InHouseMedicationQuickPicksPage from './InHouseMedicationQuickPicksPage';
-import { InsuranceSearchField } from './InsuranceSearchField';
+import InsuranceQuickPickPage from './InsuranceQuickPickPage';
 import ProcedureQuickPicksPage from './ProcedureQuickPicksPage';
 import QuickPickEditor from './QuickPickEditor';
 import { QuickTextTemplateField } from './QuickTextTemplateField';
@@ -336,30 +332,6 @@ export default function QuickPicksAdminPage(): ReactElement {
     [oystehrZambda]
   );
 
-  // ── Insurance callbacks ──
-  const fetchInsurance = useCallback(async () => {
-    if (!oystehrZambda) return [];
-    const response = await getInsuranceQuickPicks(oystehrZambda);
-    return response.quickPicks;
-  }, [oystehrZambda]);
-
-  const createInsurance = useCallback(
-    async (data: Omit<InsuranceQuickPickData, 'id'>) => {
-      if (!oystehrZambda) throw new Error('oystehrZambda was null');
-      const response = await createInsuranceQuickPick(oystehrZambda, { quickPick: data });
-      return response.quickPick;
-    },
-    [oystehrZambda]
-  );
-
-  const removeInsurance = useCallback(
-    async (id: string) => {
-      if (!oystehrZambda) throw new Error('oystehrZambda was null');
-      await removeInsuranceQuickPick(oystehrZambda, id);
-    },
-    [oystehrZambda]
-  );
-
   // ── Patient instruction callbacks ──
   const fetchPatientInstructions = useCallback(async () => {
     if (!oystehrZambda) return [];
@@ -542,30 +514,7 @@ export default function QuickPicksAdminPage(): ReactElement {
           <InHouseMedicationQuickPicksPage />
         </TabPanel>
         <TabPanel value="insurance" sx={{ px: 0 }}>
-          <QuickPickEditor<InsuranceQuickPickData>
-            title="Insurance Quick Picks"
-            description="Manage common insurance carriers that appear as quick picks when selecting a patient's insurance."
-            columns={[{ label: 'Insurance Name', getValue: (item) => item.name }]}
-            fields={[
-              {
-                key: 'name',
-                label: 'Insurance',
-                required: true,
-                renderField: (value, onValueChange, onExtraData) => (
-                  <InsuranceSearchField value={value} onChange={onValueChange} onExtraData={onExtraData} />
-                ),
-              },
-            ]}
-            editable={false}
-            fetchItems={fetchInsurance}
-            createItem={createInsurance}
-            removeItem={removeInsurance}
-            buildItemFromFields={(values) => ({
-              name: values.name.trim(),
-              payerId: values.payerId ?? '',
-              organizationReference: values.organizationReference ?? '',
-            })}
-          />
+          <InsuranceQuickPickPage />
         </TabPanel>
         <TabPanel value="patient-instructions" sx={{ px: 0 }}>
           <QuickPickEditor<PatientInstructionQuickPickData>

--- a/apps/ehr/src/features/visits/telemed/components/admin/QuickPicksAdminPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/QuickPicksAdminPage.tsx
@@ -1,20 +1,25 @@
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Autocomplete, Box, debounce, Tab, TextField } from '@mui/material';
 import { ErxSearchAllergensResponse, ErxSearchMedicationsResponse } from '@oystehr/sdk';
+import { useQuery } from '@tanstack/react-query';
+import { QuestionnaireItemAnswerOption, Reference } from 'fhir/r4b';
 import React, { ReactElement, useCallback, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   createAllergyQuickPick,
+  createInsuranceQuickPick,
   createMedicalConditionQuickPick,
   createMedicationHistoryQuickPick,
   createPatientInstructionQuickPick,
   createQuickTextQuickPick,
   getAllergyQuickPicks,
+  getInsuranceQuickPicks,
   getMedicalConditionQuickPicks,
   getMedicationHistoryQuickPicks,
   getPatientInstructionQuickPicks,
   getQuickTextQuickPicks,
   removeAllergyQuickPick,
+  removeInsuranceQuickPick,
   removeMedicalConditionQuickPick,
   removeMedicationHistoryQuickPick,
   removePatientInstructionQuickPick,
@@ -31,6 +36,7 @@ import {
 import { useApiClients } from 'src/hooks/useAppClients';
 import {
   AllergyQuickPickData,
+  InsuranceQuickPickData,
   MedicalConditionQuickPickData,
   MedicationHistoryQuickPickData,
   PatientInstructionQuickPickData,
@@ -254,6 +260,74 @@ const MedicalConditionSearchField: React.FC<{
   );
 };
 
+const InsuranceSearchField: React.FC<{
+  value: string;
+  onChange: (value: string) => void;
+  onExtraData?: (data: Record<string, string>) => void;
+}> = ({ value, onChange, onExtraData }) => {
+  const { oystehrZambda } = useApiClients();
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const { data: payers, isFetching } = useQuery({
+    queryKey: ['admin-insurance-quick-pick-payers'],
+    queryFn: async (): Promise<Reference[]> => {
+      if (!oystehrZambda) return [];
+      const res = await oystehrZambda.zambda.execute({
+        id: 'get-all-insurance-payers',
+        answerSource: { zambdaId: 'get-all-insurance-payers', prependIdentifier: true },
+      });
+      const output = (res.output as Partial<QuestionnaireItemAnswerOption>[]) ?? [];
+      return output
+        .map((option) => option.valueReference)
+        .filter((ref): ref is Reference => !!ref?.reference && !!ref?.display);
+    },
+    enabled: !!oystehrZambda,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const options = payers ?? [];
+  const selectedOption = value
+    ? options.find((opt) => opt.display === value) ?? ({ display: value } as Reference)
+    : null;
+
+  return (
+    <Autocomplete
+      value={selectedOption}
+      inputValue={searchTerm || value}
+      onInputChange={(_e, newInputValue, reason) => {
+        if (reason === 'input') setSearchTerm(newInputValue);
+      }}
+      onChange={(_e, selected) => {
+        if (selected?.display && selected.reference) {
+          onChange(selected.display);
+          // Display format is "<payerId> - <name>" when prependIdentifier=true.
+          const payerId = selected.display.includes(' - ') ? selected.display.split(' - ')[0] : '';
+          onExtraData?.({ payerId, organizationReference: selected.reference });
+          setSearchTerm('');
+        } else {
+          onChange('');
+          onExtraData?.({ payerId: '', organizationReference: '' });
+        }
+      }}
+      getOptionLabel={(option) => option.display ?? ''}
+      isOptionEqualToValue={(option, val) => option.reference === val.reference}
+      options={options}
+      loading={isFetching}
+      fullWidth
+      noOptionsText={isFetching ? 'Loading payers…' : 'No matching payers'}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label="Insurance"
+          placeholder="Search insurance carriers..."
+          required
+          InputLabelProps={{ shrink: true }}
+        />
+      )}
+    />
+  );
+};
+
 export default function QuickPicksAdminPage(): ReactElement {
   const navigate = useNavigate();
   const { _, subTab } = useParams();
@@ -327,6 +401,30 @@ export default function QuickPicksAdminPage(): ReactElement {
     async (id: string) => {
       if (!oystehrZambda) throw new Error('oystehrZambda was null');
       await removeMedicationHistoryQuickPick(oystehrZambda, id);
+    },
+    [oystehrZambda]
+  );
+
+  // ── Insurance callbacks ──
+  const fetchInsurance = useCallback(async () => {
+    if (!oystehrZambda) return [];
+    const response = await getInsuranceQuickPicks(oystehrZambda);
+    return response.quickPicks;
+  }, [oystehrZambda]);
+
+  const createInsurance = useCallback(
+    async (data: Omit<InsuranceQuickPickData, 'id'>) => {
+      if (!oystehrZambda) throw new Error('oystehrZambda was null');
+      const response = await createInsuranceQuickPick(oystehrZambda, { quickPick: data });
+      return response.quickPick;
+    },
+    [oystehrZambda]
+  );
+
+  const removeInsurance = useCallback(
+    async (id: string) => {
+      if (!oystehrZambda) throw new Error('oystehrZambda was null');
+      await removeInsuranceQuickPick(oystehrZambda, id);
     },
     [oystehrZambda]
   );
@@ -409,6 +507,7 @@ export default function QuickPicksAdminPage(): ReactElement {
             <Tab label="Radiology" value="radiology" sx={{ textTransform: 'none' }} />
             <Tab label="Immunizations" value="immunizations" sx={{ textTransform: 'none' }} />
             <Tab label="In-House Medications" value="in-house-medications" sx={{ textTransform: 'none' }} />
+            <Tab label="Insurance" value="insurance" sx={{ textTransform: 'none' }} />
             <Tab label="Patient Instructions" value="patient-instructions" sx={{ textTransform: 'none' }} />
             <Tab label="Quick Texts" value="quick-texts" sx={{ textTransform: 'none' }} />
           </TabList>
@@ -510,6 +609,32 @@ export default function QuickPicksAdminPage(): ReactElement {
         </TabPanel>
         <TabPanel value="in-house-medications" sx={{ px: 0 }}>
           <InHouseMedicationQuickPicksPage />
+        </TabPanel>
+        <TabPanel value="insurance" sx={{ px: 0 }}>
+          <QuickPickEditor<InsuranceQuickPickData>
+            title="Insurance Quick Picks"
+            description="Manage common insurance carriers that appear as quick picks when selecting a patient's insurance."
+            columns={[{ label: 'Insurance Name', getValue: (item) => item.name }]}
+            fields={[
+              {
+                key: 'name',
+                label: 'Insurance',
+                required: true,
+                renderField: (value, onValueChange, onExtraData) => (
+                  <InsuranceSearchField value={value} onChange={onValueChange} onExtraData={onExtraData} />
+                ),
+              },
+            ]}
+            editable={false}
+            fetchItems={fetchInsurance}
+            createItem={createInsurance}
+            removeItem={removeInsurance}
+            buildItemFromFields={(values) => ({
+              name: values.name.trim(),
+              payerId: values.payerId ?? '',
+              organizationReference: values.organizationReference ?? '',
+            })}
+          />
         </TabPanel>
         <TabPanel value="patient-instructions" sx={{ px: 0 }}>
           <QuickPickEditor<PatientInstructionQuickPickData>

--- a/apps/ehr/src/features/visits/telemed/components/admin/QuickPicksAdminPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/QuickPicksAdminPage.tsx
@@ -290,8 +290,8 @@ const InsuranceSearchField: React.FC<{
   const existingReferences = useMemo(() => new Set(existingPicks.map((p) => p.organizationReference)), [existingPicks]);
 
   const options = useMemo(
-    () => (payers ?? []).filter((p) => !existingReferences.has(p.reference ?? '')),
-    [payers, existingReferences]
+    () => (existingLoading ? [] : (payers ?? []).filter((p) => !existingReferences.has(p.reference ?? ''))),
+    [existingLoading, payers, existingReferences]
   );
   const selectedOption = value
     ? options.find((opt) => opt.display === value) ?? ({ display: value } as Reference)

--- a/apps/ehr/src/features/visits/telemed/components/admin/QuickPicksAdminPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/QuickPicksAdminPage.tsx
@@ -1,8 +1,6 @@
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Autocomplete, Box, debounce, Tab, TextField } from '@mui/material';
 import { ErxSearchAllergensResponse, ErxSearchMedicationsResponse } from '@oystehr/sdk';
-import { useQuery } from '@tanstack/react-query';
-import { QuestionnaireItemAnswerOption, Reference } from 'fhir/r4b';
 import React, { ReactElement, useCallback, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -34,7 +32,6 @@ import {
   useICD10SearchNew,
 } from 'src/features/visits/shared/stores/appointment/appointment.queries';
 import { useApiClients } from 'src/hooks/useAppClients';
-import { useMergedInsuranceQuickPicks } from 'src/hooks/useMergedQuickPicks';
 import {
   AllergyQuickPickData,
   InsuranceQuickPickData,
@@ -45,6 +42,7 @@ import {
 } from 'utils';
 import ImmunizationQuickPicksPage from './ImmunizationQuickPicksPage';
 import InHouseMedicationQuickPicksPage from './InHouseMedicationQuickPicksPage';
+import { InsuranceSearchField } from './InsuranceSearchField';
 import ProcedureQuickPicksPage from './ProcedureQuickPicksPage';
 import QuickPickEditor from './QuickPickEditor';
 import { QuickTextTemplateField } from './QuickTextTemplateField';
@@ -253,80 +251,6 @@ const MedicalConditionSearchField: React.FC<{
           {...params}
           label="Medical Condition"
           placeholder="Search ICD-10 codes..."
-          required
-          InputLabelProps={{ shrink: true }}
-        />
-      )}
-    />
-  );
-};
-
-const InsuranceSearchField: React.FC<{
-  value: string;
-  onChange: (value: string) => void;
-  onExtraData?: (data: Record<string, string>) => void;
-}> = ({ value, onChange, onExtraData }) => {
-  const { oystehrZambda } = useApiClients();
-  const [searchTerm, setSearchTerm] = useState('');
-
-  const { data: payers, isFetching } = useQuery({
-    queryKey: ['admin-insurance-quick-pick-payers'],
-    queryFn: async (): Promise<Reference[]> => {
-      if (!oystehrZambda) return [];
-      const res = await oystehrZambda.zambda.execute({
-        id: 'get-all-insurance-payers',
-        answerSource: { zambdaId: 'get-all-insurance-payers', prependIdentifier: true },
-      });
-      const output = (res.output as Partial<QuestionnaireItemAnswerOption>[]) ?? [];
-      return output
-        .map((option) => option.valueReference)
-        .filter((ref): ref is Reference => !!ref?.reference && !!ref?.display);
-    },
-    enabled: !!oystehrZambda,
-    staleTime: 5 * 60 * 1000,
-  });
-
-  const { quickPicks: existingPicks, loading: existingLoading } = useMergedInsuranceQuickPicks();
-  const existingReferences = useMemo(() => new Set(existingPicks.map((p) => p.organizationReference)), [existingPicks]);
-
-  const options = useMemo(
-    () => (existingLoading ? [] : (payers ?? []).filter((p) => !existingReferences.has(p.reference ?? ''))),
-    [existingLoading, payers, existingReferences]
-  );
-  const selectedOption = value
-    ? options.find((opt) => opt.display === value) ?? ({ display: value } as Reference)
-    : null;
-
-  return (
-    <Autocomplete
-      value={selectedOption}
-      inputValue={searchTerm || value}
-      onInputChange={(_e, newInputValue, reason) => {
-        if (reason === 'input') setSearchTerm(newInputValue);
-      }}
-      onChange={(_e, selected) => {
-        if (selected?.display && selected.reference) {
-          onChange(selected.display);
-          // Display format is "<payerId> - <name>" when prependIdentifier=true.
-          const payerId = selected.display.includes(' - ') ? selected.display.split(' - ')[0] : '';
-          onExtraData?.({ payerId, organizationReference: selected.reference });
-          setSearchTerm('');
-        } else {
-          onChange('');
-          onExtraData?.({ payerId: '', organizationReference: '' });
-        }
-      }}
-      getOptionLabel={(option) => option.display ?? ''}
-      isOptionEqualToValue={(option, val) => option.reference === val.reference}
-      options={options}
-      loading={isFetching || existingLoading}
-      fullWidth
-      noOptionsText={isFetching || existingLoading ? 'Loading payers…' : 'No matching payers'}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          label="Insurance"
-          placeholder="Search insurance carriers..."
           required
           InputLabelProps={{ shrink: true }}
         />

--- a/apps/ehr/src/hooks/useMergedQuickPicks.ts
+++ b/apps/ehr/src/hooks/useMergedQuickPicks.ts
@@ -4,6 +4,7 @@ import {
   getAllergyQuickPicks,
   getImmunizationQuickPicks,
   getInHouseMedicationQuickPicks,
+  getInsuranceQuickPicks,
   getMedicalConditionQuickPicks,
   getMedicationHistoryQuickPicks,
   getProcedureQuickPicks,
@@ -13,6 +14,7 @@ import {
   AllergyQuickPickData,
   ImmunizationQuickPickData,
   InHouseMedicationQuickPickData,
+  InsuranceQuickPickData,
   MedicalConditionQuickPickData,
   MedicationHistoryQuickPickData,
   ProcedureQuickPickData,
@@ -103,4 +105,10 @@ export function useMergedInHouseMedicationQuickPicks(options?: {
   enabled?: boolean;
 }): UseFhirQuickPicksResult<InHouseMedicationQuickPickData> {
   return useFhirQuickPicks(getInHouseMedicationQuickPicks, options);
+}
+
+export function useMergedInsuranceQuickPicks(options?: {
+  enabled?: boolean;
+}): UseFhirQuickPicksResult<InsuranceQuickPickData> {
+  return useFhirQuickPicks(getInsuranceQuickPicks, options);
 }

--- a/apps/ehr/tests/component/InsuranceCarrierQuickPicks.test.tsx
+++ b/apps/ehr/tests/component/InsuranceCarrierQuickPicks.test.tsx
@@ -48,7 +48,7 @@ describe('InsuranceCarrierQuickPicks', () => {
       </Harness>
     );
 
-    expect(screen.queryByRole('button', { name: /quick picks/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /insurance carrier quick picks/i })).not.toBeInTheDocument();
   });
 
   it('sets the carrier field to a Reference when a quick pick is selected', async () => {
@@ -61,7 +61,7 @@ describe('InsuranceCarrierQuickPicks', () => {
       </Harness>
     );
 
-    await user.click(screen.getByRole('button', { name: /quick picks/i }));
+    await user.click(screen.getByRole('button', { name: /insurance carrier quick picks/i }));
     await user.click(screen.getByRole('menuitem', { name: 'AET-002 - Aetna' }));
 
     expect(screen.getByTestId('form-value').textContent).toBe(

--- a/apps/ehr/tests/component/InsuranceCarrierQuickPicks.test.tsx
+++ b/apps/ehr/tests/component/InsuranceCarrierQuickPicks.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FC, ReactNode } from 'react';
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
+import { InsuranceQuickPickData } from 'utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mockedQuickPicks: InsuranceQuickPickData[] = [];
+
+vi.mock('../../src/hooks/useMergedQuickPicks', () => ({
+  useMergedInsuranceQuickPicks: () => ({ quickPicks: mockedQuickPicks, loading: false, refetch: vi.fn() }),
+}));
+
+import { InsuranceCarrierQuickPicks } from '../../src/features/visits/shared/components/patient/InsuranceCarrierQuickPicks';
+
+const PICKS: InsuranceQuickPickData[] = [
+  { id: '1', name: 'BLU-001 - Blue Cross', payerId: 'BLU-001', organizationReference: 'Organization/BLU-001' },
+  { id: '2', name: 'AET-002 - Aetna', payerId: 'AET-002', organizationReference: 'Organization/AET-002' },
+];
+
+const FIELD_KEY = 'insurance-carrier';
+
+const FormValueProbe: FC = () => {
+  const { watch } = useFormContext();
+  const value = watch(FIELD_KEY);
+  return <div data-testid="form-value">{value ? JSON.stringify(value) : 'null'}</div>;
+};
+
+const Harness: FC<{ children: ReactNode }> = ({ children }) => {
+  const methods = useForm({ defaultValues: { [FIELD_KEY]: null } });
+  return (
+    <FormProvider {...methods}>
+      {children}
+      <FormValueProbe />
+    </FormProvider>
+  );
+};
+
+describe('InsuranceCarrierQuickPicks', () => {
+  beforeEach(() => {
+    mockedQuickPicks = [];
+  });
+
+  it('renders nothing when there are no insurance quick picks configured', () => {
+    render(
+      <Harness>
+        <InsuranceCarrierQuickPicks fieldKey={FIELD_KEY} />
+      </Harness>
+    );
+
+    expect(screen.queryByRole('button', { name: /quick picks/i })).not.toBeInTheDocument();
+  });
+
+  it('sets the carrier field to a Reference when a quick pick is selected', async () => {
+    mockedQuickPicks = PICKS;
+    const user = userEvent.setup();
+
+    render(
+      <Harness>
+        <InsuranceCarrierQuickPicks fieldKey={FIELD_KEY} />
+      </Harness>
+    );
+
+    await user.click(screen.getByRole('button', { name: /quick picks/i }));
+    await user.click(screen.getByRole('menuitem', { name: 'AET-002 - Aetna' }));
+
+    expect(screen.getByTestId('form-value').textContent).toBe(
+      JSON.stringify({ reference: 'Organization/AET-002', display: 'AET-002 - Aetna' })
+    );
+  });
+});

--- a/config/oystehr-core/zambdas.json
+++ b/config/oystehr-core/zambdas.json
@@ -326,6 +326,34 @@
       "src": "src/ehr/admin-remove-medication-history-quick-pick/index",
       "zip": ".dist/zips/admin-remove-medication-history-quick-pick.zip"
     },
+    "ADMIN-GET-INSURANCE-QUICK-PICKS": {
+      "name": "admin-get-insurance-quick-picks",
+      "type": "http_auth",
+      "runtime": "nodejs22.x",
+      "src": "src/ehr/admin-get-insurance-quick-picks/index",
+      "zip": ".dist/zips/admin-get-insurance-quick-picks.zip"
+    },
+    "ADMIN-CREATE-INSURANCE-QUICK-PICK": {
+      "name": "admin-create-insurance-quick-pick",
+      "type": "http_auth",
+      "runtime": "nodejs22.x",
+      "src": "src/ehr/admin-create-insurance-quick-pick/index",
+      "zip": ".dist/zips/admin-create-insurance-quick-pick.zip"
+    },
+    "ADMIN-UPDATE-INSURANCE-QUICK-PICK": {
+      "name": "admin-update-insurance-quick-pick",
+      "type": "http_auth",
+      "runtime": "nodejs22.x",
+      "src": "src/ehr/admin-update-insurance-quick-pick/index",
+      "zip": ".dist/zips/admin-update-insurance-quick-pick.zip"
+    },
+    "ADMIN-REMOVE-INSURANCE-QUICK-PICK": {
+      "name": "admin-remove-insurance-quick-pick",
+      "type": "http_auth",
+      "runtime": "nodejs22.x",
+      "src": "src/ehr/admin-remove-insurance-quick-pick/index",
+      "zip": ".dist/zips/admin-remove-insurance-quick-pick.zip"
+    },
     "ADMIN-GET-IMMUNIZATION-QUICK-PICKS": {
       "name": "admin-get-immunization-quick-picks",
       "type": "http_auth",

--- a/packages/utils/lib/types/api/quick-picks.types.ts
+++ b/packages/utils/lib/types/api/quick-picks.types.ts
@@ -216,6 +216,23 @@ export type GetPatientInstructionQuickPicksResponse = QuickPickListResponse<Pati
 export type RemovePatientInstructionQuickPickInput = QuickPickRemoveInput;
 export type RemovePatientInstructionQuickPickResponse = QuickPickRemoveResponse;
 
+// ── Insurance Quick Picks ──
+
+export interface InsuranceQuickPickData {
+  id?: string;
+  name: string;
+  payerId: string;
+  organizationReference: string;
+}
+
+export type CreateInsuranceQuickPickInput = QuickPickCreateInput<InsuranceQuickPickData>;
+export type CreateInsuranceQuickPickResponse = QuickPickCreateResponse<InsuranceQuickPickData>;
+export type UpdateInsuranceQuickPickInput = QuickPickUpdateInput<InsuranceQuickPickData>;
+export type UpdateInsuranceQuickPickResponse = QuickPickUpdateResponse<InsuranceQuickPickData>;
+export type GetInsuranceQuickPicksResponse = QuickPickListResponse<InsuranceQuickPickData>;
+export type RemoveInsuranceQuickPickInput = QuickPickRemoveInput;
+export type RemoveInsuranceQuickPickResponse = QuickPickRemoveResponse;
+
 // ── Quick Text Quick Picks ──
 
 export interface QuickTextQuickPickData {

--- a/packages/zambdas/src/ehr/admin-create-insurance-quick-pick/index.ts
+++ b/packages/zambdas/src/ehr/admin-create-insurance-quick-pick/index.ts
@@ -1,21 +1,32 @@
-import { INVALID_INPUT_ERROR } from 'utils';
+import { InsuranceQuickPickData, INVALID_INPUT_ERROR } from 'utils';
 import { INSURANCE_QUICK_PICK_CATEGORY } from '../shared/quick-pick-categories';
+import { searchQuickPicks } from '../shared/quick-pick-helpers';
 import { makeCreateHandler } from '../shared/quick-pick-zambda';
 
-export const index = makeCreateHandler('admin-create-insurance-quick-pick', INSURANCE_QUICK_PICK_CATEGORY, (body) => {
-  const parsed = JSON.parse(body) as Record<string, unknown>;
-  const quickPick = parsed.quickPick as Record<string, unknown> | undefined;
-  if (!quickPick || typeof quickPick !== 'object') {
-    throw INVALID_INPUT_ERROR('quickPick must be an object');
+export const index = makeCreateHandler(
+  'admin-create-insurance-quick-pick',
+  INSURANCE_QUICK_PICK_CATEGORY,
+  (body) => {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    const quickPick = parsed.quickPick as Record<string, unknown> | undefined;
+    if (!quickPick || typeof quickPick !== 'object') {
+      throw INVALID_INPUT_ERROR('quickPick must be an object');
+    }
+    if (!quickPick.name || typeof quickPick.name !== 'string') {
+      throw INVALID_INPUT_ERROR('quickPick.name is required and must be a string');
+    }
+    if (!quickPick.payerId || typeof quickPick.payerId !== 'string') {
+      throw INVALID_INPUT_ERROR('quickPick.payerId is required and must be a string');
+    }
+    if (!quickPick.organizationReference || typeof quickPick.organizationReference !== 'string') {
+      throw INVALID_INPUT_ERROR('quickPick.organizationReference is required and must be a string');
+    }
+    return { quickPick: quickPick as Omit<InsuranceQuickPickData, 'id'> };
+  },
+  async (oystehr, quickPick) => {
+    const existing = await searchQuickPicks(oystehr, INSURANCE_QUICK_PICK_CATEGORY);
+    if (existing.some((p) => p.organizationReference === quickPick.organizationReference)) {
+      throw INVALID_INPUT_ERROR(`An insurance quick pick for ${quickPick.name} already exists`);
+    }
   }
-  if (!quickPick.name || typeof quickPick.name !== 'string') {
-    throw INVALID_INPUT_ERROR('quickPick.name is required and must be a string');
-  }
-  if (!quickPick.payerId || typeof quickPick.payerId !== 'string') {
-    throw INVALID_INPUT_ERROR('quickPick.payerId is required and must be a string');
-  }
-  if (!quickPick.organizationReference || typeof quickPick.organizationReference !== 'string') {
-    throw INVALID_INPUT_ERROR('quickPick.organizationReference is required and must be a string');
-  }
-  return { quickPick: quickPick as any };
-});
+);

--- a/packages/zambdas/src/ehr/admin-create-insurance-quick-pick/index.ts
+++ b/packages/zambdas/src/ehr/admin-create-insurance-quick-pick/index.ts
@@ -1,0 +1,21 @@
+import { INVALID_INPUT_ERROR } from 'utils';
+import { INSURANCE_QUICK_PICK_CATEGORY } from '../shared/quick-pick-categories';
+import { makeCreateHandler } from '../shared/quick-pick-zambda';
+
+export const index = makeCreateHandler('admin-create-insurance-quick-pick', INSURANCE_QUICK_PICK_CATEGORY, (body) => {
+  const parsed = JSON.parse(body) as Record<string, unknown>;
+  const quickPick = parsed.quickPick as Record<string, unknown> | undefined;
+  if (!quickPick || typeof quickPick !== 'object') {
+    throw INVALID_INPUT_ERROR('quickPick must be an object');
+  }
+  if (!quickPick.name || typeof quickPick.name !== 'string') {
+    throw INVALID_INPUT_ERROR('quickPick.name is required and must be a string');
+  }
+  if (!quickPick.payerId || typeof quickPick.payerId !== 'string') {
+    throw INVALID_INPUT_ERROR('quickPick.payerId is required and must be a string');
+  }
+  if (!quickPick.organizationReference || typeof quickPick.organizationReference !== 'string') {
+    throw INVALID_INPUT_ERROR('quickPick.organizationReference is required and must be a string');
+  }
+  return { quickPick: quickPick as any };
+});

--- a/packages/zambdas/src/ehr/admin-get-insurance-quick-picks/index.ts
+++ b/packages/zambdas/src/ehr/admin-get-insurance-quick-picks/index.ts
@@ -1,0 +1,4 @@
+import { INSURANCE_QUICK_PICK_CATEGORY } from '../shared/quick-pick-categories';
+import { makeGetHandler } from '../shared/quick-pick-zambda';
+
+export const index = makeGetHandler('admin-get-insurance-quick-picks', INSURANCE_QUICK_PICK_CATEGORY);

--- a/packages/zambdas/src/ehr/admin-remove-insurance-quick-pick/index.ts
+++ b/packages/zambdas/src/ehr/admin-remove-insurance-quick-pick/index.ts
@@ -1,0 +1,3 @@
+import { makeRemoveHandler } from '../shared/quick-pick-zambda';
+
+export const index = makeRemoveHandler('admin-remove-insurance-quick-pick');

--- a/packages/zambdas/src/ehr/admin-remove-insurance-quick-pick/index.ts
+++ b/packages/zambdas/src/ehr/admin-remove-insurance-quick-pick/index.ts
@@ -1,3 +1,4 @@
+import { INSURANCE_QUICK_PICK_CATEGORY } from '../shared/quick-pick-categories';
 import { makeRemoveHandler } from '../shared/quick-pick-zambda';
 
-export const index = makeRemoveHandler('admin-remove-insurance-quick-pick');
+export const index = makeRemoveHandler('admin-remove-insurance-quick-pick', INSURANCE_QUICK_PICK_CATEGORY);

--- a/packages/zambdas/src/ehr/admin-update-insurance-quick-pick/index.ts
+++ b/packages/zambdas/src/ehr/admin-update-insurance-quick-pick/index.ts
@@ -1,25 +1,36 @@
-import { INVALID_INPUT_ERROR } from 'utils';
+import { InsuranceQuickPickData, INVALID_INPUT_ERROR } from 'utils';
 import { INSURANCE_QUICK_PICK_CATEGORY } from '../shared/quick-pick-categories';
+import { searchQuickPicks } from '../shared/quick-pick-helpers';
 import { makeUpdateHandler } from '../shared/quick-pick-zambda';
 
-export const index = makeUpdateHandler('admin-update-insurance-quick-pick', INSURANCE_QUICK_PICK_CATEGORY, (body) => {
-  const parsed = JSON.parse(body) as Record<string, unknown>;
-  const quickPickId = parsed.quickPickId;
-  if (typeof quickPickId !== 'string') {
-    throw INVALID_INPUT_ERROR('quickPickId must be a string');
+export const index = makeUpdateHandler(
+  'admin-update-insurance-quick-pick',
+  INSURANCE_QUICK_PICK_CATEGORY,
+  (body) => {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    const quickPickId = parsed.quickPickId;
+    if (typeof quickPickId !== 'string') {
+      throw INVALID_INPUT_ERROR('quickPickId must be a string');
+    }
+    const quickPick = parsed.quickPick as Record<string, unknown> | undefined;
+    if (!quickPick || typeof quickPick !== 'object') {
+      throw INVALID_INPUT_ERROR('quickPick must be an object');
+    }
+    if (!quickPick.name || typeof quickPick.name !== 'string') {
+      throw INVALID_INPUT_ERROR('quickPick.name is required and must be a string');
+    }
+    if (!quickPick.payerId || typeof quickPick.payerId !== 'string') {
+      throw INVALID_INPUT_ERROR('quickPick.payerId is required and must be a string');
+    }
+    if (!quickPick.organizationReference || typeof quickPick.organizationReference !== 'string') {
+      throw INVALID_INPUT_ERROR('quickPick.organizationReference is required and must be a string');
+    }
+    return { quickPickId, quickPick: quickPick as Omit<InsuranceQuickPickData, 'id'> };
+  },
+  async (oystehr, quickPickId, quickPick) => {
+    const existing = await searchQuickPicks(oystehr, INSURANCE_QUICK_PICK_CATEGORY);
+    if (existing.some((p) => p.id !== quickPickId && p.organizationReference === quickPick.organizationReference)) {
+      throw INVALID_INPUT_ERROR(`An insurance quick pick for ${quickPick.name} already exists`);
+    }
   }
-  const quickPick = parsed.quickPick as Record<string, unknown> | undefined;
-  if (!quickPick || typeof quickPick !== 'object') {
-    throw INVALID_INPUT_ERROR('quickPick must be an object');
-  }
-  if (!quickPick.name || typeof quickPick.name !== 'string') {
-    throw INVALID_INPUT_ERROR('quickPick.name is required and must be a string');
-  }
-  if (!quickPick.payerId || typeof quickPick.payerId !== 'string') {
-    throw INVALID_INPUT_ERROR('quickPick.payerId is required and must be a string');
-  }
-  if (!quickPick.organizationReference || typeof quickPick.organizationReference !== 'string') {
-    throw INVALID_INPUT_ERROR('quickPick.organizationReference is required and must be a string');
-  }
-  return { quickPickId, quickPick: quickPick as any };
-});
+);

--- a/packages/zambdas/src/ehr/admin-update-insurance-quick-pick/index.ts
+++ b/packages/zambdas/src/ehr/admin-update-insurance-quick-pick/index.ts
@@ -1,0 +1,25 @@
+import { INVALID_INPUT_ERROR } from 'utils';
+import { INSURANCE_QUICK_PICK_CATEGORY } from '../shared/quick-pick-categories';
+import { makeUpdateHandler } from '../shared/quick-pick-zambda';
+
+export const index = makeUpdateHandler('admin-update-insurance-quick-pick', INSURANCE_QUICK_PICK_CATEGORY, (body) => {
+  const parsed = JSON.parse(body) as Record<string, unknown>;
+  const quickPickId = parsed.quickPickId;
+  if (typeof quickPickId !== 'string') {
+    throw INVALID_INPUT_ERROR('quickPickId must be a string');
+  }
+  const quickPick = parsed.quickPick as Record<string, unknown> | undefined;
+  if (!quickPick || typeof quickPick !== 'object') {
+    throw INVALID_INPUT_ERROR('quickPick must be an object');
+  }
+  if (!quickPick.name || typeof quickPick.name !== 'string') {
+    throw INVALID_INPUT_ERROR('quickPick.name is required and must be a string');
+  }
+  if (!quickPick.payerId || typeof quickPick.payerId !== 'string') {
+    throw INVALID_INPUT_ERROR('quickPick.payerId is required and must be a string');
+  }
+  if (!quickPick.organizationReference || typeof quickPick.organizationReference !== 'string') {
+    throw INVALID_INPUT_ERROR('quickPick.organizationReference is required and must be a string');
+  }
+  return { quickPickId, quickPick: quickPick as any };
+});

--- a/packages/zambdas/src/ehr/shared/quick-pick-categories.ts
+++ b/packages/zambdas/src/ehr/shared/quick-pick-categories.ts
@@ -2,6 +2,7 @@ import {
   AllergyQuickPickData,
   ImmunizationQuickPickData,
   InHouseMedicationQuickPickData,
+  InsuranceQuickPickData,
   MedicalConditionQuickPickData,
   MedicationHistoryQuickPickData,
   PatientInstructionQuickPickData,
@@ -96,6 +97,17 @@ export const PATIENT_INSTRUCTION_QUICK_PICK_CATEGORY: QuickPickCategory<PatientI
     id,
     name: title,
     ...(config as Omit<PatientInstructionQuickPickData, 'id' | 'name'>),
+  }),
+};
+
+export const INSURANCE_QUICK_PICK_CATEGORY: QuickPickCategory<InsuranceQuickPickData> = {
+  tagCode: 'insurance-quick-pick',
+  displayNameKey: 'name',
+  getDisplayName: (data) => data.name,
+  fromParsed: (id, title, config) => ({
+    id,
+    name: title,
+    ...(config as Omit<InsuranceQuickPickData, 'id' | 'name'>),
   }),
 };
 

--- a/packages/zambdas/src/ehr/shared/quick-pick-helpers.ts
+++ b/packages/zambdas/src/ehr/shared/quick-pick-helpers.ts
@@ -104,7 +104,11 @@ export async function updateQuickPick<T extends { id?: string }>(
   return activityDefinitionToQuickPick(updated, category);
 }
 
-export async function removeQuickPick(oystehr: Oystehr, quickPickId: string): Promise<void> {
+export async function removeQuickPick<T extends { id?: string }>(
+  oystehr: Oystehr,
+  quickPickId: string,
+  category?: QuickPickCategory<T>
+): Promise<void> {
   let existing: ActivityDefinition;
   try {
     existing = await oystehr.fhir.get<ActivityDefinition>({
@@ -114,9 +118,16 @@ export async function removeQuickPick(oystehr: Oystehr, quickPickId: string): Pr
   } catch {
     throw new Error(`ActivityDefinition with id ${quickPickId} not found`);
   }
-  const hasQuickPickTag = existing.meta?.tag?.some((t) => t.system === QUICK_PICK_TAG_SYSTEM);
+  const tags = existing.meta?.tag ?? [];
+  const hasQuickPickTag = tags.some((t) => t.system === QUICK_PICK_TAG_SYSTEM);
   if (!hasQuickPickTag) {
     throw new Error(`ActivityDefinition ${quickPickId} is not a quick pick resource`);
+  }
+  if (category) {
+    const matchesCategory = tags.some((t) => t.system === QUICK_PICK_TAG_SYSTEM && t.code === category.tagCode);
+    if (!matchesCategory) {
+      throw new Error(`ActivityDefinition ${quickPickId} is not a ${category.tagCode} resource`);
+    }
   }
   existing.status = 'retired';
   await oystehr.fhir.update(existing);

--- a/packages/zambdas/src/ehr/shared/quick-pick-zambda.ts
+++ b/packages/zambdas/src/ehr/shared/quick-pick-zambda.ts
@@ -48,11 +48,13 @@ export function makeGetHandler<T extends { id?: string }>(
 export function makeCreateHandler<T extends { id?: string }>(
   zambdaName: string,
   category: QuickPickCategory<T>,
-  parseQuickPick: (body: string) => { quickPick: Omit<T, 'id'> }
+  parseQuickPick: (body: string) => { quickPick: Omit<T, 'id'> },
+  validate?: (oystehr: Oystehr, quickPick: Omit<T, 'id'>) => Promise<void>
 ): Handler<ZambdaInput, APIGatewayProxyResult> {
   return makeHandler(zambdaName, async (oystehr, input): Promise<QuickPickCreateResponse<T>> => {
     if (!input.body) throw new Error('No request body provided');
     const { quickPick: quickPickData } = parseQuickPick(input.body);
+    if (validate) await validate(oystehr, quickPickData);
     const quickPick = await createQuickPick(oystehr, quickPickData, category);
     const displayName = category.getDisplayName(quickPickData);
     return { message: `Successfully created quick pick: ${displayName}`, quickPick };
@@ -62,24 +64,29 @@ export function makeCreateHandler<T extends { id?: string }>(
 export function makeUpdateHandler<T extends { id?: string }>(
   zambdaName: string,
   category: QuickPickCategory<T>,
-  parseUpdate: (body: string) => { quickPickId: string; quickPick: Omit<T, 'id'> }
+  parseUpdate: (body: string) => { quickPickId: string; quickPick: Omit<T, 'id'> },
+  validate?: (oystehr: Oystehr, quickPickId: string, quickPick: Omit<T, 'id'>) => Promise<void>
 ): Handler<ZambdaInput, APIGatewayProxyResult> {
   return makeHandler(zambdaName, async (oystehr, input): Promise<QuickPickUpdateResponse<T>> => {
     if (!input.body) throw new Error('No request body provided');
     const { quickPickId, quickPick: quickPickData } = parseUpdate(input.body);
+    if (validate) await validate(oystehr, quickPickId, quickPickData);
     const quickPick = await updateQuickPick(oystehr, quickPickId, quickPickData, category);
     const displayName = category.getDisplayName(quickPickData);
     return { message: `Successfully updated quick pick: ${displayName}`, quickPick };
   });
 }
 
-export function makeRemoveHandler(zambdaName: string): Handler<ZambdaInput, APIGatewayProxyResult> {
+export function makeRemoveHandler<T extends { id?: string }>(
+  zambdaName: string,
+  category?: QuickPickCategory<T>
+): Handler<ZambdaInput, APIGatewayProxyResult> {
   return makeHandler(zambdaName, async (oystehr, input): Promise<QuickPickRemoveResponse> => {
     if (!input.body) throw new Error('No request body provided');
     const parsed = JSON.parse(input.body) as Record<string, unknown>;
     const quickPickId = parsed.quickPickId;
     if (typeof quickPickId !== 'string') throw new Error('quickPickId must be a string');
-    await removeQuickPick(oystehr, quickPickId);
+    await removeQuickPick(oystehr, quickPickId, category);
     return { message: 'Successfully removed quick pick' };
   });
 }

--- a/packages/zambdas/test/unit/quick-pick-helpers.test.ts
+++ b/packages/zambdas/test/unit/quick-pick-helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest';
 import {
   ALLERGY_QUICK_PICK_CATEGORY,
   IMMUNIZATION_QUICK_PICK_CATEGORY,
+  INSURANCE_QUICK_PICK_CATEGORY,
   MEDICAL_CONDITION_QUICK_PICK_CATEGORY,
   MEDICATION_HISTORY_QUICK_PICK_CATEGORY,
   PATIENT_INSTRUCTION_QUICK_PICK_CATEGORY,
@@ -241,6 +242,38 @@ describe('activityDefinitionToQuickPick', () => {
     });
   });
 
+  describe('Insurance', () => {
+    test('should parse with name, payerId, and organizationReference', () => {
+      const ad = createMockActivityDefinition('insurance-quick-pick', 'Aetna', {
+        payerId: 'aetna-001',
+        organizationReference: 'Organization/aetna-org-1',
+      });
+
+      const result = activityDefinitionToQuickPick(ad, INSURANCE_QUICK_PICK_CATEGORY);
+
+      expect(result.id).toBe('test-id-123');
+      expect(result.name).toBe('Aetna');
+      expect(result.payerId).toBe('aetna-001');
+      expect(result.organizationReference).toBe('Organization/aetna-org-1');
+    });
+
+    test('should parse when config extension is missing', () => {
+      const ad: ActivityDefinition = {
+        resourceType: 'ActivityDefinition',
+        status: 'active',
+        title: 'Cigna',
+        meta: {
+          tag: [{ system: QUICK_PICK_TAG_SYSTEM, code: 'insurance-quick-pick' }],
+        },
+      };
+
+      const result = activityDefinitionToQuickPick(ad, INSURANCE_QUICK_PICK_CATEGORY);
+      expect(result.name).toBe('Cigna');
+      expect(result.payerId).toBeUndefined();
+      expect(result.organizationReference).toBeUndefined();
+    });
+  });
+
   describe('Patient instructions', () => {
     test('should parse a valid patient instruction ActivityDefinition with name and text', () => {
       const title = 'inst-title';
@@ -327,6 +360,31 @@ describe('quickPickToActivityDefinition', () => {
     const ad = quickPickToActivityDefinition(quickPick, IMMUNIZATION_QUICK_PICK_CATEGORY);
 
     expect(ad.meta?.tag).toEqual([{ system: QUICK_PICK_TAG_SYSTEM, code: 'immunization-quick-pick' }]);
+  });
+
+  test('should set correct meta tag system and code for insurance category', () => {
+    const quickPick = { name: 'Aetna', payerId: 'aetna-001', organizationReference: 'Organization/aetna-org-1' };
+
+    const ad = quickPickToActivityDefinition(quickPick, INSURANCE_QUICK_PICK_CATEGORY);
+
+    expect(ad.meta?.tag).toEqual([{ system: QUICK_PICK_TAG_SYSTEM, code: 'insurance-quick-pick' }]);
+  });
+
+  test('should serialize insurance config excluding name field', () => {
+    const quickPick = {
+      name: 'Aetna',
+      payerId: 'aetna-001',
+      organizationReference: 'Organization/aetna-org-1',
+    };
+
+    const ad = quickPickToActivityDefinition(quickPick, INSURANCE_QUICK_PICK_CATEGORY);
+
+    const configExt = ad.extension?.find((e) => e.url === QUICK_PICK_CONFIG_EXTENSION_URL);
+    expect(configExt).toBeDefined();
+    const parsed = JSON.parse(configExt!.valueString!);
+    expect(parsed.name).toBeUndefined();
+    expect(parsed.payerId).toBe('aetna-001');
+    expect(parsed.organizationReference).toBe('Organization/aetna-org-1');
   });
 
   test('should serialize immunization config excluding name field', () => {
@@ -496,6 +554,21 @@ describe('round-trip conversion', () => {
     expect(restored.units).toBe('ml');
     expect(restored.vaccine).toBeUndefined();
     expect(restored.cvx).toBeUndefined();
+  });
+
+  test('should preserve insurance data through round-trip', () => {
+    const original = {
+      name: 'Blue Cross Blue Shield',
+      payerId: 'bcbs-042',
+      organizationReference: 'Organization/bcbs-org-42',
+    };
+    const ad = quickPickToActivityDefinition(original, INSURANCE_QUICK_PICK_CATEGORY, 'ins-id');
+    const restored = activityDefinitionToQuickPick(ad, INSURANCE_QUICK_PICK_CATEGORY);
+
+    expect(restored.name).toBe('Blue Cross Blue Shield');
+    expect(restored.payerId).toBe('bcbs-042');
+    expect(restored.organizationReference).toBe('Organization/bcbs-org-42');
+    expect(restored.id).toBe('ins-id');
   });
 
   test('should preserve patient instruction data through round-trip', () => {


### PR DESCRIPTION
Generated by Claude, I haven't read this code and it needs careful review and consideration.

## Summary
- New **Admin > Quick Picks > Insurance** tab that lets staff curate a list of frequently used insurance carriers, backed by FHIR `ActivityDefinition` resources (matches the existing Medication / Allergy / etc. quick pick pattern). Carriers already saved are filtered out of the add-modal so duplicates cannot be created.
- New `Insurance Carrier Quick Picks ▾` dropdown rendered above the insurance carrier autocomplete on both the patient profile and visit details screens (shared via `PatientAccountComponent` → `InsuranceContainer`). Selecting a quick pick writes the FHIR `Reference` directly into the react-hook-form field.
- Four new admin zambdas — `admin-{get,create,update,remove}-insurance-quick-pick` — using the existing `quick-pick-zambda` handler factories.

## Test plan
- [ ] Unit/component: `npx vitest --config ./apps/ehr/vitest.config.component-tests.ts apps/ehr/tests/component/InsuranceCarrierQuickPicks.test.tsx` (2 cases: hidden when empty + sets Reference on click) — passes
- [ ] Existing `QuickPicksButton.test.tsx` (15 cases) still passes
- [ ] Manual: open Admin > Quick Picks > Insurance, add a carrier; reopen the modal and confirm it is no longer in the searchable list
- [ ] Manual: delete a saved quick pick via the trash icon and verify it returns to the searchable list on next open
- [ ] Manual: on patient profile, click \`Insurance Carrier Quick Picks ▾\` and confirm selecting a pick populates the \`Insurance carrier\` field and marks the form dirty
- [ ] Manual: repeat on the visit details screen's insurance section
- [ ] Manual: with zero quick picks configured, confirm the dropdown does not render

🤖 Generated with [Claude Code](https://claude.com/claude-code)