### PR TITLE
Fix(labs): prevent order creation with 'other' insurance, wc ins

### DIFF
--- a/packages/utils/lib/types/data/labs/labs.types.ts
+++ b/packages/utils/lib/types/data/labs/labs.types.ts
@@ -314,7 +314,7 @@ type SelfPayResource = {
 };
 type WorkersCompResource = {
   type: LabPaymentMethod.WorkersComp;
-  coverage: Coverage;
+  coverageAndOrgs: CoverageOrgRank[];
 };
 export type PaymentResources = InsurancePaymentResource | ClientBillResource | SelfPayResource | WorkersCompResource;
 

--- a/packages/zambdas/src/ehr/lab/external/create-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/external/create-lab-order/index.ts
@@ -52,6 +52,7 @@ import {
 import { checkOrCreateM2MClientToken, getMyPractitionerId, wrapHandler } from '../../../../shared';
 import { createOystehrClient } from '../../../../shared/helpers';
 import { ZambdaInput } from '../../../../shared/types';
+import { isOtherInsurance } from '../../shared/helpers';
 import { accountIsPatientBill, accountIsWorkersComp, sortCoveragesByPriority } from '../../shared/labs';
 import { labOrderCommunicationType } from '../get-lab-orders/helpers';
 import {
@@ -776,6 +777,11 @@ const getCreateOrderResources = async (input: GetCreateOrderResourcesInput): Pro
     case LabPaymentMethod.Insurance:
       if (!coveragesSortedByPriority) {
         throw EXTERNAL_LAB_ERROR(`Payment method is insurance but no insurances were found`);
+      }
+      if (coveragesSortedByPriority.some((coverage) => isOtherInsurance(coverage))) {
+        throw EXTERNAL_LAB_ERROR(
+          'Cannot order lab with "Other" insurance. Update the insurance or select a new payment method'
+        );
       }
       coverageDetails = {
         type: LabPaymentMethod.Insurance,

--- a/packages/zambdas/src/ehr/lab/external/submit-lab-order/helpers.ts
+++ b/packages/zambdas/src/ehr/lab/external/submit-lab-order/helpers.ts
@@ -677,7 +677,17 @@ function makePaymentResourceConfig(
   } else if (selfPayCoverage && coveragesAndOrgs.length === 1) {
     return { type: LabPaymentMethod.SelfPay, coverage: selfPayCoverage.coverage };
   } else if (workersCompCoverage && coveragesAndOrgs.length === 1) {
-    return { type: LabPaymentMethod.WorkersComp, coverage: workersCompCoverage.coverage };
+    // for the moment ottehr only supports one insurance for worker's comp
+    return {
+      type: LabPaymentMethod.WorkersComp,
+      coverageAndOrgs: [
+        {
+          coverage: workersCompCoverage.coverage,
+          payorOrg: workersCompCoverage.payorOrg,
+          coverageRank: 1,
+        },
+      ],
+    };
   } else {
     const coverageIdWithPaymentMethod = coveragesAndOrgs.map((data) => ({
       coverageId: data.coverage.id,

--- a/packages/zambdas/src/ehr/lab/shared/helpers.ts
+++ b/packages/zambdas/src/ehr/lab/shared/helpers.ts
@@ -1,11 +1,13 @@
 import { BatchInputPatchRequest } from '@oystehr/sdk';
 import {
   Communication,
+  Coverage,
   DiagnosticReport,
   DocumentReference,
   List,
   ListEntry,
   Observation,
+  Organization,
   Patient,
   QuestionnaireResponse,
   Reference,
@@ -13,8 +15,10 @@ import {
   Specimen,
   Task,
 } from 'fhir/r4b';
+import { isEqual } from 'lodash';
 import { DateTime } from 'luxon';
 import {
+  COVERAGE_MEMBER_IDENTIFIER_BASE,
   DR_UNSOLICITED_PATIENT_REF,
   getLabListStatus,
   getLabListType,
@@ -253,4 +257,30 @@ export const formatListEntry = (labSet: LabSetDTO): ListEntry[] => {
   }
 
   return entry;
+};
+
+export const isOtherInsurance = (resource: Coverage | Organization): boolean => {
+  const OTHER = 'other';
+  const RCM_OTHER_PAYER_REF = 'https://rcm-api.zapehr.com/v1/payer/00000';
+
+  if (resource.resourceType === 'Coverage') {
+    // to avoid another query, we'll check the assigner on the member number
+    const memberNumIdentifier = resource.identifier?.find(
+      (id) => id.type?.coding?.some((coding) => isEqual(COVERAGE_MEMBER_IDENTIFIER_BASE.type?.coding?.[0], coding))
+    );
+
+    if (!memberNumIdentifier) {
+      console.warn(`No member number identifier on Coverage/${resource.id}, cannot determine if is "Other" insurance`);
+      return false;
+    }
+
+    return (
+      memberNumIdentifier.assigner?.display?.toLowerCase() === OTHER ||
+      memberNumIdentifier.assigner?.reference === RCM_OTHER_PAYER_REF ||
+      false
+    );
+  } else {
+    // we're looking at the org itself
+    return resource.name?.toLowerCase() === OTHER || resource.id === '00000' || false;
+  }
 };

--- a/packages/zambdas/src/shared/pdf/external-labs-order-form-pdf.ts
+++ b/packages/zambdas/src/shared/pdf/external-labs-order-form-pdf.ts
@@ -246,6 +246,12 @@ async function createExternalLabsOrderFormPdfBytes(data: ExternalLabOrderFormDat
   pdfClient = drawFieldLineBoldHeader(pdfClient, textStyles, 'Bill Class:', data.billClass);
   pdfClient.newLine(STANDARD_NEW_LINE);
 
+  console.log('Determining is workers comp line. Is workers comp', data.isWorkersCompOrder);
+  if (data.isWorkersCompOrder) {
+    pdfClient = drawFieldLineBoldHeader(pdfClient, textStyles, "Worker's Comp Order:", 'Yes');
+    pdfClient.newLine(STANDARD_NEW_LINE);
+  }
+
   if (data.insuranceDetails) {
     // sort these by rank asc just to be sure
     const sortedDetails = data.insuranceDetails.sort((a, b) => a.insuranceRank - b.insuranceRank);
@@ -349,7 +355,10 @@ export function getOrderFormDataConfig(
   // this is the same logic we use in oystehr to determine PV1-20
   const getBillClass = (paymentResources: PaymentResources): string => {
     let coverage: Coverage | undefined;
-    if (paymentResources.type === LabPaymentMethod.Insurance) {
+    if (
+      paymentResources.type === LabPaymentMethod.Insurance ||
+      paymentResources.type === LabPaymentMethod.WorkersComp
+    ) {
       coverage = paymentResources.coverageAndOrgs[0].coverage;
     } else {
       // client bill or self pay
@@ -368,7 +377,7 @@ export function getOrderFormDataConfig(
   const billClass = getBillClass(paymentResources);
 
   const insuranceDetails =
-    paymentResources.type === LabPaymentMethod.Insurance
+    paymentResources.type === LabPaymentMethod.Insurance || paymentResources.type === LabPaymentMethod.WorkersComp
       ? getInsuranceDetails(paymentResources.coverageAndOrgs, patient, oystehr)
       : undefined;
 
@@ -409,6 +418,7 @@ export function getOrderFormDataConfig(
     testDetails,
     isManualOrder,
     isPscOrder,
+    isWorkersCompOrder: paymentResources.type === LabPaymentMethod.WorkersComp,
   };
 
   return dataConfig;

--- a/packages/zambdas/src/shared/pdf/types.ts
+++ b/packages/zambdas/src/shared/pdf/types.ts
@@ -179,6 +179,7 @@ export interface ExternalLabOrderFormData extends Omit<LabsData, 'orderAssessmen
   testDetails: testDataForOrderForm[];
   insuranceDetails?: OrderFormInsuranceInfo[];
   brandingProjectName?: string;
+  isWorkersCompOrder: boolean;
 }
 
 export interface ExternalLabResult {


### PR DESCRIPTION
Disallow order creation when insurance is "Other" which is just a placeholder

Add Worker's Comp Insurance info to the ottehr order form