### PR TITLE
Fix contact support dialog bugs

### DIFF
--- a/apps/ehr/src/features/visits/telemed/components/admin/support-dialog/SupportDialogAdminPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/support-dialog/SupportDialogAdminPage.tsx
@@ -6,14 +6,17 @@ import PageContainer from 'src/layout/PageContainer';
 import { useAdminGetSupportDialog, useAdminUpdateSupportDialog } from '../admin.queries';
 
 export default function SupportDialogAdminPage(): ReactElement {
-  const { data, isPending, isError, dataUpdatedAt } = useAdminGetSupportDialog();
+  const { data, isPending, isError } = useAdminGetSupportDialog();
   const { mutateAsync, isPending: isSubmitting } = useAdminUpdateSupportDialog();
 
   const [editedBodyHtml, setEditedBodyHtml] = useState<string | undefined>(undefined);
 
+  // Sync from the server only when the saved content actually changes (e.g. after a save).
+  // A background refetch (e.g. tabbing back into the window) that returns identical content
+  // must NOT clobber the user's unsaved edits.
   useEffect(() => {
     setEditedBodyHtml(undefined);
-  }, [data?.bodyHtml, dataUpdatedAt]);
+  }, [data?.bodyHtml]);
 
   const bodyHtml = editedBodyHtml ?? data?.bodyHtml ?? '';
   const savedBodyHtml = data?.bodyHtml ?? '';
@@ -44,7 +47,6 @@ export default function SupportDialogAdminPage(): ReactElement {
             ) : (
               <>
                 <RichTextEditorField
-                  key={dataUpdatedAt}
                   value={bodyHtml}
                   onChange={setEditedBodyHtml}
                   placeholder="Write the support text patients will see…"

--- a/apps/intake/src/components/ContactSupportDialog.tsx
+++ b/apps/intake/src/components/ContactSupportDialog.tsx
@@ -23,13 +23,23 @@ export const ContactSupportDialog: FC<ContactSupportDialogProps> = ({ onClose })
   });
 
   const rawBodyHtml = data?.bodyHtml?.trim();
-  const safeBodyHtml = useMemo(
-    () =>
-      rawBodyHtml
-        ? DOMPurify.sanitize(rawBodyHtml, { ALLOWED_TAGS: ALLOWED_SUPPORT_DIALOG_TAGS, ALLOWED_ATTR: [] })
-        : '',
-    [rawBodyHtml]
-  );
+  const safeBodyHtml = useMemo(() => {
+    if (!rawBodyHtml) return '';
+    const sanitized = DOMPurify.sanitize(rawBodyHtml, {
+      ALLOWED_TAGS: ALLOWED_SUPPORT_DIALOG_TAGS,
+      ALLOWED_ATTR: [],
+    });
+    // tiptap emits blank lines as <p></p> (or <p> </p>); these collapse to zero
+    // height and render invisibly. Give each blank paragraph a <br> so it occupies
+    // a full line. Done after sanitizing — <br> is already in the allowlist.
+    const doc = new DOMParser().parseFromString(sanitized, 'text/html');
+    doc.querySelectorAll('p').forEach((p) => {
+      if (!p.textContent?.trim() && !p.querySelector('br')) {
+        p.appendChild(doc.createElement('br'));
+      }
+    });
+    return doc.body.innerHTML;
+  }, [rawBodyHtml]);
 
   return (
     <CustomDialog open={true} onClose={onClose}>


### PR DESCRIPTION
### EHR Admin. Support dialog. If a user opens another tab without saving their data, the data shouldn't disappear when they return - https://linear.app/zapehr/issue/OTR-2609/ehr-admin-support-dialog-if-a-user-opens-another-tab-without-saving
Refetch now doesn't cause not saved data to disappear

### Empty lines not displayed in support modal - https://linear.app/zapehr/issue/OTR-2618/empty-lines-not-displayed-in-support-modal
Empty lines are now visible
<img width="1304" height="900" alt="image" src="https://github.com/user-attachments/assets/3b6328c6-2394-4c4f-b148-b789b7f8246b" />
<img width="724" height="670" alt="image" src="https://github.com/user-attachments/assets/b96fefcb-c5de-4896-ac60-adb121587231" />

