### PR TITLE
test(ehr): sort Patient.extension in integration data contract test

### DIFF
--- a/apps/ehr/tests/e2e/specs/integrationTestDataContractTests.spec.ts
+++ b/apps/ehr/tests/e2e/specs/integrationTestDataContractTests.spec.ts
@@ -520,6 +520,13 @@ const cleanPatient = (patient: Patient): Patient => {
       id.system?.startsWith('https://identifiers.fhir.oystehr.com/friendly-patient-id') ? { ...id, value: SKIP_ME } : id
     );
   }
+  // FHIR extension is a set, not a sequence — order isn't semantically meaningful. The
+  // generate→harvest→prefill pipeline and the fast integration path can write the same
+  // extensions in different orders (e.g. preferred-communication-method and send-marketing
+  // can land at the front or back depending on instance config), which trips toEqual.
+  if (cleanedPatient.extension) {
+    cleanedPatient.extension = [...cleanedPatient.extension].sort((a, b) => (a.url ?? '').localeCompare(b.url ?? ''));
+  }
   return cleanedPatient;
 };
 


### PR DESCRIPTION
Claude wrote it, I have read it and understand it. I've spent 10 mins on this. 

> FHIR `extension` is a set, not a sequence — order isn't semantically meaningful. The two paths emit the same items in different orders