### PR TITLE
allow quick picks to be sorted by something other than value

### DIFF
--- a/apps/ehr/src/features/visits/telemed/components/admin/InsuranceQuickPickPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/InsuranceQuickPickPage.tsx
@@ -35,7 +35,16 @@ export default function InsuranceQuickPickPage(): ReactElement {
     <QuickPickEditor<InsuranceQuickPickData>
       title="Insurance Quick Picks"
       description="Manage common insurance carriers that appear as quick picks when selecting a patient's insurance."
-      columns={[{ label: 'Insurance Name', getValue: (item) => item.name }]}
+      columns={[
+        {
+          label: 'Insurance Name',
+          getValue: (item) => item.name,
+          getSortValue: (item) => {
+            const prefix = `${item.payerId} - `;
+            return item.name.startsWith(prefix) ? item.name.slice(prefix.length) : item.name;
+          },
+        },
+      ]}
       fields={[
         {
           key: 'name',

--- a/apps/ehr/src/features/visits/telemed/components/admin/QuickPickEditor.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/QuickPickEditor.tsx
@@ -29,6 +29,7 @@ import { RoundedButton } from 'src/components/RoundedButton';
 export interface QuickPickEditorColumn<T> {
   label: string;
   getValue: (item: T) => string;
+  getSortValue?: (item: T) => string;
   width?: number;
 }
 
@@ -104,8 +105,9 @@ export default function QuickPickEditor<T extends { id?: string }>({
   const sortedItems = useMemo(() => {
     const firstCol = columns[0];
     if (!firstCol) return items;
+    const getSortValue = firstCol.getSortValue ?? firstCol.getValue;
     return [...items].sort((a, b) =>
-      firstCol.getValue(a).localeCompare(firstCol.getValue(b), undefined, { sensitivity: 'base' })
+      getSortValue(a).localeCompare(getSortValue(b), undefined, { sensitivity: 'base' })
     );
   }, [items, columns]);
 

--- a/apps/ehr/tests/component/QuickPickEditor.test.tsx
+++ b/apps/ehr/tests/component/QuickPickEditor.test.tsx
@@ -134,6 +134,32 @@ describe('QuickPickEditor', () => {
       const names = dataRows.map((row) => row.querySelector('td')?.textContent);
       expect(names).toEqual(['Aspirin', 'Ibuprofen', 'Penicillin']);
     });
+
+    it('should sort by getSortValue when provided, while displaying getValue', async () => {
+      const sortColumns: QuickPickEditorColumn<MockItem>[] = [
+        {
+          label: 'Name',
+          getValue: (item) => item.name,
+          getSortValue: (item) => item.name.split(' - ')[1] ?? item.name,
+        },
+      ];
+      mockFetchItems.mockResolvedValue([
+        { id: '1', name: 'prefix1 - value 1' },
+        { id: '2', name: 'prefix2 - value 3' },
+        { id: '3', name: 'prefix3 - value 2' },
+      ]);
+
+      render(<QuickPickEditor {...defaultProps} columns={sortColumns} />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByText('prefix3 - value 2')).toBeInTheDocument();
+      });
+
+      const rows = screen.getAllByRole('row');
+      const dataRows = rows.slice(1);
+      const names = dataRows.map((row) => row.querySelector('td')?.textContent);
+      expect(names).toEqual(['prefix1 - value 1', 'prefix3 - value 2', 'prefix2 - value 3']);
+    });
   });
 
   describe('add dialog', () => {


### PR DESCRIPTION
the insurance quick picks were sorted by their ids, not by their names