### PR TITLE
fix(ehr): fix test issues with some instances, and fix bug where radi…

### DIFF
--- a/apps/ehr/src/constants/data-test-ids.ts
+++ b/apps/ehr/src/constants/data-test-ids.ts
@@ -665,7 +665,7 @@ export const dataTestIds = {
     screeningNoteField: 'screening-note-field',
     screeningNoteItem: 'screening-note-item',
     addNoteButton: 'add-screening-note-button',
-    askPatientQuestion: 'ask-patient-question',
+    askPatientQuestion: (fieldId: string) => `ask-patient-question-${fieldId}`,
     vaccinationNoteField: 'vaccination-note-field',
     answerDropdown: 'answer-dropdown',
   },

--- a/apps/ehr/src/features/visits/in-person/components/screening/AskThePatient.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/screening/AskThePatient.tsx
@@ -333,7 +333,7 @@ const AskThePatient = (): React.ReactElement => {
     switch (field.type) {
       case 'radio':
         return (
-          <Grid data-testid={dataTestIds.screeningPage.askPatientQuestion} item xs={12} key={field.id}>
+          <Grid data-testid={dataTestIds.screeningPage.askPatientQuestion(field.id)} item xs={12} key={field.id}>
             <Typography
               sx={{
                 color: theme.palette.primary.dark,
@@ -407,7 +407,7 @@ const AskThePatient = (): React.ReactElement => {
 
       case 'date':
         return (
-          <Grid data-testid={dataTestIds.screeningPage.askPatientQuestion} item xs={12} key={field.id}>
+          <Grid data-testid={dataTestIds.screeningPage.askPatientQuestion(field.id)} item xs={12} key={field.id}>
             <Grid item xs={6}>
               <Typography
                 sx={{
@@ -458,7 +458,7 @@ const AskThePatient = (): React.ReactElement => {
 
       case 'dateRange':
         return (
-          <Grid data-testid={dataTestIds.screeningPage.askPatientQuestion} item xs={12} key={field.id}>
+          <Grid data-testid={dataTestIds.screeningPage.askPatientQuestion(field.id)} item xs={12} key={field.id}>
             <Grid item xs={6}>
               <Typography
                 sx={{
@@ -634,7 +634,7 @@ const AskThePatient = (): React.ReactElement => {
 
       case 'select':
         return (
-          <Grid data-testid={dataTestIds.screeningPage.askPatientQuestion} item xs={12} key={field.id}>
+          <Grid data-testid={dataTestIds.screeningPage.askPatientQuestion(field.id)} item xs={12} key={field.id}>
             <Grid item xs={6}>
               <Typography
                 sx={{
@@ -729,7 +729,7 @@ const AskThePatient = (): React.ReactElement => {
 
       case 'text':
         return (
-          <Grid data-testid={dataTestIds.screeningPage.askPatientQuestion} item xs={12} key={field.id}>
+          <Grid data-testid={dataTestIds.screeningPage.askPatientQuestion(field.id)} item xs={12} key={field.id}>
             <Grid item xs={6}>
               <Typography
                 sx={{
@@ -766,7 +766,7 @@ const AskThePatient = (): React.ReactElement => {
 
       case 'textarea':
         return (
-          <Grid data-testid={dataTestIds.screeningPage.askPatientQuestion} item xs={12} key={field.id}>
+          <Grid data-testid={dataTestIds.screeningPage.askPatientQuestion(field.id)} item xs={12} key={field.id}>
             <Grid item xs={6}>
               <Typography
                 sx={{

--- a/apps/ehr/src/features/visits/in-person/components/screening/useScreeningQuestionsHandler.ts
+++ b/apps/ehr/src/features/visits/in-person/components/screening/useScreeningQuestionsHandler.ts
@@ -117,18 +117,16 @@ export const useScreeningQuestionsHandler = (
       const parentFieldValue = deps.currentFormValues[parentField.id];
       const correctFhirValue = getFhirValueOrFallback(parentField, parentFieldValue as string);
 
-      const observation = noteField.conditionalValue
-        ? ({
-            ...currentObs,
-            field: noteField.fhirField,
-            value: correctFhirValue,
-            note: value,
-          } as ObservationPayload)
-        : ({
-            ...currentObs,
-            field: noteField.fhirField,
-            note: value,
-          } as ObservationPayload);
+      // Always include the parent's current value from form state, not just when
+      // noteField.conditionalValue is set. Otherwise, when the parent value's save is still
+      // in flight (debounce race), getUiData returns a stale observation without `value`,
+      // and the resulting `{ field, note }` DTO is rejected by the server.
+      const observation = {
+        ...currentObs,
+        field: noteField.fhirField,
+        value: correctFhirValue,
+        note: value,
+      } as ObservationPayload;
 
       await saveObservation(observation as ObservationDTO, noteField.id);
     },
@@ -139,9 +137,8 @@ export const useScreeningQuestionsHandler = (
     async (fieldId: string, value: FieldValue): Promise<void> => {
       const field = getFieldById(fieldId);
       const noteFieldInfo = getNoteFieldById(fieldId);
-      const mainFieldId = field?.id || noteFieldInfo?.field?.id; // used in debounce because base field and its note are connected and share debounce key
 
-      if (!mainFieldId) {
+      if (!field && !noteFieldInfo) {
         console.warn(`Field not found in config: ${fieldId}`);
         return;
       }
@@ -153,7 +150,11 @@ export const useScreeningQuestionsHandler = (
           const saveAction = (): Promise<void> => {
             return handleMainFieldChange(field, value);
           };
-          debounce(saveAction, mainFieldId);
+          // Debounce key must be unique to this field. A parent radio/select and its noteField
+          // serialize to the same FHIR observation but as independent saves (value vs note),
+          // so they need independent debounce timers — otherwise typing in the noteField
+          // within the debounce window cancels the pending parent-value save.
+          debounce(saveAction, field.id);
         } else {
           const executeMainFieldChange = async (): Promise<void> => {
             await handleMainFieldChange(field, value);
@@ -164,7 +165,7 @@ export const useScreeningQuestionsHandler = (
         const saveAction = (): Promise<void> => {
           return processNoteFieldChange(noteFieldInfo.field, noteFieldInfo.noteField, value as string);
         };
-        debounce(saveAction, mainFieldId);
+        debounce(saveAction, noteFieldInfo.noteField.id);
       }
     },
     [debounce, handleMainFieldChange, processNoteFieldChange]

--- a/apps/ehr/tests/e2e/page/in-person/ScreeningPage.ts
+++ b/apps/ehr/tests/e2e/page/in-person/ScreeningPage.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from '@playwright/test';
+import { expect, Locator, Page } from '@playwright/test';
 import { DateTime } from 'luxon';
 import { dataTestIds } from '../../../../src/constants/data-test-ids';
 import { SideMenu } from '../SideMenu';
@@ -42,40 +42,30 @@ export class ScreeningPage {
     return expectScreeningPage(this.#page);
   }
 
-  async selectRadioAnswer(question: string, answer: string): Promise<void> {
+  askPatientQuestionLocator(fieldId: string): Locator {
+    return this.#page.getByTestId(dataTestIds.screeningPage.askPatientQuestion(fieldId));
+  }
+
+  async selectRadioAnswer(fieldId: string, answer: string): Promise<void> {
     // Wait for the save API call triggered by debounced onChange (1000ms delay)
     const savePromise = this.#page.waitForResponse(
       (response) => response.url().includes('/save-chart-data') && response.status() === 200,
       { timeout: 30_000 }
     );
 
-    await this.#page
-      .getByTestId(dataTestIds.screeningPage.askPatientQuestion)
-      .or(this.#page.locator(`[data-testid^="${dataTestIds.telemedEhrFlow.hpiAdditionalQuestions('')}"]`))
-      .filter({ hasText: question })
-      .locator('label')
-      .getByText(answer, { exact: true })
-      .click();
+    await this.askPatientQuestionLocator(fieldId).locator('label').getByText(answer, { exact: true }).click();
 
     await savePromise;
   }
 
-  async selectDropdownAnswer(question: string, answer: string): Promise<void> {
-    await this.#page
-      .getByTestId(dataTestIds.screeningPage.askPatientQuestion)
-      .filter({ hasText: question })
-      .getByTestId(dataTestIds.screeningPage.answerDropdown)
-      .click();
+  async selectDropdownAnswer(fieldId: string, answer: string): Promise<void> {
+    await this.askPatientQuestionLocator(fieldId).getByTestId(dataTestIds.screeningPage.answerDropdown).click();
     await this.#page.getByText(answer, { exact: true }).click();
   }
 
-  async selectDateRange(question: string, startDate: DateTime, endDate: DateTime): Promise<void> {
+  async selectDateRange(fieldId: string, startDate: DateTime, endDate: DateTime): Promise<void> {
     // Find the question container and click on the date input to open the picker
-    const questionContainer = this.#page
-      .getByTestId(dataTestIds.screeningPage.askPatientQuestion)
-      .filter({ hasText: question });
-
-    await questionContainer.locator('input').first().click();
+    await this.askPatientQuestionLocator(fieldId).locator('input').first().click();
 
     // Wait for the calendar picker to be visible
     const calendar = this.#page.locator('.MuiDateRangeCalendar-root');
@@ -95,20 +85,12 @@ export class ScreeningPage {
     await calendar.waitFor({ state: 'hidden' });
   }
 
-  async enterTextAnswer(question: string, text: string): Promise<void> {
-    await this.#page
-      .getByTestId(dataTestIds.screeningPage.askPatientQuestion)
-      .filter({ hasText: question })
-      .locator('input')
-      .fill(text);
+  async enterTextAnswer(fieldId: string, text: string): Promise<void> {
+    await this.askPatientQuestionLocator(fieldId).locator('input').fill(text);
   }
 
-  async enterTextareaAnswer(question: string, text: string): Promise<void> {
-    await this.#page
-      .getByTestId(dataTestIds.screeningPage.askPatientQuestion)
-      .filter({ hasText: question })
-      .locator('textarea, input')
-      .fill(text);
+  async enterTextareaAnswer(fieldId: string, text: string): Promise<void> {
+    await this.askPatientQuestionLocator(fieldId).locator('textarea, input').fill(text);
   }
 }
 export async function expectScreeningPage(page: Page): Promise<ScreeningPage> {

--- a/apps/ehr/tests/e2e/specs/in-person/screening.spec.ts
+++ b/apps/ehr/tests/e2e/specs/in-person/screening.spec.ts
@@ -1,6 +1,5 @@
 import { Page, test } from '@playwright/test';
 import { DateTime } from 'luxon';
-import { dataTestIds } from 'src/constants/data-test-ids';
 import {
   expectInPersonProgressNotePage,
   InPersonProgressNotePage,
@@ -151,10 +150,7 @@ async function enterScreeningInfo(screeningInfo: ScreeningInfo, screeningPage: S
 
   for (const field of askPatientFields) {
     // Check if the question exists on the page before filling
-    const questionLocator = screeningPage
-      .page()
-      .getByTestId(dataTestIds.screeningPage.askPatientQuestion)
-      .filter({ hasText: field.question });
+    const questionLocator = screeningPage.askPatientQuestionLocator(field.id);
 
     const questionExists = await questionLocator.isVisible({ timeout: 2000 }).catch(() => false);
 
@@ -165,9 +161,9 @@ async function enterScreeningInfo(screeningInfo: ScreeningInfo, screeningPage: S
         // fieldValue is an option index
         const answer = field.options?.[fieldValue as number]?.label ?? '';
         if (field.type === 'radio') {
-          await screeningPage.selectRadioAnswer(field.question, answer);
+          await screeningPage.selectRadioAnswer(field.id, answer);
         } else if (field.type === 'select') {
-          await screeningPage.selectDropdownAnswer(field.question, answer);
+          await screeningPage.selectDropdownAnswer(field.id, answer);
         }
 
         // Handle noteField if it exists for this radio/select field
@@ -177,11 +173,9 @@ async function enterScreeningInfo(screeningInfo: ScreeningInfo, screeningPage: S
             // If noteValue exists in fieldValues, it means noteField MUST be visible
             // (conditionalValue was already checked during data generation)
             // Wait for it to appear - if it doesn't, the test should fail
-            const questionLocatorRefreshed = screeningPage
-              .page()
-              .getByTestId(dataTestIds.screeningPage.askPatientQuestion)
-              .filter({ hasText: field.question });
-            const noteFieldLocator = questionLocatorRefreshed.getByRole('textbox', { name: field.noteField.label });
+            const noteFieldLocator = screeningPage
+              .askPatientQuestionLocator(field.id)
+              .getByRole('textbox', { name: field.noteField.label });
 
             await noteFieldLocator.waitFor({ state: 'visible', timeout: 30_000 });
             await noteFieldLocator.fill(noteValue);
@@ -191,17 +185,17 @@ async function enterScreeningInfo(screeningInfo: ScreeningInfo, screeningPage: S
         // fieldValue is {startDate: DateTime, endDate: DateTime}
         const dateRangeValue = fieldValue as { startDate: DateTime; endDate: DateTime };
         if (dateRangeValue?.startDate && dateRangeValue?.endDate) {
-          await screeningPage.selectDateRange(field.question, dateRangeValue.startDate, dateRangeValue.endDate);
+          await screeningPage.selectDateRange(field.id, dateRangeValue.startDate, dateRangeValue.endDate);
         }
       } else if (field.type === 'text') {
         // fieldValue is a string
         if (fieldValue) {
-          await screeningPage.enterTextAnswer(field.question, fieldValue as string);
+          await screeningPage.enterTextAnswer(field.id, fieldValue as string);
         }
       } else if (field.type === 'textarea') {
         // fieldValue is a string
         if (fieldValue) {
-          await screeningPage.enterTextareaAnswer(field.question, fieldValue as string);
+          await screeningPage.enterTextareaAnswer(field.id, fieldValue as string);
         }
       }
     } else {
@@ -252,13 +246,13 @@ function createProgressNoteLines(screeningInfo: ScreeningInfo): string[] {
         const textValue = fieldValue as string;
         if (textValue) {
           return field.question + ' - ' + textValue;
-        } else {
-          return field.question + ' - ';
         }
+        // No value entered — nothing rendered on progress note, skip.
+        return '';
       } else {
-        // For any future field types not yet supported
-        console.warn(`Unsupported field type: ${field.type}`);
-        return field.question + ' - ';
+        // Field types not exercised by enterScreeningInfo (e.g. 'date') aren't filled,
+        // so the progress note has nothing to show for them. Skip the expected line.
+        return '';
       }
     })
     .filter((line) => line); // Filter out any empty lines


### PR DESCRIPTION
Code written by Claude Opus 4.7 xHigh. I have read and understand this code. I also ran tests after making the changes to try to check that the issues are fixed.

There are two changes in this PR:

Use test-id for screening questions e2e path so we can correctly select them for e2e tests.

Fix bug that was failing this on another instance. Claude wrote from here:

> In useScreeningQuestionsHandler.handleFieldChange, a parent radio/select and its noteField shared the same debounce key. Filling the noteField within ~1s of clicking the radio cancelled the radio's pending
  save, so the user's radio answer was lost.


