### PR TITLE
OTR-628: Add intake & provider assignment to tracking board

### DIFF
--- a/apps/ehr/src/components/AppointmentTable.tsx
+++ b/apps/ehr/src/components/AppointmentTable.tsx
@@ -22,6 +22,7 @@ import {
   OrdersForTrackingBoardTable,
 } from 'utils';
 import { dataTestIds } from '../constants/data-test-ids';
+import { useGetEmployees } from '../features/visits/shared/hooks/useGetEmployees';
 import { AppointmentsStatusChipsCount } from './AppointmentStatusChipsCount';
 import AppointmentTableHeader from './AppointmentTableHeader';
 import AppointmentTableRow from './AppointmentTableRow';
@@ -49,6 +50,15 @@ export default function AppointmentTable({
   const theme = useTheme();
   const [collapseWaiting, setCollapseWaiting] = useState<boolean>(false);
   const [collapseExam, setCollapseExam] = useState<boolean>(false);
+
+  // Intake/provider assignment is only editable on the in-office tab, so only fetch the (rarely
+  // changing) employee lists there. Discharged/Cancelled render the names read-only from the
+  // appointment's participants, so they don't need this list.
+  const { data: employees, isLoading: employeesLoading } = useGetEmployees({
+    enabled: tab === ApptTab['in-office'],
+  });
+  const intakeOptions = employees?.nonProviders ?? [];
+  const providerOptions = employees?.providers ?? [];
 
   const {
     inHouseLabOrdersByAppointmentId,
@@ -145,6 +155,9 @@ export default function AppointmentTable({
                             tab={tab}
                             table={'waiting-room'}
                             orders={ordersForAppointment(appointment.id, appointment.encounterId)}
+                            intakeOptions={intakeOptions}
+                            providerOptions={providerOptions}
+                            employeesLoading={employeesLoading}
                           />
                         );
                       })}
@@ -161,6 +174,9 @@ export default function AppointmentTable({
                       tab={tab}
                       vitals={vitalsForAppointment(appointment)}
                       orders={ordersForAppointment(appointment.id, appointment.encounterId)}
+                      intakeOptions={intakeOptions}
+                      providerOptions={providerOptions}
+                      employeesLoading={employeesLoading}
                     />
                   );
                 })
@@ -216,6 +232,9 @@ export default function AppointmentTable({
                           tab={tab}
                           table="in-exam"
                           orders={ordersForAppointment(appointment.id, appointment.encounterId)}
+                          intakeOptions={intakeOptions}
+                          providerOptions={providerOptions}
+                          employeesLoading={employeesLoading}
                         />
                       );
                     })}

--- a/apps/ehr/src/components/AppointmentTableHeader.tsx
+++ b/apps/ehr/src/components/AppointmentTableHeader.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from 'react';
 import {
   ACTION_WIDTH_MIN,
   CHAT_WIDTH_MIN,
+  INTAKE_AND_PROVIDER_WIDTH_MIN,
   NOTES_WIDTH_MIN,
   PATIENT_AND_REASON_WIDTH_MIN,
   PROVIDER_WIDTH_MIN,
@@ -46,9 +47,9 @@ export default function AppointmentTableHeader({ tab, table }: AppointmentTableH
             </Typography>
           </TableCell>
         )}
