### PR TITLE
Issue 7853. Save chart data errors with 500 when creating a medication statement with empty dosage text

### DIFF
--- a/apps/ehr/src/features/visits/in-person/pages/Medications.tsx
+++ b/apps/ehr/src/features/visits/in-person/pages/Medications.tsx
@@ -56,15 +56,16 @@ export const Medications: React.FC<MedicationsProps> = () => {
       const strength = selection.medication.strength;
       const nameAlreadyHasStrength = strength && medName.toLowerCase().includes(strength.toLowerCase());
       const displayName = nameAlreadyHasStrength || !strength ? medName : `${medName} (${strength})`;
+      const trimmedDose = selection.dose?.trim() || undefined;
       const doseIsRedundantWithStrength =
-        selection.dose && strength && strength.toLowerCase() === selection.dose.toLowerCase();
+        trimmedDose && strength && strength.toLowerCase() === trimmedDose.toLowerCase();
       try {
         const success = await onSubmit({
           name: displayName,
           id: selection.medication.id?.toString(),
           type: selection.type ?? 'scheduled',
           intakeInfo: {
-            dose: doseIsRedundantWithStrength ? undefined : selection.dose ?? undefined,
+            dose: doseIsRedundantWithStrength ? undefined : trimmedDose,
             date: selection.date,
             patientCouldNotConfirmDosage: selection.patientCouldNotConfirmDosage || undefined,
           },

--- a/packages/zambdas/src/shared/chart-data/index.ts
+++ b/packages/zambdas/src/shared/chart-data/index.ts
@@ -264,6 +264,7 @@ export function makeMedicationResource(
   data: MedicationDTO,
   fieldName: ProviderChartDataFieldsNames
 ): MedicationStatement {
+  const dose = data.intakeInfo.dose?.trim();
   return {
     id: data.resourceId,
     identifier: [{ value: data.id }],
@@ -271,7 +272,8 @@ export function makeMedicationResource(
     subject: { reference: `Patient/${patientId}` },
     context: { reference: `Encounter/${encounterId}` },
     status: data.status,
-    dosage: [{ text: data.intakeInfo.dose, asNeededBoolean: data.type === 'as-needed' }],
+    // FHIR rejects empty strings for Dosage.text, so only set it when a dose was actually provided
+    dosage: [{ ...(dose ? { text: dose } : {}), asNeededBoolean: data.type === 'as-needed' }],
     effectiveDateTime: data.intakeInfo.date,
     informationSource: { reference: `Practitioner/${practitionerId}` },
     meta: getMetaWFieldName(fieldName),


### PR DESCRIPTION
#7853