### PR TITLE
test(ehr): scope orderDeletion progress-note check to procedure items

### DIFF
--- a/apps/ehr/tests/e2e/specs/in-person/orderDeletion.spec.ts
+++ b/apps/ehr/tests/e2e/specs/in-person/orderDeletion.spec.ts
@@ -268,8 +268,13 @@ test.describe('Order Deletion - Happy Path', () => {
         await page.waitForURL(new RegExp('/review-and-sign'));
         await expect(page.getByText('Progress Note')).toBeVisible({ timeout: 10000 });
 
-        // Verify deleted procedure is not shown
-        await expect(page.getByText(PROCEDURE_TYPE)).not.toBeVisible();
+        // Scope to the Procedures section's items. CPT codes are intentionally retained
+        // on the chart after a procedure is cancelled (and render in their own section),
+        // so a page-wide getByText() can collide with the cpt-code display string when an
+        // instance's procedure dropDown happens to match the CPT display.
+        await expect(
+          page.getByTestId(dataTestIds.progressNotePage.procedureItem).filter({ hasText: PROCEDURE_TYPE })
+        ).not.toBeVisible();
       });
     } finally {
       // Cleanup: close page and context for this test


### PR DESCRIPTION
Claude found and fixed the issue. I have reviewed this code. I've spent 15 mins on this.

The deal is that for SOME procedures, the CPT code on the chart contains the name of the procedure. The test checks whether the name of the procedure shows up on the progress note after its deleted. It actually finds it sometimes, when the procedure name happens to be in the CPT code which is correctly not removed from the progress note 🤦 

🤖 Generated with [Claude Code](https://claude.com/claude-code)