-        <TableCell sx={{ width: PROVIDER_WIDTH_MIN }}>
-          <Typography variant="subtitle2" sx={{ fontSize: '14px', fontWeight: 600 }}>
-            Provider
+        <TableCell sx={{ width: tab === ApptTab.prebooked ? PROVIDER_WIDTH_MIN : INTAKE_AND_PROVIDER_WIDTH_MIN }}>
+          <Typography variant="subtitle2" sx={{ fontSize: '14px', fontWeight: 600, whiteSpace: 'nowrap' }}>
+            {tab === ApptTab.prebooked ? 'Provider' : 'Intake & Provider'}
           </Typography>
         </TableCell>
         {((tab === ApptTab['in-office'] && table === 'in-exam') || tab === ApptTab.completed) && (

--- a/apps/ehr/src/components/AppointmentTablePractitionerSelect.tsx
+++ b/apps/ehr/src/components/AppointmentTablePractitionerSelect.tsx
@@ -1,0 +1,93 @@
+import { Autocomplete, Skeleton, Stack, TextField, Typography } from '@mui/material';
+import { Coding, Encounter } from 'fhir/r4b';
+import { enqueueSnackbar } from 'notistack';
+import { ReactElement, useMemo } from 'react';
+import { ProviderDetails } from 'utils';
+import { usePractitionerActions } from '../features/visits/shared/hooks/usePractitioner';
+
+interface AppointmentTablePractitionerSelectProps {
+  /** Short prefix rendered before the input, e.g. "In:" or "Pr:". */
+  label: string;
+  options: ProviderDetails[];
+  selectedPractitionerId?: string;
+  encounter: Encounter;
+  /** FHIR participant role coding identifying which assignment this controls (Admitter / Attender). */
+  practitionerType: Coding[];
+  isLoadingOptions: boolean;
+  /** Called after a successful assignment so the tracking board can refresh. */
+  onAssigned: () => void;
+  dataTestId?: string;
+}
+
+/**
+ * Searchable, auto-complete practitioner picker used on the tracking board to assign intake staff
+ * and providers to a visit. Assignments are persisted to the encounter via {@link usePractitionerActions}
+ * (the same mechanism used by the chart header), so selections stay in sync with the progress note.
+ */
+export default function AppointmentTablePractitionerSelect({
+  label,
+  options,
+  selectedPractitionerId,
+  encounter,
+  practitionerType,
+  isLoadingOptions,
+  onAssigned,
+  dataTestId,
+}: AppointmentTablePractitionerSelectProps): ReactElement {
+  const { isEncounterUpdatePending, handleUpdatePractitioner } = usePractitionerActions(
+    encounter,
+    'start',
+    practitionerType
+  );
+
+  const sortedOptions = useMemo(
+    () => [...options].sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase())),
+    [options]
+  );
+
+  const selectedOption = useMemo(
+    () => sortedOptions.find((option) => option.practitionerId === selectedPractitionerId) ?? null,
+    [sortedOptions, selectedPractitionerId]
+  );
+
+  const handleChange = async (practitionerId: string): Promise<void> => {
+    try {
+      await handleUpdatePractitioner(practitionerId);
+      onAssigned();
+    } catch (error: any) {
+      console.error(error?.message ?? error);
+      enqueueSnackbar('An error occurred while updating the assignment. Please try again.', {
+        variant: 'error',
+      });
+    }
+  };
+
+  return (
+    <Stack direction="row" spacing={0.5} alignItems="center" sx={{ width: '100%' }}>
+      <Typography sx={{ fontSize: 14, color: 'text.secondary', whiteSpace: 'nowrap' }}>{label}</Typography>
+      {isLoadingOptions ? (
+        <Skeleton sx={{ width: '100%', minWidth: 80 }} animation="wave" />
+      ) : (
+        <Autocomplete
+          options={sortedOptions}
+          getOptionLabel={(option) => option.name}
+          isOptionEqualToValue={(option, value) => option.practitionerId === value.practitionerId}
+          value={selectedOption}
+          disabled={isEncounterUpdatePending}
+          fullWidth
+          size="small"
+          // Selecting always (re)assigns; clearing is intentionally a no-op so a visit can't be left
+          // unassigned from here — matching the chart header behaviour.
+          onChange={(_event, newValue) => {
+            if (newValue) {
+              void handleChange(newValue.practitionerId);
+            }
+          }}
+          renderInput={(params) => (
+            <TextField {...params} variant="standard" placeholder="Select" data-testid={dataTestId} />
+          )}
+        />
+      )}
+    </Stack>
+  );
+}

