### PR TITLE
OTR-2641: Fix route and exp date display in immunization and medications quick picks

### DIFF
--- a/apps/ehr/src/features/visits/telemed/components/admin/ImmunizationQuickPickDetailPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/ImmunizationQuickPickDetailPage.tsx
@@ -1,9 +1,11 @@
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { Box, CircularProgress, IconButton, Stack, Typography, useTheme } from '@mui/material';
+import { DateTime } from 'luxon';
 import React, { ReactElement } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Row } from 'src/components/layout/Row';
 import { Section } from 'src/components/layout/Section';
+import { searchRouteByCode } from 'utils';
 import { useImmunizationQuickPicksQuery } from './admin.queries';
 
 function ValueDisplay({ value }: { value: string | undefined | null }): ReactElement {
@@ -59,7 +61,7 @@ export default function ImmunizationQuickPickDetailPage(): ReactElement {
             <ValueDisplay value={quickPick.units} />
           </Row>
           <Row label="Route">
-            <ValueDisplay value={quickPick.route} />
+            <ValueDisplay value={searchRouteByCode(quickPick.route)?.display ?? quickPick.route} />
           </Row>
           <Row label="Injection Site">
             <ValueDisplay value={quickPick.location?.name} />
@@ -91,7 +93,9 @@ export default function ImmunizationQuickPickDetailPage(): ReactElement {
             <ValueDisplay value={quickPick.lot} />
           </Row>
           <Row label="Expiration Date">
-            <ValueDisplay value={quickPick.expDate} />
+            <ValueDisplay
+              value={quickPick.expDate ? DateTime.fromISO(quickPick.expDate).toFormat('yyyy-MM-dd') : undefined}
+            />
           </Row>
           <Row label="Instructions">
             <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>

--- a/apps/ehr/src/features/visits/telemed/components/admin/InHouseMedicationQuickPickDetailPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/InHouseMedicationQuickPickDetailPage.tsx
@@ -1,9 +1,11 @@
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { Box, CircularProgress, IconButton, Stack, Typography, useTheme } from '@mui/material';
+import { DateTime } from 'luxon';
 import React, { ReactElement } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Row } from 'src/components/layout/Row';
 import { Section } from 'src/components/layout/Section';
+import { searchRouteByCode } from 'utils';
 import { useInHouseMedicationQuickPicksQuery } from './admin.queries';
 
 function ValueDisplay({ value }: { value: string | number | undefined | null }): ReactElement {
@@ -61,7 +63,7 @@ export default function InHouseMedicationQuickPickDetailPage(): ReactElement {
             <ValueDisplay value={quickPick.units} />
           </Row>
           <Row label="Route">
-            <ValueDisplay value={quickPick.route} />
+            <ValueDisplay value={searchRouteByCode(quickPick.route)?.display ?? quickPick.route} />
           </Row>
           <Row label="Location">
             <ValueDisplay value={quickPick.location?.name} />
@@ -82,7 +84,9 @@ export default function InHouseMedicationQuickPickDetailPage(): ReactElement {
             <ValueDisplay value={quickPick.lotNumber} />
           </Row>
           <Row label="Expiration Date">
-            <ValueDisplay value={quickPick.expDate} />
+            <ValueDisplay
+              value={quickPick.expDate ? DateTime.fromISO(quickPick.expDate).toFormat('yyyy-MM-dd') : undefined}
+            />
           </Row>
           <Row label="Instructions">
             <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2641/quick-picks-route-is-just-a-number-in-admin-qp-details-screen

<img width="1200" height="1162" alt="image" src="https://github.com/user-attachments/assets/2db09ed9-2b30-47b6-b0f6-65fcf1efe3a2" />
<img width="1208" height="1312" alt="image" src="https://github.com/user-attachments/assets/279bbc77-11e1-4dac-b91b-19b0f598a4a8" />
