### PR TITLE
feat: admin-configurable progress note defaults

### DIFF
--- a/apps/ehr/src/api/api.ts
+++ b/apps/ehr/src/api/api.ts
@@ -13,6 +13,7 @@ import {
   AdminGetLabSetDetailInput,
   AdminGetLabSetDetailOutput,
   AdminGetLabSetListOutput,
+  AdminGetProgressNoteConfigOutput,
   AdminGetTemplateDetailInput,
   AdminGetTemplateDetailOutput,
   AdminInHouseLabConfigOutput,
@@ -22,6 +23,7 @@ import {
   AdminUpdateInHouseLabInput,
   AdminUpdateLabSetInput,
   AdminUpdatePrintingConfigInput,
+  AdminUpdateProgressNoteConfigInput,
   AiAssistedEncountersReportZambdaInput,
   AiAssistedEncountersReportZambdaOutput,
   AllergyQuickPickData,
@@ -349,6 +351,8 @@ const ADMIN_UPDATE_LAB_SET_ZAMBDA_ID = 'admin-update-lab-set';
 const CREATE_CUSTOM_FOLDER_ZAMBDA_ID = 'create-custom-folder';
 const RENAME_CUSTOM_FOLDER_ZAMBDA_ID = 'rename-custom-folder';
 const DELETE_CUSTOM_FOLDER_ZAMBDA_ID = 'delete-custom-folder';
+const GET_PROGRESS_NOTE_CONFIG_ZAMBDA_ID = 'get-progress-note-config';
+const ADMIN_UPDATE_PROGRESS_NOTE_CONFIG_ZAMBDA_ID = 'admin-update-progress-note-config';
 
 export const getUser = async (token: string): Promise<User> => {
   const oystehr = new Oystehr({
@@ -2823,6 +2827,34 @@ export const migrateExamData = async (
       ...parameters,
     });
     return chooseJson(response);
+  } catch (error: unknown) {
+    console.log(error);
+    throw apiErrorToThrow(error);
+  }
+};
+
+export const getProgressNoteConfig = async (oystehr: Oystehr): Promise<AdminGetProgressNoteConfigOutput> => {
+  try {
+    if (GET_PROGRESS_NOTE_CONFIG_ZAMBDA_ID == null) {
+      throw new Error('get progress note config environment variable could not be loaded');
+    }
+    const response = await oystehr.zambda.execute({ id: GET_PROGRESS_NOTE_CONFIG_ZAMBDA_ID });
+    return chooseJson(response);
+  } catch (error: unknown) {
+    console.log(error);
+    throw apiErrorToThrow(error);
+  }
+};
+
+export const adminUpdateProgressNoteConfig = async (
+  oystehr: Oystehr,
+  parameters: AdminUpdateProgressNoteConfigInput
+): Promise<void> => {
+  try {
+    if (ADMIN_UPDATE_PROGRESS_NOTE_CONFIG_ZAMBDA_ID == null) {
+      throw new Error('admin update progress note config environment variable could not be loaded');
+    }
+    await oystehr.zambda.execute({ id: ADMIN_UPDATE_PROGRESS_NOTE_CONFIG_ZAMBDA_ID, ...parameters });
   } catch (error: unknown) {
     console.log(error);
     throw apiErrorToThrow(error);

--- a/apps/ehr/src/features/visits/telemed/components/admin/admin.queries.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/admin.queries.tsx
@@ -11,6 +11,7 @@ import {
   adminUpdateInHouseLab,
   adminUpdateLabelPrintingConfig,
   adminUpdateLabSet,
+  adminUpdateProgressNoteConfig,
   bulkUpdateInsuranceStatus,
   createEmCode,
   deleteEmCode,
@@ -18,6 +19,7 @@ import {
   getInHouseMedicationQuickPicks,
   getLabelPrintingConfig,
   getProcedureQuickPicks,
+  getProgressNoteConfig,
   getRadiologyQuickPicks,
   removeImmunizationQuickPick,
   removeInHouseMedicationQuickPick,
@@ -39,11 +41,13 @@ import {
   AdminGetLabSetDetailInput,
   AdminGetLabSetDetailOutput,
   AdminGetLabSetListOutput,
+  AdminGetProgressNoteConfigOutput,
   AdminInHouseLabConfigOutput,
   AdminListInHouseLabsOutput,
   AdminUpdateInHouseLabInput,
   AdminUpdateLabSetInput,
   AdminUpdatePrintingConfigInput,
+  AdminUpdateProgressNoteConfigInput,
   APIError,
   BulkUpdateInsuranceStatusInput,
   CreateEmCodeInput,
@@ -644,6 +648,52 @@ export const useAdminUpdateLabelPrintingConfig = (
       // send to sentry
       safelyCaptureException(error);
       let message = 'Something went wrong! Printing config update could not be made.';
+      if (isApiError(error)) {
+        message = (error as APIError).message;
+      }
+      enqueueSnackbar(message, { variant: 'error' });
+    },
+  });
+};
+
+export const useAdminGetProgressNoteConfig = (): UseQueryResult<AdminGetProgressNoteConfigOutput, Error> => {
+  const { oystehrZambda } = useApiClients();
+
+  return useQuery({
+    queryKey: ['admin-get-progress-note-config'],
+    queryFn: async () => {
+      return getProgressNoteConfig(oystehrZambda!);
+    },
+    enabled: !!oystehrZambda,
+    staleTime: 30_000,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: true,
+  });
+};
+
+export const useAdminUpdateProgressNoteConfig = (): UseMutationResult<
+  void,
+  Error,
+  AdminUpdateProgressNoteConfigInput
+> => {
+  const { oystehrZambda } = useApiClients();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['admin-update-progress-note-config'],
+    mutationFn: async (input: AdminUpdateProgressNoteConfigInput) => {
+      if (!oystehrZambda) {
+        throw new Error('oystehr client is undefined');
+      }
+      await adminUpdateProgressNoteConfig(oystehrZambda, input);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['admin-get-progress-note-config'] });
+      enqueueSnackbar('Successfully updated progress note defaults', { variant: 'success' });
+    },
+    onError: (error: any) => {
+      safelyCaptureException(error);
+      let message = 'Something went wrong! Progress note config could not be saved.';
       if (isApiError(error)) {
         message = (error as APIError).message;
       }

--- a/apps/ehr/src/features/visits/telemed/components/admin/progress-note-config/AdminProgressNoteConfigPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/progress-note-config/AdminProgressNoteConfigPage.tsx
@@ -1,0 +1,118 @@
+import { LoadingButton } from '@mui/lab';
+import { Box, CircularProgress, Grid, Paper, TextField, Typography } from '@mui/material';
+import { ReactElement, useEffect } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import PageContainer from 'src/layout/PageContainer';
+import {
+  DispositionType,
+  getDefaultNote,
+  mapDispositionTypeToLabel,
+  MDM_FIELD_DEFAULT_TEXT,
+  ProgressNoteConfig,
+} from 'utils';
+import { useAdminGetProgressNoteConfig, useAdminUpdateProgressNoteConfig } from '../admin.queries';
+
+const DISPOSITION_TYPES: DispositionType[] = ['pcp-no-type', 'another', 'ed', 'specialty'];
+
+type FormValues = {
+  mdmDefaultText: string;
+  dispositionDefaults: Record<DispositionType, string>;
+};
+
+const buildDefaultFormValues = (): FormValues => ({
+  mdmDefaultText: MDM_FIELD_DEFAULT_TEXT,
+  dispositionDefaults: Object.fromEntries(DISPOSITION_TYPES.map((type) => [type, getDefaultNote(type)])) as Record<
+    DispositionType,
+    string
+  >,
+});
+
+export default function AdminProgressNoteConfigPage(): ReactElement {
+  const { data, isPending, isError, dataUpdatedAt } = useAdminGetProgressNoteConfig();
+  const { mutateAsync, isPending: isSubmitting } = useAdminUpdateProgressNoteConfig();
+
+  const { control, handleSubmit, reset } = useForm<FormValues>({
+    defaultValues: buildDefaultFormValues(),
+  });
+
+  useEffect(() => {
+    if (data?.config) {
+      const config = data.config;
+      reset({
+        mdmDefaultText: config.mdmDefaultText || MDM_FIELD_DEFAULT_TEXT,
+        dispositionDefaults: Object.fromEntries(
+          DISPOSITION_TYPES.map((type) => [type, config.dispositionDefaults[type] ?? getDefaultNote(type)])
+        ) as Record<DispositionType, string>,
+      });
+    }
+  }, [data?.config, dataUpdatedAt, reset]);
+
+  const onSubmit = async (values: FormValues): Promise<void> => {
+    const config: ProgressNoteConfig = {
+      mdmDefaultText: values.mdmDefaultText,
+      dispositionDefaults: values.dispositionDefaults,
+    };
+    await mutateAsync({ config });
+  };
+
+  return (
+    <PageContainer tabTitle="Update Progress Note Configuration" showEnvFooter={false}>
+      <Grid container direction="row" alignItems="flex-start" justifyContent="center">
+        <Grid item maxWidth="700px" width="100%">
+          {isPending ? (
+            <Box display="flex" justifyContent="center" py={4}>
+              <CircularProgress />
+            </Box>
+          ) : isError ? (
+            <Typography color="error">Failed to load progress note configuration.</Typography>
+          ) : (
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <Paper sx={{ padding: 3, marginTop: 2, marginBottom: 2 }}>
+                <Typography variant="h6" gutterBottom>
+                  Medical Decision Making (MDM) Defaults
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                  Default text pre-filled in the MDM input.
+                </Typography>
+                <Controller
+                  name="mdmDefaultText"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField {...field} label="MDM Default Text" multiline minRows={4} fullWidth />
+                  )}
+                />
+              </Paper>
+
+              <Paper sx={{ padding: 3, marginBottom: 2 }}>
+                <Typography variant="h6" gutterBottom>
+                  Disposition Defaults
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                  Default text for each disposition type.
+                </Typography>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                  {DISPOSITION_TYPES.map((type) => (
+                    <Controller
+                      key={type}
+                      name={`dispositionDefaults.${type}`}
+                      control={control}
+                      render={({ field }) => (
+                        <TextField {...field} label={mapDispositionTypeToLabel[type]} multiline minRows={2} fullWidth />
+                      )}
+                    />
+                  ))}
+                </Box>
+              </Paper>
+
+              <Box display="flex" justifyContent="flex-end">
+                <LoadingButton type="submit" variant="contained" loading={isSubmitting}>
+                  Save
+                </LoadingButton>
+              </Box>
+            </form>
+          )}
+        </Grid>
+      </Grid>
+    </PageContainer>
+  );
+}

--- a/apps/ehr/src/pages/AdminPage.tsx
+++ b/apps/ehr/src/pages/AdminPage.tsx
@@ -5,6 +5,7 @@ import { ButtonRounded } from 'src/features/visits/in-person/components/RoundedB
 import InHouseLabAdminPage from 'src/features/visits/telemed/components/admin/in-house-labs/InHouseLabAdminPage';
 import LabSetsAdminPage from 'src/features/visits/telemed/components/admin/lab-sets/LabSetsAdminPage';
 import AdminPrintingConfig from 'src/features/visits/telemed/components/admin/label-printing-config/AdminLabelPrintingConfigPage';
+import AdminProgressNoteConfigPage from 'src/features/visits/telemed/components/admin/progress-note-config/AdminProgressNoteConfigPage';
 import BillingConfiguration from '../features/visits/telemed/components/admin/BillingConfiguration';
 import EMCodesAdminPage from '../features/visits/telemed/components/admin/EMCodesAdminPage';
 import GlobalTemplatesAdminPage from '../features/visits/telemed/components/admin/GlobalTemplatesAdminPage';
@@ -30,6 +31,7 @@ enum PageTab {
   'em-codes' = 'em-codes',
   'lab-sets' = 'lab-sets',
   'docs-folders' = 'docs-folders',
+  'progress-note-config' = 'progress-note-config',
 }
 
 export function AdminPage(): JSX.Element {
@@ -129,6 +131,12 @@ export function AdminPage(): JSX.Element {
                   sx={{ textTransform: 'none', fontWeight: 500 }}
                   onClick={() => navigate(`/admin/${PageTab['docs-folders']}`)}
                 />
+                <Tab
+                  label="Progress Note Config"
+                  value={PageTab['progress-note-config']}
+                  sx={{ textTransform: 'none', fontWeight: 500 }}
+                  onClick={() => navigate(`/admin/${PageTab['progress-note-config']}`)}
+                />
               </TabList>
             </Box>
             <ButtonRounded
@@ -179,6 +187,9 @@ export function AdminPage(): JSX.Element {
           </TabPanel>
           <TabPanel value={PageTab['docs-folders']} sx={{ padding: 0 }}>
             <AdminCustomFoldersPage />
+          </TabPanel>
+          <TabPanel value={PageTab['progress-note-config']} sx={{ padding: 0 }}>
+            <AdminProgressNoteConfigPage />
           </TabPanel>
         </TabContext>
       </Box>

--- a/config/oystehr-core/zambdas.json
+++ b/config/oystehr-core/zambdas.json
@@ -2097,6 +2097,20 @@
       "src": "src/ehr/generate-label-xml/index",
       "zip": ".dist/zips/generate-label-xml.zip"
     },
+    "GET-PROGRESS-NOTE-CONFIG": {
+      "name": "get-progress-note-config",
+      "type": "http_auth",
+      "runtime": "nodejs22.x",
+      "src": "src/ehr/progress-note-config/get-progress-note-config/index",
+      "zip": ".dist/zips/get-progress-note-config.zip"
+    },
+    "ADMIN-UPDATE-PROGRESS-NOTE-CONFIG": {
+      "name": "admin-update-progress-note-config",
+      "type": "http_auth",
+      "runtime": "nodejs22.x",
+      "src": "src/ehr/progress-note-config/admin-update-progress-note-config/index",
+      "zip": ".dist/zips/admin-update-progress-note-config.zip"
+    },
     "GET_ALL_INSURANCE_PAYERS": {
       "name": "get-all-insurance-payers",
       "type": "http_auth",

--- a/packages/utils/lib/types/data/index.ts
+++ b/packages/utils/lib/types/data/index.ts
@@ -25,3 +25,4 @@ export * from './delete-patient-document.types';
 export * from './printing';
 export * from './upload-patient-condition-photo.types';
 export * from './custom-folder.types';
+export * from './progress-note-config';

--- a/packages/utils/lib/types/data/progress-note-config.ts
+++ b/packages/utils/lib/types/data/progress-note-config.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { DispositionType } from '../api/chart-data/chart-data.types';
+
+export const PROGRESS_NOTE_CONFIG_TAG_SYSTEM = 'https://fhir.ottehr.com/CodeSystem/progress-note-config';
+export const PROGRESS_NOTE_CONFIG_TAG_CODE = 'progress-note-defaults';
+export const PROGRESS_NOTE_CONFIG_TAG = {
+  system: PROGRESS_NOTE_CONFIG_TAG_SYSTEM,
+  code: PROGRESS_NOTE_CONFIG_TAG_CODE,
+};
+
+export const PROGRESS_NOTE_MDM_EXTENSION_URL = 'https://fhir.ottehr.com/Extension/mdm-default-text';
+export const PROGRESS_NOTE_DISPOSITION_DEFAULTS_EXTENSION_URL =
+  'https://fhir.ottehr.com/Extension/disposition-defaults';
+
+export interface ProgressNoteConfig {
+  mdmDefaultText: string;
+  dispositionDefaults: Partial<Record<DispositionType, string>>;
+}
+
+export const ProgressNoteConfigSchema = z.object({
+  mdmDefaultText: z.string(),
+  dispositionDefaults: z.record(z.string()),
+});
+
+export interface AdminGetProgressNoteConfigOutput {
+  config: ProgressNoteConfig;
+}
+
+export interface AdminUpdateProgressNoteConfigInput {
+  config: ProgressNoteConfig;
+}

--- a/packages/zambdas/src/ehr/progress-note-config/admin-update-progress-note-config/index.ts
+++ b/packages/zambdas/src/ehr/progress-note-config/admin-update-progress-note-config/index.ts
@@ -1,0 +1,87 @@
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { Basic } from 'fhir/r4b';
+import {
+  AdminUpdateProgressNoteConfigInput,
+  DispositionType,
+  PROGRESS_NOTE_CONFIG_TAG,
+  PROGRESS_NOTE_DISPOSITION_DEFAULTS_EXTENSION_URL,
+  PROGRESS_NOTE_MDM_EXTENSION_URL,
+  ProgressNoteConfig,
+  Secrets,
+} from 'utils';
+import { checkOrCreateM2MClientToken, createOystehrClient, wrapHandler, ZambdaInput } from '../../../shared';
+import { validateRequestParameters } from './validateRequestParameters';
+
+let m2mToken: string;
+const ZAMBDA_NAME = 'admin-update-progress-note-config';
+
+export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
+  console.log(`${ZAMBDA_NAME} started`);
+
+  const validatedParameters: AdminUpdateProgressNoteConfigInput & { secrets: Secrets | null; userToken: string } =
+    validateRequestParameters(input);
+
+  const { secrets, config } = validatedParameters;
+
+  m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
+  const oystehr = createOystehrClient(m2mToken, secrets);
+
+  const configResource = buildConfigResource(config);
+
+  const existingResources = (
+    await oystehr.fhir.search<Basic>({
+      resourceType: 'Basic',
+      params: [
+        {
+          name: '_tag',
+          value: `${PROGRESS_NOTE_CONFIG_TAG.system}|${PROGRESS_NOTE_CONFIG_TAG.code}`,
+        },
+      ],
+    })
+  ).unbundle();
+
+  const existing = existingResources.find((r): r is Basic => r.resourceType === 'Basic');
+
+  if (existing) {
+    await oystehr.fhir.update<Basic>({ ...configResource, id: existing.id! });
+  } else {
+    await oystehr.fhir.create<Basic>(configResource);
+  }
+
+  return {
+    statusCode: 204,
+    body: JSON.stringify({}),
+  };
+});
+
+const buildConfigResource = (config: ProgressNoteConfig): Basic => {
+  const dispositionExtensions = Object.entries(config.dispositionDefaults).map(([type, text]) => ({
+    url: type as DispositionType,
+    valueString: text,
+  }));
+
+  return {
+    resourceType: 'Basic',
+    meta: {
+      tag: [PROGRESS_NOTE_CONFIG_TAG],
+    },
+    code: {
+      coding: [
+        {
+          system: PROGRESS_NOTE_CONFIG_TAG.system,
+          code: PROGRESS_NOTE_CONFIG_TAG.code,
+        },
+      ],
+    },
+    extension: [
+      {
+        url: PROGRESS_NOTE_MDM_EXTENSION_URL,
+        valueString: config.mdmDefaultText,
+      },
+      {
+        url: PROGRESS_NOTE_DISPOSITION_DEFAULTS_EXTENSION_URL,
+        extension: dispositionExtensions,
+      },
+    ],
+  };
+};

--- a/packages/zambdas/src/ehr/progress-note-config/admin-update-progress-note-config/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/progress-note-config/admin-update-progress-note-config/validateRequestParameters.ts
@@ -1,0 +1,42 @@
+import {
+  AdminUpdateProgressNoteConfigInput,
+  INVALID_INPUT_ERROR,
+  MISSING_REQUEST_BODY,
+  ProgressNoteConfigSchema,
+  Secrets,
+} from 'utils';
+import { z } from 'zod';
+import { ZambdaInput } from '../../../shared';
+
+const validationSchema = z.object({
+  config: ProgressNoteConfigSchema,
+});
+
+export function validateRequestParameters(
+  input: ZambdaInput
+): AdminUpdateProgressNoteConfigInput & { secrets: Secrets | null; userToken: string } {
+  if (!input.body) {
+    throw MISSING_REQUEST_BODY;
+  }
+
+  const userToken = input.headers.Authorization.replace('Bearer ', '');
+  const secrets = input.secrets;
+
+  let params: AdminUpdateProgressNoteConfigInput;
+  try {
+    params = JSON.parse(input.body);
+  } catch {
+    throw INVALID_INPUT_ERROR('Unable to parse request body. Invalid JSON.');
+  }
+
+  const validatedParsed = validationSchema.safeParse(params);
+  if (!validatedParsed.success) {
+    throw INVALID_INPUT_ERROR(`Validation failed: ${JSON.stringify(validatedParsed.error.errors)}`);
+  }
+
+  return {
+    config: validatedParsed.data.config as AdminUpdateProgressNoteConfigInput['config'],
+    secrets,
+    userToken,
+  };
+}

--- a/packages/zambdas/src/ehr/progress-note-config/get-progress-note-config/index.ts
+++ b/packages/zambdas/src/ehr/progress-note-config/get-progress-note-config/index.ts
@@ -1,0 +1,80 @@
+import Oystehr from '@oystehr/sdk';
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { Basic } from 'fhir/r4b';
+import {
+  AdminGetProgressNoteConfigOutput,
+  DispositionType,
+  getDefaultNote,
+  MDM_FIELD_DEFAULT_TEXT,
+  PROGRESS_NOTE_CONFIG_TAG,
+  PROGRESS_NOTE_DISPOSITION_DEFAULTS_EXTENSION_URL,
+  PROGRESS_NOTE_MDM_EXTENSION_URL,
+  ProgressNoteConfig,
+} from 'utils';
+import { checkOrCreateM2MClientToken, createOystehrClient, wrapHandler, ZambdaInput } from '../../../shared';
+import { validateRequestParameters } from './validateRequestParameters';
+
+let m2mToken: string;
+const ZAMBDA_NAME = 'get-progress-note-config';
+
+export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
+  console.log(`${ZAMBDA_NAME} started`);
+
+  const { secrets } = validateRequestParameters(input);
+
+  m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
+  const oystehr = createOystehrClient(m2mToken, secrets);
+
+  const config = await getProgressNoteConfig(oystehr);
+
+  const output: AdminGetProgressNoteConfigOutput = { config };
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(output),
+  };
+});
+
+export const getProgressNoteConfig = async (oystehr: Oystehr): Promise<ProgressNoteConfig> => {
+  const resources = (
+    await oystehr.fhir.search<Basic>({
+      resourceType: 'Basic',
+      params: [
+        {
+          name: '_tag',
+          value: `${PROGRESS_NOTE_CONFIG_TAG.system}|${PROGRESS_NOTE_CONFIG_TAG.code}`,
+        },
+      ],
+    })
+  ).unbundle();
+
+  const resource = resources.find((r): r is Basic => r.resourceType === 'Basic');
+
+  return resource ? parseConfig(resource) : buildDefaultConfig();
+};
+
+const buildDefaultConfig = (): ProgressNoteConfig => ({
+  mdmDefaultText: MDM_FIELD_DEFAULT_TEXT,
+  dispositionDefaults: {
+    'pcp-no-type': getDefaultNote('pcp-no-type'),
+    another: getDefaultNote('another'),
+    ed: getDefaultNote('ed'),
+    specialty: getDefaultNote('specialty'),
+  },
+});
+
+const parseConfig = (resource: Basic): ProgressNoteConfig => {
+  const mdmExt = resource.extension?.find((e) => e.url === PROGRESS_NOTE_MDM_EXTENSION_URL);
+  const mdmDefaultText = mdmExt?.valueString ?? MDM_FIELD_DEFAULT_TEXT;
+
+  const dispositionExt = resource.extension?.find((e) => e.url === PROGRESS_NOTE_DISPOSITION_DEFAULTS_EXTENSION_URL);
+
+  const dispositionDefaults: Partial<Record<DispositionType, string>> = {};
+  dispositionExt?.extension?.forEach((ext) => {
+    if (ext.url && ext.valueString !== undefined) {
+      dispositionDefaults[ext.url as DispositionType] = ext.valueString;
+    }
+  });
+
+  return { mdmDefaultText, dispositionDefaults };
+};