--- a/apps/ehr/src/components/AppointmentTablePractitionerSelect.tsx
+++ b/apps/ehr/src/components/AppointmentTablePractitionerSelect.tsx
@@ -1,7 +1,7 @@
 import { Autocomplete, Skeleton, Stack, TextField, Typography } from '@mui/material';
 import { Coding, Encounter } from 'fhir/r4b';
 import { enqueueSnackbar } from 'notistack';
-import { ReactElement, useMemo } from 'react';
+import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { ProviderDetails } from 'utils';
 import { usePractitionerActions } from '../features/visits/shared/hooks/usePractitioner';
 
@@ -45,16 +45,31 @@ export default function AppointmentTablePractitionerSelect({
     [options]
   );
 
+  // The board list (`selectedPractitionerId`) is refetched fire-and-forget after assignment, so it lags
+  // behind the mutation. Track the just-selected id optimistically and display it until the props catch up,
+  // otherwise the select would briefly snap back to the previous practitioner before the new one appears.
+  const [pendingPractitionerId, setPendingPractitionerId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (pendingPractitionerId && selectedPractitionerId === pendingPractitionerId) {
+      setPendingPractitionerId(null);
+    }
+  }, [selectedPractitionerId, pendingPractitionerId]);
+
+  const effectivePractitionerId = pendingPractitionerId ?? selectedPractitionerId;
+
   const selectedOption = useMemo(
-    () => sortedOptions.find((option) => option.practitionerId === selectedPractitionerId) ?? null,
-    [sortedOptions, selectedPractitionerId]
+    () => sortedOptions.find((option) => option.practitionerId === effectivePractitionerId) ?? null,
+    [sortedOptions, effectivePractitionerId]
   );
 
   const handleChange = async (practitionerId: string): Promise<void> => {
+    setPendingPractitionerId(practitionerId);
     try {
       await handleUpdatePractitioner(practitionerId);
       onAssigned();
     } catch (error: any) {
+      setPendingPractitionerId(null);
       console.error(error?.message ?? error);
       enqueueSnackbar('An error occurred while updating the assignment. Please try again.', {
         variant: 'error',
@@ -71,6 +86,8 @@ export default function AppointmentTablePractitionerSelect({
         <Autocomplete
           options={sortedOptions}
           getOptionLabel={(option) => option.name}
+          // Practitioners can share a display name, so key on the id to avoid duplicate React keys.
+          getOptionKey={(option) => option.practitionerId}
           isOptionEqualToValue={(option, value) => option.practitionerId === value.practitionerId}
           value={selectedOption}
           disabled={isEncounterUpdatePending}

--- a/apps/ehr/src/components/AppointmentTableRow.tsx
+++ b/apps/ehr/src/components/AppointmentTableRow.tsx
@@ -54,6 +54,7 @@ import {
   NON_LOS_STATUSES,
   OrdersForTrackingBoardRow,
   PRACTITIONER_CODINGS,
+  ProviderDetails,
   ROOM_EXTENSION_URL,
   VisitStatusHistoryEntry,
   VisitStatusWithoutUnknown,
@@ -74,6 +75,7 @@ import { useApiClients } from '../hooks/useAppClients';
 import useEvolveUser from '../hooks/useEvolveUser';
 import { useSupportPhonesMap } from '../hooks/useLocationSupportPhones';
 import AppointmentNote from './AppointmentNote';
+import AppointmentTablePractitionerSelect from './AppointmentTablePractitionerSelect';
 import AppointmentTableRowMobile from './AppointmentTableRowMobile';
 import { ApptTab } from './AppointmentTabs';
 import GoToButton from './GoToButton';
@@ -93,6 +95,12 @@ interface AppointmentTableRowProps {
   orders: OrdersForTrackingBoardRow;
   vitals?: GetVitalsResponseData;
   table?: 'waiting-room' | 'in-exam';
+  /** Intake-staff options for the editable "Intake & Provider" column (in-office tab). */
+  intakeOptions?: ProviderDetails[];
+  /** Provider options for the editable "Intake & Provider" column (in-office tab). */
+  providerOptions?: ProviderDetails[];
+  /** Whether the intake/provider option lists are still loading. */
+  employeesLoading?: boolean;
 }
 
 const linkStyle = {
@@ -184,6 +192,9 @@ export default function AppointmentTableRow({
   orders,
   vitals,
   table,
+  intakeOptions,
+  providerOptions,
+  employeesLoading,
 }: AppointmentTableRowProps): ReactElement | null {
   const { oystehr, oystehrZambda } = useApiClients();
   const apiClient = useOystehrAPIClient();
@@ -566,6 +577,14 @@ export default function AppointmentTableRow({
   const primaryAction = getTrackingBoardPrimaryAction(appointment.status, { isVirtualVisit: isVirtual(appointment) });
   const assignedIntakePerformerId = getAdmitterPractitionerId(encounter);
   const assignedProviderId = getAttendingPractitionerId(encounter);
+  // Read-only display (Discharged/Cancelled tabs) uses the names resolved on the appointment's
+  // participants so we don't need to fetch the employee list on those tabs.
+  const assignedIntakeName = appointment.participants?.admitter
+    ? `${appointment.participants.admitter.firstName} ${appointment.participants.admitter.lastName}`.trim()
+    : '';
+  const assignedProviderName = appointment.participants?.attender
+    ? `${appointment.participants.attender.firstName} ${appointment.participants.attender.lastName}`.trim()
+    : '';
 
   const handleStatusAction = async (
     updatedStatus: VisitStatusWithoutUnknown,
@@ -982,7 +1001,37 @@ export default function AppointmentTableRow({
         </TableCell>
       )}
       <TableCell sx={{ verticalAlign: 'center' }}>
-        <Typography sx={{ fontSize: 14, display: 'inline' }}>{appointment.provider}</Typography>
+        {tab === ApptTab.prebooked ? (
+          <Typography sx={{ fontSize: 14, display: 'inline' }}>{appointment.provider}</Typography>
+        ) : tab === ApptTab['in-office'] ? (
+          <Stack spacing={0.5} sx={{ minWidth: 150 }}>
+            <AppointmentTablePractitionerSelect
+              label="In:"
+              options={intakeOptions ?? []}
+              selectedPractitionerId={assignedIntakePerformerId}
+              encounter={encounter}
+              practitionerType={PRACTITIONER_CODINGS.Admitter}
+              isLoadingOptions={!!employeesLoading}
+              onAssigned={updateAppointments}
+              dataTestId={dataTestIds.dashboard.tableRowIntakeInput(appointment.id)}
+            />
+            <AppointmentTablePractitionerSelect
+              label="Pr:"
+              options={providerOptions ?? []}
+              selectedPractitionerId={assignedProviderId}
+              encounter={encounter}
+              practitionerType={PRACTITIONER_CODINGS.Attender}
+              isLoadingOptions={!!employeesLoading}
+              onAssigned={updateAppointments}
+              dataTestId={dataTestIds.dashboard.tableRowProviderInput(appointment.id)}
+            />
+          </Stack>
+        ) : (
+          <Stack spacing={0.5} sx={{ minWidth: 150 }}>
+            <Typography sx={{ fontSize: 14 }}>In: {assignedIntakeName || '—'}</Typography>
+            <Typography sx={{ fontSize: 14 }}>Pr: {assignedProviderName || '—'}</Typography>
+          </Stack>
+        )}
       </TableCell>
       {((tab === ApptTab['in-office'] && table === 'in-exam') || tab === ApptTab.completed) && (
         <TableCell sx={{ verticalAlign: 'center' }}>

--- a/apps/ehr/src/constants/data-test-ids.ts
+++ b/apps/ehr/src/constants/data-test-ids.ts
@@ -36,6 +36,8 @@ export const dataTestIds = {
     loadingIndicator: 'loading-indicator',
     tableRowWrapper: (appointmentId: string) => `appointments-table-row-${appointmentId}`,
     tableRowStatus: (appointmentId: string) => `appointments-table-row-status-${appointmentId}`,
+    tableRowIntakeInput: (appointmentId: string) => `appointments-table-row-intake-input-${appointmentId}`,
+    tableRowProviderInput: (appointmentId: string) => `appointments-table-row-provider-input-${appointmentId}`,
     inOfficeTab: 'in-office-tab',
     groupSelect: 'group-select',
     dischargedTab: 'discharged-tab',

--- a/apps/ehr/src/constants/index.ts
+++ b/apps/ehr/src/constants/index.ts
@@ -42,6 +42,7 @@ export const TIME_WIDTH_MIN = '140px';
 export const PATIENT_AND_REASON_WIDTH_MIN = '300px';
 export const ROOM_WIDTH_MIN = '120px';
 export const PROVIDER_WIDTH_MIN = '140px';
+export const INTAKE_AND_PROVIDER_WIDTH_MIN = '200px';
 export const VISIT_ICONS_WIDTH_MIN = '160px';
 export const VITALS_ICON_WIDTH_MIN = '90px';
 export const NOTES_WIDTH_MIN = '220px';

--- a/apps/ehr/src/features/visits/in-person/components/Header.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/Header.tsx
@@ -21,7 +21,6 @@ import {
 } from '@mui/material';
 import { TypographyOptions } from '@mui/material/styles/createTypography';
 import { styled } from '@mui/system';
-import { useQuery } from '@tanstack/react-query';
 import { DateTime } from 'luxon';
 import { enqueueSnackbar } from 'notistack';
 import { ReactElement, useEffect, useState } from 'react';
@@ -45,18 +44,17 @@ import {
   isInPersonAppointment,
   PaymentVariant,
   PRACTITIONER_CODINGS,
-  ProviderDetails,
   VisitStatusLabel,
   VitalFieldNames,
   type VitalsWeightObservationDTO,
 } from 'utils';
-import { getEmployees } from '../../../../api/api';
 import { dataTestIds } from '../../../../constants/data-test-ids';
 import { useApiClients } from '../../../../hooks/useAppClients';
 import { ProfileAvatar } from '../../shared/components/ProfileAvatar';
 import { useGetHistoricalVitals, useGetVitals } from '../../shared/components/vitals/hooks/useGetVitals';
 import { useChartFields } from '../../shared/hooks/useChartFields';
 import { useGetAppointmentAccessibility } from '../../shared/hooks/useGetAppointmentAccessibility';
+import { useGetEmployees } from '../../shared/hooks/useGetEmployees';
 import { useOystehrAPIClient } from '../../shared/hooks/useOystehrAPIClient';
 import { usePractitionerActions } from '../../shared/hooks/usePractitioner';
 import { useAppointmentData, useChartData } from '../../shared/stores/appointment/appointment.store';
@@ -334,44 +332,7 @@ export const Header = (): JSX.Element => {
 
   const { oystehrZambda } = useApiClients();
 
-  const { data: employees, isLoading: employeesIsLoading } = useQuery({
-    queryKey: ['progress-note-header-employees'],
-    queryFn: async () => {
-      if (!oystehrZambda) return null;
-      const getEmployeesRes = await getEmployees(oystehrZambda, { lite: true });
-      const activeEmployees = getEmployeesRes.employees.filter((employee) => employee.status === 'Active');
-      const providers = activeEmployees.filter((employee) => employee.isProvider && !employee.isCustomerSupport);
-      const formattedProviders: ProviderDetails[] = providers
-        .map((prov) => {
-          const id = prov.profile.split('/')[1];
-          return {
-            practitionerId: id,
-            name: `${prov.firstName} ${prov.lastName}`.trim(),
-          };
-        })
-        .filter((prov) => prov.name);
-
-      // TODO: remove this once we have nurses role
-      // const nonProviders = getEmployeesRes.employees.filter((employee) => !employee.isProvider);
-      const nonProviders = activeEmployees.filter((employee) => !employee.isCustomerSupport);
-      const formattedNonProviders: ProviderDetails[] = nonProviders
-        .map((prov) => {
-          const id = prov.profile.split('/')[1];
-          return {
-            practitionerId: id,
-            name: `${prov.firstName} ${prov.lastName}`.trim(),
-          };
-        })
-        .filter((prov) => prov.name);
-      return {
-        providers: formattedProviders,
-        nonProviders: formattedNonProviders,
-      };
-    },
-    enabled: !!oystehrZambda,
-    // Employees rarely change — cache across navigations to keep the header fast.
-    staleTime: 5 * 60 * 1000,
-  });
+  const { data: employees, isLoading: employeesIsLoading } = useGetEmployees();
 
   if (!employeesIsLoading && oystehrZambda && !employees) {
     return <Box sx={{ padding: '16px' }}>There must be some employees registered to use charting.</Box>;

--- a/apps/ehr/src/features/visits/shared/hooks/useGetEmployees.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useGetEmployees.ts
@@ -1,0 +1,58 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { ProviderDetails } from 'utils';
+import { getEmployees } from '../../../../api/api';
+import { useApiClients } from '../../../../hooks/useAppClients';
+
+export interface EmployeesForAssignment {
+  /** Active employees flagged as providers — used to populate the "Provider" assignment list. */
+  providers: ProviderDetails[];
+  /** Active, non-customer-support employees — used to populate the "Intake" assignment list. */
+  nonProviders: ProviderDetails[];
+}
+
+const toProviderDetails = (employee: { profile: string; firstName: string; lastName: string }): ProviderDetails => ({
+  practitionerId: employee.profile.split('/')[1],
+  name: `${employee.firstName} ${employee.lastName}`.trim(),
+});
+
+/**
+ * Fetches the intake-staff and provider lists used for assigning practitioners to an encounter.
+ *
+ * Shared by the chart header and the tracking board so both surfaces display the exact same lists.
+ * Uses a stable query key + long stale time so the (rarely-changing) employee list is fetched once
+ * and reused across navigations and across every tracking-board row.
+ */
+export const useGetEmployees = (options?: {
+  enabled?: boolean;
+}): UseQueryResult<EmployeesForAssignment | null, Error> => {
+  const { oystehrZambda } = useApiClients();
+
+  return useQuery({
+    queryKey: ['progress-note-header-employees'],
+    queryFn: async () => {
+      if (!oystehrZambda) return null;
+      const getEmployeesRes = await getEmployees(oystehrZambda, { lite: true });
+      const activeEmployees = getEmployeesRes.employees.filter((employee) => employee.status === 'Active');
+
+      const formattedProviders: ProviderDetails[] = activeEmployees
+        .filter((employee) => employee.isProvider && !employee.isCustomerSupport)
+        .map(toProviderDetails)
+        .filter((prov) => prov.name);
+
+      // TODO: remove this once we have nurses role
+      // const nonProviders = getEmployeesRes.employees.filter((employee) => !employee.isProvider);
+      const formattedNonProviders: ProviderDetails[] = activeEmployees
+        .filter((employee) => !employee.isCustomerSupport)
+        .map(toProviderDetails)
+        .filter((prov) => prov.name);
+
+      return {
+        providers: formattedProviders,
+        nonProviders: formattedNonProviders,
+      };
+    },
+    enabled: !!oystehrZambda && (options?.enabled ?? true),
+    // Employees rarely change — cache across navigations to keep the UI fast.
+    staleTime: 5 * 60 * 1000,
+  });
+};


### PR DESCRIPTION
Add editable Intake/Provider auto-complete dropdowns to the in-office (Active) tracking board tab and read-only display to the Discharged and Cancelled tabs. Assignments persist to the encounter via the same mechanism the chart header uses, so selections stay in sync with the progress note.

- Extract the employee-list fetch into a shared useGetEmployees hook used by both the chart header and the tracking board so both show the same intake-staff and provider lists.
- Add AppointmentTablePractitionerSelect: a searchable, auto-complete picker bound to the Admitter/Attender encounter participant roles.
- Replace the single "Provider" column with "Intake & Provider" on the in-office/discharged/cancelled tabs; prebooked keeps the existing provider display.
