### PR TITLE
Fix "Patient info" stale data after patiens merge

### DIFF
--- a/apps/ehr/src/pages/PatientPage.tsx
+++ b/apps/ehr/src/pages/PatientPage.tsx
@@ -81,10 +81,10 @@ export default function PatientPage(): JSX.Element {
   // queries so the UI picks up the merged state.
   useEffect(() => {
     if (mergeTaskData && mergeTaskData.task === null) {
-      void queryClient.invalidateQueries({ queryKey: ['useGetPatientPatientResources'] });
-      void queryClient.invalidateQueries({ queryKey: ['patient-account-get'] });
-      void queryClient.invalidateQueries({ queryKey: ['patient-coverages'] });
-      void queryClient.invalidateQueries({ queryKey: ['otherPatientsWithSameNameResources'] });
+      void queryClient.refetchQueries({ queryKey: ['useGetPatientPatientResources'], type: 'all' });
+      void queryClient.refetchQueries({ queryKey: ['patient-account-get'], type: 'all' });
+      void queryClient.refetchQueries({ queryKey: ['patient-coverages'], type: 'all' });
+      void queryClient.refetchQueries({ queryKey: ['otherPatientsWithSameNameResources'], type: 'all' });
     }
   }, [mergeTaskData, queryClient]);
 


### PR DESCRIPTION
`invalidateQueries` doesn't work for invalidating `patient-account-get` query because of `refetchOnMount: false` and the query is not mount when `invalidateQueries` is called. Use `refetchQueries` insted of `invalidateQueries`.