### PR TITLE
fix(OTR-2388): sort immunization quick picks dropdown alphabetically

### DIFF
--- a/apps/ehr/src/features/immunization/hooks/useImmunizationQuickPickManagement.ts
+++ b/apps/ehr/src/features/immunization/hooks/useImmunizationQuickPickManagement.ts
@@ -33,7 +33,8 @@ export const useImmunizationQuickPickManagement = ({
   applyOrderDetails,
 }: UseImmunizationQuickPickManagementProps): UseImmunizationQuickPickManagementReturn => {
   const { oystehrZambda } = useApiClients();
-  const { quickPicks: mergedQuickPicks, refetch: refetchQuickPicks } = useMergedImmunizationQuickPicks();
+  const { quickPicks: rawQuickPicks, refetch: refetchQuickPicks } = useMergedImmunizationQuickPicks();
+  const mergedQuickPicks = [...rawQuickPicks].sort((a, b) => a.name.localeCompare(b.name));
   const [quickPickDialogOpen, setQuickPickDialogOpen] = useState(false);
   const [quickPickName, setQuickPickName] = useState('');
   const [existingQuickPicks, setExistingQuickPicks] = useState<ImmunizationQuickPickData[]>([]);

--- a/apps/ehr/src/features/immunization/hooks/useImmunizationQuickPickManagement.ts
+++ b/apps/ehr/src/features/immunization/hooks/useImmunizationQuickPickManagement.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { createImmunizationQuickPick, getImmunizationQuickPicks, updateImmunizationQuickPick } from 'src/api/api';
 import { useApiClients } from 'src/hooks/useAppClients';
-import { useMergedImmunizationQuickPicks } from 'src/hooks/useMergedQuickPicks';
+import { sortQuickPicks, useMergedImmunizationQuickPicks } from 'src/hooks/useMergedQuickPicks';
 import { ROUTE_OPTIONS } from 'src/shared/utils/options';
 import { ImmunizationQuickPickData } from 'utils';
 
@@ -73,7 +73,7 @@ export const useImmunizationQuickPickManagement = ({
     if (!oystehrZambda) return;
     try {
       const response = await getImmunizationQuickPicks(oystehrZambda);
-      setExistingQuickPicks(response.quickPicks);
+      setExistingQuickPicks([...response.quickPicks].sort(sortQuickPicks));
     } catch (error) {
       console.error('Failed to load existing quick picks:', error);
       setExistingQuickPicks(mergedQuickPicks);

--- a/apps/ehr/src/features/radiology/pages/CreateRadiologyOrder.tsx
+++ b/apps/ehr/src/features/radiology/pages/CreateRadiologyOrder.tsx
@@ -63,7 +63,7 @@ import {
 } from '../../../api/api';
 import { useApiClients } from '../../../hooks/useAppClients';
 import useEvolveUser from '../../../hooks/useEvolveUser';
-import { useMergedRadiologyQuickPicks } from '../../../hooks/useMergedQuickPicks';
+import { sortQuickPicks, useMergedRadiologyQuickPicks } from '../../../hooks/useMergedQuickPicks';
 import { WithRadiologyBreadcrumbs } from '../components/RadiologyBreadcrumbs';
 import { useRadiologyConsentExists } from '../components/useRadiologyConsentExists';
 
@@ -178,7 +178,7 @@ export const CreateRadiologyOrder: React.FC<CreateRadiologyOrdersProps> = () => 
     if (!oystehrZambda) return;
     try {
       const response = await getRadiologyQuickPicks(oystehrZambda);
-      setExistingQuickPicks(response.quickPicks);
+      setExistingQuickPicks([...response.quickPicks].sort(sortQuickPicks));
     } catch (error) {
       console.error('Failed to load existing quick picks:', error);
       setExistingQuickPicks(mergedQuickPicks);
@@ -330,7 +330,7 @@ export const CreateRadiologyOrder: React.FC<CreateRadiologyOrdersProps> = () => 
               <Grid container sx={{ width: '100%' }} spacing={1} rowSpacing={2}>
                 <Grid item xs={12}>
                   <QuickPicksButton
-                    quickPicks={[...mergedQuickPicks].sort((a, b) => a.name.localeCompare(b.name))}
+                    quickPicks={mergedQuickPicks}
                     getLabel={(qp) => {
                       const parts = [qp.name] as string[];
                       if (qp.cptCode) parts.push(qp.cptCode);

--- a/apps/ehr/src/features/visits/in-person/components/medication-administration/medication-editable-card/EditableMedicationCard.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/medication-administration/medication-editable-card/EditableMedicationCard.tsx
@@ -29,7 +29,7 @@ import { useAppointmentData } from 'src/features/visits/shared/stores/appointmen
 import { useApiClients } from 'src/hooks/useAppClients';
 import { useCommandPaletteSource } from 'src/hooks/useCommandPaletteSource';
 import useEvolveUser from 'src/hooks/useEvolveUser';
-import { useMergedInHouseMedicationQuickPicks } from 'src/hooks/useMergedQuickPicks';
+import { sortQuickPicks, useMergedInHouseMedicationQuickPicks } from 'src/hooks/useMergedQuickPicks';
 import { usePendingQuickPick } from 'src/hooks/usePendingQuickPick';
 import {
   CODE_SYSTEM_CPT,
@@ -291,7 +291,7 @@ export const EditableMedicationCard: React.FC<{
     if (!oystehrZambda) return;
     try {
       const response = await getInHouseMedicationQuickPicks(oystehrZambda);
-      setExistingQuickPicksForDialog(response.quickPicks);
+      setExistingQuickPicksForDialog([...response.quickPicks].sort(sortQuickPicks));
     } catch (error) {
       console.error('Failed to load existing quick picks:', error);
       setExistingQuickPicksForDialog(fhirQuickPicks);

--- a/apps/ehr/src/features/visits/in-person/pages/ProceduresNew.tsx
+++ b/apps/ehr/src/features/visits/in-person/pages/ProceduresNew.tsx
@@ -45,7 +45,7 @@ import { dataTestIds } from 'src/constants/data-test-ids';
 import { useApiClients } from 'src/hooks/useAppClients';
 import { useCommandPaletteSource } from 'src/hooks/useCommandPaletteSource';
 import useEvolveUser from 'src/hooks/useEvolveUser';
-import { useMergedProcedureQuickPicks } from 'src/hooks/useMergedQuickPicks';
+import { sortQuickPicks, useMergedProcedureQuickPicks } from 'src/hooks/useMergedQuickPicks';
 import { usePendingQuickPick } from 'src/hooks/usePendingQuickPick';
 import { useDebounce } from 'src/shared/hooks/useDebounce';
 import {
@@ -493,7 +493,7 @@ export default function ProceduresNew(): ReactElement {
     if (!oystehrZambda) return;
     try {
       const response = await getProcedureQuickPicks(oystehrZambda);
-      setExistingQuickPicks(response.quickPicks);
+      setExistingQuickPicks([...response.quickPicks].sort(sortQuickPicks));
     } catch (error) {
       console.error('Failed to load existing quick picks:', error);
       setExistingQuickPicks(mergedQuickPicks);

--- a/apps/ehr/src/hooks/useMergedQuickPicks.ts
+++ b/apps/ehr/src/hooks/useMergedQuickPicks.ts
@@ -32,6 +32,9 @@ export const sortQuickPicks = (a: any, b: any): number => {
   return aLabel.localeCompare(bLabel);
 };
 
+/**
+ * Generic hook that fetches FHIR-based quick picks from a zambda endpoint.
+ */
 export function useFhirQuickPicks<T>(
   fetchFn: (oystehr: any) => Promise<{ quickPicks: T[] }>,
   options?: { enabled?: boolean }

--- a/apps/ehr/src/hooks/useMergedQuickPicks.ts
+++ b/apps/ehr/src/hooks/useMergedQuickPicks.ts
@@ -26,9 +26,12 @@ interface UseFhirQuickPicksResult<T> {
   refetch: () => Promise<void>;
 }
 
-/**
- * Generic hook that fetches FHIR-based quick picks from a zambda endpoint.
- */
+export const sortQuickPicks = (a: any, b: any): number => {
+  const aLabel = a.name ?? a.display ?? '';
+  const bLabel = b.name ?? b.display ?? '';
+  return aLabel.localeCompare(bLabel);
+};
+
 export function useFhirQuickPicks<T>(
   fetchFn: (oystehr: any) => Promise<{ quickPicks: T[] }>,
   options?: { enabled?: boolean }
@@ -47,7 +50,7 @@ export function useFhirQuickPicks<T>(
     setLoading(true);
     try {
       const response = await fetchFn(oystehrZambda);
-      setQuickPicks(response.quickPicks);
+      setQuickPicks([...response.quickPicks].sort(sortQuickPicks));
     } catch (error) {
       console.error('Failed to load quick picks:', error);
       enqueueSnackbar('Failed to load quick picks', { variant: 'error' });


### PR DESCRIPTION
## Summary

- Quick picks are now sorted alphabetically by name in `useImmunizationQuickPickManagement`
- Applies to all quick pick usages: the dropdown in the Immunization Order form and the admin management page

## Test plan

- [ ] Create several immunization quick picks with names out of alphabetical order
- [ ] Open the Immunization Order form — verify quick picks appear in alphabetical order
- [ ] Verify the admin Quick Picks list is also sorted alphabetically

https://linear.app/ottehr/issue/OTR-2388

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUBXLXp7ycdBfy3L2uE9hJ)_