### PR TITLE
fix vitals tests failing with differing vitals configurations.

### DIFF
--- a/packages/zambdas/test/data/config-files/vitals-standard-spec.ts
+++ b/packages/zambdas/test/data/config-files/vitals-standard-spec.ts
@@ -1,0 +1,53 @@
+// Stable fixture for tests that assert behavior of the bracket-lookup logic.
+// Pinning to a fixed config keeps these tests independent of the per-instance
+// vitals config that CI overlays via copy-config.
+const VitalsConfig = {
+  'vital-heartbeat': {
+    alertThresholds: [
+      {
+        rules: [
+          { type: 'min', units: 'bpm', value: 57, criticality: 'abnormal' },
+          { type: 'max', units: 'bpm', value: 100, criticality: 'abnormal' },
+        ],
+        minAge: { unit: 'years', value: 15 },
+      },
+    ],
+  },
+  'vital-respiration-rate': {
+    alertThresholds: [
+      {
+        rules: [
+          { type: 'min', units: '', value: 25, criticality: 'abnormal' },
+          { type: 'max', units: '', value: 60, criticality: 'abnormal' },
+        ],
+        minAge: { unit: 'months', value: 0 },
+        maxAge: { unit: 'months', value: 2 },
+      },
+      {
+        rules: [
+          { type: 'min', units: '', value: 28, criticality: 'abnormal' },
+          { type: 'max', units: '', value: 52, criticality: 'abnormal' },
+        ],
+        minAge: { unit: 'months', value: 2 },
+        maxAge: { unit: 'months', value: 5 },
+      },
+      {
+        rules: [
+          { type: 'min', units: '', value: 26, criticality: 'abnormal' },
+          { type: 'max', units: '', value: 49, criticality: 'abnormal' },
+        ],
+        minAge: { unit: 'months', value: 5 },
+        maxAge: { unit: 'months', value: 8 },
+      },
+      {
+        rules: [
+          { type: 'min', units: '', value: 11, criticality: 'abnormal' },
+          { type: 'max', units: '', value: 21, criticality: 'abnormal' },
+        ],
+        minAge: { unit: 'months', value: 215 },
+      },
+    ],
+  },
+};
+
+export default VitalsConfig;

--- a/packages/zambdas/test/vitals-configuration.test.ts
+++ b/packages/zambdas/test/vitals-configuration.test.ts
@@ -21,6 +21,7 @@ import InvalidAgeVitals from './data/config-files/vitals-invalid-ages-spec';
 import InvalidBloodPressureShapeVitals from './data/config-files/vitals-invalid-bp-shape-spec';
 import InvalidMinMaxValVitals from './data/config-files/vitals-invalid-min-max-val-spec';
 import InvalidRuleTypeVitals from './data/config-files/vitals-invalid-rule-type-spec';
