### PR TITLE
Fix billing for in-house medications

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/assessment-tab/BillingCodesContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/assessment-tab/BillingCodesContainer.tsx
@@ -410,9 +410,16 @@ export const BillingCodesContainer: FC<BillingCodesContainerProps> = ({
             dataTestId={dataTestIds.billingContainer.container}
             getKey={(value, index) => value.resourceId || index}
             renderItem={(value) => (
-              <Typography data-testid={dataTestIds.billingContainer.cptCodeEntry(value.code)}>
-                {makeCptCodeDisplay(value)}
-              </Typography>
+              <Box>
+                <Typography data-testid={dataTestIds.billingContainer.cptCodeEntry(value.code)}>
+                  {makeCptCodeDisplay(value)}
+                </Typography>
+                {value.ndcCode && (
+                  <Typography variant="body2" color="textSecondary">
+                    NDC: {value.ndcCode}
+                  </Typography>
+                )}
+              </Box>
             )}
             renderActions={
               isReadOnly

--- a/packages/utils/lib/types/api/chart-data/chart-data.types.ts
+++ b/packages/utils/lib/types/api/chart-data/chart-data.types.ts
@@ -320,6 +320,7 @@ export interface CPTCodeDTO extends SaveableDTO {
   code: string;
   display: string;
   modifier?: { code: string; display: string }[];
+  ndcCode?: string;
 }
 
 export const clinicalImpressionDTOSchema = z.object({

--- a/packages/zambdas/src/ehr/create-update-medication-order/index.ts
+++ b/packages/zambdas/src/ehr/create-update-medication-order/index.ts
@@ -14,11 +14,8 @@ import {
 } from 'fhir/r4b';
 import { DateTime } from 'luxon';
 import {
-  chooseJson,
   createCancellationTagOperations,
   FHIR_RESOURCE_NOT_FOUND_CUSTOM,
-  GetChartDataRequest,
-  GetChartDataResponse,
   getMedicationFromMA,
   getMedicationName,
   getMedicationTypeCode,
@@ -75,7 +72,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   const practitionerId = await getMyPractitionerId(userToken, validatedParameters.secrets);
   console.log('Created zapToken, fhir and clients.');
 
-  const response = await performEffect(oystehr, validatedParameters, practitionerId, userToken);
+  const response = await performEffect(oystehr, validatedParameters, practitionerId);
   return {
     statusCode: 200,
     body: JSON.stringify(response),
@@ -85,8 +82,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 async function performEffect(
   oystehr: Oystehr,
   params: UpdateMedicationOrderInput,
-  practitionerIdCalledZambda: string,
-  userToken: string
+  practitionerIdCalledZambda: string
 ): Promise<any> {
   const { orderId, newStatus, orderData } = params;
   if (orderId && orderData) {
@@ -100,7 +96,6 @@ async function performEffect(
         encounterIdFromMA,
         newStatus,
         orderResources.medicationAdministration,
-        userToken,
         orderData.cptCodes
       );
     } else console.log('Manage additional CPT codes for order was skipped because no encounterId was found in MA');
@@ -119,8 +114,7 @@ async function performEffect(
         oystehr,
         encounterIdFromMA,
         newStatus,
-        orderResources.medicationAdministration,
-        userToken
+        orderResources.medicationAdministration
       );
     } else console.log('Manage additional CPT codes for order was skipped because no encounterId was found in MA');
 
@@ -457,7 +451,6 @@ async function manageAdditionalCptCodesForOrder(
   encounterId: string,
   medicationStatus: MedicationOrderStatusesType,
   medicationAdministration: MedicationAdministration,
-  userToken: string,
   cptCodes?: { code: string; display: string }[]
 ): Promise<void> {
   try {
@@ -489,28 +482,14 @@ async function manageAdditionalCptCodesForOrder(
     }
 
     console.log('Adding CPT codes to chart data from order');
-    const chartDataResponse = await oystehr.zambda.execute(
-      { id: 'get-chart-data', encounterId } as GetChartDataRequest & { id: string },
-      { accessToken: userToken }
-    );
-    const chartData = chooseJson(chartDataResponse) as GetChartDataResponse;
-    const chartDataCptCodes = chartData.cptCodes?.map((code) => code.code) ?? [];
-
     const patientId = assertDefined(
       medicationAdministration.subject.reference?.replace('Patient/', ''),
       'MedicationAdministration.subject.reference'
     );
     const partOfRef = `MedicationAdministration/${medicationAdministration.id}`;
 
-    const newCodes = orderCptCodes.filter((oc) => !chartDataCptCodes.includes(oc.code));
-    console.log('CPT codes to create as Procedures: ', newCodes.map((c) => c.code).join(', '));
-
-    if (newCodes.length === 0) {
-      console.log('All CPT codes already exist as Procedures, skipping');
-      return;
-    }
-
-    const requests: BatchInputRequest<FhirResource>[] = newCodes.map((cptCode) => ({
+    console.log('CPT codes to create as Procedures: ', orderCptCodes.map((c) => c.code).join(', '));
+    const requests: BatchInputRequest<FhirResource>[] = orderCptCodes.map((cptCode) => ({
       method: 'POST',
       url: '/Procedure',
       resource: makeProcedureResource(encounterId, patientId, cptCode, 'cpt-code', partOfRef),

--- a/packages/zambdas/src/ehr/get-chart-data/helpers.ts
+++ b/packages/zambdas/src/ehr/get-chart-data/helpers.ts
@@ -1,10 +1,12 @@
 import Oystehr, { BatchInputGetRequest } from '@oystehr/sdk';
-import { Bundle, Encounter, FhirResource, Patient, Resource } from 'fhir/r4b';
+import { Bundle, Encounter, FhirResource, MedicationAdministration, Patient, Procedure, Resource } from 'fhir/r4b';
 import {
   addSearchParams,
   ChartDataRequestedFields,
   ChartDataWithResources,
   GetChartDataResponse,
+  getMedicationFromMA,
+  getNdcCodeFromMedication,
   PharmacyDTO,
   SCHOOL_WORK_NOTE,
   SearchParams,
@@ -224,6 +226,47 @@ export async function convertSearchResultsToResponse(
     getChartDataResponse = updatedChartData.chartDataResponse;
     if (updatedChartData.resourceMapped) chartDataResources.push(resource);
   });
+
+  if (getChartDataResponse.cptCodes?.length && oystehr) {
+    // Build procedure ID → MA ID map from partOf references
+    const procedureMaIdMap = new Map<string, string>();
+    resources.forEach((r) => {
+      if (r.resourceType === 'Procedure' && r.id) {
+        const proc = r as Procedure;
+        const maRef = proc.partOf?.find((ref) => ref.reference?.startsWith('MedicationAdministration/'));
+        if (maRef?.reference) {
+          procedureMaIdMap.set(r.id, maRef.reference.replace('MedicationAdministration/', ''));
+        }
+      }
+    });
+
+    if (procedureMaIdMap.size > 0) {
+      const maIds = [...new Set(procedureMaIdMap.values())];
+      const maBundle = await oystehr.fhir.search<MedicationAdministration>({
+        resourceType: 'MedicationAdministration',
+        params: [{ name: '_id', value: maIds.join(',') }],
+      });
+      const maMap = new Map<string, MedicationAdministration>();
+      maBundle.unbundle().forEach((ma) => {
+        if (ma.id) maMap.set(ma.id, ma);
+      });
+
+      const procedureNdcMap = new Map<string, string>();
+      procedureMaIdMap.forEach((maId, procedureId) => {
+        const ma = maMap.get(maId);
+        const med = ma ? getMedicationFromMA(ma) : undefined;
+        const ndc = med ? getNdcCodeFromMedication(med) : undefined;
+        if (ndc) procedureNdcMap.set(procedureId, ndc);
+      });
+
+      if (procedureNdcMap.size > 0) {
+        getChartDataResponse.cptCodes = getChartDataResponse.cptCodes.map((cpt) => {
+          const ndc = cpt.resourceId ? procedureNdcMap.get(cpt.resourceId) : undefined;
+          return ndc ? { ...cpt, ndcCode: ndc } : cpt;
+        });
+      }
+    }
+  }
 
   getChartDataResponse = handleCustomDTOExtractions(getChartDataResponse, resources) as GetChartDataResponse;
   if (getChartDataResponse.externalLabResults || getChartDataResponse.inHouseLabResults) {


### PR DESCRIPTION
Removed deduplication logic from assessment additional codes list so now we can add any number of same cpt code. Also added little gray label with NDC code under each cpt if it was created automatically from medication administration. I made this fix to allow few medications with same cpt code be billed with different ndc codes if it occurs.

Initially i was resolving this [issue](https://linear.app/zapehr/issue/OTR-2473/ehr-in-house-medications-ndc-code-is-not-flowing-to-rcm-any-more#comment-295869f6), and here the [thread](https://masslight.slack.com/archives/C082FH08J4F/p1779297370216509) about it