### PR TITLE
fix(OTR-2365): show Edit icon for completed/administered medications

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/medication-administration/mar/MedicationActions.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/medication-administration/mar/MedicationActions.tsx
@@ -34,7 +34,9 @@ export const MedicationActions: React.FC<MedicationActionsProps> = ({ medication
     medication.status === 'administered-partly' ||
     medication.status === 'administered-not';
   const isEditable = canEditMedication(medication);
+  // Edit is available for pending (edit order) and completed (view/edit completed details)
   const showEdit = isEditable || isCompleted;
+  // Delete is available only for pending medications
   const showDelete = isEditable;
 
   if (!showEdit && !showDelete) {

--- a/apps/ehr/src/features/visits/in-person/components/medication-administration/mar/MedicationActions.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/medication-administration/mar/MedicationActions.tsx
@@ -34,10 +34,8 @@ export const MedicationActions: React.FC<MedicationActionsProps> = ({ medication
     medication.status === 'administered-partly' ||
     medication.status === 'administered-not';
   const isEditable = canEditMedication(medication);
-  // Edit is available for pending (edit order) and completed (view/edit completed details)
   const showEdit = isEditable || isCompleted;
-  // Delete is available only for pending medications
-  const showDelete = medication.status === 'pending';
+  const showDelete = isEditable;
 
   if (!showEdit && !showDelete) {
     return null;

--- a/apps/ehr/src/features/visits/in-person/components/medication-administration/mar/MedicationActions.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/medication-administration/mar/MedicationActions.tsx
@@ -29,10 +29,15 @@ export const MedicationActions: React.FC<MedicationActionsProps> = ({ medication
     }
   }, [error]);
 
+  const isCompleted =
+    medication.status === 'administered' ||
+    medication.status === 'administered-partly' ||
+    medication.status === 'administered-not';
   const isEditable = canEditMedication(medication);
-  // Delete is available for all statuses except cancelled, edit only for pending
-  const showEdit = isEditable;
-  const showDelete = medication.status !== 'cancelled';
+  // Edit is available for pending (edit order) and completed (view/edit completed details)
+  const showEdit = isEditable || isCompleted;
+  // Delete is available only for pending medications
+  const showDelete = medication.status === 'pending';
 
   if (!showEdit && !showDelete) {
     return null;


### PR DESCRIPTION
## Summary

- Edit button now appears for medications in `administered`, `administered-partly`, and `administered-not` statuses
- Delete button is now restricted to `pending` status only (was previously shown for all non-cancelled statuses)

## Test plan

- [ ] Mark a medication as administered — verify the Edit icon appears
- [ ] Click Edit on an administered medication — verify it opens for editing
- [ ] Verify the Delete icon is NOT shown for administered medications
- [ ] Verify the Delete icon still appears for pending medications

https://linear.app/ottehr/issue/OTR-2365

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUBXLXp7ycdBfy3L2uE9hJ)_