### PR TITLE
NPI for Demo/E2E users

### DIFF
--- a/scripts/setup/project/README.md
+++ b/scripts/setup/project/README.md
@@ -14,11 +14,11 @@ export const OYSTEHR_AUTH_TOKEN = '';   // short-lived bearer token from console
 export const SENDGRID_AUTH_TOKEN = '';  // optional — leave empty to skip SendGrid key creation
 
 export const DEMO_USERS = [
-  { email: 'demo@example.com', firstName: 'Demo', lastName: 'User', password: 'your-password' },
+  { email: 'demo@example.com', firstName: 'Demo', lastName: 'User', password: 'your-password', npi: '1234567890' },
 ];
 
 export const E2E_USERS = [
-  { email: 'e2e@example.com', firstName: 'E2E', lastName: 'User', password: 'your-password' },
+  { email: 'e2e@example.com', firstName: 'E2E', lastName: 'User', password: 'your-password', npi: '1234567890' },
 ];
 
 export const DEVELOPERS = [

--- a/scripts/setup/project/invite-demo-user.ts
+++ b/scripts/setup/project/invite-demo-user.ts
@@ -21,7 +21,8 @@ async function main(): Promise<void> {
     user.email,
     user.firstName,
     user.lastName,
-    roleIds
+    roleIds,
+    user.npi
   );
 
   console.log(`Invite sent! User ID: ${inviteResponse.id}`);

--- a/scripts/setup/project/invite-e2e-user.ts
+++ b/scripts/setup/project/invite-e2e-user.ts
@@ -21,7 +21,8 @@ async function main(): Promise<void> {
     user.email,
     user.firstName,
     user.lastName,
-    roleIds
+    roleIds,
+    user.npi
   );
 
   console.log(`Invite sent! User ID: ${inviteResponse.id}`);

--- a/scripts/setup/project/types.ts
+++ b/scripts/setup/project/types.ts
@@ -8,6 +8,7 @@ export interface DemoUser {
   firstName: string;
   lastName: string;
   password: string;
+  npi?: string;
 }
 
 export interface Developer {

--- a/scripts/setup/project/utils.ts
+++ b/scripts/setup/project/utils.ts
@@ -95,7 +95,8 @@ export async function sendUserInvite(
   email: string,
   firstName: string,
   lastName: string,
-  roleIds: string[]
+  roleIds: string[],
+  npi?: string
 ): Promise<{ invitationUrl?: string; profile: string; id: string }> {
   return apiFetch('/user/invite', config, {
     method: 'POST',
@@ -107,6 +108,14 @@ export async function sendUserInvite(
       resource: {
         resourceType: 'Practitioner',
         name: [{ family: lastName, given: [firstName] }],
+        ...(npi && {
+          identifier: [
+            {
+              system: 'http://hl7.org/fhir/sid/us-npi',
+              value: npi,
+            },
+          ],
+        }),
       },
       accessPolicy: {
         rule: [


### PR DESCRIPTION
How to use:

In scripts/setup/project/setup.config.ts, add the optional npi field:
```
export const DEMO_USERS = [
  { email: 'demo@example.com', firstName: 'Demo', lastName: 'User', password: 'pwd', npi: '1234567890' },
];
```
Run npm run invite:demo — the Practitioner will be created with the NPI identifier.