### PR TITLE
test(zambdas): fix flaky cancel validation in booking integration test

### DIFF
--- a/packages/zambdas/test/integration/booking-integration.test.ts
+++ b/packages/zambdas/test/integration/booking-integration.test.ts
@@ -50,6 +50,27 @@ import {
   tagForProcessId,
 } from '../helpers/testScheduleUtils';
 
+/**
+ * Polls `fetch` until `predicate` returns true or the timeout elapses, then
+ * returns the most recent value. Used to absorb the brief propagation delay
+ * between a mutating zambda returning 200 and the change becoming readable
+ * through the FHIR API — otherwise an immediate read-back can race the write
+ * and flake (e.g. seeing 'booked' right after a successful cancel).
+ */
+const pollUntil = async <T>(
+  fetch: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  { timeoutMs = 15_000, intervalMs = 500 }: { timeoutMs?: number; intervalMs?: number } = {}
+): Promise<T> => {
+  const deadline = Date.now() + timeoutMs;
+  let value = await fetch();
+  while (!predicate(value) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    value = await fetch();
+  }
+  return value;
+};
+
 const createSlotAndValidate = async (
   input: { params: CreateSlotParams; schedule: Schedule; selectedSlot?: SlotListItem },
   oystehr: Oystehr
@@ -590,10 +611,14 @@ describe('prebook integration - from getting list of slots to booking with selec
       expect(false).toBeTruthy(); // fail the test if we can't cancel the appointment
     }
 
-    const canceledAppointment = await oystehrAdmin.fhir.get<Appointment>({
-      resourceType: 'Appointment',
-      id: appointmentId,
-    });
+    const canceledAppointment = await pollUntil(
+      () =>
+        oystehrAdmin.fhir.get<Appointment>({
+          resourceType: 'Appointment',
+          id: appointmentId,
+        }),
+      (appointment) => appointment?.status === 'cancelled'
+    );
     expect(canceledAppointment).toBeDefined();
     assert(canceledAppointment);
     expect(canceledAppointment.status).toEqual('cancelled');
@@ -606,15 +631,19 @@ describe('prebook integration - from getting list of slots to booking with selec
     } else {
       expect(canceledAppointment.cancelationReason?.coding?.[0]?.code).toBe('Patient improved');
     }
-    const slotSearch = await oystehrAdmin.fhir.search<Slot>({
-      resourceType: 'Slot',
-      params: [
-        {
-          name: '_id',
-          value: oldSlotId,
-        },
-      ],
-    });
+    const slotSearch = await pollUntil(
+      () =>
+        oystehrAdmin.fhir.search<Slot>({
+          resourceType: 'Slot',
+          params: [
+            {
+              name: '_id',
+              value: oldSlotId,
+            },
+          ],
+        }),
+      (search) => search.unbundle().length === 0
+    );
     expect(slotSearch).toBeDefined();
     const unbundledSlots = slotSearch.unbundle();
     expect(unbundledSlots.length).toBe(0);


### PR DESCRIPTION
🤖  generated code. Don't look at this yet I am still reviewing it. 

## Problem

A nightly `config-and-test` leg failed intermittently on:

```
FAIL test/integration/booking-integration.test.ts > prebook integration … >
  successfully creates a virtual appointment for a new patient after selecting an available slot
AssertionError: expected 'booked' to deeply equal 'cancelled'
  ❯ cancelAndValidate  booking-integration.test.ts:599
```

`cancelAndValidate` calls the `cancel-appointment` zambda (which returns `200`) and then **immediately reads the Appointment back once** and asserts `status === 'cancelled'`. The status change isn't always readable through the FHIR API in that same instant, so the read-back occasionally races the write and observes the pre-cancel `'booked'` status — an intermittent flake. It's intermittent precisely because it depends on propagation timing. The old-Slot deletion check right after has the same shape.

## Fix

Add a small bounded-retry helper, `pollUntil(fetch, predicate, { timeoutMs, intervalMs })`, and use it for both post-cancel read-backs (appointment status → `cancelled`, old slot → deleted). It returns as soon as the expected state is observed and only waits when needed, so the happy path stays fast. All **five** `cancelAndValidate` call sites benefit since they share the helper. No production code changes — the zambda's `200` contract is unchanged; this only hardens the test's read-back.

## Validation

⚠️ I could **not** run this integration test in my environment — it requires the local zambda server + live Oystehr M2M credentials (`config/.env/<env>.json`), which aren't present here, and it exercises a real Oystehr project. So I validated two ways instead:

1. **Logic simulation** of the exact race (cancel returns immediately; status flips to `cancelled` after a small propagation delay), 3000 runs:
   - old single-read: fails whenever delay > 0
   - `pollUntil`: 0 failures
2. **Type-check** of the helper + call-site generic inference with `tsc --strict` (clean).

Please let CI run the integration suite to confirm against the real backend. If reviewers prefer, the default `timeoutMs`/`intervalMs` (15s / 500ms) can be tuned.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019UTv8NEvW8KHEDWu6ZNG4D)_