### PR TITLE
fix: return 200 instead of throwing error when QuestionnaireResponse is completed

### DIFF
--- a/packages/zambdas/src/patient/ai-interview/handle-answer/index.ts
+++ b/packages/zambdas/src/patient/ai-interview/handle-answer/index.ts
@@ -31,7 +31,11 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     id: questionnaireResponseId,
   });
   if (questionnaireResponse.status === 'completed') {
-    throw new Error('QuestionnaireResponse is completed.');
+    console.log(`QuestionnaireResponse ${questionnaireResponseId} is already completed, returning existing response`);
+    return {
+      statusCode: 200,
+      body: JSON.stringify(questionnaireResponse),
+    };
   }
   questionnaireResponse.item?.push({
     linkId,

--- a/packages/zambdas/src/patient/ai-interview/handle-answer/index.ts
+++ b/packages/zambdas/src/patient/ai-interview/handle-answer/index.ts
@@ -2,7 +2,14 @@ import { BaseMessageLike } from '@langchain/core/messages';
 import Oystehr from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Questionnaire, QuestionnaireResponse } from 'fhir/r4b';
-import { createOystehrClient, getSecret, HandleAnswerInput, Secrets, SecretsKeys } from 'utils';
+import {
+  createOystehrClient,
+  getSecret,
+  HandleAnswerInput,
+  QUESTIONNAIRE_RESPONSE_INVALID_CUSTOM_ERROR,
+  Secrets,
+  SecretsKeys,
+} from 'utils';
 import {
   assertDefined,
   getAuth0Token,
@@ -31,11 +38,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     id: questionnaireResponseId,
   });
   if (questionnaireResponse.status === 'completed') {
-    console.log(`QuestionnaireResponse ${questionnaireResponseId} is already completed, returning existing response`);
-    return {
-      statusCode: 200,
-      body: JSON.stringify(questionnaireResponse),
-    };
+    throw QUESTIONNAIRE_RESPONSE_INVALID_CUSTOM_ERROR('QuestionnaireResponse is already completed.');
   }
   questionnaireResponse.item?.push({
     linkId,


### PR DESCRIPTION
## Summary
- When staff moves a visit to "ready for provider", the QuestionnaireResponse status is set to completed
- If the patient then sends another answer, the `ai-interview-handle-answer` zambda was throwing an error which triggered PagerDuty alerts
- This change returns the existing completed response with a 200 status instead of throwing an error

## Test plan
- [ ] Deploy to staging and verify that when a QuestionnaireResponse is already completed, the zambda returns 200 with the existing response instead of throwing an error
- [ ] Verify no PagerDuty alerts are triggered for this scenario

## Related
- Slack thread: https://masslight.slack.com/archives/C06M4NZK8P6/p1779120996478989?thread_ts=1778954090.484559&cid=C06M4NZK8P6

https://claude.ai/code/session_01TqRmBLE8i5WfhFrwz1vYXT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqRmBLE8i5WfhFrwz1vYXT)_