### PR TITLE
Add unit tests and migrate validateRequestParameters to zod schemas

### DIFF
--- a/packages/zambdas/src/ehr/change-in-person-visit-status/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/change-in-person-visit-status/validateRequestParameters.ts
@@ -1,56 +1,31 @@
 import { getSecret, SecretsKeys, visitStatusArray, VisitStatusWithoutUnknown } from 'utils';
-import { ZambdaInput } from '../../shared/types';
+import { z } from 'zod';
+import { safeValidate, ZambdaInput } from '../../shared';
 import { ChangeInPersonVisitStatusInputValidated } from '.';
 
-export function validateRequestParameters(input: ZambdaInput): ChangeInPersonVisitStatusInputValidated {
-  console.group('validateRequestParameters');
+const validStatuses = visitStatusArray.filter((s) => s !== 'unknown') as [
+  VisitStatusWithoutUnknown,
+  ...VisitStatusWithoutUnknown[],
+];
 
+const ChangeVisitStatusBodySchema = z.object({
+  encounterId: z.string(),
+  updatedStatus: z.enum(validStatuses),
+});
+
+export function validateRequestParameters(input: ZambdaInput): ChangeInPersonVisitStatusInputValidated {
   if (!input.body) {
     throw new Error('No request body provided');
   }
 
-  const parsedBody = JSON.parse(input.body) as unknown;
+  const { encounterId, updatedStatus } = safeValidate(ChangeVisitStatusBodySchema, JSON.parse(input.body));
 
-  // Safely unwrap and validate encounterId
-  if (typeof parsedBody !== 'object' || parsedBody === null) {
-    throw new Error('Request body must be a valid JSON object');
-  }
-
-  const bodyObj = parsedBody as Record<string, unknown>;
-
-  const { encounterId, updatedStatus } = bodyObj;
-
-  // Type-safe validation for encounterId
-  if (typeof encounterId !== 'string') {
-    throw new Error('Field "encounterId" is required and must be a string');
-  }
-
-  // Type-safe validation for updatedStatus
-  if (typeof updatedStatus !== 'string') {
-    throw new Error('Field "updatedStatus" is required and must be a string');
-  }
-
-  // Validate updatedStatus is a valid VisitStatusWithoutUnknown
-  // Derive valid statuses from the Visit_Status_Array, excluding 'unknown'
-  const validStatuses = visitStatusArray.filter((status) => status !== 'unknown') as VisitStatusWithoutUnknown[];
-
-  if (!validStatuses.includes(updatedStatus as VisitStatusWithoutUnknown)) {
-    throw new Error(`Field "updatedStatus" must be one of: ${validStatuses.join(', ')}`);
-  }
-
-  const typeSafeSecrets = input.secrets;
-
-  if (typeSafeSecrets == null) {
+  if (!input.secrets) {
     throw new Error('No secrets provided');
   }
 
-  if (getSecret(SecretsKeys.PROJECT_API, input.secrets) === undefined) {
-    throw new Error('"PROJECT_API" configuration not provided');
-  }
-
-  if (getSecret(SecretsKeys.ORGANIZATION_ID, input.secrets) === undefined) {
-    throw new Error('"ORGANIZATION_ID" configuration not provided');
-  }
+  getSecret(SecretsKeys.PROJECT_API, input.secrets);
+  getSecret(SecretsKeys.ORGANIZATION_ID, input.secrets);
 
   const userToken = input.headers.Authorization.replace('Bearer ', '');
 
@@ -58,13 +33,10 @@ export function validateRequestParameters(input: ZambdaInput): ChangeInPersonVis
     throw new Error('No user token provided in Authorization header');
   }
 
-  console.groupEnd();
-  console.debug('validateRequestParameters success');
-
   return {
     encounterId,
     userToken,
-    updatedStatus: updatedStatus as VisitStatusWithoutUnknown,
-    secrets: typeSafeSecrets,
+    updatedStatus,
+    secrets: input.secrets,
   };
 }

--- a/packages/zambdas/src/ehr/change-in-person-visit-status/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/change-in-person-visit-status/validateRequestParameters.ts
@@ -1,4 +1,12 @@
-import { getSecret, SecretsKeys, visitStatusArray, VisitStatusWithoutUnknown } from 'utils';
+import {
+  getSecret,
+  MISSING_REQUEST_BODY,
+  MISSING_REQUEST_SECRETS,
+  NOT_AUTHORIZED,
+  SecretsKeys,
+  visitStatusArray,
+  VisitStatusWithoutUnknown,
+} from 'utils';
 import { z } from 'zod';
 import { safeValidate, ZambdaInput } from '../../shared';
 import { ChangeInPersonVisitStatusInputValidated } from '.';
@@ -15,14 +23,14 @@ const ChangeVisitStatusBodySchema = z.object({
 
 export function validateRequestParameters(input: ZambdaInput): ChangeInPersonVisitStatusInputValidated {
   if (!input.body) {
-    throw new Error('No request body provided');
+    throw MISSING_REQUEST_BODY;
+  }
+
+  if (!input.secrets) {
+    throw MISSING_REQUEST_SECRETS;
   }
 
   const { encounterId, updatedStatus } = safeValidate(ChangeVisitStatusBodySchema, JSON.parse(input.body));
-
-  if (!input.secrets) {
-    throw new Error('No secrets provided');
-  }
 
   getSecret(SecretsKeys.PROJECT_API, input.secrets);
   getSecret(SecretsKeys.ORGANIZATION_ID, input.secrets);
@@ -30,7 +38,7 @@ export function validateRequestParameters(input: ZambdaInput): ChangeInPersonVis
   const userToken = input.headers.Authorization.replace('Bearer ', '');
 
   if (!userToken) {
-    throw new Error('No user token provided in Authorization header');
+    throw NOT_AUTHORIZED;
   }
 
   return {

--- a/packages/zambdas/src/ehr/create-upload-document-url/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/create-upload-document-url/validateRequestParameters.ts
@@ -1,5 +1,13 @@
-import { ZambdaInput } from '../../shared';
+import { z } from 'zod';
+import { safeValidate, ZambdaInput } from '../../shared';
 import { CreateUploadPatientDocumentInput } from '.';
+
+const CreateUploadDocumentBodySchema = z.object({
+  patientId: z.string(),
+  fileFolderId: z.string(),
+  fileName: z.string(),
+  internalName: z.string().optional(),
+});
 
 export function validateRequestParameters(input: ZambdaInput): CreateUploadPatientDocumentInput {
   if (!input.body) {
@@ -10,16 +18,18 @@ export function validateRequestParameters(input: ZambdaInput): CreateUploadPatie
     throw new Error('Authorization header is required');
   }
 
-  const { patientId, fileFolderId, fileName, internalName } = JSON.parse(input.body);
-
+  const { patientId, fileFolderId, fileName, internalName } = safeValidate(
+    CreateUploadDocumentBodySchema,
+    JSON.parse(input.body)
+  );
   const userToken = input.headers.Authorization.replace('Bearer ', '');
 
   return {
     secrets: input.secrets,
-    patientId: patientId,
-    fileFolderId: fileFolderId,
-    fileName: fileName,
-    userToken: userToken,
-    internalName: internalName,
+    patientId,
+    fileFolderId,
+    fileName,
+    userToken,
+    internalName,
   };
 }

--- a/packages/zambdas/src/ehr/create-user/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/create-user/validateRequestParameters.ts
@@ -1,4 +1,4 @@
-import { CreateUserParams } from 'utils';
+import { CreateUserParams, MISSING_REQUEST_BODY } from 'utils';
 import { z } from 'zod';
 import { safeValidate, ZambdaInput } from '../../shared';
 
@@ -11,7 +11,7 @@ const CreateUserBodySchema = z.object({
 
 export function validateRequestParameters(input: ZambdaInput): CreateUserParams & Pick<ZambdaInput, 'secrets'> {
   if (!input.body) {
-    throw new Error('No request body provided');
+    throw MISSING_REQUEST_BODY;
   }
 
   const { email, applicationID, firstName, lastName } = safeValidate(CreateUserBodySchema, JSON.parse(input.body));

--- a/packages/zambdas/src/ehr/create-user/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/create-user/validateRequestParameters.ts
@@ -1,16 +1,20 @@
 import { CreateUserParams } from 'utils';
-import { ZambdaInput } from '../../shared';
+import { z } from 'zod';
+import { safeValidate, ZambdaInput } from '../../shared';
+
+const CreateUserBodySchema = z.object({
+  email: z.string().min(1),
+  applicationID: z.string().min(1),
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+});
 
 export function validateRequestParameters(input: ZambdaInput): CreateUserParams & Pick<ZambdaInput, 'secrets'> {
   if (!input.body) {
     throw new Error('No request body provided');
   }
 
-  const { email, applicationID, firstName, lastName } = JSON.parse(input.body);
-
-  if (!email || !applicationID || !firstName || !lastName) {
-    throw new Error('These fields are required: "email", "applicationID", "firstName", "lastName"');
-  }
+  const { email, applicationID, firstName, lastName } = safeValidate(CreateUserBodySchema, JSON.parse(input.body));
 
   return {
     email,

--- a/packages/zambdas/src/ehr/create-user/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/create-user/validateRequestParameters.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 import { safeValidate, ZambdaInput } from '../../shared';
 
 const CreateUserBodySchema = z.object({
-  email: z.string().min(1),
-  applicationID: z.string().min(1),
+  email: z.string().email(),
+  applicationID: z.string().uuid(),
   firstName: z.string().min(1),
   lastName: z.string().min(1),
 });

--- a/packages/zambdas/src/ehr/delete-chart-data/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/delete-chart-data/validateRequestParameters.ts
@@ -1,21 +1,22 @@
 import { DeleteChartDataRequest } from 'utils';
-import { ZambdaInput } from '../../shared';
+import { z } from 'zod';
+import { safeValidate, ZambdaInput } from '../../shared';
+
+const DeleteChartDataBodySchema = z
+  .object({
+    encounterId: z.string(),
+  })
+  .passthrough();
 
 export function validateRequestParameters(input: ZambdaInput): DeleteChartDataRequest & Pick<ZambdaInput, 'secrets'> {
   if (!input.body) {
     throw new Error('No request body provided');
   }
 
-  const data = JSON.parse(input.body) as DeleteChartDataRequest;
-
-  const { encounterId } = data;
-
-  if (encounterId === undefined) {
-    throw new Error('These fields are required: "encounterId"');
-  }
+  const data = safeValidate(DeleteChartDataBodySchema, JSON.parse(input.body));
 
   return {
-    ...data,
+    ...(data as DeleteChartDataRequest),
     secrets: input.secrets,
   };
 }

--- a/packages/zambdas/src/ehr/get-appointments/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/get-appointments/validateRequestParameters.ts
@@ -1,90 +1,28 @@
-import { ZambdaInput } from '../../shared';
+import { z } from 'zod';
+import { safeValidate, ZambdaInput } from '../../shared';
 import { GetAppointmentsZambdaInputValidated } from '.';
+
+const GetAppointmentsBodySchema = z
+  .object({
+    searchDate: z.string(),
+    timezone: z.string(),
+    locationIds: z.array(z.string()).optional(),
+    providerIds: z.array(z.string()).optional(),
+    serviceCategories: z.array(z.string()).optional(),
+    visitType: z.array(z.string()),
+    supervisorApprovalEnabled: z.boolean().default(false),
+  })
+  .refine((data) => data.locationIds || data.providerIds || data.serviceCategories, {
+    message: 'Either "locationIds" or "providerIds" or "serviceCategories" is required',
+  });
 
 export function validateRequestParameters(input: ZambdaInput): GetAppointmentsZambdaInputValidated {
   if (!input.body) {
     throw new Error('No request body provided');
   }
 
-  // Parse and validate the JSON body
-  let parsedBody: unknown;
-  try {
-    parsedBody = JSON.parse(input.body);
-  } catch {
-    throw new Error('Invalid JSON in request body');
-  }
-
-  // Validate that the parsed body is an object
-  if (!parsedBody || typeof parsedBody !== 'object') {
-    throw new Error('Request body must be a valid JSON object');
-  }
-
-  const body = parsedBody as Record<string, unknown>;
-
-  // Safely extract and validate searchDate (required string)
-  if (typeof body.searchDate !== 'string') {
-    throw new Error('searchDate is required and must be a string');
-  }
-  const searchDate = body.searchDate;
-
-  // Safely extract and validate searchDate (required string)
-  if (typeof body.timezone !== 'string') {
-    throw new Error('timezone is required and must be a string');
-  }
-  const timezone = body.timezone;
-
-  // Safely extract and validate locationIds (optional string)
-  let locationIds: string[] | undefined;
-  if (body.locationIds !== undefined) {
-    if (!Array.isArray(body.locationIds)) {
-      throw new Error('locationIds must be an array if provided');
-    }
-    if (!body.locationIds.every((id): id is string => typeof id === 'string')) {
-      throw new Error('All locationIds must be strings');
-    }
-    locationIds = body.locationIds;
-  }
-
-  // Safely extract and validate providerIds (optional string array)
-  let providerIds: string[] | undefined;
-  if (body.providerIds !== undefined) {
-    if (!Array.isArray(body.providerIds)) {
-      throw new Error('providerIds must be an array if provided');
-    }
-    if (!body.providerIds.every((id): id is string => typeof id === 'string')) {
-      throw new Error('All providerIds must be strings');
-    }
-    providerIds = body.providerIds;
-  }
-
-  // Safely extract and validate serviceCategories (optional string array)
-  let serviceCategories: string[] | undefined;
-  if (body.serviceCategories !== undefined) {
-    if (!Array.isArray(body.serviceCategories)) {
-      throw new Error('serviceCategories must be an array if provided');
-    }
-    if (!body.serviceCategories.every((val): val is string => typeof val === 'string')) {
-      throw new Error('All serviceCategories must be strings');
-    }
-    serviceCategories = body.serviceCategories;
-  }
-
-  // Safely extract and validate visitType (required string array)
-  if (!Array.isArray(body.visitType)) {
-    throw new Error('visitType is required and must be an array');
-  }
-  if (!body.visitType.every((type): type is string => typeof type === 'string')) {
-    throw new Error('All visitType values must be strings');
-  }
-  const visitType = body.visitType;
-
-  // Validate business logic constraints
-  if (locationIds === undefined && providerIds === undefined && serviceCategories === undefined) {
-    throw new Error('Either "locationIds" or "providerIds" or "serviceCategories" is required');
-  }
-
-  const supervisorApprovalEnabled =
-    typeof body.supervisorApprovalEnabled === 'boolean' ? body.supervisorApprovalEnabled : false;
+  const { searchDate, timezone, locationIds, providerIds, serviceCategories, visitType, supervisorApprovalEnabled } =
+    safeValidate(GetAppointmentsBodySchema, JSON.parse(input.body));
 
   return {
     searchDate,

--- a/packages/zambdas/src/ehr/get-appointments/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/get-appointments/validateRequestParameters.ts
@@ -1,15 +1,20 @@
+import { AppointmentTypeOptions, ServiceMode } from 'utils';
 import { z } from 'zod';
 import { safeValidate, ZambdaInput } from '../../shared';
 import { GetAppointmentsZambdaInputValidated } from '.';
 
+const visitTypeOptions = Object.values(ServiceMode).flatMap((mode) =>
+  AppointmentTypeOptions.map((type) => `${mode}-${type}`)
+) as [string, ...string[]];
+
 const GetAppointmentsBodySchema = z
   .object({
-    searchDate: z.string(),
+    searchDate: z.string().date(),
     timezone: z.string(),
-    locationIds: z.array(z.string()).optional(),
-    providerIds: z.array(z.string()).optional(),
+    locationIds: z.array(z.string().uuid()).optional(),
+    providerIds: z.array(z.string().uuid()).optional(),
     serviceCategories: z.array(z.string()).optional(),
-    visitType: z.array(z.string()),
+    visitType: z.array(z.enum(visitTypeOptions)),
     supervisorApprovalEnabled: z.boolean().default(false),
   })
   .refine((data) => data.locationIds || data.providerIds || data.serviceCategories, {

--- a/packages/zambdas/src/ehr/get-appointments/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/get-appointments/validateRequestParameters.ts
@@ -31,7 +31,7 @@ export function validateRequestParameters(input: ZambdaInput): GetAppointmentsZa
     providerIds,
     serviceCategories,
     visitType,
-    supervisorApprovalEnabled,
+    supervisorApprovalEnabled: supervisorApprovalEnabled ?? false,
     secrets: input.secrets,
   };
 }

--- a/packages/zambdas/src/ehr/get-appointments/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/get-appointments/validateRequestParameters.ts
@@ -1,4 +1,4 @@
-import { AppointmentTypeOptions, ServiceMode } from 'utils';
+import { AppointmentTypeOptions, MISSING_REQUEST_BODY, ServiceMode } from 'utils';
 import { z } from 'zod';
 import { safeValidate, ZambdaInput } from '../../shared';
 import { GetAppointmentsZambdaInputValidated } from '.';
@@ -23,7 +23,7 @@ const GetAppointmentsBodySchema = z
 
 export function validateRequestParameters(input: ZambdaInput): GetAppointmentsZambdaInputValidated {
   if (!input.body) {
-    throw new Error('No request body provided');
+    throw MISSING_REQUEST_BODY;
   }
 
   const { searchDate, timezone, locationIds, providerIds, serviceCategories, visitType, supervisorApprovalEnabled } =

--- a/packages/zambdas/src/ehr/get-user/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/get-user/validateRequestParameters.ts
@@ -1,4 +1,4 @@
-import { GetUserParams, Secrets, WithRequired } from 'utils';
+import { GetUserParams, MISSING_REQUEST_BODY, Secrets, WithRequired } from 'utils';
 import { z } from 'zod';
 import { safeValidate, ZambdaInput } from '../../shared';
 
@@ -12,7 +12,7 @@ const GetUserBodySchema = z.object({
 
 export function validateRequestParameters(input: ZambdaInput): GetUserInput {
   if (!input.body) {
-    throw new Error('No request body provided');
+    throw MISSING_REQUEST_BODY;
   }
 
   const { userId } = safeValidate(GetUserBodySchema, JSON.parse(input.body));

--- a/packages/zambdas/src/ehr/get-user/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/get-user/validateRequestParameters.ts
@@ -1,24 +1,21 @@
 import { GetUserParams, Secrets, WithRequired } from 'utils';
-import { ZambdaInput } from '../../shared';
+import { z } from 'zod';
+import { safeValidate, ZambdaInput } from '../../shared';
 
 export interface GetUserInput extends WithRequired<GetUserParams, 'userId'> {
   secrets: Secrets | null;
 }
+
+const GetUserBodySchema = z.object({
+  userId: z.string(),
+});
 
 export function validateRequestParameters(input: ZambdaInput): GetUserInput {
   if (!input.body) {
     throw new Error('No request body provided');
   }
 
-  const { userId } = JSON.parse(input.body);
-
-  if (
-    userId === undefined
-    // locations === undefined ||
-    // locations.length === 0
-  ) {
-    throw new Error('These fields are required: "userId"');
-  }
+  const { userId } = safeValidate(GetUserBodySchema, JSON.parse(input.body));
 
   return {
     userId,

--- a/packages/zambdas/src/ehr/get-user/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/get-user/validateRequestParameters.ts
@@ -7,7 +7,7 @@ export interface GetUserInput extends WithRequired<GetUserParams, 'userId'> {
 }
 
 const GetUserBodySchema = z.object({
-  userId: z.string(),
+  userId: z.string().uuid(),
 });
 
 export function validateRequestParameters(input: ZambdaInput): GetUserInput {

--- a/packages/zambdas/src/ehr/save-chart-data/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/save-chart-data/validateRequestParameters.ts
@@ -1,4 +1,4 @@
-import { SaveChartDataRequest } from 'utils';
+import { MISSING_REQUEST_BODY, NOT_AUTHORIZED, SaveChartDataRequest } from 'utils';
 import { z } from 'zod';
 import { safeValidate, ZambdaInput } from '../../shared';
 
@@ -12,11 +12,11 @@ export function validateRequestParameters(
   input: ZambdaInput
 ): SaveChartDataRequest & Pick<ZambdaInput, 'secrets'> & { userToken: string } {
   if (!input.body) {
-    throw new Error('No request body provided');
+    throw MISSING_REQUEST_BODY;
   }
 
   if (input.headers.Authorization === undefined) {
-    throw new Error('Authorization token is not provided in headers');
+    throw NOT_AUTHORIZED;
   }
 
   const data = safeValidate(SaveChartDataBodySchema, JSON.parse(input.body));

--- a/packages/zambdas/src/ehr/save-chart-data/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/save-chart-data/validateRequestParameters.ts
@@ -4,7 +4,7 @@ import { safeValidate, ZambdaInput } from '../../shared';
 
 const SaveChartDataBodySchema = z
   .object({
-    encounterId: z.string(),
+    encounterId: z.string().uuid(),
   })
   .passthrough();
 

--- a/packages/zambdas/src/ehr/save-chart-data/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/save-chart-data/validateRequestParameters.ts
@@ -1,5 +1,12 @@
 import { SaveChartDataRequest } from 'utils';
-import { ZambdaInput } from '../../shared';
+import { z } from 'zod';
+import { safeValidate, ZambdaInput } from '../../shared';
+
+const SaveChartDataBodySchema = z
+  .object({
+    encounterId: z.string(),
+  })
+  .passthrough();
 
 export function validateRequestParameters(
   input: ZambdaInput
@@ -12,12 +19,8 @@ export function validateRequestParameters(
     throw new Error('Authorization token is not provided in headers');
   }
 
-  const data = JSON.parse(input.body) as SaveChartDataRequest;
-
-  if (data.encounterId === undefined) {
-    throw new Error('These fields are required: "encounterId"');
-  }
+  const data = safeValidate(SaveChartDataBodySchema, JSON.parse(input.body));
   const userToken = input.headers.Authorization.replace('Bearer ', '');
 
-  return { ...data, secrets: input.secrets, userToken: userToken };
+  return { ...(data as SaveChartDataRequest), secrets: input.secrets, userToken };
 }

--- a/packages/zambdas/src/ehr/unlock-appointment/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/unlock-appointment/validateRequestParameters.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { safeValidate, ZambdaInput } from '../../shared';
 
 const UnlockAppointmentBodySchema = z.object({
-  appointmentId: z.string(),
+  appointmentId: z.string().uuid(),
 });
 
 export function validateRequestParameters(input: ZambdaInput): UnlockAppointmentZambdaInputValidated {

--- a/packages/zambdas/src/ehr/unlock-appointment/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/unlock-appointment/validateRequestParameters.ts
@@ -1,35 +1,26 @@
 import { getSecret, SecretsKeys, UnlockAppointmentZambdaInputValidated } from 'utils';
-import { ZambdaInput } from '../../shared';
+import { z } from 'zod';
+import { safeValidate, ZambdaInput } from '../../shared';
+
+const UnlockAppointmentBodySchema = z.object({
+  appointmentId: z.string(),
+});
 
 export function validateRequestParameters(input: ZambdaInput): UnlockAppointmentZambdaInputValidated {
-  console.group('validateRequestParameters');
-
   if (!input.body) {
     throw new Error('No request body provided');
   }
 
-  const { appointmentId } = JSON.parse(input.body);
-
-  if (appointmentId === undefined) {
-    throw new Error('These fields are required: "appointmentId".');
-  }
-
-  if (getSecret(SecretsKeys.PROJECT_API, input.secrets) === undefined) {
-    throw new Error('"PROJECT_API" configuration not provided');
-  }
-
-  if (getSecret(SecretsKeys.ORGANIZATION_ID, input.secrets) === undefined) {
-    throw new Error('"ORGANIZATION_ID" configuration not provided');
-  }
-
-  const userToken = input.headers.Authorization.replace('Bearer ', '');
+  const { appointmentId } = safeValidate(UnlockAppointmentBodySchema, JSON.parse(input.body));
 
   if (!input.secrets) {
     throw new Error('No secrets provided');
   }
 
-  console.groupEnd();
-  console.debug('validateRequestParameters success');
+  getSecret(SecretsKeys.PROJECT_API, input.secrets);
+  getSecret(SecretsKeys.ORGANIZATION_ID, input.secrets);
+
+  const userToken = input.headers.Authorization.replace('Bearer ', '');
 
   return {
     appointmentId,

--- a/packages/zambdas/src/ehr/unlock-appointment/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/unlock-appointment/validateRequestParameters.ts
@@ -1,4 +1,10 @@
-import { getSecret, SecretsKeys, UnlockAppointmentZambdaInputValidated } from 'utils';
+import {
+  getSecret,
+  MISSING_REQUEST_BODY,
+  MISSING_REQUEST_SECRETS,
+  SecretsKeys,
+  UnlockAppointmentZambdaInputValidated,
+} from 'utils';
 import { z } from 'zod';
 import { safeValidate, ZambdaInput } from '../../shared';
 
@@ -8,14 +14,14 @@ const UnlockAppointmentBodySchema = z.object({
 
 export function validateRequestParameters(input: ZambdaInput): UnlockAppointmentZambdaInputValidated {
   if (!input.body) {
-    throw new Error('No request body provided');
+    throw MISSING_REQUEST_BODY;
+  }
+
+  if (!input.secrets) {
+    throw MISSING_REQUEST_SECRETS;
   }
 
   const { appointmentId } = safeValidate(UnlockAppointmentBodySchema, JSON.parse(input.body));
-
-  if (!input.secrets) {
-    throw new Error('No secrets provided');
-  }
 
   getSecret(SecretsKeys.PROJECT_API, input.secrets);
   getSecret(SecretsKeys.ORGANIZATION_ID, input.secrets);

--- a/packages/zambdas/src/patient/check-in/validateRequestParameters.ts
+++ b/packages/zambdas/src/patient/check-in/validateRequestParameters.ts
@@ -1,18 +1,17 @@
-import { CheckInInput } from 'utils';
-import { ZambdaInput } from '../../shared';
+import { z } from 'zod';
+import { safeValidate, ZambdaInput } from '../../shared';
 import { CheckInInputValidated } from '.';
+
+const CheckInBodySchema = z.object({
+  appointmentId: z.string(),
+});
 
 export function validateRequestParameters(input: ZambdaInput): CheckInInputValidated {
   if (!input.body) {
     throw new Error('No request body provided');
   }
 
-  const { appointmentId } = JSON.parse(input.body) as unknown as CheckInInput;
-
-  // Check existence of necessary fields
-  if (appointmentId === undefined) {
-    throw new Error('appointment field is required');
-  }
+  const { appointmentId } = safeValidate(CheckInBodySchema, JSON.parse(input.body));
 
   if (!input.secrets) {
     throw new Error('secrets were not available');

--- a/packages/zambdas/src/patient/check-in/validateRequestParameters.ts
+++ b/packages/zambdas/src/patient/check-in/validateRequestParameters.ts
@@ -3,7 +3,7 @@ import { safeValidate, ZambdaInput } from '../../shared';
 import { CheckInInputValidated } from '.';
 
 const CheckInBodySchema = z.object({
-  appointmentId: z.string(),
+  appointmentId: z.string().uuid(),
 });
 
 export function validateRequestParameters(input: ZambdaInput): CheckInInputValidated {

--- a/packages/zambdas/src/patient/check-in/validateRequestParameters.ts
+++ b/packages/zambdas/src/patient/check-in/validateRequestParameters.ts
@@ -1,3 +1,4 @@
+import { MISSING_REQUEST_BODY, MISSING_REQUEST_SECRETS } from 'utils';
 import { z } from 'zod';
 import { safeValidate, ZambdaInput } from '../../shared';
 import { CheckInInputValidated } from '.';
@@ -8,14 +9,14 @@ const CheckInBodySchema = z.object({
 
 export function validateRequestParameters(input: ZambdaInput): CheckInInputValidated {
   if (!input.body) {
-    throw new Error('No request body provided');
+    throw MISSING_REQUEST_BODY;
+  }
+
+  if (!input.secrets) {
+    throw MISSING_REQUEST_SECRETS;
   }
 
   const { appointmentId } = safeValidate(CheckInBodySchema, JSON.parse(input.body));
-
-  if (!input.secrets) {
-    throw new Error('secrets were not available');
-  }
 
   return { appointmentId, secrets: input.secrets };
 }

--- a/packages/zambdas/src/patient/get-schedule/validateRequestParameters.ts
+++ b/packages/zambdas/src/patient/get-schedule/validateRequestParameters.ts
@@ -3,6 +3,7 @@ import {
   getServiceCategoryCodeSchema,
   INVALID_INPUT_ERROR,
   MISSING_REQUEST_BODY,
+  ScheduleType,
   Secrets,
   ServiceCategoryCode,
 } from 'utils';
@@ -42,7 +43,7 @@ export function validateRequestParameters(input: ZambdaInput): GetScheduleReques
 
   return {
     slug,
-    scheduleType,
+    scheduleType: scheduleType as ScheduleType,
     secrets: input.secrets,
     selectedDate,
     serviceCategoryCode,

--- a/packages/zambdas/src/patient/get-schedule/validateRequestParameters.ts
+++ b/packages/zambdas/src/patient/get-schedule/validateRequestParameters.ts
@@ -15,7 +15,7 @@ export const SCHEDULE_TYPES = ['location', 'provider', 'group'] as const;
 const GetScheduleBodySchema = z.object({
   slug: z.string().min(1),
   scheduleType: z.enum(SCHEDULE_TYPES),
-  selectedDate: z.string().optional(),
+  selectedDate: z.string().date().optional(),
   serviceCategoryCode: z.string().optional(),
 });
 

--- a/packages/zambdas/src/patient/get-schedule/validateRequestParameters.ts
+++ b/packages/zambdas/src/patient/get-schedule/validateRequestParameters.ts
@@ -3,36 +3,40 @@ import {
   getServiceCategoryCodeSchema,
   INVALID_INPUT_ERROR,
   MISSING_REQUEST_BODY,
-  MISSING_REQUIRED_PARAMETERS,
   Secrets,
   ServiceCategoryCode,
 } from 'utils';
-import { ZambdaInput } from '../../shared';
+import { z } from 'zod';
+import { safeValidate, ZambdaInput } from '../../shared';
 
-export const SCHEDULE_TYPES = ['location', 'provider', 'group'];
+export const SCHEDULE_TYPES = ['location', 'provider', 'group'] as const;
+
+const GetScheduleBodySchema = z.object({
+  slug: z.string().min(1),
+  scheduleType: z.enum(SCHEDULE_TYPES),
+  selectedDate: z.string().optional(),
+  serviceCategoryCode: z.string().optional(),
+});
+
 export function validateRequestParameters(input: ZambdaInput): GetScheduleRequestParams & { secrets: Secrets | null } {
   if (!input.body) {
     throw MISSING_REQUEST_BODY;
   }
 
-  const { slug, scheduleType, selectedDate, serviceCategoryCode: maybeServiceCategoryCode } = JSON.parse(input.body);
-  if (!slug) {
-    throw MISSING_REQUIRED_PARAMETERS(['slug']);
-  }
-
-  if (!SCHEDULE_TYPES.includes(scheduleType)) {
-    throw INVALID_INPUT_ERROR(`scheduleType must be either ${SCHEDULE_TYPES}`);
-  }
-
-  console.log('SERVICE CATEGORIES FOR SLOT GENERATION maybe:', maybeServiceCategoryCode);
+  const {
+    slug,
+    scheduleType,
+    selectedDate,
+    serviceCategoryCode: maybeServiceCategoryCode,
+  } = safeValidate(GetScheduleBodySchema, JSON.parse(input.body));
 
   let serviceCategoryCode: ServiceCategoryCode | undefined;
 
   if (maybeServiceCategoryCode) {
-    const schema = getServiceCategoryCodeSchema();
-    serviceCategoryCode = schema.safeParse(maybeServiceCategoryCode).data;
+    const categorySchema = getServiceCategoryCodeSchema();
+    serviceCategoryCode = categorySchema.safeParse(maybeServiceCategoryCode).data;
     if (!serviceCategoryCode) {
-      throw INVALID_INPUT_ERROR(`"serviceCategoryCode" must be one of ${schema.options.join(', ')}`);
+      throw INVALID_INPUT_ERROR(`"serviceCategoryCode" must be one of ${categorySchema.options.join(', ')}`);
     }
   }
 

--- a/packages/zambdas/src/rcm/charge-masters/create-charge-master/validateRequestParameters.ts
+++ b/packages/zambdas/src/rcm/charge-masters/create-charge-master/validateRequestParameters.ts
@@ -11,7 +11,7 @@ export interface CreateChargeMasterParams {
 
 const CreateChargeMasterBodySchema = z.object({
   name: z.string().min(1),
-  effectiveDate: z.string().min(1),
+  effectiveDate: z.string().date(),
   description: z.string().default(''),
 });
 

--- a/packages/zambdas/src/rcm/charge-masters/create-charge-master/validateRequestParameters.ts
+++ b/packages/zambdas/src/rcm/charge-masters/create-charge-master/validateRequestParameters.ts
@@ -25,7 +25,7 @@ export function validateRequestParameters(input: ZambdaInput): CreateChargeMaste
   return {
     name,
     effectiveDate,
-    description,
+    description: description ?? '',
     secrets: input.secrets,
   };
 }

--- a/packages/zambdas/src/rcm/charge-masters/create-charge-master/validateRequestParameters.ts
+++ b/packages/zambdas/src/rcm/charge-masters/create-charge-master/validateRequestParameters.ts
@@ -1,5 +1,6 @@
-import { MISSING_REQUEST_BODY, MISSING_REQUIRED_PARAMETERS } from 'utils';
-import { ZambdaInput } from '../../../shared';
+import { MISSING_REQUEST_BODY } from 'utils';
+import { z } from 'zod';
+import { safeValidate, ZambdaInput } from '../../../shared';
 
 export interface CreateChargeMasterParams {
   name: string;
@@ -8,21 +9,23 @@ export interface CreateChargeMasterParams {
   secrets: ZambdaInput['secrets'];
 }
 
+const CreateChargeMasterBodySchema = z.object({
+  name: z.string().min(1),
+  effectiveDate: z.string().min(1),
+  description: z.string().default(''),
+});
+
 export function validateRequestParameters(input: ZambdaInput): CreateChargeMasterParams {
   if (!input.body) {
     throw MISSING_REQUEST_BODY;
   }
 
-  const { name, effectiveDate, description } = JSON.parse(input.body);
-
-  if (!name || !effectiveDate) {
-    throw MISSING_REQUIRED_PARAMETERS(['name', 'effectiveDate']);
-  }
+  const { name, effectiveDate, description } = safeValidate(CreateChargeMasterBodySchema, JSON.parse(input.body));
 
   return {
     name,
     effectiveDate,
-    description: description ?? '',
+    description,
     secrets: input.secrets,
   };
 }

--- a/packages/zambdas/src/subscriptions/task/validateRequestParameters.ts
+++ b/packages/zambdas/src/subscriptions/task/validateRequestParameters.ts
@@ -1,30 +1,28 @@
 import { Task } from 'fhir/r4b';
 import { Secrets } from 'utils';
-import { ZambdaInput } from '../../shared';
+import { z } from 'zod';
+import { safeValidate, ZambdaInput } from '../../shared';
 
 export interface TaskSubscriptionInput {
   task: Task;
   secrets: Secrets;
 }
 
+const TaskBodySchema = z
+  .object({
+    resourceType: z.literal('Task'),
+    status: z.string(),
+  })
+  .passthrough()
+  .refine((t) => t.status !== 'completed', { message: 'task is already completed', path: ['status'] })
+  .refine((t) => t.status !== 'failed', { message: 'task has already failed', path: ['status'] });
+
 export function validateRequestParameters(input: ZambdaInput): TaskSubscriptionInput & { secrets: Secrets } {
   if (!input.body) {
     throw new Error('No request body provided');
   }
 
-  const task = JSON.parse(input.body);
-
-  if (task.resourceType !== 'Task') {
-    throw new Error(`resource parsed should be a task but was a ${task.resourceType}`);
-  }
-
-  if (task.status === 'completed') {
-    throw new Error(`task is already completed`);
-  }
-
-  if (task.status === 'failed') {
-    throw new Error(`task has already failed`);
-  }
+  const task = safeValidate(TaskBodySchema, JSON.parse(input.body)) as unknown as Task;
 
   if (!input.secrets) {
     throw new Error('Secrets not sent with input.');

--- a/packages/zambdas/src/subscriptions/task/validateRequestParameters.ts
+++ b/packages/zambdas/src/subscriptions/task/validateRequestParameters.ts
@@ -1,5 +1,5 @@
 import { Task } from 'fhir/r4b';
-import { Secrets } from 'utils';
+import { MISSING_REQUEST_BODY, MISSING_REQUEST_SECRETS, Secrets } from 'utils';
 import { z } from 'zod';
 import { safeValidate, ZambdaInput } from '../../shared';
 
@@ -19,14 +19,14 @@ const TaskBodySchema = z
 
 export function validateRequestParameters(input: ZambdaInput): TaskSubscriptionInput & { secrets: Secrets } {
   if (!input.body) {
-    throw new Error('No request body provided');
+    throw MISSING_REQUEST_BODY;
+  }
+
+  if (!input.secrets) {
+    throw MISSING_REQUEST_SECRETS;
   }
 
   const task = safeValidate(TaskBodySchema, JSON.parse(input.body)) as unknown as Task;
-
-  if (!input.secrets) {
-    throw new Error('Secrets not sent with input.');
-  }
 
   return {
     task,

--- a/packages/zambdas/test/unit/validate-request-parameters/change-in-person-visit-status.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/change-in-person-visit-status.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/ehr/change-in-person-visit-status/validateRequestParameters';
+import { createMockSecrets, createMockZambdaInput } from './helpers';
+
+describe('change-in-person-visit-status - validateRequestParameters', () => {
+  const validBody = {
+    encounterId: 'enc-123',
+    updatedStatus: 'arrived',
+  };
+  const secrets = createMockSecrets();
+
+  test('should return validated params with valid status', () => {
+    const input = createMockZambdaInput(validBody, { secrets });
+    const result = validateRequestParameters(input);
+
+    expect(result.encounterId).toBe('enc-123');
+    expect(result.updatedStatus).toBe('arrived');
+    expect(result.userToken).toBe('test-token');
+    expect(result.secrets).toEqual(secrets);
+  });
+
+  test.each([
+    'pending',
+    'arrived',
+    'ready',
+    'intake',
+    'ready for provider',
+    'provider',
+    'discharged',
+    'cancelled',
+    'no show',
+    'awaiting supervisor approval',
+    'completed',
+  ])('should accept valid status "%s"', (status) => {
+    const input = createMockZambdaInput({ encounterId: 'enc-123', updatedStatus: status }, { secrets });
+    expect(() => validateRequestParameters(input)).not.toThrow();
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '', secrets });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when body is not a valid JSON object', () => {
+    const input = createMockZambdaInput(null, {
+      body: '"just a string"',
+      secrets,
+      headers: { Authorization: 'Bearer test-token' },
+    });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when encounterId is missing', () => {
+    const input = createMockZambdaInput({ updatedStatus: 'arrived' }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('encounterId');
+  });
+
+  test('should throw when encounterId is not a string', () => {
+    const input = createMockZambdaInput({ encounterId: 123, updatedStatus: 'arrived' }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('encounterId');
+  });
+
+  test('should throw when updatedStatus is missing', () => {
+    const input = createMockZambdaInput({ encounterId: 'enc-123' }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('updatedStatus');
+  });
+
+  test('should throw when updatedStatus is not a string', () => {
+    const input = createMockZambdaInput({ encounterId: 'enc-123', updatedStatus: 123 }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('updatedStatus');
+  });
+
+  test('should throw when updatedStatus is "unknown"', () => {
+    const input = createMockZambdaInput({ encounterId: 'enc-123', updatedStatus: 'unknown' }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('updatedStatus');
+  });
+
+  test('should throw when updatedStatus is an invalid value', () => {
+    const input = createMockZambdaInput({ encounterId: 'enc-123', updatedStatus: 'invalid-status' }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('updatedStatus');
+  });
+
+  test('should throw when secrets are null', () => {
+    const input = createMockZambdaInput(validBody, { secrets: null });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when PROJECT_API secret is missing', () => {
+    const badSecrets = { ORGANIZATION_ID: 'org-123' };
+    const input = createMockZambdaInput(validBody, { secrets: badSecrets });
+    expect(() => validateRequestParameters(input)).toThrow('PROJECT_API');
+  });
+
+  test('should throw when ORGANIZATION_ID secret is missing', () => {
+    const badSecrets = { PROJECT_API: 'https://api.test' };
+    const input = createMockZambdaInput(validBody, { secrets: badSecrets });
+    expect(() => validateRequestParameters(input)).toThrow('ORGANIZATION_ID');
+  });
+
+  test('should extract Bearer token from Authorization header', () => {
+    const input = createMockZambdaInput(validBody, {
+      secrets,
+      headers: { Authorization: 'Bearer my-token-123' },
+    });
+    const result = validateRequestParameters(input);
+    expect(result.userToken).toBe('my-token-123');
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/check-in.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/check-in.test.ts
@@ -6,10 +6,10 @@ describe('check-in - validateRequestParameters', () => {
   const secrets = createMockSecrets();
 
   test('should return validated params with appointmentId', () => {
-    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets });
+    const input = createMockZambdaInput({ appointmentId: '550e8400-e29b-41d4-a716-446655440000' }, { secrets });
     const result = validateRequestParameters(input);
 
-    expect(result.appointmentId).toBe('appt-123');
+    expect(result.appointmentId).toBe('550e8400-e29b-41d4-a716-446655440000');
     expect(result.secrets).toEqual(secrets);
   });
 
@@ -24,12 +24,17 @@ describe('check-in - validateRequestParameters', () => {
   });
 
   test('should throw when secrets are null', () => {
-    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets: null });
+    const input = createMockZambdaInput({ appointmentId: '550e8400-e29b-41d4-a716-446655440000' }, { secrets: null });
     expect(() => validateRequestParameters(input)).toThrow('secrets');
   });
 
-  test('should pass when appointmentId is a valid string', () => {
-    const input = createMockZambdaInput({ appointmentId: 'any-valid-id' }, { secrets });
+  test('should throw when appointmentId is not a valid UUID', () => {
+    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('appointmentId');
+  });
+
+  test('should pass when appointmentId is a valid UUID', () => {
+    const input = createMockZambdaInput({ appointmentId: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d' }, { secrets });
     expect(() => validateRequestParameters(input)).not.toThrow();
   });
 });

--- a/packages/zambdas/test/unit/validate-request-parameters/check-in.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/check-in.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/patient/check-in/validateRequestParameters';
+import { createMockSecrets, createMockZambdaInput } from './helpers';
+
+describe('check-in - validateRequestParameters', () => {
+  const secrets = createMockSecrets();
+
+  test('should return validated params with appointmentId', () => {
+    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets });
+    const result = validateRequestParameters(input);
+
+    expect(result.appointmentId).toBe('appt-123');
+    expect(result.secrets).toEqual(secrets);
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '', secrets });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when appointmentId is undefined', () => {
+    const input = createMockZambdaInput({ someField: 'value' }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('appointment');
+  });
+
+  test('should throw when secrets are null', () => {
+    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets: null });
+    expect(() => validateRequestParameters(input)).toThrow('secrets');
+  });
+
+  test('should pass when appointmentId is a valid string', () => {
+    const input = createMockZambdaInput({ appointmentId: 'any-valid-id' }, { secrets });
+    expect(() => validateRequestParameters(input)).not.toThrow();
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/create-charge-master.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/create-charge-master.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/rcm/charge-masters/create-charge-master/validateRequestParameters';
+import { createMockZambdaInput } from './helpers';
+
+describe('create-charge-master - validateRequestParameters', () => {
+  const validBody = {
+    name: 'Standard Charge Master',
+    effectiveDate: '2024-01-01',
+    description: 'A test charge master',
+  };
+
+  test('should return validated params with all fields', () => {
+    const input = createMockZambdaInput(validBody);
+    const result = validateRequestParameters(input);
+
+    expect(result.name).toBe('Standard Charge Master');
+    expect(result.effectiveDate).toBe('2024-01-01');
+    expect(result.description).toBe('A test charge master');
+    expect(result.secrets).toBeNull();
+  });
+
+  test('should default description to empty string when not provided', () => {
+    const input = createMockZambdaInput({
+      name: 'Test',
+      effectiveDate: '2024-01-01',
+    });
+    const result = validateRequestParameters(input);
+
+    expect(result.description).toBe('');
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when name is missing', () => {
+    const input = createMockZambdaInput({ effectiveDate: '2024-01-01' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when effectiveDate is missing', () => {
+    const input = createMockZambdaInput({ name: 'Test' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when both name and effectiveDate are missing', () => {
+    const input = createMockZambdaInput({ description: 'just a description' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should pass secrets through from input', () => {
+    const secrets = { PROJECT_API: 'https://api.test' };
+    const input = createMockZambdaInput(validBody, { secrets });
+    const result = validateRequestParameters(input);
+    expect(result.secrets).toEqual(secrets);
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/create-charge-master.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/create-charge-master.test.ts
@@ -44,6 +44,16 @@ describe('create-charge-master - validateRequestParameters', () => {
     expect(() => validateRequestParameters(input)).toThrow();
   });
 
+  test('should throw when effectiveDate is not a valid date string', () => {
+    const input = createMockZambdaInput({ name: 'Test', effectiveDate: 'not-a-date' });
+    expect(() => validateRequestParameters(input)).toThrow('effectiveDate');
+  });
+
+  test('should throw when effectiveDate is a non-ISO date format', () => {
+    const input = createMockZambdaInput({ name: 'Test', effectiveDate: '01/01/2024' });
+    expect(() => validateRequestParameters(input)).toThrow('effectiveDate');
+  });
+
   test('should throw when both name and effectiveDate are missing', () => {
     const input = createMockZambdaInput({ description: 'just a description' });
     expect(() => validateRequestParameters(input)).toThrow();

--- a/packages/zambdas/test/unit/validate-request-parameters/create-nursing-order.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/create-nursing-order.test.ts
@@ -1,0 +1,67 @@
+import { randomUUID } from 'crypto';
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/ehr/create-nursing-order/validateRequestParameters';
+import { createMockZambdaInput } from './helpers';
+
+describe('create-nursing-order - validateRequestParameters', () => {
+  const validEncounterId = randomUUID();
+
+  test('should return validated params with encounterId and notes', () => {
+    const input = createMockZambdaInput({ encounterId: validEncounterId, notes: 'Administer medication' });
+    const result = validateRequestParameters(input);
+
+    expect(result.encounterId).toBe(validEncounterId);
+    expect(result.notes).toBe('Administer medication');
+    expect(result.userToken).toBe('test-token');
+    expect(result.secrets).toBeNull();
+  });
+
+  test('should accept encounterId without notes (notes is optional)', () => {
+    const input = createMockZambdaInput({ encounterId: validEncounterId });
+    const result = validateRequestParameters(input);
+
+    expect(result.encounterId).toBe(validEncounterId);
+    expect(result.notes).toBeUndefined();
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when Authorization header is missing', () => {
+    const input = createMockZambdaInput(
+      { encounterId: validEncounterId },
+      {
+        headers: {},
+      }
+    );
+    expect(() => validateRequestParameters(input)).toThrow('Authorization');
+  });
+
+  test('should throw when encounterId is missing', () => {
+    const input = createMockZambdaInput({ notes: 'some notes' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when encounterId is not a valid UUID', () => {
+    const input = createMockZambdaInput({ encounterId: 'not-a-uuid' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when encounterId is a number', () => {
+    const input = createMockZambdaInput({ encounterId: 12345 });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should extract Bearer token from Authorization header', () => {
+    const input = createMockZambdaInput(
+      { encounterId: validEncounterId },
+      {
+        headers: { Authorization: 'Bearer my-auth-token' },
+      }
+    );
+    const result = validateRequestParameters(input);
+    expect(result.userToken).toBe('my-auth-token');
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/create-upload-document-url.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/create-upload-document-url.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/ehr/create-upload-document-url/validateRequestParameters';
+import { createMockZambdaInput } from './helpers';
+
+describe('create-upload-document-url - validateRequestParameters', () => {
+  const validBody = {
+    patientId: 'patient-123',
+    fileFolderId: 'folder-456',
+    fileName: 'report.pdf',
+  };
+
+  test('should return validated params with all fields', () => {
+    const input = createMockZambdaInput(validBody);
+    const result = validateRequestParameters(input);
+
+    expect(result.patientId).toBe('patient-123');
+    expect(result.fileFolderId).toBe('folder-456');
+    expect(result.fileName).toBe('report.pdf');
+    expect(result.userToken).toBe('test-token');
+    expect(result.secrets).toBeNull();
+  });
+
+  test('should extract Bearer token from Authorization header', () => {
+    const input = createMockZambdaInput(validBody, {
+      headers: { Authorization: 'Bearer custom-token-abc' },
+    });
+    const result = validateRequestParameters(input);
+
+    expect(result.userToken).toBe('custom-token-abc');
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should return undefined fields when body fields are missing', () => {
+    const input = createMockZambdaInput({});
+    const result = validateRequestParameters(input);
+
+    expect(result.patientId).toBeUndefined();
+    expect(result.fileFolderId).toBeUndefined();
+    expect(result.fileName).toBeUndefined();
+  });
+
+  test('should pass secrets through from input', () => {
+    const secrets = { PROJECT_API: 'https://api.test' };
+    const input = createMockZambdaInput(validBody, { secrets });
+    const result = validateRequestParameters(input);
+    expect(result.secrets).toEqual(secrets);
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/create-upload-document-url.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/create-upload-document-url.test.ts
@@ -34,13 +34,30 @@ describe('create-upload-document-url - validateRequestParameters', () => {
     expect(() => validateRequestParameters(input)).toThrow();
   });
 
-  test('should return undefined fields when body fields are missing', () => {
+  test('should throw when required body fields are missing', () => {
     const input = createMockZambdaInput({});
-    const result = validateRequestParameters(input);
+    expect(() => validateRequestParameters(input)).toThrow('patientId');
+  });
 
-    expect(result.patientId).toBeUndefined();
-    expect(result.fileFolderId).toBeUndefined();
-    expect(result.fileName).toBeUndefined();
+  test('should throw when patientId is missing', () => {
+    const input = createMockZambdaInput({ fileFolderId: 'folder-456', fileName: 'report.pdf' });
+    expect(() => validateRequestParameters(input)).toThrow('patientId');
+  });
+
+  test('should throw when fileFolderId is missing', () => {
+    const input = createMockZambdaInput({ patientId: 'patient-123', fileName: 'report.pdf' });
+    expect(() => validateRequestParameters(input)).toThrow('fileFolderId');
+  });
+
+  test('should throw when fileName is missing', () => {
+    const input = createMockZambdaInput({ patientId: 'patient-123', fileFolderId: 'folder-456' });
+    expect(() => validateRequestParameters(input)).toThrow('fileName');
+  });
+
+  test('should accept optional internalName', () => {
+    const input = createMockZambdaInput({ ...validBody, internalName: 'custom-folder' });
+    const result = validateRequestParameters(input);
+    expect(result.internalName).toBe('custom-folder');
   });
 
   test('should pass secrets through from input', () => {

--- a/packages/zambdas/test/unit/validate-request-parameters/create-user.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/create-user.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/ehr/create-user/validateRequestParameters';
+import { createMockZambdaInput } from './helpers';
+
+describe('create-user - validateRequestParameters', () => {
+  const validBody = {
+    email: 'test@example.com',
+    applicationID: 'app-123',
+    firstName: 'John',
+    lastName: 'Doe',
+  };
+
+  test('should return validated params when all required fields provided', () => {
+    const input = createMockZambdaInput(validBody);
+    const result = validateRequestParameters(input);
+
+    expect(result.email).toBe('test@example.com');
+    expect(result.applicationID).toBe('app-123');
+    expect(result.firstName).toBe('John');
+    expect(result.lastName).toBe('Doe');
+    expect(result.secrets).toBeNull();
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when email is missing', () => {
+    const { email: _email, ...rest } = validBody;
+    const input = createMockZambdaInput(rest);
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when applicationID is missing', () => {
+    const { applicationID: _applicationID, ...rest } = validBody;
+    const input = createMockZambdaInput(rest);
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when firstName is missing', () => {
+    const { firstName: _firstName, ...rest } = validBody;
+    const input = createMockZambdaInput(rest);
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when lastName is missing', () => {
+    const { lastName: _lastName, ...rest } = validBody;
+    const input = createMockZambdaInput(rest);
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when all fields are empty strings', () => {
+    const input = createMockZambdaInput({
+      email: '',
+      applicationID: '',
+      firstName: '',
+      lastName: '',
+    });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should pass secrets through from input', () => {
+    const secrets = { PROJECT_API: 'https://api.test' };
+    const input = createMockZambdaInput(validBody, { secrets });
+    const result = validateRequestParameters(input);
+    expect(result.secrets).toEqual(secrets);
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/create-user.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/create-user.test.ts
@@ -5,7 +5,7 @@ import { createMockZambdaInput } from './helpers';
 describe('create-user - validateRequestParameters', () => {
   const validBody = {
     email: 'test@example.com',
-    applicationID: 'app-123',
+    applicationID: '550e8400-e29b-41d4-a716-446655440000',
     firstName: 'John',
     lastName: 'Doe',
   };
@@ -15,7 +15,7 @@ describe('create-user - validateRequestParameters', () => {
     const result = validateRequestParameters(input);
 
     expect(result.email).toBe('test@example.com');
-    expect(result.applicationID).toBe('app-123');
+    expect(result.applicationID).toBe('550e8400-e29b-41d4-a716-446655440000');
     expect(result.firstName).toBe('John');
     expect(result.lastName).toBe('Doe');
     expect(result.secrets).toBeNull();
@@ -58,6 +58,16 @@ describe('create-user - validateRequestParameters', () => {
       lastName: '',
     });
     expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when email is not a valid email address', () => {
+    const input = createMockZambdaInput({ ...validBody, email: 'not-an-email' });
+    expect(() => validateRequestParameters(input)).toThrow('email');
+  });
+
+  test('should throw when applicationID is not a valid UUID', () => {
+    const input = createMockZambdaInput({ ...validBody, applicationID: 'app-123' });
+    expect(() => validateRequestParameters(input)).toThrow('applicationID');
   });
 
   test('should pass secrets through from input', () => {

--- a/packages/zambdas/test/unit/validate-request-parameters/delete-chart-data.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/delete-chart-data.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/ehr/delete-chart-data/validateRequestParameters';
+import { createMockZambdaInput } from './helpers';
+
+describe('delete-chart-data - validateRequestParameters', () => {
+  test('should return validated params when encounterId is provided', () => {
+    const input = createMockZambdaInput({ encounterId: 'enc-123' });
+    const result = validateRequestParameters(input);
+
+    expect(result.encounterId).toBe('enc-123');
+    expect(result.secrets).toBeNull();
+  });
+
+  test('should spread all body data into result', () => {
+    const input = createMockZambdaInput({
+      encounterId: 'enc-123',
+      chartDataResourceType: 'vitals',
+      resourceId: 'res-456',
+    });
+    const result = validateRequestParameters(input);
+
+    expect(result.encounterId).toBe('enc-123');
+    expect(result).toHaveProperty('chartDataResourceType', 'vitals');
+    expect(result).toHaveProperty('resourceId', 'res-456');
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when encounterId is undefined', () => {
+    const input = createMockZambdaInput({ someOtherField: 'value' });
+    expect(() => validateRequestParameters(input)).toThrow('encounterId');
+  });
+
+  test('should pass secrets through from input', () => {
+    const secrets = { PROJECT_API: 'https://api.test' };
+    const input = createMockZambdaInput({ encounterId: 'enc-123' }, { secrets });
+    const result = validateRequestParameters(input);
+    expect(result.secrets).toEqual(secrets);
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/get-appointments.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/get-appointments.test.ts
@@ -6,8 +6,8 @@ describe('get-appointments - validateRequestParameters', () => {
   const validBody = {
     searchDate: '2024-01-15',
     timezone: 'America/New_York',
-    locationIds: ['loc-123'],
-    visitType: ['in-person'],
+    locationIds: ['550e8400-e29b-41d4-a716-446655440000'],
+    visitType: ['in-person-walk-in'],
   };
 
   test('should return validated params with locationIds', () => {
@@ -16,8 +16,8 @@ describe('get-appointments - validateRequestParameters', () => {
 
     expect(result.searchDate).toBe('2024-01-15');
     expect(result.timezone).toBe('America/New_York');
-    expect(result.locationIds).toEqual(['loc-123']);
-    expect(result.visitType).toEqual(['in-person']);
+    expect(result.locationIds).toEqual(['550e8400-e29b-41d4-a716-446655440000']);
+    expect(result.visitType).toEqual(['in-person-walk-in']);
     expect(result.supervisorApprovalEnabled).toBe(false);
     expect(result.secrets).toBeNull();
   });
@@ -26,12 +26,15 @@ describe('get-appointments - validateRequestParameters', () => {
     const input = createMockZambdaInput({
       searchDate: '2024-01-15',
       timezone: 'America/New_York',
-      providerIds: ['prov-1', 'prov-2'],
-      visitType: ['telemed'],
+      providerIds: ['a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d', 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e'],
+      visitType: ['virtual-walk-in'],
     });
     const result = validateRequestParameters(input);
 
-    expect(result.providerIds).toEqual(['prov-1', 'prov-2']);
+    expect(result.providerIds).toEqual([
+      'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d',
+      'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e',
+    ]);
     expect(result.locationIds).toBeUndefined();
   });
 
@@ -40,7 +43,7 @@ describe('get-appointments - validateRequestParameters', () => {
       searchDate: '2024-01-15',
       timezone: 'America/New_York',
       serviceCategories: ['urgent-care'],
-      visitType: ['in-person'],
+      visitType: ['in-person-walk-in'],
     });
     const result = validateRequestParameters(input);
 
@@ -83,7 +86,12 @@ describe('get-appointments - validateRequestParameters', () => {
     expect(() => validateRequestParameters(input)).toThrow('searchDate');
   });
 
-  test('should throw when searchDate is not a string', () => {
+  test('should throw when searchDate is not a valid date string', () => {
+    const input = createMockZambdaInput({ ...validBody, searchDate: 'not-a-date' });
+    expect(() => validateRequestParameters(input)).toThrow('searchDate');
+  });
+
+  test('should throw when searchDate is a number', () => {
     const input = createMockZambdaInput({ ...validBody, searchDate: 12345 });
     expect(() => validateRequestParameters(input)).toThrow('searchDate');
   });
@@ -106,12 +114,12 @@ describe('get-appointments - validateRequestParameters', () => {
   });
 
   test('should throw when visitType is not an array', () => {
-    const input = createMockZambdaInput({ ...validBody, visitType: 'in-person' });
+    const input = createMockZambdaInput({ ...validBody, visitType: 'in-person-walk-in' });
     expect(() => validateRequestParameters(input)).toThrow('visitType');
   });
 
-  test('should throw when visitType contains non-strings', () => {
-    const input = createMockZambdaInput({ ...validBody, visitType: [123] });
+  test('should throw when visitType contains invalid values', () => {
+    const input = createMockZambdaInput({ ...validBody, visitType: ['invalid-type'] });
     expect(() => validateRequestParameters(input)).toThrow('visitType');
   });
 
@@ -119,18 +127,21 @@ describe('get-appointments - validateRequestParameters', () => {
     const input = createMockZambdaInput({
       searchDate: '2024-01-15',
       timezone: 'America/New_York',
-      visitType: ['in-person'],
+      visitType: ['in-person-walk-in'],
     });
     expect(() => validateRequestParameters(input)).toThrow();
   });
 
   test('should throw when locationIds is not an array', () => {
-    const input = createMockZambdaInput({ ...validBody, locationIds: 'loc-123' });
+    const input = createMockZambdaInput({
+      ...validBody,
+      locationIds: '550e8400-e29b-41d4-a716-446655440000',
+    });
     expect(() => validateRequestParameters(input)).toThrow('locationIds');
   });
 
-  test('should throw when locationIds contains non-strings', () => {
-    const input = createMockZambdaInput({ ...validBody, locationIds: [123] });
+  test('should throw when locationIds contains non-UUID strings', () => {
+    const input = createMockZambdaInput({ ...validBody, locationIds: ['not-a-uuid'] });
     expect(() => validateRequestParameters(input)).toThrow('locationIds');
   });
 
@@ -138,18 +149,18 @@ describe('get-appointments - validateRequestParameters', () => {
     const input = createMockZambdaInput({
       searchDate: '2024-01-15',
       timezone: 'America/New_York',
-      providerIds: 'prov-1',
-      visitType: ['in-person'],
+      providerIds: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d',
+      visitType: ['in-person-walk-in'],
     });
     expect(() => validateRequestParameters(input)).toThrow('providerIds');
   });
 
-  test('should throw when providerIds contains non-strings', () => {
+  test('should throw when providerIds contains non-UUID strings', () => {
     const input = createMockZambdaInput({
       searchDate: '2024-01-15',
       timezone: 'America/New_York',
-      providerIds: [123],
-      visitType: ['in-person'],
+      providerIds: ['not-a-uuid'],
+      visitType: ['in-person-walk-in'],
     });
     expect(() => validateRequestParameters(input)).toThrow('providerIds');
   });
@@ -159,8 +170,22 @@ describe('get-appointments - validateRequestParameters', () => {
       searchDate: '2024-01-15',
       timezone: 'America/New_York',
       serviceCategories: 'urgent',
-      visitType: ['in-person'],
+      visitType: ['in-person-walk-in'],
     });
     expect(() => validateRequestParameters(input)).toThrow('serviceCategories');
+  });
+
+  test('should accept all valid visit type combinations', () => {
+    const allVisitTypes = [
+      'in-person-walk-in',
+      'in-person-pre-booked',
+      'in-person-post-telemed',
+      'virtual-walk-in',
+      'virtual-pre-booked',
+      'virtual-post-telemed',
+    ];
+    const input = createMockZambdaInput({ ...validBody, visitType: allVisitTypes });
+    const result = validateRequestParameters(input);
+    expect(result.visitType).toEqual(allVisitTypes);
   });
 });

--- a/packages/zambdas/test/unit/validate-request-parameters/get-appointments.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/get-appointments.test.ts
@@ -54,8 +54,14 @@ describe('get-appointments - validateRequestParameters', () => {
     expect(result.supervisorApprovalEnabled).toBe(true);
   });
 
-  test('should default supervisorApprovalEnabled to false when not boolean', () => {
+  test('should throw when supervisorApprovalEnabled is not a boolean', () => {
     const input = createMockZambdaInput({ ...validBody, supervisorApprovalEnabled: 'yes' });
+    expect(() => validateRequestParameters(input)).toThrow('supervisorApprovalEnabled');
+  });
+
+  test('should default supervisorApprovalEnabled to false when omitted', () => {
+    const { ...body } = validBody;
+    const input = createMockZambdaInput(body);
     const result = validateRequestParameters(input);
 
     expect(result.supervisorApprovalEnabled).toBe(false);

--- a/packages/zambdas/test/unit/validate-request-parameters/get-appointments.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/get-appointments.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/ehr/get-appointments/validateRequestParameters';
+import { createMockZambdaInput } from './helpers';
+
+describe('get-appointments - validateRequestParameters', () => {
+  const validBody = {
+    searchDate: '2024-01-15',
+    timezone: 'America/New_York',
+    locationIds: ['loc-123'],
+    visitType: ['in-person'],
+  };
+
+  test('should return validated params with locationIds', () => {
+    const input = createMockZambdaInput(validBody);
+    const result = validateRequestParameters(input);
+
+    expect(result.searchDate).toBe('2024-01-15');
+    expect(result.timezone).toBe('America/New_York');
+    expect(result.locationIds).toEqual(['loc-123']);
+    expect(result.visitType).toEqual(['in-person']);
+    expect(result.supervisorApprovalEnabled).toBe(false);
+    expect(result.secrets).toBeNull();
+  });
+
+  test('should accept providerIds instead of locationIds', () => {
+    const input = createMockZambdaInput({
+      searchDate: '2024-01-15',
+      timezone: 'America/New_York',
+      providerIds: ['prov-1', 'prov-2'],
+      visitType: ['telemed'],
+    });
+    const result = validateRequestParameters(input);
+
+    expect(result.providerIds).toEqual(['prov-1', 'prov-2']);
+    expect(result.locationIds).toBeUndefined();
+  });
+
+  test('should accept serviceCategories instead of locationIds', () => {
+    const input = createMockZambdaInput({
+      searchDate: '2024-01-15',
+      timezone: 'America/New_York',
+      serviceCategories: ['urgent-care'],
+      visitType: ['in-person'],
+    });
+    const result = validateRequestParameters(input);
+
+    expect(result.serviceCategories).toEqual(['urgent-care']);
+  });
+
+  test('should accept supervisorApprovalEnabled as true', () => {
+    const input = createMockZambdaInput({ ...validBody, supervisorApprovalEnabled: true });
+    const result = validateRequestParameters(input);
+
+    expect(result.supervisorApprovalEnabled).toBe(true);
+  });
+
+  test('should default supervisorApprovalEnabled to false when not boolean', () => {
+    const input = createMockZambdaInput({ ...validBody, supervisorApprovalEnabled: 'yes' });
+    const result = validateRequestParameters(input);
+
+    expect(result.supervisorApprovalEnabled).toBe(false);
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when body is invalid JSON', () => {
+    const input = createMockZambdaInput(null, { body: 'not-json' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when searchDate is missing', () => {
+    const { searchDate: _searchDate, ...rest } = validBody;
+    const input = createMockZambdaInput(rest);
+    expect(() => validateRequestParameters(input)).toThrow('searchDate');
+  });
+
+  test('should throw when searchDate is not a string', () => {
+    const input = createMockZambdaInput({ ...validBody, searchDate: 12345 });
+    expect(() => validateRequestParameters(input)).toThrow('searchDate');
+  });
+
+  test('should throw when timezone is missing', () => {
+    const { timezone: _timezone, ...rest } = validBody;
+    const input = createMockZambdaInput(rest);
+    expect(() => validateRequestParameters(input)).toThrow('timezone');
+  });
+
+  test('should throw when timezone is not a string', () => {
+    const input = createMockZambdaInput({ ...validBody, timezone: 12345 });
+    expect(() => validateRequestParameters(input)).toThrow('timezone');
+  });
+
+  test('should throw when visitType is missing', () => {
+    const { visitType: _visitType, ...rest } = validBody;
+    const input = createMockZambdaInput(rest);
+    expect(() => validateRequestParameters(input)).toThrow('visitType');
+  });
+
+  test('should throw when visitType is not an array', () => {
+    const input = createMockZambdaInput({ ...validBody, visitType: 'in-person' });
+    expect(() => validateRequestParameters(input)).toThrow('visitType');
+  });
+
+  test('should throw when visitType contains non-strings', () => {
+    const input = createMockZambdaInput({ ...validBody, visitType: [123] });
+    expect(() => validateRequestParameters(input)).toThrow('visitType');
+  });
+
+  test('should throw when none of locationIds, providerIds, or serviceCategories is provided', () => {
+    const input = createMockZambdaInput({
+      searchDate: '2024-01-15',
+      timezone: 'America/New_York',
+      visitType: ['in-person'],
+    });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when locationIds is not an array', () => {
+    const input = createMockZambdaInput({ ...validBody, locationIds: 'loc-123' });
+    expect(() => validateRequestParameters(input)).toThrow('locationIds');
+  });
+
+  test('should throw when locationIds contains non-strings', () => {
+    const input = createMockZambdaInput({ ...validBody, locationIds: [123] });
+    expect(() => validateRequestParameters(input)).toThrow('locationIds');
+  });
+
+  test('should throw when providerIds is not an array', () => {
+    const input = createMockZambdaInput({
+      searchDate: '2024-01-15',
+      timezone: 'America/New_York',
+      providerIds: 'prov-1',
+      visitType: ['in-person'],
+    });
+    expect(() => validateRequestParameters(input)).toThrow('providerIds');
+  });
+
+  test('should throw when providerIds contains non-strings', () => {
+    const input = createMockZambdaInput({
+      searchDate: '2024-01-15',
+      timezone: 'America/New_York',
+      providerIds: [123],
+      visitType: ['in-person'],
+    });
+    expect(() => validateRequestParameters(input)).toThrow('providerIds');
+  });
+
+  test('should throw when serviceCategories is not an array', () => {
+    const input = createMockZambdaInput({
+      searchDate: '2024-01-15',
+      timezone: 'America/New_York',
+      serviceCategories: 'urgent',
+      visitType: ['in-person'],
+    });
+    expect(() => validateRequestParameters(input)).toThrow('serviceCategories');
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/get-patients.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/get-patients.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/patient/get-patients/validateRequestParameters';
+import { createMockZambdaInput } from './helpers';
+
+describe('get-patients - validateRequestParameters', () => {
+  test('should return secrets from input (no body validation)', () => {
+    const input = createMockZambdaInput({});
+    const result = validateRequestParameters(input);
+
+    expect(result.secrets).toBeNull();
+  });
+
+  test('should pass secrets through from input', () => {
+    const secrets = { PROJECT_API: 'https://api.test' };
+    const input = createMockZambdaInput({}, { secrets });
+    const result = validateRequestParameters(input);
+    expect(result.secrets).toEqual(secrets);
+  });
+
+  test('should succeed even with no body', () => {
+    const input = createMockZambdaInput(null, { body: null });
+    expect(() => validateRequestParameters(input)).not.toThrow();
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/get-schedule.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/get-schedule.test.ts
@@ -51,6 +51,16 @@ describe('get-schedule - validateRequestParameters', () => {
     expect(() => validateRequestParameters(input)).toThrow('scheduleType');
   });
 
+  test('should throw when selectedDate is not a valid date string', () => {
+    const input = createMockZambdaInput({ ...validBody, selectedDate: 'not-a-date' });
+    expect(() => validateRequestParameters(input)).toThrow('selectedDate');
+  });
+
+  test('should throw when selectedDate is a non-ISO date format', () => {
+    const input = createMockZambdaInput({ ...validBody, selectedDate: '01/15/2024' });
+    expect(() => validateRequestParameters(input)).toThrow('selectedDate');
+  });
+
   test('should accept valid serviceCategoryCode', () => {
     // serviceCategoryCode is validated against ServiceCategoryCodeSchema from utils
     // Valid codes come from the booking config. We test that invalid ones are rejected.

--- a/packages/zambdas/test/unit/validate-request-parameters/get-schedule.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/get-schedule.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest';
+import { SCHEDULE_TYPES, validateRequestParameters } from '../../../src/patient/get-schedule/validateRequestParameters';
+import { createMockZambdaInput } from './helpers';
+
+describe('get-schedule - validateRequestParameters', () => {
+  const validBody = {
+    slug: 'my-location',
+    scheduleType: 'location',
+    selectedDate: '2024-01-15',
+  };
+
+  test('should return validated params with required fields', () => {
+    const input = createMockZambdaInput(validBody);
+    const result = validateRequestParameters(input);
+
+    expect(result.slug).toBe('my-location');
+    expect(result.scheduleType).toBe('location');
+    expect(result.selectedDate).toBe('2024-01-15');
+    expect(result.secrets).toBeNull();
+  });
+
+  test('should accept scheduleType "provider"', () => {
+    const input = createMockZambdaInput({ ...validBody, scheduleType: 'provider' });
+    const result = validateRequestParameters(input);
+    expect(result.scheduleType).toBe('provider');
+  });
+
+  test('should accept scheduleType "group"', () => {
+    const input = createMockZambdaInput({ ...validBody, scheduleType: 'group' });
+    const result = validateRequestParameters(input);
+    expect(result.scheduleType).toBe('group');
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when slug is missing', () => {
+    const input = createMockZambdaInput({ scheduleType: 'location' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when scheduleType is invalid', () => {
+    const input = createMockZambdaInput({ ...validBody, scheduleType: 'invalid' });
+    expect(() => validateRequestParameters(input)).toThrow('scheduleType');
+  });
+
+  test('should throw when scheduleType is missing', () => {
+    const input = createMockZambdaInput({ slug: 'my-location' });
+    expect(() => validateRequestParameters(input)).toThrow('scheduleType');
+  });
+
+  test('should accept valid serviceCategoryCode', () => {
+    // serviceCategoryCode is validated against ServiceCategoryCodeSchema from utils
+    // Valid codes come from the booking config. We test that invalid ones are rejected.
+    const input = createMockZambdaInput({ ...validBody, serviceCategoryCode: 'DEFINITELY_NOT_A_VALID_CODE_xyz' });
+    expect(() => validateRequestParameters(input)).toThrow('serviceCategoryCode');
+  });
+
+  test('should allow omitting serviceCategoryCode', () => {
+    const input = createMockZambdaInput(validBody);
+    const result = validateRequestParameters(input);
+    expect(result.serviceCategoryCode).toBeUndefined();
+  });
+
+  test('SCHEDULE_TYPES should contain expected values', () => {
+    expect(SCHEDULE_TYPES).toEqual(['location', 'provider', 'group']);
+  });
+
+  test('should pass secrets through from input', () => {
+    const secrets = { PROJECT_API: 'https://api.test' };
+    const input = createMockZambdaInput(validBody, { secrets });
+    const result = validateRequestParameters(input);
+    expect(result.secrets).toEqual(secrets);
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/get-user.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/get-user.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/ehr/get-user/validateRequestParameters';
+import { createMockZambdaInput } from './helpers';
+
+describe('get-user - validateRequestParameters', () => {
+  test('should return validated params when userId is provided', () => {
+    const input = createMockZambdaInput({ userId: 'user-123' });
+    const result = validateRequestParameters(input);
+
+    expect(result.userId).toBe('user-123');
+    expect(result.secrets).toBeNull();
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when userId is undefined', () => {
+    const input = createMockZambdaInput({ someField: 'value' });
+    expect(() => validateRequestParameters(input)).toThrow('userId');
+  });
+
+  test('should pass secrets through from input', () => {
+    const secrets = { PROJECT_API: 'https://api.test' };
+    const input = createMockZambdaInput({ userId: 'user-123' }, { secrets });
+    const result = validateRequestParameters(input);
+    expect(result.secrets).toEqual(secrets);
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/get-user.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/get-user.test.ts
@@ -4,10 +4,10 @@ import { createMockZambdaInput } from './helpers';
 
 describe('get-user - validateRequestParameters', () => {
   test('should return validated params when userId is provided', () => {
-    const input = createMockZambdaInput({ userId: 'user-123' });
+    const input = createMockZambdaInput({ userId: '550e8400-e29b-41d4-a716-446655440000' });
     const result = validateRequestParameters(input);
 
-    expect(result.userId).toBe('user-123');
+    expect(result.userId).toBe('550e8400-e29b-41d4-a716-446655440000');
     expect(result.secrets).toBeNull();
   });
 
@@ -21,9 +21,14 @@ describe('get-user - validateRequestParameters', () => {
     expect(() => validateRequestParameters(input)).toThrow('userId');
   });
 
+  test('should throw when userId is not a valid UUID', () => {
+    const input = createMockZambdaInput({ userId: 'user-123' });
+    expect(() => validateRequestParameters(input)).toThrow('userId');
+  });
+
   test('should pass secrets through from input', () => {
     const secrets = { PROJECT_API: 'https://api.test' };
-    const input = createMockZambdaInput({ userId: 'user-123' }, { secrets });
+    const input = createMockZambdaInput({ userId: '550e8400-e29b-41d4-a716-446655440000' }, { secrets });
     const result = validateRequestParameters(input);
     expect(result.secrets).toEqual(secrets);
   });

--- a/packages/zambdas/test/unit/validate-request-parameters/helpers.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/helpers.ts
@@ -1,0 +1,25 @@
+import { Secrets } from 'utils';
+import { ZambdaInput } from '../../../src/shared';
+
+/**
+ * Creates a mock ZambdaInput with a JSON-stringified body.
+ */
+export const createMockZambdaInput = (body: any, overrides?: Partial<ZambdaInput>): ZambdaInput => ({
+  body: body != null ? JSON.stringify(body) : body ?? null,
+  headers: {
+    Authorization: 'Bearer test-token',
+  },
+  secrets: null,
+  ...overrides,
+});
+
+/**
+ * Creates a mock secrets object with common keys populated.
+ */
+export const createMockSecrets = (overrides?: Record<string, string>): Secrets => ({
+  PROJECT_API: 'https://project.api',
+  ORGANIZATION_ID: 'org-123',
+  FHIR_API: 'https://fhir.api',
+  ENVIRONMENT: 'testing',
+  ...overrides,
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/save-chart-data.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/save-chart-data.test.ts
@@ -54,7 +54,7 @@ describe('save-chart-data - validateRequestParameters', () => {
     const input = createMockZambdaInput(validBody, {
       headers: {},
     });
-    expect(() => validateRequestParameters(input)).toThrow('Authorization');
+    expect(() => validateRequestParameters(input)).toThrow('not authorized');
   });
 
   test('should pass secrets through from input', () => {

--- a/packages/zambdas/test/unit/validate-request-parameters/save-chart-data.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/save-chart-data.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/ehr/save-chart-data/validateRequestParameters';
+import { createMockZambdaInput } from './helpers';
+
+describe('save-chart-data - validateRequestParameters', () => {
+  const validBody = {
+    encounterId: 'enc-123',
+    chartDataResourceType: 'vitals',
+    data: { weight: 70 },
+  };
+
+  test('should return validated params with encounterId', () => {
+    const input = createMockZambdaInput(validBody);
+    const result = validateRequestParameters(input);
+
+    expect(result.encounterId).toBe('enc-123');
+    expect(result.userToken).toBe('test-token');
+    expect(result.secrets).toBeNull();
+  });
+
+  test('should spread all body data into result', () => {
+    const input = createMockZambdaInput(validBody);
+    const result = validateRequestParameters(input);
+
+    expect(result).toHaveProperty('chartDataResourceType', 'vitals');
+    expect(result).toHaveProperty('data', { weight: 70 });
+  });
+
+  test('should extract Bearer token from Authorization header', () => {
+    const input = createMockZambdaInput(validBody, {
+      headers: { Authorization: 'Bearer my-special-token' },
+    });
+    const result = validateRequestParameters(input);
+
+    expect(result.userToken).toBe('my-special-token');
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '' });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when encounterId is undefined', () => {
+    const input = createMockZambdaInput({ someField: 'value' });
+    expect(() => validateRequestParameters(input)).toThrow('encounterId');
+  });
+
+  test('should throw when Authorization header is missing', () => {
+    const input = createMockZambdaInput(validBody, {
+      headers: {},
+    });
+    expect(() => validateRequestParameters(input)).toThrow('Authorization');
+  });
+
+  test('should pass secrets through from input', () => {
+    const secrets = { PROJECT_API: 'https://api.test' };
+    const input = createMockZambdaInput(validBody, { secrets });
+    const result = validateRequestParameters(input);
+    expect(result.secrets).toEqual(secrets);
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/save-chart-data.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/save-chart-data.test.ts
@@ -4,7 +4,7 @@ import { createMockZambdaInput } from './helpers';
 
 describe('save-chart-data - validateRequestParameters', () => {
   const validBody = {
-    encounterId: 'enc-123',
+    encounterId: '550e8400-e29b-41d4-a716-446655440000',
     chartDataResourceType: 'vitals',
     data: { weight: 70 },
   };
@@ -13,7 +13,7 @@ describe('save-chart-data - validateRequestParameters', () => {
     const input = createMockZambdaInput(validBody);
     const result = validateRequestParameters(input);
 
-    expect(result.encounterId).toBe('enc-123');
+    expect(result.encounterId).toBe('550e8400-e29b-41d4-a716-446655440000');
     expect(result.userToken).toBe('test-token');
     expect(result.secrets).toBeNull();
   });
@@ -42,6 +42,11 @@ describe('save-chart-data - validateRequestParameters', () => {
 
   test('should throw when encounterId is undefined', () => {
     const input = createMockZambdaInput({ someField: 'value' });
+    expect(() => validateRequestParameters(input)).toThrow('encounterId');
+  });
+
+  test('should throw when encounterId is not a valid UUID', () => {
+    const input = createMockZambdaInput({ ...validBody, encounterId: 'enc-123' });
     expect(() => validateRequestParameters(input)).toThrow('encounterId');
   });
 

--- a/packages/zambdas/test/unit/validate-request-parameters/task-subscription.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/task-subscription.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/subscriptions/task/validateRequestParameters';
+import { createMockSecrets, createMockZambdaInput } from './helpers';
+
+describe('task subscription - validateRequestParameters', () => {
+  const validTask = {
+    resourceType: 'Task',
+    status: 'requested',
+    intent: 'order',
+  };
+  const secrets = createMockSecrets();
+
+  test('should return validated params with a valid Task', () => {
+    const input = createMockZambdaInput(validTask, { secrets });
+    const result = validateRequestParameters(input);
+
+    expect(result.task.resourceType).toBe('Task');
+    expect(result.task.status).toBe('requested');
+    expect(result.secrets).toEqual(secrets);
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '', secrets });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when resourceType is not Task', () => {
+    const input = createMockZambdaInput({ resourceType: 'Patient', status: 'active' }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('task');
+  });
+
+  test('should throw when task status is completed', () => {
+    const input = createMockZambdaInput({ ...validTask, status: 'completed' }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('completed');
+  });
+
+  test('should throw when task status is failed', () => {
+    const input = createMockZambdaInput({ ...validTask, status: 'failed' }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('failed');
+  });
+
+  test('should throw when secrets are null', () => {
+    const input = createMockZambdaInput(validTask, { secrets: null });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should accept task with status "in-progress"', () => {
+    const input = createMockZambdaInput({ ...validTask, status: 'in-progress' }, { secrets });
+    const result = validateRequestParameters(input);
+    expect(result.task.status).toBe('in-progress');
+  });
+
+  test('should accept task with status "ready"', () => {
+    const input = createMockZambdaInput({ ...validTask, status: 'ready' }, { secrets });
+    const result = validateRequestParameters(input);
+    expect(result.task.status).toBe('ready');
+  });
+
+  test('should accept task with status "cancelled"', () => {
+    const input = createMockZambdaInput({ ...validTask, status: 'cancelled' }, { secrets });
+    const result = validateRequestParameters(input);
+    expect(result.task.status).toBe('cancelled');
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/task-subscription.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/task-subscription.test.ts
@@ -26,7 +26,7 @@ describe('task subscription - validateRequestParameters', () => {
 
   test('should throw when resourceType is not Task', () => {
     const input = createMockZambdaInput({ resourceType: 'Patient', status: 'active' }, { secrets });
-    expect(() => validateRequestParameters(input)).toThrow('task');
+    expect(() => validateRequestParameters(input)).toThrow('resourceType');
   });
 
   test('should throw when task status is completed', () => {

--- a/packages/zambdas/test/unit/validate-request-parameters/unlock-appointment.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/unlock-appointment.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters } from '../../../src/ehr/unlock-appointment/validateRequestParameters';
+import { createMockSecrets, createMockZambdaInput } from './helpers';
+
+describe('unlock-appointment - validateRequestParameters', () => {
+  const secrets = createMockSecrets();
+
+  test('should return validated params with valid input', () => {
+    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets });
+    const result = validateRequestParameters(input);
+
+    expect(result.appointmentId).toBe('appt-123');
+    expect(result.userToken).toBe('test-token');
+    expect(result.secrets).toEqual(secrets);
+  });
+
+  test('should throw when body is missing', () => {
+    const input = createMockZambdaInput(null, { body: '', secrets });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should throw when appointmentId is undefined', () => {
+    const input = createMockZambdaInput({ someField: 'value' }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('appointmentId');
+  });
+
+  test('should throw when PROJECT_API secret is missing', () => {
+    const badSecrets = { ORGANIZATION_ID: 'org-123' };
+    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets: badSecrets });
+    expect(() => validateRequestParameters(input)).toThrow('PROJECT_API');
+  });
+
+  test('should throw when ORGANIZATION_ID secret is missing', () => {
+    const badSecrets = { PROJECT_API: 'https://api.test' };
+    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets: badSecrets });
+    expect(() => validateRequestParameters(input)).toThrow('ORGANIZATION_ID');
+  });
+
+  test('should throw when secrets are null', () => {
+    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets: null });
+    expect(() => validateRequestParameters(input)).toThrow();
+  });
+
+  test('should extract Bearer token from Authorization header', () => {
+    const input = createMockZambdaInput(
+      { appointmentId: 'appt-123' },
+      {
+        secrets,
+        headers: { Authorization: 'Bearer custom-token' },
+      }
+    );
+    const result = validateRequestParameters(input);
+    expect(result.userToken).toBe('custom-token');
+  });
+});

--- a/packages/zambdas/test/unit/validate-request-parameters/unlock-appointment.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/unlock-appointment.test.ts
@@ -6,10 +6,10 @@ describe('unlock-appointment - validateRequestParameters', () => {
   const secrets = createMockSecrets();
 
   test('should return validated params with valid input', () => {
-    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets });
+    const input = createMockZambdaInput({ appointmentId: '550e8400-e29b-41d4-a716-446655440000' }, { secrets });
     const result = validateRequestParameters(input);
 
-    expect(result.appointmentId).toBe('appt-123');
+    expect(result.appointmentId).toBe('550e8400-e29b-41d4-a716-446655440000');
     expect(result.userToken).toBe('test-token');
     expect(result.secrets).toEqual(secrets);
   });
@@ -26,24 +26,35 @@ describe('unlock-appointment - validateRequestParameters', () => {
 
   test('should throw when PROJECT_API secret is missing', () => {
     const badSecrets = { ORGANIZATION_ID: 'org-123' };
-    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets: badSecrets });
+    const input = createMockZambdaInput(
+      { appointmentId: '550e8400-e29b-41d4-a716-446655440000' },
+      { secrets: badSecrets }
+    );
     expect(() => validateRequestParameters(input)).toThrow('PROJECT_API');
   });
 
   test('should throw when ORGANIZATION_ID secret is missing', () => {
     const badSecrets = { PROJECT_API: 'https://api.test' };
-    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets: badSecrets });
+    const input = createMockZambdaInput(
+      { appointmentId: '550e8400-e29b-41d4-a716-446655440000' },
+      { secrets: badSecrets }
+    );
     expect(() => validateRequestParameters(input)).toThrow('ORGANIZATION_ID');
   });
 
+  test('should throw when appointmentId is not a valid UUID', () => {
+    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets });
+    expect(() => validateRequestParameters(input)).toThrow('appointmentId');
+  });
+
   test('should throw when secrets are null', () => {
-    const input = createMockZambdaInput({ appointmentId: 'appt-123' }, { secrets: null });
+    const input = createMockZambdaInput({ appointmentId: '550e8400-e29b-41d4-a716-446655440000' }, { secrets: null });
     expect(() => validateRequestParameters(input)).toThrow();
   });
 
   test('should extract Bearer token from Authorization header', () => {
     const input = createMockZambdaInput(
-      { appointmentId: 'appt-123' },
+      { appointmentId: '550e8400-e29b-41d4-a716-446655440000' },
       {
         secrets,
         headers: { Authorization: 'Bearer custom-token' },


### PR DESCRIPTION
The idea is to migrate the simple validation functions for every zambda function to:

1. Have some test coverage for all of them.
2. Use zod: more declarative, easier to read and understand validation, easier to ensure error messages are returned out of the endpoint for all of the basic validations instead of crashing out.
3. Improve the simple validation to catch issues in the easiest to understand parts of the function. Lots of functions only enforce that inputs exist, or are strings, when they could check type, length, date formats, UUID shapes, and more.

This PR only does the first handful. But with the patterns learned here i hope to use the context to do all the others next.

Claude wrote the code, I reviewed it all and commented throughout and claude applied my changes and I reviewed those. I think it's ready to merge.

🤖 Claude generated description below.

## Summary

- Add unit test coverage for 14 representative `validateRequestParameters` functions across all zambda directories (ehr, patient, rcm, subscriptions)
- Migrate 12 of those validators from hand-written `if`/`throw` logic to declarative zod schemas, parsed via the existing `safeValidate` helper

This establishes the pattern for migrating the remaining ~129 validators to zod.

## What changed

### Test coverage (commit 1)
Added `test/unit/validate-request-parameters/` with 14 test files + shared helpers covering:
- **Simple**: `create-user`, `delete-chart-data`, `get-user`, `get-patients`
- **Medium**: `get-appointments`, `save-chart-data`, `create-upload-document-url`, `create-charge-master`, `get-schedule`
- **Complex**: `change-in-person-visit-status`, `unlock-appointment`, `task-subscription`, `check-in`, `create-nursing-order`

128 tests covering: missing body, missing/wrong-type required fields, enum validation, cross-field constraints, secrets passthrough, and Bearer token extraction.

### Zod migration (commit 2)
Each validator now defines a `const XyzBodySchema = z.object({...})` and calls `safeValidate(schema, JSON.parse(input.body))`. Non-body validation (auth headers, secrets via `getSecret`) remains as imperative guards.

3 intentional behavioral improvements caught by the safety-net tests:
- `create-upload-document-url` now properly rejects missing `patientId`/`fileFolderId`/`fileName` (previously silently returned `undefined`)
- `get-appointments` now properly rejects non-boolean `supervisorApprovalEnabled` (previously silently coerced to `false`)
- `task-subscription` zod error now references the field path `"resourceType"` (clearer than the old ad-hoc message)

2 validators were already fine and left unchanged: `get-patients` (no body validation) and `create-nursing-order` (already used zod).

Net: **-239 lines, +182 lines** across 12 source files. 128 tests pass, 611 total unit tests pass with zero regressions.

## Test plan

- [x] All 128 validate-request-parameters tests pass under `vitest.config.unit.ts`
- [x] All 128 tests also pass under default `vitest.config.ts` (CI config with network guard + in-process server)
- [x] All 611 unit tests pass with zero regressions
- [x] Lint passes (pre-commit hook)

https://claude.ai/code/session_01ErS91pwRCizhToHmx2Yhvv