--- a/packages/zambdas/src/ehr/progress-note-config/get-progress-note-config/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/progress-note-config/get-progress-note-config/validateRequestParameters.ts
@@ -1,0 +1,13 @@
+import { MISSING_REQUEST_BODY, Secrets } from 'utils';
+import { ZambdaInput } from '../../../shared';
+
+export function validateRequestParameters(input: ZambdaInput): { secrets: Secrets | null; userToken: string } {
+  if (!input.body) {
+    throw MISSING_REQUEST_BODY;
+  }
+
+  const userToken = input.headers.Authorization.replace('Bearer ', '');
+  const secrets = input.secrets;
+
+  return { secrets, userToken };
+}

--- a/packages/zambdas/src/subscriptions/appointment/appointment-chart-data-prefilling/index.ts
+++ b/packages/zambdas/src/subscriptions/appointment/appointment-chart-data-prefilling/index.ts
@@ -13,6 +13,7 @@ import {
   MDM_FIELD_DEFAULT_TEXT,
   Secrets,
 } from 'utils';
+import { getProgressNoteConfig } from '../../../ehr/progress-note-config/get-progress-note-config';
 import { checkOrCreateM2MClientToken, saveResourceRequest, wrapHandler, ZambdaInput } from '../../../shared';
 import {
   createDispositionServiceRequest,
@@ -57,6 +58,8 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   const oystehr = createOystehrClient(oystehrToken, secrets);
   console.log('Created zapToken and fhir client');
 
+  const progressNoteConfig = await getProgressNoteConfig(oystehr);
+
   const resourceBundle = (
     await oystehr.fhir.search<Appointment | Encounter | Patient>({
       resourceType: 'Appointment',
@@ -94,7 +97,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
   const disposition: DispositionDTO = {
     type: 'pcp-no-type',
-    note: getDefaultNote('pcp-no-type'),
+    note: progressNoteConfig.dispositionDefaults['pcp-no-type'] ?? getDefaultNote('pcp-no-type'),
   };
 
   saveOrUpdateRequests.push(
@@ -105,10 +108,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     })
   );
 
+  const mdmText = progressNoteConfig.mdmDefaultText || MDM_FIELD_DEFAULT_TEXT;
   saveOrUpdateRequests.push(
-    saveResourceRequest(
-      makeClinicalImpressionResource(encounterId, patient.id, { text: MDM_FIELD_DEFAULT_TEXT }, 'medical-decision')
-    )
+    saveResourceRequest(makeClinicalImpressionResource(encounterId, patient.id, { text: mdmText }, 'medical-decision'))
   );
 
   encounterUpdateRequests.push(


### PR DESCRIPTION
## Summary

- Adds a **Progress Note Config** tab to the admin panel (`/admin/progress-note-config`)
- Admins can configure the default text pre-filled in the **Medical Decision Making (MDM)** and **Disposition** fields for new appointments
- Defaults are stored as a `Basic` FHIR resource (tagged `progress-note-defaults`) and fall back to the existing hardcoded strings if no config has been saved
- The `appointment-chart-data-prefilling` subscription zambda now fetches the configured defaults before pre-filling new appointments — **requires redeployment of that zambda to take effect**

## New zambdas

- `get-progress-note-config` — fetches the config, returns hardcoded defaults if none saved
- `admin-update-progress-note-config` — upserts the config by tag

## Test plan

- [ ] Visit `/admin/progress-note-config`, verify MDM and disposition fields load with current defaults
- [ ] Edit MDM text, save — verify success snackbar
- [ ] Reload page — verify saved values persist
- [ ] Deploy `appointment-chart-data-prefilling` zambda, create a new appointment, verify MDM and disposition are pre-filled with the configured values
- [ ] Without saving any config, create a new appointment — verify pre-fill behavior is unchanged from before

🤖 Generated with [Claude Code](https://claude.com/claude-code)