### PR TITLE
Visit status workflow patches

### DIFF
--- a/apps/ehr/src/components/AppointmentTableRow.tsx
+++ b/apps/ehr/src/components/AppointmentTableRow.tsx
@@ -42,6 +42,7 @@ import {
   formatMinutes,
   getAbnormalVitals,
   getAdmitterPractitionerId,
+  getAttendingPractitionerId,
   getDurationOfStatus,
   getPatchBinary,
   getSupportPhoneFor,
@@ -566,6 +567,7 @@ export default function AppointmentTableRow({
   const encounterId: string = encounter.id;
   const primaryAction = getTrackingBoardPrimaryAction(appointment.status);
   const assignedIntakePerformerId = getAdmitterPractitionerId(encounter);
+  const assignedProviderId = getAttendingPractitionerId(encounter);
 
   const handleStatusAction = async (
     updatedStatus: VisitStatusWithoutUnknown,
@@ -662,6 +664,11 @@ export default function AppointmentTableRow({
         setPrimaryActionButtonLoading(false);
       }
 
+      return;
+    }
+
+    if (appointment.status === 'ready for provider' && !assignedProviderId) {
+      enqueueSnackbar('Please assign provider', { variant: 'error' });
       return;
     }
 

--- a/apps/ehr/src/components/AppointmentTableRow.tsx
+++ b/apps/ehr/src/components/AppointmentTableRow.tsx
@@ -565,7 +565,7 @@ export default function AppointmentTableRow({
     return null;
   }
   const encounterId: string = encounter.id;
-  const primaryAction = getTrackingBoardPrimaryAction(appointment.status);
+  const primaryAction = getTrackingBoardPrimaryAction(appointment.status, { isVirtualVisit: isVirtual(appointment) });
   const assignedIntakePerformerId = getAdmitterPractitionerId(encounter);
   const assignedProviderId = getAttendingPractitionerId(encounter);
 
@@ -669,6 +669,11 @@ export default function AppointmentTableRow({
 
     if (appointment.status === 'ready for provider' && !assignedProviderId) {
       enqueueSnackbar('Please assign provider', { variant: 'error' });
+      return;
+    }
+
+    if (primaryAction.skipStatusUpdate && primaryAction.navigateToChart) {
+      navigate(getInPersonUrlByAppointmentType(appointment, 'patient-info'));
       return;
     }
 

--- a/apps/ehr/src/constants/data-test-ids.ts
+++ b/apps/ehr/src/constants/data-test-ids.ts
@@ -47,7 +47,6 @@ export const dataTestIds = {
   },
   appointmentPage: {
     patientFullName: 'patient-full-name',
-    changeStatusDropdown: 'change-status-dropdown-in-appointment-page',
   },
   addPatientPage: {
     pageTitle: 'page-title',

--- a/apps/ehr/src/helpers/trackingBoardPrimaryAction.ts
+++ b/apps/ehr/src/helpers/trackingBoardPrimaryAction.ts
@@ -6,8 +6,13 @@ export interface TrackingBoardPrimaryAction {
   label: string;
   missingUserMessage: string;
   navigateToChart?: boolean;
+  skipStatusUpdate?: boolean;
   successMessage?: string;
   updatedStatus: VisitStatusWithoutUnknown;
+}
+
+interface TrackingBoardPrimaryActionOptions {
+  isVirtualVisit?: boolean;
 }
 
 type ActionableVisitStatus = 'arrived' | 'ready' | 'intake' | 'ready for provider' | 'provider';
@@ -50,5 +55,24 @@ const trackingBoardPrimaryActions = {
   },
 } satisfies Record<ActionableVisitStatus, TrackingBoardPrimaryAction>;
 
-export const getTrackingBoardPrimaryAction = (status: VisitStatusLabel): TrackingBoardPrimaryAction | undefined =>
-  status in trackingBoardPrimaryActions ? trackingBoardPrimaryActions[status as ActionableVisitStatus] : undefined;
+export const getTrackingBoardPrimaryAction = (
+  status: VisitStatusLabel,
+  options?: TrackingBoardPrimaryActionOptions
+): TrackingBoardPrimaryAction | undefined => {
+  if (!(status in trackingBoardPrimaryActions)) {
+    return undefined;
+  }
+
+  const action = trackingBoardPrimaryActions[status as ActionableVisitStatus];
+
+  if (status === 'ready for provider' && options?.isVirtualVisit) {
+    return {
+      ...action,
+      navigateToChart: true,
+      skipStatusUpdate: true,
+      successMessage: undefined,
+    };
+  }
+
+  return action;
+};

--- a/apps/ehr/src/pages/VisitDetailsPage.tsx
+++ b/apps/ehr/src/pages/VisitDetailsPage.tsx
@@ -9,8 +9,6 @@ import {
   Box,
   Button,
   Checkbox,
-  CircularProgress,
-  FormControl,
   Grid,
   IconButton,
   Link as MUILink,
@@ -104,7 +102,6 @@ import { PriorityIconWithBorder } from '../components/PriorityIconWithBorder';
 import { HOP_QUEUE_URI } from '../constants';
 import { dataTestIds } from '../constants/data-test-ids';
 import { FEATURE_FLAGS } from '../constants/feature-flags';
-import { ChangeStatusDropdown } from '../features/visits/in-person/components/ChangeStatusDropdown';
 import { PencilIconButton } from '../features/visits/telemed/components/patient-visit-details/PencilIconButton';
 import { formatLastModifiedTag } from '../helpers';
 import {
@@ -1385,27 +1382,6 @@ export default function VisitDetailsPage(): ReactElement {
             </Grid>
           </Grid>
         </Grid>
-        {!loading && encounter && (
-          <Grid container direction="row" justifyContent="space-between">
-            <Grid item>
-              {loading || !status ? (
-                <Skeleton sx={{ marginLeft: { xs: 0, sm: 2 } }} aria-busy="true" width={200} />
-              ) : (
-                <div id="user-set-appointment-status">
-                  <FormControl size="small" sx={{ marginTop: 2, marginLeft: { xs: 0, sm: 8 } }}>
-                    <ChangeStatusDropdown
-                      appointmentID={appointmentID}
-                      onStatusChange={setStatus}
-                      getAndSetResources={getAndSetHistoricResources}
-                      dataTestId={dataTestIds.appointmentPage.changeStatusDropdown}
-                    />
-                  </FormControl>
-                  {loading && <CircularProgress size="20px" sx={{ marginTop: 2.8, marginLeft: 1 }} />}
-                </div>
-              )}
-            </Grid>
-          </Grid>
-        )}
         <Grid container direction="row">
           <Grid item sx={{ marginLeft: { xs: 0, sm: 8 }, marginTop: 2, marginBottom: 50 }}>
             <Stack direction="row" spacing={1} useFlexGap>

--- a/apps/ehr/tests/unit/tracking-board-primary-action.test.ts
+++ b/apps/ehr/tests/unit/tracking-board-primary-action.test.ts
@@ -62,6 +62,18 @@ describe('getTrackingBoardPrimaryAction', () => {
     expect(getTrackingBoardPrimaryAction(status as VisitStatusLabel)).toEqual(expectedAction);
   });
 
+  test('returns a navigate-only start provider action for virtual ready for provider visits', () => {
+    expect(getTrackingBoardPrimaryAction('ready for provider', { isVirtualVisit: true })).toEqual({
+      dataTestId: dataTestIds.dashboard.startProviderButton,
+      label: 'Start Provider',
+      missingUserMessage: 'User is not available. Cannot start provider visit.',
+      navigateToChart: true,
+      skipStatusUpdate: true,
+      successMessage: undefined,
+      updatedStatus: 'provider',
+    });
+  });
+
   test.each(nonActionableStatuses)('returns no board action for %s', (status) => {
     expect(getTrackingBoardPrimaryAction(status)).toBeUndefined();
   });


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2521/patient-app-waiting-room-internal-service-error-when-apointments
https://linear.app/zapehr/issue/OTR-1252/updates-to-visit-status-workflow-on-tracking-board#comment-ed248083
https://linear.app/zapehr/issue/OTR-2520/ehr-error-should-be-displayed-when-clicking-start-provider-without