### PR TITLE
Fix seeded appointment date to use location timezone

### DIFF
--- a/apps/ehr/tests/e2e-utils/resource-handler.ts
+++ b/apps/ehr/tests/e2e-utils/resource-handler.ts
@@ -35,6 +35,7 @@ import {
   formatPhoneNumber,
   genderMap,
   GetPaperworkAnswers,
+  getTimezone,
   IN_PERSON_INTAKE_PAPERWORK_CANONICAL,
   RelationshipOption,
   SampleAppointmentResponse,
@@ -349,11 +350,18 @@ export class ResourceHandler {
     // Seed data only needs the canonical URL+version pair, not a full Q body.
     const { url, version } = IN_PERSON_INTAKE_PAPERWORK_CANONICAL;
 
+    // Use the location's timezone (not UTC) so the seeded appointment lands on the same
+    // calendar day the tracking board searches — it filters in the location's timezone,
+    // so a UTC-keyed date is wrong in the evenings local time (e.g. 8pm-midnight ET).
+    const locationTimezone = getTimezone(schedule);
     let seedDataString = JSON.stringify(fastSeedData);
     seedDataString = seedDataString.replace(/\{\{locationId\}\}/g, process.env.LOCATION_ID);
     seedDataString = seedDataString.replace(/\{\{scheduleId\}\}/g, schedule.id!);
     seedDataString = seedDataString.replace(/\{\{questionnaireUrl\}\}/g, `${url}|${version}`);
-    seedDataString = seedDataString.replace(/\{\{date\}\}/g, DateTime.now().toUTC().toFormat('yyyy-MM-dd'));
+    seedDataString = seedDataString.replace(
+      /\{\{date\}\}/g,
+      DateTime.now().setZone(locationTimezone).toFormat('yyyy-MM-dd')
+    );
 
     // TODO do something about the DocumentReference attachments? For the moment all of these tests point to the exact same files. Maybe that's great. Or maybe we should upload images each time?
 


### PR DESCRIPTION
Claude wrote this. I have read and understand the code. I spent 10 minutes on this.

> ## Summary
> Fixed a bug in E2E test seed data generation where appointment dates were being set in UTC instead of the location's timezone. This caused seeded appointments to land on the wrong calendar day when the tracking board filters appointments in the location's local timezone.
> 
> ## Changes
> - Import `getTimezone` utility function to extract the location's timezone from the schedule
> - Update the seed data date replacement to use `DateTime.now().setZone(locationTimezone)` instead of `DateTime.now().toUTC()`
> - Add explanatory comment clarifying why location timezone is necessary for correct filtering behavior
> 
> ## Implementation Details
> The issue occurred because the tracking board filters appointments by date in the location's timezone, but the seeded appointment was being keyed with a UTC date. This mismatch caused appointments created in the evening (e.g., 8pm-midnight ET) to be assigned the next calendar day in UTC, making them invisible to the filtering logic.
> 
> By using the location's timezone via `getTimezone(schedule)`, the seeded appointment now lands on the same calendar day that the tracking board searches for, ensuring test appointments are properly discoverable.
> 
> https://claude.ai/code/session_018rhPsYE2x5JvVNZfQarRPU