### PR TITLE
fix(ehr): exclude Medical Conditions from global templates

### DIFF
--- a/packages/zambdas/src/ehr/admin-create-template/index.ts
+++ b/packages/zambdas/src/ehr/admin-create-template/index.ts
@@ -1,6 +1,6 @@
 import Oystehr from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { BundleEntry, Condition, Encounter, List, Patient } from 'fhir/r4b';
+import { BundleEntry, Encounter, List, Patient } from 'fhir/r4b';
 import {
   AdminCreateTemplateInput,
   AdminCreateTemplateOutput,
@@ -10,13 +10,12 @@ import {
   getSecret,
   GLOBAL_TEMPLATE_IN_PERSON_CODE_SYSTEM,
   GLOBAL_TEMPLATE_TELEMED_CODE_SYSTEM,
-  ICD_10_CODE_SYSTEM,
   SecretsKeys,
 } from 'utils';
 import { v4 as uuidV4 } from 'uuid';
 import { checkOrCreateM2MClientToken, topLevelCatch, wrapHandler, ZambdaInput } from '../../shared';
 import { createOystehrClient } from '../../shared/helpers';
-import { findHolderList } from '../shared/template-helpers';
+import { findHolderList, hasTemplateRelevantTag, isDiagnosisCondition } from '../shared/template-helpers';
 import { validateRequestParameters } from './validateRequestParameters';
 
 // Lifting up value to outside of the handler allows it to stay in memory across warm lambda invocations
@@ -127,13 +126,10 @@ const performEffect = async (
 
   const seenTags = new Set<string>();
   encounterBundle.entry = encounterBundle.entry.filter((entry) => {
-    // ICD-10 diagnoses are additive (multiple per encounter), so skip deduplication for them
-    if (
-      entry.resource?.resourceType === 'Condition' &&
-      (entry.resource as Condition).code?.coding?.some((c) => c.system === ICD_10_CODE_SYSTEM)
-    ) {
-      return true;
-    }
+    // Diagnoses are additive (multiple per encounter), so skip deduplication for them.
+    // We identify diagnoses by the `diagnosis` meta tag, NOT by ICD-10 code — Medical Conditions can also
+    // carry ICD-10 codes but they are patient-specific history, not template content.
+    if (isDiagnosisCondition(entry.resource)) return true;
     const tags = entry.resource?.meta?.tag?.map((tag) => `${tag.system}|${tag.code}`);
     if (!tags) return true;
     // CPT codes and patient instructions are additive (multiple per encounter), so skip deduplication for them
@@ -149,30 +145,10 @@ const performEffect = async (
     return !isDuplicate;
   });
 
-  // Filter to only resources relevant to template sections
-  const TEMPLATE_TAG_SYSTEMS = new Set([
-    chartDataTagSystem('chief-complaint'),
-    chartDataTagSystem('mechanism-of-injury'),
-    chartDataTagSystem('ros'), // legacy
-    chartDataTagSystem('exam-observation-field'),
-    chartDataTagSystem('ros-observation-field'),
-    chartDataTagSystem('medical-decision'),
-    chartDataTagSystem('patient-instruction'),
-    chartDataTagSystem('cpt-code'),
-    chartDataTagSystem('em-code'),
-  ]);
-
+  // Keep only the Encounter and resources tagged as template content. See TEMPLATE_TAG_SYSTEMS for the allow-list.
   encounterBundle.entry = encounterBundle.entry.filter((entry) => {
     if (!entry.resource || entry.resource.resourceType === 'Encounter') return true;
-    // Keep ICD-10 Conditions (Assessment / Diagnoses)
-    if (
-      entry.resource.resourceType === 'Condition' &&
-      (entry.resource as Condition).code?.coding?.some((c) => c.system === ICD_10_CODE_SYSTEM)
-    ) {
-      return true;
-    }
-    // Keep resources with a template-relevant meta tag
-    return entry.resource.meta?.tag?.some((tag) => tag.system && TEMPLATE_TAG_SYSTEMS.has(tag.system));
+    return hasTemplateRelevantTag(entry.resource);
   });
 
   console.log('Count of resources after filtering to template-relevant:', encounterBundle.entry.length);

--- a/packages/zambdas/src/ehr/admin-get-template-detail/index.ts
+++ b/packages/zambdas/src/ehr/admin-get-template-detail/index.ts
@@ -22,7 +22,7 @@ import {
 } from 'utils';
 import { checkOrCreateM2MClientToken, topLevelCatch, wrapHandler, ZambdaInput } from '../../shared';
 import { createOystehrClient } from '../../shared/helpers';
-import { analyzeTemplateVersionData, verifyIsTemplate } from '../shared/template-helpers';
+import { analyzeTemplateVersionData, isDiagnosisCondition, verifyIsTemplate } from '../shared/template-helpers';
 import { validateRequestParameters } from './validateRequestParameters';
 
 // Lifting up value to outside of the handler allows it to stay in memory across warm lambda invocations
@@ -212,10 +212,9 @@ const performEffect = async (
   ) as ClinicalImpression | undefined;
   const mdm = mdmResource?.summary ?? null;
 
-  // Parse diagnoses (ICD-10 coded Conditions)
-  const diagnosisConditions = contained.filter(
-    (r) => r.resourceType === 'Condition' && (r as Condition).code?.coding?.some((c) => c.system === ICD_10_CODE_SYSTEM)
-  ) as Condition[];
+  // Parse diagnoses. Identify them by the `diagnosis` meta tag — Medical Conditions are also Conditions with
+  // ICD-10 codes, so a code-system check alone would surface them as diagnoses incorrectly.
+  const diagnosisConditions = contained.filter((r) => isDiagnosisCondition(r)) as Condition[];
 
   const diagnoses: TemplateCodeInfo[] = diagnosisConditions.map((cond) => {
     const icdCoding = cond.code?.coding?.find((c) => c.system === ICD_10_CODE_SYSTEM);

--- a/packages/zambdas/src/ehr/apply-template/index.ts
+++ b/packages/zambdas/src/ehr/apply-template/index.ts
@@ -7,16 +7,11 @@ import Oystehr, {
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Operation } from 'fast-json-patch';
 import { ClinicalImpression, Communication, Condition, Encounter, List, Observation, Procedure } from 'fhir/r4b';
-import {
-  ApplyTemplateZambdaInput,
-  chartDataTagSystem,
-  chunkThings,
-  GLOBAL_TEMPLATE_META_TAG_CODE_SYSTEM,
-  ICD_10_CODE_SYSTEM,
-} from 'utils';
+import { ApplyTemplateZambdaInput, chartDataTagSystem, chunkThings, GLOBAL_TEMPLATE_META_TAG_CODE_SYSTEM } from 'utils';
 import { v4 as uuidV4 } from 'uuid';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
 import { createOystehrClient } from '../../shared/helpers';
+import { hasTemplateRelevantTag, isDiagnosisCondition } from '../shared/template-helpers';
 import { validateRequestParameters } from './validateRequestParameters';
 
 interface ComplexValidationOutput {
@@ -264,6 +259,16 @@ const makeCreateRequests = (
       continue;
     }
 
+    // Defensive guard: only apply resources whose meta tag is template-relevant. Older templates created before
+    // the create-side filter was tightened may still contain patient-specific resources (e.g. Medical Conditions);
+    // skip them rather than recreate that data on this chart.
+    if (containedResource.resourceType !== 'Encounter' && !hasTemplateRelevantTag(containedResource)) {
+      console.log(
+        `Skipping contained resource ${containedResource.resourceType}/${containedResource.id}: no template-relevant meta tag`
+      );
+      continue;
+    }
+
     // For Chief Complaint, if there is an existing HPI Condition, instead of creating, we will patch so skip.
     if (
       containedResource.meta?.tag?.some((tag) => tag.system === chartDataTagSystem('chief-complaint')) &&
@@ -308,11 +313,9 @@ const makeCreateRequests = (
       continue;
     }
 
-    // For Condition resources that are ICD-10 codes, we need to update the Encounter.diagnosis references
-    if (
-      resourceToCreate.resourceType === 'Condition' &&
-      resourceToCreate.code?.coding?.find((c) => c.system === ICD_10_CODE_SYSTEM)
-    ) {
+    // For Diagnosis Conditions we also need to update the Encounter.diagnosis references.
+    // Use the `diagnosis` meta tag (not the presence of an ICD-10 code) so Medical Conditions are not picked up.
+    if (isDiagnosisCondition(resourceToCreate)) {
       const diagnosisToAdd = templateEncounterDiagnoses?.find((d) => {
         return d.condition.reference?.split('/')[1] === containedResource.id;
       });

--- a/packages/zambdas/src/ehr/shared/template-helpers.ts
+++ b/packages/zambdas/src/ehr/shared/template-helpers.ts
@@ -1,10 +1,43 @@
 import Oystehr from '@oystehr/sdk';
 import { Condition, List, Observation, Resource } from 'fhir/r4b';
 import {
+  chartDataTagSystem,
   GLOBAL_TEMPLATE_IN_PERSON_CODE_SYSTEM,
   GLOBAL_TEMPLATE_META_TAG_CODE_SYSTEM,
   GLOBAL_TEMPLATE_TELEMED_CODE_SYSTEM,
 } from 'utils';
+
+// Meta-tag systems that mark a resource as belonging in a global template.
+// IMPORTANT: this is a positive allow-list, not "any Condition with an ICD-10 code". Medical Conditions are also
+// FHIR Conditions and can carry ICD-10 codes, but they are patient-specific history and must never be templated.
+export const TEMPLATE_TAG_SYSTEMS: ReadonlySet<string> = new Set([
+  chartDataTagSystem('chief-complaint'),
+  chartDataTagSystem('mechanism-of-injury'),
+  chartDataTagSystem('ros'), // legacy
+  chartDataTagSystem('exam-observation-field'),
+  chartDataTagSystem('ros-observation-field'),
+  chartDataTagSystem('medical-decision'),
+  chartDataTagSystem('patient-instruction'),
+  chartDataTagSystem('cpt-code'),
+  chartDataTagSystem('em-code'),
+  chartDataTagSystem('diagnosis'),
+]);
+
+// Minimal shape for tag-based predicates so callers can pass resources from any FHIR version (R4B / R5) without
+// fighting cross-version type unions. The runtime shape of meta.tag is identical across versions.
+type TaggedResource = {
+  resourceType?: string;
+  meta?: { tag?: Array<{ system?: string; code?: string }> };
+};
+
+export function hasTemplateRelevantTag(resource: TaggedResource | undefined): boolean {
+  return resource?.meta?.tag?.some((tag) => !!tag.system && TEMPLATE_TAG_SYSTEMS.has(tag.system)) ?? false;
+}
+
+export function isDiagnosisCondition(resource: TaggedResource | undefined): boolean {
+  if (resource?.resourceType !== 'Condition') return false;
+  return resource.meta?.tag?.some((tag) => tag.system === chartDataTagSystem('diagnosis')) ?? false;
+}
 
 export function verifyIsTemplate(templateList: List, templateId: string): void {
   const isTemplate = templateList.code?.coding?.some(

--- a/packages/zambdas/src/ehr/shared/template-helpers.ts
+++ b/packages/zambdas/src/ehr/shared/template-helpers.ts
@@ -8,8 +8,7 @@ import {
 } from 'utils';
 
 // Meta-tag systems that mark a resource as belonging in a global template.
-// IMPORTANT: this is a positive allow-list, not "any Condition with an ICD-10 code". Medical Conditions are also
-// FHIR Conditions and can carry ICD-10 codes, but they are patient-specific history and must never be templated.
+// IMPORTANT: this is a positive allow-list
 export const TEMPLATE_TAG_SYSTEMS: ReadonlySet<string> = new Set([
   chartDataTagSystem('chief-complaint'),
   chartDataTagSystem('mechanism-of-injury'),

--- a/packages/zambdas/test/unit/template-helpers.test.ts
+++ b/packages/zambdas/test/unit/template-helpers.test.ts
@@ -1,0 +1,115 @@
+import { Condition, Observation, Procedure } from 'fhir/r4b';
+import { chartDataTagSystem, ICD_10_CODE_SYSTEM } from 'utils';
+import { describe, expect, test } from 'vitest';
+import { hasTemplateRelevantTag, isDiagnosisCondition } from '../../src/ehr/shared/template-helpers';
+
+const taggedCondition = (tagField: string, opts: { withIcd10?: boolean } = {}): Condition => ({
+  resourceType: 'Condition',
+  subject: { reference: 'Patient/p1' },
+  encounter: { reference: 'Encounter/e1' },
+  meta: { tag: [{ system: chartDataTagSystem(tagField), code: tagField }] },
+  code: opts.withIcd10
+    ? { coding: [{ system: ICD_10_CODE_SYSTEM, code: 'J45.909', display: 'Unspecified asthma, uncomplicated' }] }
+    : undefined,
+});
+
+describe('isDiagnosisCondition', () => {
+  test('returns true for a Condition tagged `diagnosis` with an ICD-10 code', () => {
+    expect(isDiagnosisCondition(taggedCondition('diagnosis', { withIcd10: true }))).toBe(true);
+  });
+
+  test('returns false for a Medical Condition (Condition tagged `medical-condition`) even when it carries an ICD-10 code', () => {
+    // This is the bug we are guarding against: Medical Conditions can carry ICD-10 codes (the UI lets users pick one),
+    // and the previous discriminator (presence of ICD-10 code) would surface them as diagnoses incorrectly.
+    expect(isDiagnosisCondition(taggedCondition('medical-condition', { withIcd10: true }))).toBe(false);
+  });
+
+  test('returns false for a Medical Condition without any ICD-10 code', () => {
+    expect(isDiagnosisCondition(taggedCondition('medical-condition'))).toBe(false);
+  });
+
+  test('returns false for a Condition with no meta tag', () => {
+    const cond: Condition = {
+      resourceType: 'Condition',
+      subject: { reference: 'Patient/p1' },
+      code: { coding: [{ system: ICD_10_CODE_SYSTEM, code: 'J45.909' }] },
+    };
+    expect(isDiagnosisCondition(cond)).toBe(false);
+  });
+
+  test('returns false for non-Condition resources', () => {
+    const obs: Observation = {
+      resourceType: 'Observation',
+      status: 'final',
+      code: { coding: [] },
+      meta: { tag: [{ system: chartDataTagSystem('diagnosis'), code: 'diagnosis' }] },
+    };
+    expect(isDiagnosisCondition(obs)).toBe(false);
+  });
+
+  test('returns false for undefined resource', () => {
+    expect(isDiagnosisCondition(undefined)).toBe(false);
+  });
+});
+
+describe('hasTemplateRelevantTag', () => {
+  test.each([
+    'chief-complaint',
+    'mechanism-of-injury',
+    'ros',
+    'exam-observation-field',
+    'ros-observation-field',
+    'medical-decision',
+    'patient-instruction',
+    'cpt-code',
+    'em-code',
+    'diagnosis',
+  ])('returns true for a resource tagged `%s`', (tagField) => {
+    const resource: Observation = {
+      resourceType: 'Observation',
+      status: 'final',
+      code: { coding: [] },
+      meta: { tag: [{ system: chartDataTagSystem(tagField), code: tagField }] },
+    };
+    expect(hasTemplateRelevantTag(resource)).toBe(true);
+  });
+
+  test('returns false for a Medical Condition (the bug scenario)', () => {
+    expect(hasTemplateRelevantTag(taggedCondition('medical-condition', { withIcd10: true }))).toBe(false);
+    expect(hasTemplateRelevantTag(taggedCondition('medical-condition'))).toBe(false);
+  });
+
+  test('returns false for resources tagged with unrelated chart-data fields', () => {
+    expect(hasTemplateRelevantTag(taggedCondition('known-allergy'))).toBe(false);
+    expect(hasTemplateRelevantTag(taggedCondition('surgical-history'))).toBe(false);
+    expect(hasTemplateRelevantTag(taggedCondition('hospitalization'))).toBe(false);
+  });
+
+  test('returns false for a resource with no meta tag', () => {
+    const proc: Procedure = {
+      resourceType: 'Procedure',
+      status: 'completed',
+      subject: { reference: 'Patient/p1' },
+    };
+    expect(hasTemplateRelevantTag(proc)).toBe(false);
+  });
+
+  test('returns false for undefined resource', () => {
+    expect(hasTemplateRelevantTag(undefined)).toBe(false);
+  });
+
+  test('returns true if any one tag matches (resource may carry multiple tags)', () => {
+    const resource: Procedure = {
+      resourceType: 'Procedure',
+      status: 'completed',
+      subject: { reference: 'Patient/p1' },
+      meta: {
+        tag: [
+          { system: 'https://example.com/unrelated', code: 'foo' },
+          { system: chartDataTagSystem('cpt-code'), code: 'cpt-code' },
+        ],
+      },
+    };
+    expect(hasTemplateRelevantTag(resource)).toBe(true);
+  });
+});


### PR DESCRIPTION
Code and description below by Claude Opus 4.7 xHigh. 

Global templates were using the presence of an ICD-10 code on a Condition resource as the discriminator for "this is an Assessment/Diagnosis and belongs in the template". Medical Conditions are also FHIR Condition resources and can carry ICD-10 codes (the Medical Conditions UI lets users pick one from the ICD-10 autocomplete), so they were being scooped into templates and then recreated on every chart the template was applied to.

Switch the discriminator to the canonical `diagnosis` meta tag in admin-create-template, apply-template, and admin-get-template-detail. Add a defensive guard in apply-template that skips contained resources without a template-relevant meta tag, so templates created before this fix can no longer poison new charts.

https://claude.ai/code/session_01AwHL9wJuwFXKLCjrWsEkmS