### PR TITLE
Alex/ci downstream build check

### DIFF
--- a/.github/workflows/downstream-build-check.yml
+++ b/.github/workflows/downstream-build-check.yml
@@ -38,14 +38,12 @@ jobs:
           CORE_SHA: ${{ github.event.pull_request.head.sha }}
           DOWNSTREAM_REPO: ${{ github.repository_owner }}/${{ vars.DOWNSTREAM_BUILD_REPO }}
           DOWNSTREAM_WORKFLOW: ${{ vars.DOWNSTREAM_BUILD_WORKFLOW }}
-          DOWNSTREAM_PROJECTS: ${{ vars.DOWNSTREAM_BUILD_PROJECTS }}
         run: |
           set -euo pipefail
           gh workflow run "$DOWNSTREAM_WORKFLOW" \
             -R "$DOWNSTREAM_REPO" \
             --ref develop \
-            -f projects="$DOWNSTREAM_PROJECTS" \
-            -f branch="$CORE_SHA"
+            -f core_sha="$CORE_SHA"
           echo "Dispatched downstream build for $CORE_SHA"
 
       - name: Find dispatched run

--- a/.github/workflows/downstream-build-check.yml
+++ b/.github/workflows/downstream-build-check.yml
@@ -86,8 +86,33 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DOWNSTREAM_REPO: ${{ github.repository_owner }}/${{ vars.DOWNSTREAM_BUILD_REPO }}
+          RUN_ID: ${{ steps.find-run.outputs.run_id }}
         run: |
-          gh run watch \
-            -R "$DOWNSTREAM_REPO" \
-            --exit-status \
-            ${{ steps.find-run.outputs.run_id }}
+          set -euo pipefail
+          # Poll status only — never stream the downstream's job/step
+          # structure into this log, since job names there may include
+          # internal project identifiers that shouldn't leak into the
+          # public log of this run. Cap iterations so a stuck downstream
+          # can't keep this job pinned indefinitely.
+          MAX_ITERS=180   # 180 * 20s = 60 min
+          for i in $(seq 1 "$MAX_ITERS"); do
+            RESP=$(gh api "repos/$DOWNSTREAM_REPO/actions/runs/$RUN_ID" --jq '{status, conclusion}')
+            STATUS=$(echo "$RESP" | jq -r '.status')
+            CONCLUSION=$(echo "$RESP" | jq -r '.conclusion')
+            if [ "$STATUS" = "completed" ]; then
+              echo "Downstream run completed with conclusion: $CONCLUSION"
+              echo "See https://github.com/$DOWNSTREAM_REPO/actions/runs/$RUN_ID for details."
+              if [ "$CONCLUSION" = "success" ]; then
+                exit 0
+              fi
+              exit 1
+            fi
+            # Print one line per minute (every third iteration) to keep the
+            # log compact but show liveness.
+            if [ $((i % 3)) -eq 1 ]; then
+              echo "Status: $STATUS (poll $i/$MAX_ITERS)"
+            fi
+            sleep 20
+          done
+          echo "::error::Downstream run did not complete within $((MAX_ITERS * 20 / 60)) minutes."
+          exit 1

