### PR TITLE
Add Reports tab to top navigation bar for all roles with admin-only r…

### DIFF
--- a/apps/ehr/src/App.tsx
+++ b/apps/ehr/src/App.tsx
@@ -61,6 +61,7 @@ import {
   DailyPayments,
   DataExports,
   IncompleteEncounters,
+  InvoiceablePatients,
   MailedStatements,
   PracticeKpis,
   RecentPatients,
@@ -197,18 +198,31 @@ function App(): ReactElement {
                 <Route path="*" element={<LoadingScreen />} />
               </>
             )}
-            {currentUser?.hasRole([RoleType.Administrator, RoleType.CustomerSupport]) && (
+            {currentUser?.hasRole([
+              RoleType.Administrator,
+              RoleType.Manager,
+              RoleType.Staff,
+              RoleType.Provider,
+              RoleType.CustomerSupport,
+            ]) && (
               <>
-                <Route path="/tasks-observability" element={<TaskAdmin />} />
                 <Route path="/reports" element={<Reports />} />
                 <Route path="/reports/incomplete-encounters" element={<IncompleteEncounters />} />
                 <Route path="/reports/complete-encounters" element={<CompleteEncounters />} />
-                <Route path="/reports/ai-assisted-encounters" element={<AiAssistedEncounters />} />
                 <Route path="/reports/daily-payments" element={<DailyPayments />} />
-                <Route path="/reports/practice-kpis" element={<PracticeKpis />} />
-                <Route path="/reports/data-exports" element={<DataExports />} />
                 <Route path="/reports/visits-overview" element={<VisitsOverview />} />
                 <Route path="/reports/recent-patients" element={<RecentPatients />} />
+              </>
+            )}
+            {currentUser?.hasRole([RoleType.Administrator, RoleType.CustomerSupport]) && (
+              <Route path="/tasks-observability" element={<TaskAdmin />} />
+            )}
+            {currentUser?.hasRole([RoleType.Administrator]) && (
+              <>
+                <Route path="/reports/ai-assisted-encounters" element={<AiAssistedEncounters />} />
+                <Route path="/reports/practice-kpis" element={<PracticeKpis />} />
+                <Route path="/reports/data-exports" element={<DataExports />} />
+                <Route path="/reports/invoiceable-patients" element={<InvoiceablePatients />} />
                 <Route path="/reports/mailed-statements" element={<MailedStatements />} />
               </>
             )}

--- a/apps/ehr/src/components/navigation/Navbar.tsx
+++ b/apps/ehr/src/components/navigation/Navbar.tsx
@@ -24,6 +24,7 @@ const administratorNavbarItems: NavbarItems = {
   'Tracking Board': { urls: ['/visits', '/visit'] },
   Patients: { urls: ['/patients', '/patient'] },
   Admin: { urls: ['/admin'] },
+  Reports: { urls: ['/reports'] },
 };
 
 const managerNavbarItems: NavbarItems = {
@@ -31,24 +32,28 @@ const managerNavbarItems: NavbarItems = {
   Patients: { urls: ['/patients', '/patient'] },
   Admin: { urls: ['/admin'] },
   Tasks: { urls: ['/tasks'] },
+  Reports: { urls: ['/reports'] },
 };
 
 const staffNavbarItems: NavbarItems = {
   'Tracking Board': { urls: ['/visits', '/visit'] },
   Patients: { urls: ['/patients', '/patient'] },
   Tasks: { urls: ['/tasks'] },
+  Reports: { urls: ['/reports'] },
 };
 
 const providerNavbarItems: NavbarItems = {
   'Tracking Board': { urls: ['/visits', '/visit'] },
   Patients: { urls: ['/patients', '/patient'] },
   Tasks: { urls: ['/tasks'] },
+  Reports: { urls: ['/reports'] },
 };
 
 const customerSupportNavbarItems: NavbarItems = {
   'Tracking Board': { urls: ['/visits', '/visit'] },
   Patients: { urls: ['/patients', '/patient'] },
   Admin: { urls: ['/admin'] },
+  Reports: { urls: ['/reports'] },
 };
 
 const hideNavbarPathPatterns = [/^\/telemed\/appointments\/(?!.*\/visit-details$)/, /^\/patient\/[^/]+\/info$/];

--- a/apps/ehr/src/pages/AdminPage.tsx
+++ b/apps/ehr/src/pages/AdminPage.tsx
@@ -1,7 +1,6 @@
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Tab } from '@mui/material';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ButtonRounded } from 'src/features/visits/in-person/components/RoundedButton';
 import InHouseLabAdminPage from 'src/features/visits/telemed/components/admin/in-house-labs/InHouseLabAdminPage';
 import LabSetsAdminPage from 'src/features/visits/telemed/components/admin/lab-sets/LabSetsAdminPage';
 import AdminPrintingConfig from 'src/features/visits/telemed/components/admin/label-printing-config/AdminLabelPrintingConfigPage';
@@ -136,15 +135,6 @@ export function AdminPage(): JSX.Element {
                 />
               </TabList>
             </Box>
-            <ButtonRounded
-              onClick={() => navigate(`/reports`)}
-              variant="outlined"
-              sx={{
-                whiteSpace: 'nowrap',
-              }}
-            >
-              Reports
-            </ButtonRounded>
           </Box>
           <TabPanel value={PageTab.schedules} sx={{ padding: 0 }}>
             <SchedulesPage />

--- a/apps/ehr/src/pages/Reports.tsx
+++ b/apps/ehr/src/pages/Reports.tsx
@@ -6,6 +6,7 @@ import InsightsIcon from '@mui/icons-material/Insights';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import PeopleIcon from '@mui/icons-material/People';
 import PsychologyIcon from '@mui/icons-material/Psychology';
+import SummarizeIcon from '@mui/icons-material/Summarize';
 import { Box, Card, CardActionArea, CardContent, Grid, Typography, useTheme } from '@mui/material';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';

--- a/apps/ehr/src/pages/Reports.tsx
+++ b/apps/ehr/src/pages/Reports.tsx
@@ -86,68 +86,79 @@ function ReportTile({ title, description, icon, onClick }: ReportTileProps): Rea
   );
 }
 
