### PR TITLE
fix(OTR-2259): remove duplicate provider credentials from excuse footer

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/plan-tab/components/GenerateExcuseDialog.tsx
+++ b/apps/ehr/src/features/visits/shared/components/plan-tab/components/GenerateExcuseDialog.tsx
@@ -59,7 +59,6 @@ export const GenerateExcuseDialog: FC<GenerateExcuseDialogExtendedProps> = (prop
       patientName,
       parentName: fullParentName,
       providerName: user?.userName,
-      suffix: user?.profileResource?.name?.[0]?.suffix?.join(' '),
       phoneNumber: supportPhoneNumber,
       patientOrRelatedPerson: 'patient',
     }),

--- a/apps/ehr/src/features/visits/telemed/utils/school-work-excuse.helper.ts
+++ b/apps/ehr/src/features/visits/telemed/utils/school-work-excuse.helper.ts
@@ -171,7 +171,6 @@ export const getDefaultExcuseFormValues = (params: {
   isSchool: boolean;
   isTemplate: boolean;
   providerName?: string;
-  suffix?: string;
   phoneNumber?: string;
 }): ExcuseFormValues => {
   const defaultFormValues = {
@@ -209,9 +208,7 @@ export const getDefaultExcuseFormValues = (params: {
     if (params.phoneNumber) {
       defaultFormValues.footerNote = `For any questions, please do not hesitate to call ${params.phoneNumber}.\n`;
     }
-    defaultFormValues.footerNote += `Sincerely,\n${params.providerName || '{Provider name}'}, ${
-      params.suffix || 'Medical Doctor'
-    }`;
+    defaultFormValues.footerNote += `Sincerely,\n${params.providerName || '{Provider name}'}`;
   }
 
   return defaultFormValues;


### PR DESCRIPTION
## Summary

- Removed the `suffix` parameter from `getDefaultExcuseFormValues` — the provider's credentials (e.g. "MD") are already included in `providerName` via `getFullestAvailableName`, so appending them again caused duplication
- Updated `GenerateExcuseDialog` to stop passing the suffix argument

## Test plan

- [ ] Generate a school or work excuse for a provider with credentials (e.g. "Dr. Smith, MD")
- [ ] Verify the footer shows the provider name once with credentials, not doubled (e.g. "Dr. Smith, MD" not "Dr. Smith, MD, MD")

https://linear.app/ottehr/issue/OTR-2259

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUBXLXp7ycdBfy3L2uE9hJ)_