--- a/.github/workflows/downstream-build-check.yml
+++ b/.github/workflows/downstream-build-check.yml
@@ -1,0 +1,90 @@
+name: Downstream Build Check
+
+# Triggers a build in a downstream consumer repository on every PR and blocks
+# until that build completes. Catches the bug class where a change in core
+# breaks an existing downstream consumer's configuration before it's merged.
+#
+# The target repo, workflow, and project list are configured via repo
+# variables so this file does not name them directly.
+
+on:
+  pull_request:
+    branches: [main, develop, "release/**"]
+
+concurrency:
+  group: downstream-build-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-check:
+    name: Downstream build check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: ${{ !contains(github.event.pull_request.body, '/skip-build-and-lint') && vars.DOWNSTREAM_BUILD_REPO != '' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Generate GitHub App Token
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
+        id: app-token
+        with:
+          app-id: ${{ secrets.OTTEHR_GITHUB_APP_ID }}
+          private-key: ${{ secrets.OTTEHR_GITHUB_APP_PRIVATE_KEY }}
+          repositories: ${{ vars.DOWNSTREAM_BUILD_REPO }}
+
+      - name: Dispatch downstream build
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CORE_SHA: ${{ github.event.pull_request.head.sha }}
+          DOWNSTREAM_REPO: ${{ github.repository_owner }}/${{ vars.DOWNSTREAM_BUILD_REPO }}
+          DOWNSTREAM_WORKFLOW: ${{ vars.DOWNSTREAM_BUILD_WORKFLOW }}
+          DOWNSTREAM_PROJECTS: ${{ vars.DOWNSTREAM_BUILD_PROJECTS }}
+        run: |
+          set -euo pipefail
+          gh workflow run "$DOWNSTREAM_WORKFLOW" \
+            -R "$DOWNSTREAM_REPO" \
+            --ref develop \
+            -f projects="$DOWNSTREAM_PROJECTS" \
+            -f branch="$CORE_SHA"
+          echo "Dispatched downstream build for $CORE_SHA"
+
+      - name: Find dispatched run
+        id: find-run
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CORE_SHA: ${{ github.event.pull_request.head.sha }}
+          DOWNSTREAM_REPO: ${{ github.repository_owner }}/${{ vars.DOWNSTREAM_BUILD_REPO }}
+          DOWNSTREAM_WORKFLOW: ${{ vars.DOWNSTREAM_BUILD_WORKFLOW }}
+        run: |
+          set -euo pipefail
+          # The downstream workflow embeds the `branch` input (our PR head SHA)
+          # in its display title, so we poll for a recent dispatched run with
+          # that SHA in the title.
+          for i in $(seq 1 30); do
+            RUN_ID=$(gh run list \
+              -R "$DOWNSTREAM_REPO" \
+              --workflow="$DOWNSTREAM_WORKFLOW" \
+              --event=workflow_dispatch \
+              --limit=20 \
+              --json databaseId,displayTitle \
+              --jq "[.[] | select(.displayTitle | contains(\"$CORE_SHA\"))][0].databaseId")
+            if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
+              echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+              echo "Found downstream run: https://github.com/$DOWNSTREAM_REPO/actions/runs/$RUN_ID"
+              exit 0
+            fi
+            echo "Run not yet visible (attempt $i/30), waiting 5s..."
+            sleep 5
+          done
+          echo "::error::Failed to locate dispatched downstream run after 150s"
+          exit 1
+
+      - name: Wait for downstream run to complete
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DOWNSTREAM_REPO: ${{ github.repository_owner }}/${{ vars.DOWNSTREAM_BUILD_REPO }}
+        run: |
+          gh run watch \
+            -R "$DOWNSTREAM_REPO" \
+            --exit-status \
+            ${{ steps.find-run.outputs.run_id }}

--- a/.github/workflows/downstream-build-check.yml
+++ b/.github/workflows/downstream-build-check.yml
@@ -20,7 +20,7 @@ jobs:
     name: Downstream build check
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ !contains(github.event.pull_request.body, '/skip-build-and-lint') && vars.DOWNSTREAM_BUILD_REPO != '' }}
+    if: ${{ !contains(github.event.pull_request.body, '/skip-build-and-lint') && vars.DOWNSTREAM_BUILD_REPO != '' && vars.DOWNSTREAM_BUILD_WORKFLOW != '' }}
     permissions:
       contents: read
     steps:
@@ -38,11 +38,16 @@ jobs:
           CORE_SHA: ${{ github.event.pull_request.head.sha }}
           DOWNSTREAM_REPO: ${{ github.repository_owner }}/${{ vars.DOWNSTREAM_BUILD_REPO }}
           DOWNSTREAM_WORKFLOW: ${{ vars.DOWNSTREAM_BUILD_WORKFLOW }}
+          # `--ref` selects which version of the downstream workflow file to
+          # run, not which code is being built (that's `core_sha`). Default
+          # to develop; admin can override via the repo variable when the
+          # downstream uses a different default branch.
+          DOWNSTREAM_REF: ${{ vars.DOWNSTREAM_BUILD_REF || 'develop' }}
         run: |
           set -euo pipefail
           gh workflow run "$DOWNSTREAM_WORKFLOW" \
             -R "$DOWNSTREAM_REPO" \
-            --ref develop \
+            --ref "$DOWNSTREAM_REF" \
             -f core_sha="$CORE_SHA"
           echo "Dispatched downstream build for $CORE_SHA"
 
@@ -55,9 +60,9 @@ jobs:
           DOWNSTREAM_WORKFLOW: ${{ vars.DOWNSTREAM_BUILD_WORKFLOW }}
         run: |
           set -euo pipefail
-          # The downstream workflow embeds the `branch` input (our PR head SHA)
-          # in its display title, so we poll for a recent dispatched run with
-          # that SHA in the title.
+          # The downstream workflow embeds the `core_sha` input in its
+          # run-name, so we poll for a recent dispatched run whose display
+          # title contains the SHA.
           for i in $(seq 1 30); do
             RUN_ID=$(gh run list \
               -R "$DOWNSTREAM_REPO" \

--- a/README.md
+++ b/README.md
@@ -186,3 +186,4 @@ This repository uses a monorepo structure.
 ## Zambdas
 
 - [Zambda Documentation](./packages/zambdas/README.md)
+ 


### PR DESCRIPTION
Claude Opus 4.7 xHigh wrote this. It is a check that stands on its own, it shouldn't mess with other stuff in the product. So we can try it out and improve it into something we like if there is much to be desired. I have read the code and think it looks ready to try.

On PR to ottehr, you'll get an action that dispatches to 'downstream' which runs build for a few downstream cases to give feedback at PR time about some of the changes that may be needed in downstreams before a PR merges in ottehr.