-const ADMIN_ONLY_REPORTS = new Set([
-  'AI-Assisted Encounters',
-  'Practice KPIs',
-  'Invoiceable patients',
-  'Mailed Statements',
-]);
+interface ReportTileConfig {
+  title: string;
+  description: string;
+  icon: React.ReactElement;
+  path: string;
+  adminOnly?: boolean;
+}
+
+const REPORT_TILES: ReportTileConfig[] = [
+  {
+    title: 'Incomplete Encounters',
+    description: 'View and manage encounters that are missing required information or documentation',
+    icon: <AssignmentLateIcon />,
+    path: '/reports/incomplete-encounters',
+  },
+  {
+    title: 'Complete Encounters',
+    description: 'View encounters that have been completed',
+    icon: <AssignmentTurnedInIcon />,
+    path: '/reports/complete-encounters',
+  },
+  {
+    title: 'AI-Assisted Encounters',
+    description: 'View encounters with AI-generated documentation and assistant interactions',
+    icon: <PsychologyIcon />,
+    path: '/reports/ai-assisted-encounters',
+    adminOnly: true,
+  },
+  {
+    title: 'Daily Payments',
+    description: 'Review daily payment reports and transaction summaries',
+    icon: <AttachMoneyIcon />,
+    path: '/reports/daily-payments',
+  },
+  {
+    title: 'Practice KPIs',
+    description: 'View location-level performance metrics for in-person visits',
+    icon: <InsightsIcon />,
+    path: '/reports/practice-kpis',
+    adminOnly: true,
+  },
+  {
+    title: 'Visits Overview',
+    description: 'View appointment statistics and charts showing visit types (in-person vs telemed)',
+    icon: <AssessmentIcon />,
+    path: '/reports/visits-overview',
+  },
+  {
+    title: 'Recent Patients',
+    description: 'View list of recent patients with contact information and visit details',
+    icon: <PeopleIcon />,
+    path: '/reports/recent-patients',
+  },
+  {
+    title: 'Invoiceable patients',
+    description: 'View invoiceable patients report',
+    icon: <SummarizeIcon />,
+    path: '/reports/invoiceable-patients',
+    adminOnly: true,
+  },
+  {
+    title: 'Mailed Statements',
+    description: 'View patient statements sent by mail via PostGrid',
+    icon: <MailOutlineIcon />,
+    path: '/reports/mailed-statements',
+    adminOnly: true,
+  },
+];
 
 export default function Reports(): React.ReactElement {
   const navigate = useNavigate();
   const user = useEvolveUser();
   const isAdmin = user?.hasRole([RoleType.Administrator]) ?? false;
-
-  const reportTiles = [
-    {
-      title: 'Incomplete Encounters',
-      description: 'View and manage encounters that are missing required information or documentation',
-      icon: <AssignmentLateIcon />,
-      path: '/reports/incomplete-encounters',
-    },
-    {
-      title: 'Complete Encounters',
-      description: 'View encounters that have been completed',
-      icon: <AssignmentTurnedInIcon />,
-      path: '/reports/complete-encounters',
-    },
-    {
-      title: 'AI-Assisted Encounters',
-      description: 'View encounters with AI-generated documentation and assistant interactions',
-      icon: <PsychologyIcon />,
-      path: '/reports/ai-assisted-encounters',
-    },
-    {
-      title: 'Daily Payments',
-      description: 'Review daily payment reports and transaction summaries',
-      icon: <AttachMoneyIcon />,
-      path: '/reports/daily-payments',
-    },
-    {
-      title: 'Practice KPIs',
-      description: 'View location-level performance metrics for in-person visits',
-      icon: <InsightsIcon />,
-      path: '/reports/practice-kpis',
-    },
-    {
-      title: 'Visits Overview',
-      description: 'View appointment statistics and charts showing visit types (in-person vs telemed)',
-      icon: <AssessmentIcon />,
-      path: '/reports/visits-overview',
-    },
-    {
-      title: 'Recent Patients',
-      description: 'View list of recent patients with contact information and visit details',
-      icon: <PeopleIcon />,
-      path: '/reports/recent-patients',
-    },
-    {
-      title: 'Mailed Statements',
-      description: 'View patient statements sent by mail',
-      icon: <MailOutlineIcon />,
-      path: '/reports/mailed-statements',
-    },
-  ];
 
   const handleTileClick = (path: string): void => {
     navigate(path);
@@ -166,19 +177,17 @@ export default function Reports(): React.ReactElement {
         </Box>
 
         <Grid container spacing={3}>
-          {reportTiles
-            .filter((tile) => isAdmin || !ADMIN_ONLY_REPORTS.has(tile.title))
-            .map((tile) => (
-              <Grid item xs={12} sm={6} md={4} lg={3} key={tile.path}>
-                <ReportTile
-                  title={tile.title}
-                  description={tile.description}
-                  icon={tile.icon}
-                  path={tile.path}
-                  onClick={() => handleTileClick(tile.path)}
-                />
-              </Grid>
-            ))}
+          {REPORT_TILES.filter((tile) => isAdmin || !tile.adminOnly).map((tile) => (
+            <Grid item xs={12} sm={6} md={4} lg={3} key={tile.path}>
+              <ReportTile
+                title={tile.title}
+                description={tile.description}
+                icon={tile.icon}
+                path={tile.path}
+                onClick={() => handleTileClick(tile.path)}
+              />
+            </Grid>
+          ))}
         </Grid>
       </Box>
     </PageContainer>

--- a/apps/ehr/src/pages/Reports.tsx
+++ b/apps/ehr/src/pages/Reports.tsx
@@ -9,6 +9,8 @@ import PsychologyIcon from '@mui/icons-material/Psychology';
 import { Box, Card, CardActionArea, CardContent, Grid, Typography, useTheme } from '@mui/material';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { RoleType } from 'utils';
+import useEvolveUser from '../hooks/useEvolveUser';
 import PageContainer from '../layout/PageContainer';
 
 interface ReportTileProps {
@@ -84,8 +86,17 @@ function ReportTile({ title, description, icon, onClick }: ReportTileProps): Rea
   );
 }
 
+const ADMIN_ONLY_REPORTS = new Set([
+  'AI-Assisted Encounters',
+  'Practice KPIs',
+  'Invoiceable patients',
+  'Mailed Statements',
+]);
+
 export default function Reports(): React.ReactElement {
   const navigate = useNavigate();
+  const user = useEvolveUser();
+  const isAdmin = user?.hasRole([RoleType.Administrator]) ?? false;
 
   const reportTiles = [
     {
@@ -155,17 +166,19 @@ export default function Reports(): React.ReactElement {
         </Box>
 
         <Grid container spacing={3}>
-          {reportTiles.map((tile) => (
-            <Grid item xs={12} sm={6} md={4} lg={3} key={tile.path}>
-              <ReportTile
-                title={tile.title}
-                description={tile.description}
-                icon={tile.icon}
-                path={tile.path}
-                onClick={() => handleTileClick(tile.path)}
-              />
-            </Grid>
-          ))}
+          {reportTiles
+            .filter((tile) => isAdmin || !ADMIN_ONLY_REPORTS.has(tile.title))
+            .map((tile) => (
+              <Grid item xs={12} sm={6} md={4} lg={3} key={tile.path}>
+                <ReportTile
+                  title={tile.title}
+                  description={tile.description}
+                  icon={tile.icon}
+                  path={tile.path}
+                  onClick={() => handleTileClick(tile.path)}
+                />
+              </Grid>
+            ))}
         </Grid>
       </Box>
     </PageContainer>

--- a/apps/ehr/src/state/nav.store.ts
+++ b/apps/ehr/src/state/nav.store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-export type AppTab = 'Tracking Board' | 'Schedules' | 'Employees' | 'Patients' | 'Admin' | 'Tasks';
+export type AppTab = 'Tracking Board' | 'Patients' | 'Admin' | 'Tasks' | 'Reports';
 
 interface NavState {
   currentTab?: string;


### PR DESCRIPTION
## Summary
Reports was previously only accessible via a button inside the Admin page, meaning Staff, Provider, and Customer Support users had no way to view reports at all. This PR moves Reports to the top navigation bar so all roles can access it, while keeping sensitive reports (AI-Assisted Encounters, Practice KPIs, Invoiceable Patients, Mailed Statements) restricted to Administrators only.

## Changes
- Added Reports tab to the top nav for all roles
- Admin-only report tiles are hidden from non-admin users on the Reports page
- Removed the old Reports button from the Admin page
- Cleaned up unused `'Schedules'` and `'Employees'` entries from `AppTab`(CHECK THIS PLEASE AS I AM NOT 100% SURE)

Closes #7665
