### PR TITLE
OTR-2621: atomically claim Task in wrapTaskHandler via If-Match

### DIFF
--- a/packages/zambdas/src/subscriptions/helpers.ts
+++ b/packages/zambdas/src/subscriptions/helpers.ts
@@ -5,31 +5,91 @@ interface PatchTaskStatusInput {
   task: Pick<Task, 'id'>;
   taskStatusToUpdate: Task['status'];
   statusReasonToUpdate?: string;
+  /**
+   * Enable FHIR optimistic locking on the patch. When set, the request is sent
+   * with `If-Match: W/"<versionId>"` (FHIR optimistic-locking format). If the
+   * Task has been modified since the version provided — e.g. a concurrent
+   * subscription delivery already claimed it — the server returns HTTP 412
+   * Precondition Failed and {@link patchTaskStatus} throws
+   * {@link TaskStatusPreconditionFailedError}.
+   *
+   * Note: JSON Patch `test` ops are not sufficient here — Oystehr applies
+   * concurrent patches against snapshot state, so two racing callers can both
+   * have their `test` op pass against the same unclaimed snapshot. If-Match
+   * is the only check that's enforced atomically against committed state.
+   */
+  optimisticLockingVersionId?: string;
+}
+
+/**
+ * Thrown by {@link patchTaskStatus} when an `optimisticLockingVersionId` was
+ * provided but the Task had already been updated by another writer before
+ * our PATCH committed (HTTP 412 Precondition Failed). Callers that opt into
+ * optimistic locking should catch this specifically to distinguish "lost
+ * the claim race" from a real error.
+ */
+export class TaskStatusPreconditionFailedError extends Error {
+  readonly taskId: string;
+  readonly attemptedVersionId: string;
+
+  constructor(taskId: string, attemptedVersionId: string, cause?: unknown) {
+    super(
+      `Task/${taskId} optimistic lock failed: attempted versionId='${attemptedVersionId}' but the resource has been updated since`
+    );
+    this.name = 'TaskStatusPreconditionFailedError';
+    this.taskId = taskId;
+    this.attemptedVersionId = attemptedVersionId;
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
 }
 
 export const patchTaskStatus = async (input: PatchTaskStatusInput, oystehr: Oystehr): Promise<Task> => {
-  const { task, taskStatusToUpdate, statusReasonToUpdate } = input;
-  return oystehr.fhir.patch({
-    resourceType: 'Task',
-    id: task.id || '',
-    operations: [
+  const { task, taskStatusToUpdate, statusReasonToUpdate, optimisticLockingVersionId } = input;
+  const taskId = task.id || '';
+
+  try {
+    return await oystehr.fhir.patch(
       {
-        op: 'replace',
-        path: '/status',
-        value: taskStatusToUpdate,
-      },
-      {
-        op: 'add',
-        path: '/statusReason',
-        value: {
-          coding: [
-            {
-              system: 'status-reason',
-              code: statusReasonToUpdate || 'no reason given',
+        resourceType: 'Task',
+        id: taskId,
+        operations: [
+          {
+            op: 'replace',
+            path: '/status',
+            value: taskStatusToUpdate,
+          },
+          {
+            op: 'add',
+            path: '/statusReason',
+            value: {
+              coding: [
+                {
+                  system: 'status-reason',
+                  code: statusReasonToUpdate || 'no reason given',
+                },
+              ],
             },
-          ],
-        },
+          },
+        ],
       },
-    ],
-  });
+      optimisticLockingVersionId ? { optimisticLockingVersionId } : undefined
+    );
+  } catch (error) {
+    // Surface the precondition-failed case as a typed error so callers can
+    // distinguish "lost the claim race" from real errors. The SDK throws an
+    // OystehrSdkError with code=412 when the If-Match check fails.
+    if (optimisticLockingVersionId && isPreconditionFailed(error)) {
+      throw new TaskStatusPreconditionFailedError(taskId, optimisticLockingVersionId, error);
+    }
+    throw error;
+  }
+};
+
+const isPreconditionFailed = (error: unknown): boolean => {
+  const code = (error as { code?: number; statusCode?: number; status?: number } | null)?.code;
+  const statusCode = (error as { statusCode?: number } | null)?.statusCode;
+  const status = (error as { status?: number } | null)?.status;
+  return code === 412 || statusCode === 412 || status === 412;
 };

--- a/packages/zambdas/src/subscriptions/task/helpers.ts
+++ b/packages/zambdas/src/subscriptions/task/helpers.ts
@@ -17,7 +17,7 @@ import {
   wrapHandler,
   ZambdaInput,
 } from '../../shared';
-import { patchTaskStatus } from '../helpers';
+import { patchTaskStatus, TaskStatusPreconditionFailedError } from '../helpers';
 import { TaskSubscriptionInput, validateRequestParameters } from './validateRequestParameters';
 
 export const getDocReferenceIDFromFocus = (task: Task): string => {
@@ -121,8 +121,24 @@ export function wrapTaskHandler(
     }
 
     try {
-      await markTaskInProgress(taskId, oystehr);
+      await markTaskInProgress(taskId, params.task.meta?.versionId, oystehr);
     } catch (error) {
+      // Duplicate subscription delivery: another invocation already claimed
+      // this Task (If-Match version no longer current). Ack the redelivery
+      // without re-running the handler so its writes don't race the in-flight
+      // (or already-completed) original.
+      if (error instanceof TaskStatusPreconditionFailedError) {
+        console.log(
+          `Task ${taskId} already claimed by an earlier invocation (attempted versionId=${error.attemptedVersionId}); skipping duplicate delivery of ${zambdaName}`
+        );
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            taskStatus: 'skipped',
+            statusReason: 'task already claimed by an earlier invocation',
+          }),
+        };
+      }
       console.error('Error patching task status to in-progress:', error);
       try {
         await markTaskFailed(
@@ -156,9 +172,22 @@ export function wrapTaskHandler(
   });
 }
 
-async function markTaskInProgress(taskId: string, oystehr: Oystehr): Promise<void> {
+async function markTaskInProgress(taskId: string, versionId: string | undefined, oystehr: Oystehr): Promise<void> {
+  // Atomic claim via FHIR optimistic locking: the patch carries `If-Match`
+  // for the versionId the subscription delivered. If a concurrent
+  // subscription delivery already claimed the task, the version has moved
+  // on and this patch returns 412 — `patchTaskStatus` surfaces it as
+  // `TaskStatusPreconditionFailedError` and `wrapTaskHandler` short-circuits.
+  //
+  // If the subscription payload didn't carry a versionId for some reason,
+  // fall back to the old behavior (unconditional patch) rather than failing.
   await patchTaskStatus(
-    { task: { id: taskId }, taskStatusToUpdate: 'in-progress', statusReasonToUpdate: 'started processing' },
+    {
+      task: { id: taskId },
+      taskStatusToUpdate: 'in-progress',
+      statusReasonToUpdate: 'started processing',
+      optimisticLockingVersionId: versionId,
+    },
     oystehr
   );
 }

--- a/packages/zambdas/test/integration/patch-task-status-concurrency.test.ts
+++ b/packages/zambdas/test/integration/patch-task-status-concurrency.test.ts
@@ -1,0 +1,168 @@
+import Oystehr from '@oystehr/sdk';
+import { Task } from 'fhir/r4b';
+import { M2MClientMockType } from 'utils';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { patchTaskStatus, TaskStatusPreconditionFailedError } from '../../src/subscriptions/helpers';
+import { addProcessIdMetaTagToResource, setupIntegrationTest } from '../helpers/integration-test-seed-data-setup';
+
+/**
+ * Regression coverage for OTR-2621.
+ *
+ * `patchTaskStatus` supports `optimisticLockingVersionId`, which sends the
+ * FHIR `If-Match` header so the patch only commits if the Task is still at
+ * the supplied version. Two concurrent callers trying to flip the same Task
+ * to `in-progress` can't both win — only the one whose patch arrives while
+ * the version still matches succeeds; the other gets HTTP 412 surfaced as a
+ * {@link TaskStatusPreconditionFailedError}.
+ *
+ * This is the primitive `wrapTaskHandler.markTaskInProgress` now uses to
+ * dedupe at-least-once subscription deliveries (e.g. duplicate invocations
+ * of `sub-merge-patients` from a single Task event) — the root cause of the
+ * flake on `merge-patients > should merge coverages from both patients into
+ * the surviving PBILLACCT`.
+ *
+ * Note: JSON Patch `test` ops aren't sufficient — Oystehr evaluates them
+ * against snapshot state, so two racing callers can both pass the same
+ * `test` op against an unclaimed snapshot. If-Match is enforced against
+ * committed state, which is what we need.
+ */
+describe('patchTaskStatus — atomic claim via optimisticLockingVersionId', () => {
+  let oystehrAdmin: Oystehr;
+  let processId: string;
+  let cleanup: () => Promise<void>;
+  const createdTaskIds: string[] = [];
+
+  beforeAll(async () => {
+    const setup = await setupIntegrationTest(
+      'integration/patch-task-status-concurrency.test.ts',
+      M2MClientMockType.provider
+    );
+    oystehrAdmin = setup.oystehr;
+    processId = setup.processId;
+    cleanup = setup.cleanup;
+  }, 60_000);
+
+  afterAll(async () => {
+    // Tasks aren't reachable from cleanAppointmentGraph (it walks the
+    // appointment graph), so delete each tracked Task explicitly first.
+    for (const id of createdTaskIds) {
+      try {
+        await oystehrAdmin.fhir.delete({ resourceType: 'Task', id });
+      } catch (e) {
+        console.warn(`Failed to delete test Task/${id}:`, e);
+      }
+    }
+    await cleanup();
+  });
+
+  const createTask = async (): Promise<Task> => {
+    const created = await oystehrAdmin.fhir.create<Task>(
+      addProcessIdMetaTagToResource(
+        {
+          resourceType: 'Task',
+          status: 'requested',
+          intent: 'order',
+          code: {
+            coding: [{ system: 'https://fhir.ottehr.com/CodeSystem/test-task', code: 'concurrency-test' }],
+          },
+        },
+        processId
+      ) as Task
+    );
+    if (created.id) createdTaskIds.push(created.id);
+    return created;
+  };
+
+  it('without optimisticLockingVersionId: both concurrent patches succeed (existing behavior preserved)', async () => {
+    const task = await createTask();
+    const [a, b] = await Promise.allSettled([
+      patchTaskStatus(
+        { task: { id: task.id! }, taskStatusToUpdate: 'in-progress', statusReasonToUpdate: 'a' },
+        oystehrAdmin
+      ),
+      patchTaskStatus(
+        { task: { id: task.id! }, taskStatusToUpdate: 'in-progress', statusReasonToUpdate: 'b' },
+        oystehrAdmin
+      ),
+    ]);
+    expect(a.status).toBe('fulfilled');
+    expect(b.status).toBe('fulfilled');
+  });
+
+  it('with optimisticLockingVersionId: exactly one of two concurrent claims succeeds', async () => {
+    const task = await createTask();
+    const versionId = task.meta?.versionId;
+    expect(versionId).toBeDefined();
+
+    const [a, b] = await Promise.allSettled([
+      patchTaskStatus(
+        {
+          task: { id: task.id! },
+          taskStatusToUpdate: 'in-progress',
+          statusReasonToUpdate: 'a',
+          optimisticLockingVersionId: versionId,
+        },
+        oystehrAdmin
+      ),
+      patchTaskStatus(
+        {
+          task: { id: task.id! },
+          taskStatusToUpdate: 'in-progress',
+          statusReasonToUpdate: 'b',
+          optimisticLockingVersionId: versionId,
+        },
+        oystehrAdmin
+      ),
+    ]);
+
+    const fulfilled = [a, b].filter((r) => r.status === 'fulfilled');
+    const rejected = [a, b].filter((r) => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+
+    const rejection = rejected[0] as PromiseRejectedResult;
+    expect(rejection.reason).toBeInstanceOf(TaskStatusPreconditionFailedError);
+    const err = rejection.reason as TaskStatusPreconditionFailedError;
+    expect(err.taskId).toBe(task.id!);
+    expect(err.attemptedVersionId).toBe(versionId);
+
+    const final = await oystehrAdmin.fhir.get<Task>({ resourceType: 'Task', id: task.id! });
+    expect(final.status).toBe('in-progress');
+  });
+
+  it('with optimisticLockingVersionId: a sequential second claim against an already-claimed task rejects', async () => {
+    const task = await createTask();
+    const originalVersionId = task.meta?.versionId;
+    expect(originalVersionId).toBeDefined();
+
+    await patchTaskStatus(
+      {
+        task: { id: task.id! },
+        taskStatusToUpdate: 'in-progress',
+        statusReasonToUpdate: 'first',
+        optimisticLockingVersionId: originalVersionId,
+      },
+      oystehrAdmin
+    );
+
+    // Second attempt against the now-stale original versionId.
+    let caught: unknown = undefined;
+    try {
+      await patchTaskStatus(
+        {
+          task: { id: task.id! },
+          taskStatusToUpdate: 'in-progress',
+          statusReasonToUpdate: 'second',
+          optimisticLockingVersionId: originalVersionId,
+        },
+        oystehrAdmin
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(TaskStatusPreconditionFailedError);
+    const err = caught as TaskStatusPreconditionFailedError;
+    expect(err.attemptedVersionId).toBe(originalVersionId);
+  });
+});


### PR DESCRIPTION
Claude wrote this I am still digesting it. I did run this 10x already to check that it fixes the flakes with patient merge. 

## Summary

`wrapTaskHandler.markTaskInProgress` now uses FHIR optimistic locking (`If-Match` via the SDK's `optimisticLockingVersionId`) to atomically claim the Task it's processing. Duplicate subscription deliveries that previously ran in parallel are now deduped server-side — only the first claim succeeds; the others get `412 Precondition Failed`, which surfaces as a typed `TaskStatusPreconditionFailedError` that `wrapTaskHandler` catches and short-circuits with `statusCode: 200, taskStatus: 'skipped'`.

## Diagnosis

`merge-patients > should merge coverages from both patients into the surviving PBILLACCT` failed ~80% of the time locally and intermittently in CI. The root cause wasn't search consistency — Oystehr's search is read-after-write consistent. It was that `sub-merge-patients` could be invoked more than once for the same Task event (at-least-once delivery / retry from the subscription engine).

When that happened, two `performMerge` invocations both ran. Each did its own read-modify-write on the survivor's PBILLACCT. Inside the lagging invocation, Step 1 read the survivor with `coverage = [mainCov, otherCov]` (already consolidated by the first invocation). `resolveCoverageUpdates` orders existing coverages by priority — both entries were priority 1, so `existingCoverages.secondary` was undefined. `preserveOmittedCoverages` then preserved only the primary, and the Step 1 PUT wrote back a single-coverage account. That's exactly the `Array(1)` the test was seeing.

## Fix

Make the Task-claim atomic so duplicate deliveries can't both run `performMerge`. The patch carries `If-Match` for the `versionId` the subscription delivered; concurrent (or duplicate-delivery) invocations send PATCHes with the same If-Match — first wins, others get 412 → short-circuit.

`patchTaskStatus` gained an optional `optimisticLockingVersionId` parameter (backwards-compatible; all existing callers pass nothing). `markTaskInProgress` opts in using `params.task.meta.versionId` from the subscription payload.

## Out of scope

There's a latent issue worth a separate ticket: `resolveCoverageUpdates` silently drops anything past primary+secondary when ordering coverages. After this fix the duplicate-invocation scenario stops triggering it, but an Account with multiple priority-1 coverages still can't be faithfully preserved by the harvest path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)