### PR TITLE
Optimize get-employees endpoint with lite mode for dropdown population

### DIFF
--- a/apps/ehr/src/api/api.ts
+++ b/apps/ehr/src/api/api.ts
@@ -899,7 +899,7 @@ export const cancelAppointment = async (
   }
 };
 
-export const getEmployees = async (oystehr: Oystehr): Promise<GetEmployeesResponse> => {
+export const getEmployees = async (oystehr: Oystehr, options?: { lite?: boolean }): Promise<GetEmployeesResponse> => {
   try {
     if (GET_EMPLOYEES_ZAMBDA_ID == null) {
       throw new Error('get employees environment variable could not be loaded');
@@ -907,6 +907,7 @@ export const getEmployees = async (oystehr: Oystehr): Promise<GetEmployeesRespon
 
     const response = await oystehr.zambda.execute({
       id: GET_EMPLOYEES_ZAMBDA_ID,
+      ...(options?.lite ? { lite: true } : {}),
     });
     return chooseJson(response);
   } catch (error: unknown) {

--- a/apps/ehr/src/features/visits/in-person/components/Header.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/Header.tsx
@@ -333,49 +333,46 @@ export const Header = (): JSX.Element => {
 
   const { oystehrZambda } = useApiClients();
 
-  const { data: employees, isFetching: employeesIsFetching } = useQuery({
-    queryKey: ['get-employees', { oystehrZambda }],
+  const { data: employees, isLoading: employeesIsLoading } = useQuery({
+    queryKey: ['progress-note-header-employees'],
     queryFn: async () => {
-      if (oystehrZambda) {
-        const getEmployeesRes = await getEmployees(oystehrZambda);
-        const activeEmployees = getEmployeesRes.employees.filter((employee) => employee.status === 'Active');
-        const providers = activeEmployees.filter((employee) => employee.isProvider && !employee.isCustomerSupport);
-        const formattedProviders: ProviderDetails[] = providers
-          .map((prov) => {
-            const id = prov.profile.split('/')[1];
-            return {
-              practitionerId: id,
-              name: `${prov.firstName} ${prov.lastName}`.trim(),
-            };
-          })
-          .filter((prov) => prov.name);
+      if (!oystehrZambda) return null;
+      const getEmployeesRes = await getEmployees(oystehrZambda, { lite: true });
+      const activeEmployees = getEmployeesRes.employees.filter((employee) => employee.status === 'Active');
+      const providers = activeEmployees.filter((employee) => employee.isProvider && !employee.isCustomerSupport);
+      const formattedProviders: ProviderDetails[] = providers
+        .map((prov) => {
+          const id = prov.profile.split('/')[1];
+          return {
+            practitionerId: id,
+            name: `${prov.firstName} ${prov.lastName}`.trim(),
+          };
+        })
+        .filter((prov) => prov.name);
 
-        // TODO: remove this once we have nurses role
-        // const nonProviders = getEmployeesRes.employees.filter((employee) => !employee.isProvider);
-        const nonProviders = activeEmployees.filter((employee) => !employee.isCustomerSupport);
-        const formattedNonProviders: ProviderDetails[] = nonProviders
-          .map((prov) => {
-            const id = prov.profile.split('/')[1];
-            return {
-              practitionerId: id,
-              name: `${prov.firstName} ${prov.lastName}`.trim(),
-            };
-          })
-          .filter((prov) => prov.name);
-        return {
-          providers: formattedProviders,
-          nonProviders: formattedNonProviders,
-        };
-      }
-      return null;
+      // TODO: remove this once we have nurses role
+      // const nonProviders = getEmployeesRes.employees.filter((employee) => !employee.isProvider);
+      const nonProviders = activeEmployees.filter((employee) => !employee.isCustomerSupport);
+      const formattedNonProviders: ProviderDetails[] = nonProviders
+        .map((prov) => {
+          const id = prov.profile.split('/')[1];
+          return {
+            practitionerId: id,
+            name: `${prov.firstName} ${prov.lastName}`.trim(),
+          };
+        })
+        .filter((prov) => prov.name);
+      return {
+        providers: formattedProviders,
+        nonProviders: formattedNonProviders,
+      };
     },
+    enabled: !!oystehrZambda,
+    // Employees rarely change — cache across navigations to keep the header fast.
+    staleTime: 5 * 60 * 1000,
   });
 
-  if (employeesIsFetching) {
-    return <HeaderSkeleton />;
-  }
-
-  if (!employees) {
+  if (!employeesIsLoading && oystehrZambda && !employees) {
     return <Box sx={{ padding: '16px' }}>There must be some employees registered to use charting.</Box>;
   }
 
@@ -472,55 +469,7 @@ export const Header = (): JSX.Element => {
                     {isFollowup ? (
                       <Stack direction="row" spacing={1} alignItems="center">
                         <PatientMetadata sx={{ whiteSpace: 'nowrap' }}>Follow-up provider: </PatientMetadata>
-                        <TextField
-                          select
-                          fullWidth
-                          data-testid={dataTestIds.inPersonHeader.providerPractitionerInput}
-                          sx={{ minWidth: 120 }}
-                          variant="standard"
-                          value={assignedProviderId ?? ''}
-                          disabled={isUpdatingPractitionerForProvider}
-                          onChange={(e) => {
-                            void handleUpdateProviderAssignment(e.target.value);
-                          }}
-                        >
-                          {employees.providers
-                            ?.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
-                            ?.map((provider) => (
-                              <MenuItem key={provider.practitionerId} value={provider.practitionerId}>
-                                {provider.name}
-                              </MenuItem>
-                            ))}
-                        </TextField>
-                      </Stack>
-                    ) : (
-                      <Stack direction="row" spacing={2}>
-                        <Stack direction="row" spacing={1} alignItems="center">
-                          <PatientMetadata>Intake: </PatientMetadata>
-                          <TextField
-                            select
-                            fullWidth
-                            data-testid={dataTestIds.inPersonHeader.intakePractitionerInput}
-                            sx={{ minWidth: 120 }}
-                            variant="standard"
-                            value={assignedIntakePerformerId ?? ''}
-                            disabled={isUpdatingPractitionerForIntake}
-                            onChange={(e) => {
-                              void handleUpdateIntakeAssignment(e.target.value);
-                            }}
-                          >
-                            {employees.nonProviders
-                              ?.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
-                              ?.map((nonProvider) => (
-                                <MenuItem key={nonProvider.practitionerId} value={nonProvider.practitionerId}>
-                                  {nonProvider.name}
-                                </MenuItem>
-                              ))}
-                          </TextField>
-                        </Stack>
-
-                        <Stack direction="row" spacing={1} alignItems="center">
-                          <PatientMetadata>Provider: </PatientMetadata>
+                        {employees ? (
                           <TextField
                             select
                             fullWidth
@@ -541,6 +490,66 @@ export const Header = (): JSX.Element => {
                                 </MenuItem>
                               ))}
                           </TextField>
+                        ) : (
+                          <Skeleton sx={{ width: 120, minWidth: 120 }} animation="wave" />
+                        )}
+                      </Stack>
+                    ) : (
+                      <Stack direction="row" spacing={2}>
+                        <Stack direction="row" spacing={1} alignItems="center">
+                          <PatientMetadata>Intake: </PatientMetadata>
+                          {employees ? (
+                            <TextField
+                              select
+                              fullWidth
+                              data-testid={dataTestIds.inPersonHeader.intakePractitionerInput}
+                              sx={{ minWidth: 120 }}
+                              variant="standard"
+                              value={assignedIntakePerformerId ?? ''}
+                              disabled={isUpdatingPractitionerForIntake}
+                              onChange={(e) => {
+                                void handleUpdateIntakeAssignment(e.target.value);
+                              }}
+                            >
+                              {employees.nonProviders
+                                ?.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
+                                ?.map((nonProvider) => (
+                                  <MenuItem key={nonProvider.practitionerId} value={nonProvider.practitionerId}>
+                                    {nonProvider.name}
+                                  </MenuItem>
+                                ))}
+                            </TextField>
+                          ) : (
+                            <Skeleton sx={{ width: 120, minWidth: 120 }} animation="wave" />
+                          )}
+                        </Stack>
+
+                        <Stack direction="row" spacing={1} alignItems="center">
+                          <PatientMetadata>Provider: </PatientMetadata>
+                          {employees ? (
+                            <TextField
+                              select
+                              fullWidth
+                              data-testid={dataTestIds.inPersonHeader.providerPractitionerInput}
+                              sx={{ minWidth: 120 }}
+                              variant="standard"
+                              value={assignedProviderId ?? ''}
+                              disabled={isUpdatingPractitionerForProvider}
+                              onChange={(e) => {
+                                void handleUpdateProviderAssignment(e.target.value);
+                              }}
+                            >
+                              {employees.providers
+                                ?.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
+                                ?.map((provider) => (
+                                  <MenuItem key={provider.practitionerId} value={provider.practitionerId}>
+                                    {provider.name}
+                                  </MenuItem>
+                                ))}
+                            </TextField>
+                          ) : (
+                            <Skeleton sx={{ width: 120, minWidth: 120 }} animation="wave" />
+                          )}
                         </Stack>
                       </Stack>
                     )}
@@ -656,79 +665,6 @@ export const Header = (): JSX.Element => {
                   </MenuItem>
                 </Menu>
                 <CreateTaskDialog open={showCreateTaskDialog} handleClose={() => setShowCreateTaskDialog(false)} />
-              </Grid>
-            </Grid>
-          </Grid>
-        </Grid>
-      </Stack>
-    </HeaderWrapper>
-  );
-};
-
-const HeaderSkeleton = (): JSX.Element => {
-  return (
-    <HeaderWrapper>
-      <Stack flexDirection="row">
-        <Box sx={{ width: 70 }} display="flex" alignItems="center" justifyContent="center">
-          <Skeleton sx={{ height: 40, width: 40 }} animation="wave" variant="circular" />
-        </Box>
-        <Grid container spacing={2} sx={{ padding: '0 18px 0 4px' }}>
-          <Grid item xs={12}>
-            <Grid container alignItems="center" justifyContent="space-between">
-              <Grid item>
-                <Grid container alignItems="center" spacing={2}>
-                  <Grid item>
-                    <Skeleton sx={{ width: 120, height: 40 }} animation="wave" />
-                  </Grid>
-                  <Grid item>
-                    <Skeleton sx={{ width: 200 }} animation="wave" variant="text" />
-                  </Grid>
-                  <Grid item>
-                    <Stack direction="row" spacing={2}>
-                      <Stack direction="row" spacing={1} alignItems="center">
-                        <Skeleton sx={{ width: 60 }} animation="wave" variant="text" />
-                        <Skeleton sx={{ width: 120 }} animation="wave" />
-                      </Stack>
-
-                      <Stack direction="row" spacing={1} alignItems="center">
-                        <Skeleton sx={{ width: 60 }} animation="wave" variant="text" />
-                        <Skeleton sx={{ width: 120 }} animation="wave" />
-                      </Stack>
-                    </Stack>
-                  </Grid>
-                </Grid>
-              </Grid>
-              <Grid item>
-                <Skeleton sx={{ height: 40, width: 40 }} animation="wave" variant="circular" />
-              </Grid>
-            </Grid>
-          </Grid>
-          <Grid item xs={12} sx={{ mt: -2 }}>
-            <Grid container alignItems="center" spacing={2}>
-              <Grid item>
-                <Skeleton sx={{ height: 50, width: 50 }} animation="wave" variant="circular" />
-              </Grid>
-              <Grid item xs>
-                <PatientInfoWrapper>
-                  <Skeleton sx={{ width: 160 }} animation="wave" variant="text" />
-                  <Skeleton sx={{ width: 120 }} animation="wave" variant="text" />
-                </PatientInfoWrapper>
-                <PatientInfoWrapper>
-                  <Skeleton sx={{ width: 120 }} animation="wave" variant="text" />
-                  <Skeleton sx={{ width: 140 }} animation="wave" variant="text" />
-                </PatientInfoWrapper>
-              </Grid>
-              <Grid
-                item
-                sx={{
-                  '@media (max-width: 1179px)': {
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 0.5,
-                  },
-                }}
-              >
-                <Skeleton width={200} height={40} animation="wave" />
               </Grid>
             </Grid>
           </Grid>

--- a/packages/zambdas/src/ehr/get-employees/index.ts
+++ b/packages/zambdas/src/ehr/get-employees/index.ts
@@ -28,13 +28,21 @@ if (process.env.IS_OFFLINE === 'true') {
 
 export interface GetEmployeesInput {
   secrets: Secrets | null;
+  /**
+   * When true, skips the expensive Encounter queries and the heavy Practitioner enrichment
+   * (qualifications, telecom, notification settings, last-login meta). Use this when the caller
+   * only needs id, name, and role classification — e.g. populating dropdowns. The fields that
+   * depend on the skipped work (`seenPatientRecently`, `gettingAlerts`, `licenses`,
+   * `phoneNumber`, `lastLogin`) are returned as empty/default values.
+   */
+  lite?: boolean;
 }
 
 let oystehrToken: string;
 export const index = wrapHandler('get-employees', async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   console.group('validateRequestParameters');
   const validatedParameters = validateRequestParameters(input);
-  const { secrets } = validatedParameters;
+  const { secrets, lite } = validatedParameters;
   console.groupEnd();
   console.debug('validateRequestParameters success');
 
@@ -59,17 +67,25 @@ export const index = wrapHandler('get-employees', async (input: ZambdaInput): Pr
     throw new Error('Error searching for Inactive, Provider or CustomerSupport role.');
   }
 
-  console.log('Preparing the FHIR batch request.');
+  console.log(`Preparing the FHIR batch request (lite=${Boolean(lite)}).`);
 
   const practitionerIds = allEmployees
     .filter((employee) => employee.profile?.startsWith('Practitioner/'))
     .map((employee) => employee.profile.split('/')[1]);
-  const encounterCutDate = DateTime.now().minus({ minutes: 30 }).toFormat("yyyy-MM-dd'T'HH:mm");
-  const getResourcesRequest = getResourcesFromBatchInlineRequests(oystehr, [
-    `Practitioner?_id=${practitionerIds.join(',')}&_elements=id,meta,qualification,name,extension,telecom`,
-    `Encounter?status=in-progress&_elements=id,participant`,
-    `Encounter?status=finished&date=gt${encounterCutDate}&_elements=id,participant`,
-  ]);
+
+  // Lite mode skips the organization-wide Encounter queries (used only for `seenPatientRecently`)
+  // and trims Practitioner _elements to just what's needed for names.
+  const fhirRequests = lite
+    ? [`Practitioner?_id=${practitionerIds.join(',')}&_elements=id,name`]
+    : (() => {
+        const encounterCutDate = DateTime.now().minus({ minutes: 30 }).toFormat("yyyy-MM-dd'T'HH:mm");
+        return [
+          `Practitioner?_id=${practitionerIds.join(',')}&_elements=id,meta,qualification,name,extension,telecom`,
+          `Encounter?status=in-progress&_elements=id,participant`,
+          `Encounter?status=finished&date=gt${encounterCutDate}&_elements=id,participant`,
+        ];
+      })();
+  const getResourcesRequest = getResourcesFromBatchInlineRequests(oystehr, fhirRequests);
 
   console.log('Do mixed promises in parallel...');
 
@@ -98,7 +114,9 @@ export const index = wrapHandler('get-employees', async (input: ZambdaInput): Pr
   const providerMemberIds = providerRoleMembers.map((member: { id: string }) => member.id);
   const customerSupportMemberIds = customerSupportRoleMembers.map((member: { id: string }) => member.id);
 
-  const recentlyActivePractitioners: string[] = extractParticipantsRefsFromResources(resources as FhirResource[]);
+  const recentlyActivePractitioners: string[] = lite
+    ? []
+    : extractParticipantsRefsFromResources(resources as FhirResource[]);
 
   console.log('recentlyActivePractitioners.length:', recentlyActivePractitioners.length);
 
@@ -110,10 +128,10 @@ export const index = wrapHandler('get-employees', async (input: ZambdaInput): Pr
       ? (resources.find((resource) => resource.id === practitionerId) as Practitioner | undefined)
       : undefined;
 
-    const phone = practitioner?.telecom?.find((telecom) => telecom.system === 'sms')?.value;
+    const phone = lite ? undefined : practitioner?.telecom?.find((telecom) => telecom.system === 'sms')?.value;
 
     const licenses: PractitionerLicense[] = [];
-    if (practitioner?.qualification) {
+    if (!lite && practitioner?.qualification) {
       practitioner.qualification.forEach((qualification: PractitionerQualification) => {
         const qualificationStatusCode =
           qualification.extension?.[0].extension?.[1].valueCodeableConcept?.coding?.[0].code;
@@ -129,7 +147,7 @@ export const index = wrapHandler('get-employees', async (input: ZambdaInput): Pr
       });
     }
 
-    const notificationSettings = getProviderNotificationSettingsForPractitioner(practitioner);
+    const notificationSettings = lite ? undefined : getProviderNotificationSettingsForPractitioner(practitioner);
     return {
       id: employee.id,
       profile: employee.profile,
@@ -138,7 +156,7 @@ export const index = wrapHandler('get-employees', async (input: ZambdaInput): Pr
       status: status,
       isProvider: Boolean(providerMemberIds.includes(employee.id)),
       isCustomerSupport: Boolean(customerSupportMemberIds.includes(employee.id)),
-      lastLogin: practitioner?.meta?.tag?.find((tag) => tag.system === 'last-login')?.code ?? '',
+      lastLogin: lite ? '' : practitioner?.meta?.tag?.find((tag) => tag.system === 'last-login')?.code ?? '',
       firstName: getFirstName(practitioner) ?? '',
       lastName: getLastName(practitioner) ?? '',
       phoneNumber: phone ? standardizePhoneNumber(phone)! : '',

--- a/packages/zambdas/src/ehr/get-employees/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/get-employees/validateRequestParameters.ts
@@ -2,7 +2,17 @@ import { ZambdaInput } from '../../shared';
 import { GetEmployeesInput } from '.';
 
 export function validateRequestParameters(input: ZambdaInput): GetEmployeesInput {
+  let lite = false;
+  if (input.body) {
+    try {
+      const parsed = JSON.parse(input.body);
+      lite = parsed?.lite === true;
+    } catch {
+      // Body is optional for this endpoint; ignore parse errors and fall back to full payload.
+    }
+  }
   return {
     secrets: input.secrets,
+    lite,
   };
 }


### PR DESCRIPTION
## Summary
Refactors the `get-employees` endpoint to support a lightweight "lite" mode that skips expensive FHIR queries and enrichment operations. This improves performance when the endpoint is called solely to populate UI dropdowns (provider/intake selectors), where only names and role classification are needed.

## Key Changes

**Backend (zambdas)**
- Added optional `lite` parameter to `GetEmployeesInput` interface with documentation
- When `lite=true`, the endpoint skips:
  - Organization-wide Encounter queries (used only for `seenPatientRecently`)
  - Heavy Practitioner enrichment (qualifications, telecom, notification settings, last-login metadata)
  - Returns empty/default values for dependent fields (`seenPatientRecently`, `gettingAlerts`, `licenses`, `phoneNumber`, `lastLogin`)
- Updated FHIR batch request to conditionally include only `id,name` elements for Practitioners in lite mode
- Added parameter validation in `validateRequestParameters.ts` to parse `lite` from request body

**Frontend (EHR)**
- Updated `getEmployees()` API call to accept optional `{ lite: true }` parameter
- Modified Header component's employee query to:
  - Call `getEmployees(oystehrZambda, { lite: true })` for dropdown population
  - Changed query key to `'progress-note-header-employees'` for clarity
  - Replaced `isFetching` with `isLoading` for more accurate loading state
  - Added `enabled` condition and 5-minute `staleTime` for better caching across navigations
- Replaced full-page `HeaderSkeleton` component with inline `Skeleton` components in the provider/intake selector dropdowns
- Removed the `HeaderSkeleton` component entirely as it's no longer needed

## Implementation Details
- The lite mode is opt-in; existing callers continue to receive full employee data
- Lite mode reduces FHIR request count from 3 to 1 and eliminates expensive participant extraction logic
- Inline skeleton loaders provide better UX by showing loading state only for the affected dropdowns rather than the entire header
- Query caching prevents redundant requests when navigating between visits

https://claude.ai/code/session_017CZqpYsnJfT3qBxzRjPYPB