### PR TITLE
awaiting supervisor approval from status dropdown

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/ChangeStatusDropdown.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/ChangeStatusDropdown.tsx
@@ -111,6 +111,12 @@ export const ChangeStatusDropdown = ({
       alert('To mark a visit as completed, scroll to the bottom of the "Progress Note" and click "Review & Sign"');
       return;
     }
+    if (targetValue === 'awaiting supervisor approval') {
+      alert(
+        'To mark a visit as awaiting supervisor approval, scroll to the bottom of the "Progress Note" and click "Review & Sign"'
+      );
+      return;
+    }
     if (
       !assignedIntakePerformerId &&
       !assignedProviderId &&


### PR DESCRIPTION
Summary:

Selecting "awaiting supervisor approval" from the visit status dropdown now shows an alert directing the user to use Review & Sign instead, preventing the visit from incorrectly transitioning to completed with empty required fields
Follows the same pattern as the existing "completed" status guard in the same dropdown

Closes #7064