+import StandardVitals from './data/config-files/vitals-standard-spec';
 import { makeTestPatient } from './helpers/testScheduleUtils';
 
 describe('testing vitals config validation', () => {
@@ -418,6 +419,7 @@ describe('testing vitals config validation', () => {
       patientDOB,
       vitalsObservation: tachyObservation,
       patientSex: teenPatient.gender,
+      configOverride: StandardVitals,
     });
 
     expect(criticality).toBe(VitalAlertCriticality.Abnormal);
@@ -464,10 +466,13 @@ describe('testing vitals config validation', () => {
   });
 
   suite('age boundary threshold selection', () => {
-    // These tests use respiration rate thresholds (not mutated by prior concurrent tests):
-    // 0–2 months: min 25, max 60
-    // 2–5 months: min 28, max 52
-    // 5–8 months: min 26, max 49
+    // These tests pin to the StandardVitals fixture (not the per-instance config) so
+    // bracket-lookup behavior is verified against a known schema. Fixture respiration
+    // rate brackets:
+    //   0–2 months:  min 25, max 60
+    //   2–5 months:  min 28, max 52
+    //   5–8 months:  min 26, max 49
+    //   215+ months: min 11, max 21
     // At boundary points (e.g. exactly 2 months), only the older-age bracket should apply.
 
     test("patient in the middle of a threshold range gets that range's rules", () => {
@@ -479,11 +484,16 @@ describe('testing vitals config validation', () => {
       const lowResp: VitalsRespirationRateObservationDTO = {
         patientId: patient.id,
         field: VitalFieldNames.VitalRespirationRate,
-        value: 29,
+        value: 24,
         resourceId: randomUUID(),
       };
       expect(
-        getVitalObservationAlertLevel({ patientDOB, vitalsObservation: lowResp, patientSex: patient.gender })
+        getVitalObservationAlertLevel({
+          patientDOB,
+          vitalsObservation: lowResp,
+          patientSex: patient.gender,
+          configOverride: StandardVitals,
+        })
       ).toBe(VitalAlertCriticality.Abnormal);
     });
 
@@ -503,7 +513,12 @@ describe('testing vitals config validation', () => {
         resourceId: randomUUID(),
       };
       expect(
-        getVitalObservationAlertLevel({ patientDOB, vitalsObservation: borderlineResp, patientSex: patient.gender })
+        getVitalObservationAlertLevel({
+          patientDOB,
+          vitalsObservation: borderlineResp,
+          patientSex: patient.gender,
+          configOverride: StandardVitals,
+        })
       ).toBe(VitalAlertCriticality.Abnormal);
 
       // 29 is above the 2–5 month min (28) and below max (52), should NOT alert
@@ -514,7 +529,12 @@ describe('testing vitals config validation', () => {
         resourceId: randomUUID(),
       };
       expect(
-        getVitalObservationAlertLevel({ patientDOB, vitalsObservation: normalResp, patientSex: patient.gender })
+        getVitalObservationAlertLevel({
+          patientDOB,
+          vitalsObservation: normalResp,
+          patientSex: patient.gender,
+          configOverride: StandardVitals,
+        })
       ).toBeUndefined();
     });
 
@@ -532,7 +552,12 @@ describe('testing vitals config validation', () => {
         resourceId: randomUUID(),
       };
       expect(
-        getVitalObservationAlertLevel({ patientDOB, vitalsObservation: normalResp, patientSex: patient.gender })
+        getVitalObservationAlertLevel({
+          patientDOB,
+          vitalsObservation: normalResp,
+          patientSex: patient.gender,
+          configOverride: StandardVitals,
+        })
       ).toBeUndefined();
     });
 
@@ -552,7 +577,12 @@ describe('testing vitals config validation', () => {
         resourceId: randomUUID(),
       };
       expect(
-        getVitalObservationAlertLevel({ patientDOB, vitalsObservation: borderlineHighResp, patientSex: patient.gender })
+        getVitalObservationAlertLevel({
+          patientDOB,
+          vitalsObservation: borderlineHighResp,
+          patientSex: patient.gender,
+          configOverride: StandardVitals,
+        })
       ).toBe(VitalAlertCriticality.Abnormal);
 
       // 48 is below 5–8 month max (49), should NOT alert
@@ -563,7 +593,12 @@ describe('testing vitals config validation', () => {
         resourceId: randomUUID(),
       };
       expect(
-        getVitalObservationAlertLevel({ patientDOB, vitalsObservation: normalResp, patientSex: patient.gender })
+        getVitalObservationAlertLevel({
+          patientDOB,
+          vitalsObservation: normalResp,
+          patientSex: patient.gender,
+          configOverride: StandardVitals,
+        })
       ).toBeUndefined();
     });
 
@@ -580,7 +615,12 @@ describe('testing vitals config validation', () => {
         resourceId: randomUUID(),
       };
       expect(
-        getVitalObservationAlertLevel({ patientDOB, vitalsObservation: highResp, patientSex: patient.gender })
+        getVitalObservationAlertLevel({
+          patientDOB,
+          vitalsObservation: highResp,
+          patientSex: patient.gender,
+          configOverride: StandardVitals,
+        })
       ).toBe(VitalAlertCriticality.Abnormal);
 
       const normalResp: VitalsRespirationRateObservationDTO = {
@@ -590,7 +630,12 @@ describe('testing vitals config validation', () => {
         resourceId: randomUUID(),
       };
       expect(
-        getVitalObservationAlertLevel({ patientDOB, vitalsObservation: normalResp, patientSex: patient.gender })
+        getVitalObservationAlertLevel({
+          patientDOB,
+          vitalsObservation: normalResp,
+          patientSex: patient.gender,
+          configOverride: StandardVitals,
+        })
       ).toBeUndefined();
     });
   });


### PR DESCRIPTION
Use stubs or make tests config aware in the vitals tests