### PR TITLE
OTR-2607: Fix reason for visit and additional info fields

### DIFF
--- a/apps/ehr/src/features/visits/ChiefComplaintField.tsx
+++ b/apps/ehr/src/features/visits/ChiefComplaintField.tsx
@@ -6,7 +6,7 @@ import { useChartFields } from './shared/hooks/useChartFields';
 import { useDebounceNotesField } from './shared/hooks/useDebounceNotesField';
 
 export const ChiefComplaintField: FC = () => {
-  const { data: chartDataFields } = useChartFields({
+  const { data: chartDataFields, isFetched: isChartDataFetched } = useChartFields({
     requestedFields: {
       historyOfPresentIllness: {
         _tag: 'history-of-present-illness',
@@ -21,10 +21,10 @@ export const ChiefComplaintField: FC = () => {
   });
 
   useEffect(() => {
-    if (chartDataFields?.historyOfPresentIllness?.text !== undefined) {
-      methods.setValue('chiefComplaint', chartDataFields.historyOfPresentIllness.text);
+    if (isChartDataFetched) {
+      methods.setValue('chiefComplaint', chartDataFields?.historyOfPresentIllness?.text ?? '');
     }
-  }, [chartDataFields?.historyOfPresentIllness?.text, methods]);
+  }, [chartDataFields?.historyOfPresentIllness?.text, isChartDataFetched, methods]);
 
   const { control } = methods;
 

--- a/apps/ehr/src/features/visits/ReasonForVisitField.tsx
+++ b/apps/ehr/src/features/visits/ReasonForVisitField.tsx
@@ -8,15 +8,15 @@ import { useAppointmentData, useSaveChartData } from './shared/stores/appointmen
 export const ReasonForVisitField: FC = () => {
   const saveChartData = useSaveChartData();
   const [reasonForVisit, setReasonForVisit] = useState<string>('');
-  const { data: chartFields } = useChartFields({
+  const { data: chartFields, isFetched: isChartFieldsFetched } = useChartFields({
     requestedFields: { reasonForVisit: {} },
   });
 
   useEffect(() => {
-    if (chartFields?.reasonForVisit?.text) {
-      setReasonForVisit(chartFields.reasonForVisit.text);
+    if (isChartFieldsFetched) {
+      setReasonForVisit(chartFields?.reasonForVisit?.text ?? '');
     }
-  }, [chartFields]);
+  }, [chartFields, isChartFieldsFetched]);
 
   const { appointment } = useAppointmentData();
   const serviceCategory = getCoding(appointment?.serviceCategory, SERVICE_CATEGORY_SYSTEM)?.code;


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2607/scheduled-follow-up-chief-complaint-is-not-refreshed-after-selecting

Now reason for visit and additional information fields display correct data for different follow-ups even if the data is empty