### PR TITLE
fix(OTR-2385): validate that medication dose is greater than zero

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/medication-administration/medication-editable-card/MedicationCardField.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/medication-administration/medication-editable-card/MedicationCardField.tsx
@@ -308,6 +308,12 @@ export const MedicationCardField: React.FC<MedicationCardFieldProps> = ({
     );
   }
 
+  const isDoseField = field === 'dose';
+  const isDoseInvalid = isDoseField && value !== undefined && value !== '' && Number(value) <= 0;
+  const isFieldEmpty = !value && value !== 0;
+  const hasError = showError && required && (isFieldEmpty || isDoseInvalid);
+  const errorMessage = isDoseInvalid ? 'Dose must be greater than 0' : REQUIRED_FIELD_ERROR_MESSAGE;
+
   return (
     <StyledTextField
       data-testid={dataTestIds.orderMedicationPage.inputField(field)}
@@ -319,13 +325,13 @@ export const MedicationCardField: React.FC<MedicationCardFieldProps> = ({
       value={value ?? ''}
       onChange={(e) => handleChange(e.target.value)}
       type={type}
-      {...(type === 'number' ? { inputProps: { min: 0 } } : {})}
+      {...(type === 'number' ? { inputProps: { min: isDoseField ? 0.001 : 0 } } : {})}
       multiline={isInstruction}
       rows={isInstruction ? 3 : undefined}
       InputLabelProps={type === 'datetime' || isInstruction ? { shrink: true } : undefined}
       required={required}
-      error={showError && required && !value}
-      helperText={showError && required && !value ? REQUIRED_FIELD_ERROR_MESSAGE : ''}
+      error={hasError}
+      helperText={hasError ? errorMessage : ''}
       // https://github.com/mui/material-ui/issues/7960#issuecomment-1858083123
       {...(type === 'number'
         ? { onFocus: (e) => e.target.addEventListener('wheel', (e) => e.preventDefault(), { passive: false }) }

--- a/apps/ehr/src/features/visits/in-person/components/medication-administration/medication-editable-card/utils.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/medication-administration/medication-editable-card/utils.tsx
@@ -42,7 +42,10 @@ export const getFieldType = (field: keyof MedicationData): InHouseMedicationFiel
 
 export const validateMedicationField = (field: string, value: string | number, type: MedicationOrderType): boolean => {
   const config = fieldsConfig[type][field as keyof (typeof fieldsConfig)[typeof type]];
-  return config?.isRequired ? value.toString().trim() !== '' : true;
+  if (!config?.isRequired) return true;
+  if (value.toString().trim() === '') return false;
+  if (field === 'dose') return Number(value) > 0;
+  return true;
 };
 
 export const validateAllMedicationFields = (


### PR DESCRIPTION
## Summary

- Added dose-specific validation: dose must be greater than 0 (not just non-empty)
- Shows "Dose must be greater than 0" inline error when an invalid dose is entered
- Changed the dose input's `min` attribute from `0` to `0.001` to prevent browser-native zero submission
- Updated `validateMedicationField` utility to enforce dose > 0

## Test plan

- [ ] Open a medication administration card in edit mode
- [ ] Enter `0` as the dose — verify an error message appears and save is blocked
- [ ] Enter a negative dose — verify it is rejected
- [ ] Enter a valid dose (e.g., `0.5`) — verify the error clears and save succeeds

https://linear.app/ottehr/issue/OTR-2385

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUBXLXp7ycdBfy3L2uE9hJ)_