### PR TITLE
coerce on-demand virtual visits to show up on the tracking board's active tab

### DIFF
--- a/packages/zambdas/src/ehr/get-appointments/index.ts
+++ b/packages/zambdas/src/ehr/get-appointments/index.ts
@@ -28,7 +28,6 @@ import {
   getAttestedConsentFromEncounter,
   getChatContainsUnreadMessages,
   getCoding,
-  getInPersonVisitStatus,
   getMiddleName,
   getPatientFirstName,
   getPatientLastName,
@@ -53,6 +52,7 @@ import {
 import {
   checkOrCreateM2MClientToken,
   createOystehrClient,
+  getTrackingBoardVisitStatus,
   sortAppointments,
   wrapHandler,
   ZambdaInput,
@@ -744,7 +744,7 @@ const makeAppointmentInformation = (
   const idCard = docRefComplete('Photo ID cards', 'photo-id-front');
   const insuranceCard = docRefComplete('Insurance cards', 'insurance-card-front');
   const cancellationReason = appointment.cancelationReason?.coding?.[0].code;
-  const status = getInPersonVisitStatus(appointment, encounter, supervisorApprovalEnabled);
+  const status = getTrackingBoardVisitStatus(appointment, encounter, supervisorApprovalEnabled);
 
   const waitingMinutesString = appointment.meta?.tag?.find((tag) => tag.system === 'waiting-minutes-estimate')?.code;
   const waitingMinutes = waitingMinutesString ? parseInt(waitingMinutesString) : undefined;

--- a/packages/zambdas/src/shared/appointment/helpers.ts
+++ b/packages/zambdas/src/shared/appointment/helpers.ts
@@ -5,12 +5,14 @@ import { DateTime } from 'luxon';
 import { uuid } from 'short-uuid';
 import {
   AppointmentInsuranceRelatedResourcesExtension,
+  appointmentTypeForAppointment,
   createPatientDocumentLists,
   createUserResourcesForPatient,
   FHIR_EXTENSION,
   formatPhoneNumber,
   getPatchBinary,
   getPatientResourceWithVerifiedPhoneNumber,
+  isTelemedAppointment,
   makeSSNIdentifier,
   normalizePhoneNumber,
   PATIENT_NOT_FOUND_ERROR,
@@ -25,6 +27,11 @@ export function getPatientFromAppointment(appointment: Appointment): string | un
   return appointment.participant
     .find((participantTemp) => participantTemp.actor?.reference?.startsWith('Patient/'))
     ?.actor?.reference?.split('/')[1];
+}
+
+// on-demand virtual visits override so they're shown on the 'Active' tab
+export function isOnDemandVirtualAppointment(appointment: Appointment): boolean {
+  return isTelemedAppointment(appointment) && appointmentTypeForAppointment(appointment) === 'walk-in';
 }
 
 export async function patchAppointmentResource(

--- a/packages/zambdas/src/shared/queueingUtils.ts
+++ b/packages/zambdas/src/shared/queueingUtils.ts
@@ -1,7 +1,21 @@
 import { Appointment, Encounter } from 'fhir/r4b';
 import { DateTime } from 'luxon';
-import { appointmentTypeForAppointment, getInPersonVisitStatus } from 'utils';
+import { appointmentTypeForAppointment, getInPersonVisitStatus, VisitStatusLabel } from 'utils';
+import { isOnDemandVirtualAppointment } from './appointment';
 import { getTimeSpentInCurrentStatus, getWaitingTimeForAppointment } from './waitTimeUtils';
+
+export const getTrackingBoardVisitStatus = (
+  appointment: Appointment,
+  encounter: Encounter,
+  supervisorApprovalEnabled = false
+): VisitStatusLabel => {
+  const status = getInPersonVisitStatus(appointment, encounter, supervisorApprovalEnabled);
+  // pending for "Virtual visit with X at Y" notifications, arrived for tracking board
+  if (status === 'pending' && isOnDemandVirtualAppointment(appointment)) {
+    return 'arrived';
+  }
+  return status;
+};
 
 const ARRIVED_PREBOOKED_EARLY_ARRIVAL_LIMIT = 15;
 const READY_PREBOOKED_EARLY_ARRIVAL_LIMIT = 10;
@@ -331,7 +345,7 @@ class QueueBuilder {
     appointments.forEach((appointment) => {
       const encounter = apptRefToEncounterMap[`Appointment/${appointment.id}`];
       if (encounter && appointment) {
-        const status = getInPersonVisitStatus(appointment, encounter);
+        const status = getTrackingBoardVisitStatus(appointment, encounter);
 
         if (status === 'pending') {
           this.insertNew(appointment, encounter, this.queues.prebooked);

--- a/packages/zambdas/test/appointment-helpers.test.ts
+++ b/packages/zambdas/test/appointment-helpers.test.ts
@@ -1,0 +1,44 @@
+import { Appointment } from 'fhir/r4b';
+import { OTTEHR_MODULE } from 'utils';
+import { describe, expect, test } from 'vitest';
+import { isOnDemandVirtualAppointment } from '../src/shared';
+
+const makeAppointment = (module: OTTEHR_MODULE, appointmentTypeText?: string): Appointment => ({
+  resourceType: 'Appointment',
+  status: 'booked',
+  participant: [],
+  meta: {
+    tag: [{ code: module }],
+  },
+  ...(appointmentTypeText && {
+    appointmentType: {
+      text: appointmentTypeText,
+    },
+  }),
+});
+
+describe('isOnDemandVirtualAppointment', () => {
+  test('returns true for a telemed walk-in appointment', () => {
+    expect(isOnDemandVirtualAppointment(makeAppointment(OTTEHR_MODULE.TM, 'walkin'))).toBe(true);
+  });
+
+  test('returns true for a telemed appointment with no appointmentType (defaults to walk-in)', () => {
+    expect(isOnDemandVirtualAppointment(makeAppointment(OTTEHR_MODULE.TM))).toBe(true);
+  });
+
+  test('returns false for a pre-booked telemed appointment', () => {
+    expect(isOnDemandVirtualAppointment(makeAppointment(OTTEHR_MODULE.TM, 'prebook'))).toBe(false);
+  });
+
+  test('returns false for a post-telemed appointment', () => {
+    expect(isOnDemandVirtualAppointment(makeAppointment(OTTEHR_MODULE.TM, 'posttelemed'))).toBe(false);
+  });
+
+  test('returns false for an in-person walk-in appointment', () => {
+    expect(isOnDemandVirtualAppointment(makeAppointment(OTTEHR_MODULE.IP, 'walkin'))).toBe(false);
+  });
+
+  test('returns false for a pre-booked in-person appointment', () => {
+    expect(isOnDemandVirtualAppointment(makeAppointment(OTTEHR_MODULE.IP, 'prebook'))).toBe(false);
+  });
+});

--- a/packages/zambdas/test/patient-queue.test.ts
+++ b/packages/zambdas/test/patient-queue.test.ts
@@ -5,6 +5,7 @@ import {
   AppointmentType,
   FhirAppointmentStatus,
   FhirEncounterStatus,
+  getInPersonVisitStatus,
   OTTEHR_MODULE,
   visitStatusToFhirAppointmentStatusMap,
   visitStatusToFhirEncounterStatusMap,
@@ -12,7 +13,7 @@ import {
 } from 'utils';
 import { beforeAll, expect, test } from 'vitest';
 import { HOP_QUEUE_URI } from '../src/shared/constants';
-import { sortAppointments } from '../src/shared/queueingUtils';
+import { getTrackingBoardVisitStatus, sortAppointments } from '../src/shared/queueingUtils';
 
 let NOW: DateTime;
 
@@ -652,4 +653,13 @@ test('on-demand virtual visits land in the active queue, while pre-booked teleme
 
   expect(prebookedIds).toContain(prebookedVirtual.appointment.id);
   expect(activeIds).not.toContain(prebookedVirtual.appointment.id);
+});
+
+test('on-demand virtual visit reads as pending for notifications but arrived for the tracking board', () => {
+  const { appointment, encounter } = asTelemed(makeVisit_Pending('walk-in', 0));
+
+  // for "Virtual visit with X at Y" notifications
+  expect(getInPersonVisitStatus(appointment, encounter)).toBe('pending');
+  // Active tab
+  expect(getTrackingBoardVisitStatus(appointment, encounter)).toBe('arrived');
 });

--- a/packages/zambdas/test/patient-queue.test.ts
+++ b/packages/zambdas/test/patient-queue.test.ts
@@ -5,6 +5,7 @@ import {
   AppointmentType,
   FhirAppointmentStatus,
   FhirEncounterStatus,
+  OTTEHR_MODULE,
   visitStatusToFhirAppointmentStatusMap,
   visitStatusToFhirEncounterStatusMap,
   VisitStatusWithoutUnknown,
@@ -261,6 +262,17 @@ const addParticipant = (
     encounter.participant = [newParticipant];
   }
   return encounter;
+};
+
+const asTelemed = (visit: VisitDetails): VisitDetails => {
+  visit.appointment.meta = {
+    tag: [
+      {
+        code: OTTEHR_MODULE.TM,
+      },
+    ],
+  };
+  return visit;
 };
 
 const getAppointmentsAndMap = (
@@ -623,4 +635,21 @@ test('prebooked patients queue', () => {
     console.log(val.id);
     expect(val.id).toBe(expectedOrder[idx].id);
   });
+});
+
+test('on-demand virtual visits land in the active queue, while pre-booked telemed stays prebooked', () => {
+  const onDemandVirtual = asTelemed(makeVisit_Pending('walk-in', 0));
+  const prebookedVirtual = asTelemed(makeVisit_Pending('pre-booked', -15));
+
+  const { appointments, apptRefToEncounterMap } = getAppointmentsAndMap([onDemandVirtual, prebookedVirtual]);
+  const sorted = sortAppointments(appointments, apptRefToEncounterMap);
+
+  const activeIds = sorted.inOffice.waitingRoom.arrived.map((appointment) => appointment.id);
+  const prebookedIds = sorted.prebooked.map((appointment) => appointment.id);
+
+  expect(activeIds).toContain(onDemandVirtual.appointment.id);
+  expect(prebookedIds).not.toContain(onDemandVirtual.appointment.id);
+
+  expect(prebookedIds).toContain(prebookedVirtual.appointment.id);
+  expect(activeIds).not.toContain(prebookedVirtual.appointment.id);
 });


### PR DESCRIPTION
need to leave them in `pending` canonically in fhir for "Virtual visit with X at Y" notifications to continue to work