### PR TITLE
Feat(global temp): include in-office procedures in global templates

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
+++ b/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
@@ -35,6 +35,7 @@ import {
   TEMPLATE_SECTIONS_NO_OVERWRITE,
   TemplateCptCodeInfo,
   TemplateInHouseLabPlanDetail,
+  TemplateProcedurePlan,
   TemplateSectionAction,
   TemplateSectionActions,
   TemplateSectionDescriptor,
@@ -149,6 +150,17 @@ const getSectionSummary = (sections: AdminGetTemplateDetailOutput['sections'], k
       const missing = sections.inHouseLabs.filter((p) => p.missing).length;
       return missing > 0 ? `${summary} (${missing} unavailable)` : summary;
     }
+    case 'procedures': {
+      // Use whatever short label we have for each plan: procedureType code if
+      // it's there, otherwise fall back to the first CPT code so the summary
+      // still says something concrete. "Unnamed procedure" is a last resort for
+      // very sparse template entries.
+      const labels = sections.procedures
+        .slice(0, NUM_ITEMS_IN_SECTION_TO_SHOW)
+        .map((p) => p.procedureType ?? p.cptCodes[0]?.code ?? 'Unnamed procedure');
+      const extra = sections.procedures.length - NUM_ITEMS_IN_SECTION_TO_SHOW;
+      return extra > 0 ? `${labels.join(', ')} +${extra} more` : labels.join(', ');
+    }
     default:
       return '';
   }
@@ -176,6 +188,8 @@ const sectionHasContent = (sections: AdminGetTemplateDetailOutput['sections'], k
       return Boolean(sections.emCode);
     case 'inHouseLabs':
       return sections.inHouseLabs.length > 0;
+    case 'procedures':
+      return sections.procedures.length > 0;
     default:
       return false;
   }
@@ -333,6 +347,8 @@ const SectionPreview: React.FC<{
       return sections.emCode ? <CodeList items={[sections.emCode]} /> : null;
     case 'inHouseLabs':
       return <InHouseLabPlansList plans={sections.inHouseLabs} />;
+    case 'procedures':
+      return <ProcedurePlansList plans={sections.procedures} />;
     default:
       return null;
   }
@@ -395,6 +411,90 @@ const InHouseLabPlansList: React.FC<{ plans: TemplateInHouseLabPlanDetail[] }> =
     ))}
   </Stack>
 );
+
+// Procedure cards show the procedure type as a clear subheading, then a
+// left-indented block of details: labeled CPT and diagnosis lists (with the
+// uppercase-caption section labels the ROS preview uses, so the codes
+// underneath visibly belong to them) and the form-field rows. We only render
+// fields the template actually carried - the procedure form has a lot of
+// optional inputs and a template that didn't fill them in would look noisy
+// with a wall of empty rows.
+const ProcedurePlansList: React.FC<{ plans: TemplateProcedurePlan[] }> = ({ plans }) => (
+  <Stack spacing={2}>
+    {plans.map((plan) => (
+      <Box key={plan.planId}>
+        <Typography variant="subtitle2" sx={{ color: 'text.primary', fontWeight: 600 }}>
+          {plan.procedureType ?? plan.cptCodes[0]?.display ?? plan.cptCodes[0]?.code ?? 'Procedure'}
+        </Typography>
+        <Stack spacing={1} sx={{ mt: 0.5, pl: 2 }}>
+          {plan.cptCodes.length > 0 ? (
+            <Box>
+              <Typography variant="caption" sx={{ color: 'text.secondary', textTransform: 'uppercase' }}>
+                CPT codes
+              </Typography>
+              <CodeList items={plan.cptCodes} />
+            </Box>
+          ) : null}
+          {plan.diagnoses.length > 0 ? (
+            <Box>
+              <Typography variant="caption" sx={{ color: 'text.secondary', textTransform: 'uppercase' }}>
+                Diagnoses
+              </Typography>
+              <CodeList items={plan.diagnoses} />
+            </Box>
+          ) : null}
+          <ProcedurePlanFields plan={plan} />
+        </Stack>
+      </Box>
+    ))}
+  </Stack>
+);
+
+// Picks the procedure form fields that have a value and lays them out as a
+// compact label/value table. Booleans render as Yes/No so the provider doesn't
+// have to interpret 'true'/'false'.
+const ProcedurePlanFields: React.FC<{ plan: TemplateProcedurePlan }> = ({ plan }) => {
+  const yesNo = (v: boolean | undefined): string | undefined => (v === undefined ? undefined : v ? 'Yes' : 'No');
+  const rows: { label: string; value: string }[] = [
+    { label: 'Performer type', value: plan.performerType ?? '' },
+    { label: 'Body site', value: plan.bodySite ?? '' },
+    { label: 'Body side', value: plan.bodySide ?? '' },
+    { label: 'Technique', value: plan.technique.join(', ') },
+    { label: 'Medication used', value: plan.medicationUsed ?? '' },
+    { label: 'Supplies used', value: plan.suppliesUsed ?? '' },
+    { label: 'Specimen sent', value: yesNo(plan.specimenSent) ?? '' },
+    { label: 'Complications', value: plan.complications ?? '' },
+    { label: 'Patient response', value: plan.patientResponse ?? '' },
+    { label: 'Time spent', value: plan.timeSpent ?? '' },
+    { label: 'Documented by', value: plan.documentedBy ?? '' },
+    { label: 'Consent obtained', value: yesNo(plan.consentObtained) ?? '' },
+  ].filter((r) => r.value.length > 0);
+
+  const blocks: { label: string; value: string }[] = [
+    { label: 'Procedure details', value: plan.procedureDetails ?? '' },
+    { label: 'Post-procedure instructions', value: plan.postInstructions ?? '' },
+  ].filter((b) => b.value.length > 0);
+
+  if (rows.length === 0 && blocks.length === 0) return null;
+  // Free-text blocks render the same shape as the row entries - label inline
+  // with the value - but with whiteSpace: 'pre-wrap' so longer multi-line
+  // content still wraps cleanly instead of being forced onto its own line for
+  // one-line values.
+  return (
+    <Stack spacing={0.75}>
+      {rows.map((row) => (
+        <Typography key={row.label} variant="body2" sx={{ color: 'text.primary' }}>
+          <strong>{row.label}:</strong> {row.value}
+        </Typography>
+      ))}
+      {blocks.map((block) => (
+        <Typography key={block.label} variant="body2" sx={{ color: 'text.primary', whiteSpace: 'pre-wrap' }}>
+          <strong>{block.label}:</strong> {block.value}
+        </Typography>
+      ))}
+    </Stack>
+  );
+};
 
 const SectionCard: React.FC<{
   descriptor: TemplateSectionDescriptor;

--- a/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
+++ b/apps/ehr/src/features/visits/shared/components/templates/TemplatePreviewDialog.tsx
@@ -21,7 +21,7 @@ import { useQuery } from '@tanstack/react-query';
 import React, { useEffect, useMemo, useState } from 'react';
 import { getTemplateDetail } from 'src/api/api';
 import { ContainedPrimaryToggleButton } from 'src/components/ContainedPrimaryToggleButton';
-import { formatCptCodeAndModifiersForDisplay } from 'src/helpers/templates';
+import { formatCptCodeAndModifiersForDisplay, getProcedureDisplayFields } from 'src/helpers/templates';
 import { useApiClients } from 'src/hooks/useAppClients';
 import {
   AdminGetTemplateDetailOutput,
@@ -450,46 +450,21 @@ const ProcedurePlansList: React.FC<{ plans: TemplateProcedurePlan[] }> = ({ plan
   </Stack>
 );
 
-// Picks the procedure form fields that have a value and lays them out as a
-// compact label/value table. Booleans render as Yes/No so the provider doesn't
-// have to interpret 'true'/'false'.
+// Renders the procedure form fields as a compact label/value list, with the
+// `multiline` flag selecting whiteSpace: pre-wrap so free-text fields wrap
+// cleanly without being forced onto their own line for short values.
 const ProcedurePlanFields: React.FC<{ plan: TemplateProcedurePlan }> = ({ plan }) => {
-  const yesNo = (v: boolean | undefined): string | undefined => (v === undefined ? undefined : v ? 'Yes' : 'No');
-  const rows: { label: string; value: string }[] = [
-    { label: 'Performer type', value: plan.performerType ?? '' },
-    { label: 'Body site', value: plan.bodySite ?? '' },
-    { label: 'Body side', value: plan.bodySide ?? '' },
-    { label: 'Technique', value: plan.technique.join(', ') },
-    { label: 'Medication used', value: plan.medicationUsed ?? '' },
-    { label: 'Supplies used', value: plan.suppliesUsed ?? '' },
-    { label: 'Specimen sent', value: yesNo(plan.specimenSent) ?? '' },
-    { label: 'Complications', value: plan.complications ?? '' },
-    { label: 'Patient response', value: plan.patientResponse ?? '' },
-    { label: 'Time spent', value: plan.timeSpent ?? '' },
-    { label: 'Documented by', value: plan.documentedBy ?? '' },
-    { label: 'Consent obtained', value: yesNo(plan.consentObtained) ?? '' },
-  ].filter((r) => r.value.length > 0);
-
-  const blocks: { label: string; value: string }[] = [
-    { label: 'Procedure details', value: plan.procedureDetails ?? '' },
-    { label: 'Post-procedure instructions', value: plan.postInstructions ?? '' },
-  ].filter((b) => b.value.length > 0);
-
-  if (rows.length === 0 && blocks.length === 0) return null;
-  // Free-text blocks render the same shape as the row entries - label inline
-  // with the value - but with whiteSpace: 'pre-wrap' so longer multi-line
-  // content still wraps cleanly instead of being forced onto its own line for
-  // one-line values.
+  const fields = getProcedureDisplayFields(plan);
+  if (fields.length === 0) return null;
   return (
     <Stack spacing={0.75}>
-      {rows.map((row) => (
-        <Typography key={row.label} variant="body2" sx={{ color: 'text.primary' }}>
-          <strong>{row.label}:</strong> {row.value}
-        </Typography>
-      ))}
-      {blocks.map((block) => (
-        <Typography key={block.label} variant="body2" sx={{ color: 'text.primary', whiteSpace: 'pre-wrap' }}>
-          <strong>{block.label}:</strong> {block.value}
+      {fields.map((f) => (
+        <Typography
+          key={f.label}
+          variant="body2"
+          sx={{ color: 'text.primary', ...(f.multiline ? { whiteSpace: 'pre-wrap' } : {}) }}
+        >
+          <strong>{f.label}:</strong> {f.value}
         </Typography>
       ))}
     </Stack>

--- a/apps/ehr/src/features/visits/telemed/components/admin/GlobalTemplateDetailPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/GlobalTemplateDetailPage.tsx
@@ -447,6 +447,73 @@ export default function GlobalTemplateDetailPage(): ReactElement {
               <NotIncluded />
             )}
           </SectionCard>
+
+          {/* Procedures */}
+          <SectionCard title="Procedures">
+            {sections.procedures.length > 0 ? (
+              <Stack spacing={2}>
+                {sections.procedures.map((plan) => {
+                  const yesNo = (v: boolean | undefined): string | undefined =>
+                    v === undefined ? undefined : v ? 'Yes' : 'No';
+                  const fields: { label: string; value: string }[] = [
+                    { label: 'Performer type', value: plan.performerType ?? '' },
+                    { label: 'Body site', value: plan.bodySite ?? '' },
+                    { label: 'Body side', value: plan.bodySide ?? '' },
+                    { label: 'Technique', value: plan.technique.join(', ') },
+                    { label: 'Medication used', value: plan.medicationUsed ?? '' },
+                    { label: 'Supplies used', value: plan.suppliesUsed ?? '' },
+                    { label: 'Specimen sent', value: yesNo(plan.specimenSent) ?? '' },
+                    { label: 'Complications', value: plan.complications ?? '' },
+                    { label: 'Patient response', value: plan.patientResponse ?? '' },
+                    { label: 'Time spent', value: plan.timeSpent ?? '' },
+                    { label: 'Documented by', value: plan.documentedBy ?? '' },
+                    { label: 'Consent obtained', value: yesNo(plan.consentObtained) ?? '' },
+                  ].filter((f) => f.value.length > 0);
+                  return (
+                    <Box key={plan.planId}>
+                      <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
+                        {plan.procedureType ?? plan.cptCodes[0]?.display ?? plan.cptCodes[0]?.code ?? 'Procedure'}
+                      </Typography>
+                      {plan.cptCodes.length > 0 ? (
+                        <Typography variant="body2" sx={{ mt: 0.5 }}>
+                          <strong>CPT codes:</strong>{' '}
+                          {plan.cptCodes
+                            .map((c) => {
+                              const label = formatCptCodeAndModifiersForDisplay(c);
+                              return c.display ? `${label} — ${c.display}` : label;
+                            })
+                            .join('; ')}
+                        </Typography>
+                      ) : null}
+                      {plan.diagnoses.length > 0 ? (
+                        <Typography variant="body2">
+                          <strong>Diagnoses:</strong>{' '}
+                          {plan.diagnoses.map((d) => (d.display ? `${d.code} — ${d.display}` : d.code)).join('; ')}
+                        </Typography>
+                      ) : null}
+                      {fields.map((f) => (
+                        <Typography key={f.label} variant="body2">
+                          <strong>{f.label}:</strong> {f.value}
+                        </Typography>
+                      ))}
+                      {plan.procedureDetails ? (
+                        <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                          <strong>Procedure details:</strong> {plan.procedureDetails}
+                        </Typography>
+                      ) : null}
+                      {plan.postInstructions ? (
+                        <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                          <strong>Post-procedure instructions:</strong> {plan.postInstructions}
+                        </Typography>
+                      ) : null}
+                    </Box>
+                  );
+                })}
+              </Stack>
+            ) : (
+              <NotIncluded />
+            )}
+          </SectionCard>
         </Stack>
       </Box>
     </PageContainer>

--- a/apps/ehr/src/features/visits/telemed/components/admin/GlobalTemplateDetailPage.tsx
+++ b/apps/ehr/src/features/visits/telemed/components/admin/GlobalTemplateDetailPage.tsx
@@ -23,7 +23,7 @@ import { getTemplateDetail } from 'src/api/api';
 import { GLOBAL_TEMPLATES_URL } from 'src/App';
 import CustomBreadcrumbs from 'src/components/CustomBreadcrumbs';
 import { QUERY_STALE_TIME } from 'src/constants';
-import { formatCptCodeAndModifiersForDisplay } from 'src/helpers/templates';
+import { formatCptCodeAndModifiersForDisplay, getProcedureDisplayFields } from 'src/helpers/templates';
 import { useApiClients } from 'src/hooks/useAppClients';
 import PageContainer from 'src/layout/PageContainer';
 import {
@@ -452,63 +452,39 @@ export default function GlobalTemplateDetailPage(): ReactElement {
           <SectionCard title="Procedures">
             {sections.procedures.length > 0 ? (
               <Stack spacing={2}>
-                {sections.procedures.map((plan) => {
-                  const yesNo = (v: boolean | undefined): string | undefined =>
-                    v === undefined ? undefined : v ? 'Yes' : 'No';
-                  const fields: { label: string; value: string }[] = [
-                    { label: 'Performer type', value: plan.performerType ?? '' },
-                    { label: 'Body site', value: plan.bodySite ?? '' },
-                    { label: 'Body side', value: plan.bodySide ?? '' },
-                    { label: 'Technique', value: plan.technique.join(', ') },
-                    { label: 'Medication used', value: plan.medicationUsed ?? '' },
-                    { label: 'Supplies used', value: plan.suppliesUsed ?? '' },
-                    { label: 'Specimen sent', value: yesNo(plan.specimenSent) ?? '' },
-                    { label: 'Complications', value: plan.complications ?? '' },
-                    { label: 'Patient response', value: plan.patientResponse ?? '' },
-                    { label: 'Time spent', value: plan.timeSpent ?? '' },
-                    { label: 'Documented by', value: plan.documentedBy ?? '' },
-                    { label: 'Consent obtained', value: yesNo(plan.consentObtained) ?? '' },
-                  ].filter((f) => f.value.length > 0);
-                  return (
-                    <Box key={plan.planId}>
-                      <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
-                        {plan.procedureType ?? plan.cptCodes[0]?.display ?? plan.cptCodes[0]?.code ?? 'Procedure'}
+                {sections.procedures.map((plan) => (
+                  <Box key={plan.planId}>
+                    <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
+                      {plan.procedureType ?? plan.cptCodes[0]?.display ?? plan.cptCodes[0]?.code ?? 'Procedure'}
+                    </Typography>
+                    {plan.cptCodes.length > 0 ? (
+                      <Typography variant="body2" sx={{ mt: 0.5 }}>
+                        <strong>CPT codes:</strong>{' '}
+                        {plan.cptCodes
+                          .map((c) => {
+                            const label = formatCptCodeAndModifiersForDisplay(c);
+                            return c.display ? `${label} — ${c.display}` : label;
+                          })
+                          .join('; ')}
                       </Typography>
-                      {plan.cptCodes.length > 0 ? (
-                        <Typography variant="body2" sx={{ mt: 0.5 }}>
-                          <strong>CPT codes:</strong>{' '}
-                          {plan.cptCodes
-                            .map((c) => {
-                              const label = formatCptCodeAndModifiersForDisplay(c);
-                              return c.display ? `${label} — ${c.display}` : label;
-                            })
-                            .join('; ')}
-                        </Typography>
-                      ) : null}
-                      {plan.diagnoses.length > 0 ? (
-                        <Typography variant="body2">
-                          <strong>Diagnoses:</strong>{' '}
-                          {plan.diagnoses.map((d) => (d.display ? `${d.code} — ${d.display}` : d.code)).join('; ')}
-                        </Typography>
-                      ) : null}
-                      {fields.map((f) => (
-                        <Typography key={f.label} variant="body2">
-                          <strong>{f.label}:</strong> {f.value}
-                        </Typography>
-                      ))}
-                      {plan.procedureDetails ? (
-                        <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
-                          <strong>Procedure details:</strong> {plan.procedureDetails}
-                        </Typography>
-                      ) : null}
-                      {plan.postInstructions ? (
-                        <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
-                          <strong>Post-procedure instructions:</strong> {plan.postInstructions}
-                        </Typography>
-                      ) : null}
-                    </Box>
-                  );
-                })}
+                    ) : null}
+                    {plan.diagnoses.length > 0 ? (
+                      <Typography variant="body2">
+                        <strong>Diagnoses:</strong>{' '}
+                        {plan.diagnoses.map((d) => (d.display ? `${d.code} — ${d.display}` : d.code)).join('; ')}
+                      </Typography>
+                    ) : null}
+                    {getProcedureDisplayFields(plan).map((f) => (
+                      <Typography
+                        key={f.label}
+                        variant="body2"
+                        sx={f.multiline ? { whiteSpace: 'pre-wrap' } : undefined}
+                      >
+                        <strong>{f.label}:</strong> {f.value}
+                      </Typography>
+                    ))}
+                  </Box>
+                ))}
               </Stack>
             ) : (
               <NotIncluded />

--- a/apps/ehr/src/helpers/templates.ts
+++ b/apps/ehr/src/helpers/templates.ts
@@ -1,5 +1,36 @@
-import { TemplateCptCodeInfo } from 'utils';
+import { TemplateCptCodeInfo, TemplateProcedurePlan } from 'utils';
 
 export const formatCptCodeAndModifiersForDisplay = (info: TemplateCptCodeInfo): string => {
   return `${info.code}${info.modifiers.length ? `-${info.modifiers.map((mod) => mod.display).join(',-')}` : ''}`;
+};
+
+export interface ProcedureDisplayField {
+  label: string;
+  value: string;
+  /** Whether the value can span multiple lines and should render with whiteSpace: pre-wrap. */
+  multiline?: boolean;
+}
+
+// Picks the procedure form fields that have a non-empty value, in the order
+// they should display. Used by the apply-template preview dialog and the admin
+// detail page so the two surfaces stay in sync. Booleans render as Yes/No so
+// the provider doesn't have to interpret 'true'/'false'.
+export const getProcedureDisplayFields = (plan: TemplateProcedurePlan): ProcedureDisplayField[] => {
+  const yesNo = (v: boolean | undefined): string | undefined => (v === undefined ? undefined : v ? 'Yes' : 'No');
+  return [
+    { label: 'Performer type', value: plan.performerType ?? '' },
+    { label: 'Body site', value: plan.bodySite ?? '' },
+    { label: 'Body side', value: plan.bodySide ?? '' },
+    { label: 'Technique', value: plan.technique.join(', ') },
+    { label: 'Medication used', value: plan.medicationUsed ?? '' },
+    { label: 'Supplies used', value: plan.suppliesUsed ?? '' },
+    { label: 'Specimen sent', value: yesNo(plan.specimenSent) ?? '' },
+    { label: 'Complications', value: plan.complications ?? '' },
+    { label: 'Patient response', value: plan.patientResponse ?? '' },
+    { label: 'Time spent', value: plan.timeSpent ?? '' },
+    { label: 'Documented by', value: plan.documentedBy ?? '' },
+    { label: 'Consent obtained', value: yesNo(plan.consentObtained) ?? '' },
+    { label: 'Procedure details', value: plan.procedureDetails ?? '', multiline: true },
+    { label: 'Post-procedure instructions', value: plan.postInstructions ?? '', multiline: true },
+  ].filter((f) => f.value.length > 0);
 };

--- a/apps/ehr/tests/component/ApplyTemplate.test.tsx
+++ b/apps/ehr/tests/component/ApplyTemplate.test.tsx
@@ -142,6 +142,28 @@ const mockTemplateDetail = {
         missing: true,
       },
     ],
+    procedures: [
+      {
+        planId: 'proc-1',
+        procedureType: 'Splint application',
+        performerType: 'Provider',
+        bodySite: 'Wrist',
+        bodySide: 'Left',
+        technique: ['Closed reduction'],
+        medicationUsed: 'Lidocaine 1%',
+        suppliesUsed: 'Splint kit',
+        procedureDetails: 'Applied volar splint after reduction.',
+        specimenSent: false,
+        complications: undefined,
+        patientResponse: 'Tolerated well',
+        postInstructions: 'Keep splint dry. Follow up in 1 week.',
+        timeSpent: '15 minutes',
+        documentedBy: 'Provider',
+        consentObtained: true,
+        diagnoses: [{ code: 'S62.001A', display: 'Fracture of left wrist' }],
+        cptCodes: [{ code: '29105', display: 'Application of long arm splint', modifiers: [] }],
+      },
+    ],
   },
 };
 
@@ -449,6 +471,7 @@ describe('ApplyTemplate', () => {
             cptCodes: 'append',
             emCode: 'overwrite',
             inHouseLabs: 'append',
+            procedures: 'append',
           },
         })
       );
@@ -570,6 +593,49 @@ describe('ApplyTemplate', () => {
     });
   });
 
+  it('should render the procedures section and hide Overwrite', async () => {
+    const user = userEvent.setup();
+    render(<ApplyTemplate />, { wrapper: createWrapper() });
+
+    await user.click(await screen.findByLabelText('Select condition'));
+    await user.click(await screen.findByText('Sore Throat'));
+
+    const procCard = await screen.findByTestId('template-section-procedures');
+    // Summary surfaces the procedure type so the user can identify the entry while collapsed.
+    expect(within(procCard).getByText(/Splint application/)).toBeInTheDocument();
+
+    // Procedures are append-or-skip only, like in-house labs.
+    expect(within(procCard).queryByRole('button', { name: 'Overwrite' })).toBeNull();
+    expect(within(procCard).getByRole('button', { name: 'Skip' })).toBeInTheDocument();
+    expect(within(procCard).getByRole('button', { name: 'Append' })).toBeInTheDocument();
+
+    await user.click(within(procCard).getByTestId('template-section-procedures-header'));
+
+    // Expanding shows the linked CPT/diagnosis codes and a few of the form fields.
+    await waitFor(() => {
+      expect(within(procCard).getByText(/29105/)).toBeInTheDocument();
+    });
+    expect(within(procCard).getByText(/S62.001A/)).toBeInTheDocument();
+    expect(within(procCard).getByText(/Wrist/)).toBeInTheDocument();
+    expect(within(procCard).getByText(/Closed reduction/)).toBeInTheDocument();
+  });
+
+  it('should not render the procedures section when the template carries no procedures', async () => {
+    mockGetTemplateDetail.mockResolvedValue({
+      ...mockTemplateDetail,
+      sections: { ...mockTemplateDetail.sections, procedures: [] },
+    });
+    const user = userEvent.setup();
+    render(<ApplyTemplate />, { wrapper: createWrapper() });
+
+    await user.click(await screen.findByLabelText('Select condition'));
+    await user.click(await screen.findByText('Sore Throat'));
+
+    // Other sections still render; the procedures card is suppressed when empty.
+    await screen.findByTestId('template-section-hpi');
+    expect(screen.queryByTestId('template-section-procedures')).toBeNull();
+  });
+
   it('should disable Apply when every section is set to Skip', async () => {
     const user = userEvent.setup();
     mockGetTemplateDetail.mockResolvedValue({
@@ -584,6 +650,7 @@ describe('ApplyTemplate', () => {
         emCode: null,
         mdm: null,
         inHouseLabs: [],
+        procedures: [],
         // Only HPI has content.
       },
     });

--- a/packages/utils/lib/types/data/admin-template.types.ts
+++ b/packages/utils/lib/types/data/admin-template.types.ts
@@ -106,6 +106,41 @@ export interface TemplateInHouseLabPlanDetail {
   missing: boolean;
 }
 
+// Each in-office procedure plan saved on a template captures everything the
+// chart UI's procedure form exposes - the procedure type, body site/side,
+// performer, technique, and the rest of the form's checkbox/dropdown answers -
+// plus the diagnosis and CPT-code links the original procedure carried, so a
+// provider applying the template gets the same documentation skeleton they
+// would by recreating the procedure by hand.
+//
+// Diagnosis and CPT links are resolved into inline {code, display} tuples here
+// so the UI can show "J02.9 - Acute pharyngitis" without having to follow
+// references into the template's other contained resources.
+export interface TemplateProcedurePlan {
+  planId: string;
+  procedureType: string | undefined;
+  performerType: string | undefined;
+  bodySite: string | undefined;
+  bodySide: string | undefined;
+  technique: string[];
+  medicationUsed: string | undefined;
+  suppliesUsed: string | undefined;
+  procedureDetails: string | undefined;
+  specimenSent: boolean | undefined;
+  complications: string | undefined;
+  patientResponse: string | undefined;
+  postInstructions: string | undefined;
+  timeSpent: string | undefined;
+  documentedBy: string | undefined;
+  consentObtained: boolean | undefined;
+  diagnoses: TemplateCodeInfo[];
+  // Carries modifiers alongside the code/display so CPTs with attached modifiers
+  // (e.g. "29105-LT") render the same in the procedure card as in the standalone
+  // CPT Codes section. The shared CodeList component already handles both
+  // TemplateCodeInfo and TemplateCptCodeInfo via isTemplateCptCodeInfo.
+  cptCodes: TemplateCptCodeInfo[];
+}
+
 export interface AdminGetTemplateDetailOutput {
   templateName: string;
   templateId: string;
@@ -124,5 +159,6 @@ export interface AdminGetTemplateDetailOutput {
     emCode: TemplateCodeInfo | null;
     accident: TemplateAccidentInfo | null;
     inHouseLabs: TemplateInHouseLabPlanDetail[];
+    procedures: TemplateProcedurePlan[];
   };
 }

--- a/packages/utils/lib/types/data/apply-template.types.ts
+++ b/packages/utils/lib/types/data/apply-template.types.ts
@@ -10,7 +10,8 @@ export type TemplateSectionKey =
   | 'patientInstructions'
   | 'cptCodes'
   | 'emCode'
-  | 'inHouseLabs';
+  | 'inHouseLabs'
+  | 'procedures';
 
 export type TemplateSectionActions = Partial<Record<TemplateSectionKey, TemplateSectionAction>>;
 
@@ -25,6 +26,7 @@ export const TEMPLATE_SECTION_DEFAULT_ACTIONS: Record<TemplateSectionKey, Templa
   cptCodes: 'append',
   emCode: 'overwrite',
   inHouseLabs: 'append',
+  procedures: 'append',
 };
 
 export const TEMPLATE_SECTIONS_NO_APPEND: ReadonlySet<TemplateSectionKey> = new Set<TemplateSectionKey>([
@@ -49,13 +51,16 @@ export const TEMPLATE_SECTIONS_IN_ORDER: readonly TemplateSectionDescriptor[] = 
   { key: 'cptCodes', label: 'CPT Codes' },
   { key: 'emCode', label: 'E&M Code' },
   { key: 'inHouseLabs', label: 'In-House Lab Orders' },
+  { key: 'procedures', label: 'Procedures' },
 ];
-// In-house lab orders are additive only - replacing existing in-flight orders on
-// an encounter doesn't make sense (specimens, tasks, and results that may already
-// exist for those orders shouldn't be silently destroyed), so we constrain the
-// section to Skip or Append.
+// In-house lab orders and in-office Procedures are additive only - replacing
+// existing entries on an encounter is destructive (in-house labs may have
+// specimens/results; procedures carry post-facto documentation a provider
+// shouldn't lose by clicking the wrong toggle), so we constrain both sections
+// to Skip or Append.
 export const TEMPLATE_SECTIONS_NO_OVERWRITE: ReadonlySet<TemplateSectionKey> = new Set<TemplateSectionKey>([
   'inHouseLabs',
+  'procedures',
 ]);
 
 export interface ApplyTemplateZambdaInput {

--- a/packages/zambdas/src/ehr/admin-create-template/index.ts
+++ b/packages/zambdas/src/ehr/admin-create-template/index.ts
@@ -158,6 +158,17 @@ const performEffect = async (
     isValidInHouseLabServiceRequest(resource)
   );
 
+  // Capture in-office procedure ServiceRequests for the same reason as in-house
+  // labs: chart-data procedures are identified by their 'procedure' meta tag
+  // rather than by being included in TEMPLATE_TAG_SYSTEMS below, so the tag
+  // filter would otherwise drop them. delete-chart-data marks procedures as
+  // status='entered-in-error' (the chart UI hides them by status); the inclusion
+  // list below keeps those out so a saved template doesn't carry forward a
+  // procedure the provider had already deleted.
+  const procedureOrders = encounterBundle.filter((resource): resource is ServiceRequest =>
+    isValidProcedureServiceRequest(resource)
+  );
+
   // Filter to only resources relevant to template sections
   const diagnosesRefFromEncounterSet = new Set(
     oldEncounter.diagnosis?.map((dx) => dx.condition.reference).filter((elm) => elm !== undefined) ?? []
@@ -227,6 +238,64 @@ const performEffect = async (
           {
             system: chartDataTagSystem('in-house-lab-template-plan'),
             code: 'in-house-lab-template-plan',
+          },
+        ],
+      },
+    };
+    listToCreate.contained!.push(plan);
+    listToCreate.entry!.push({
+      item: { reference: `#${planId}` },
+    });
+  }
+
+  // Materialize each captured in-office procedure as a "plan" ServiceRequest on
+  // the template. Unlike in-house labs (which re-run the live create-order flow
+  // at apply time from a small input set), procedures save the full procedure
+  // ServiceRequest payload - the category/performerType/bodySite plus the dozen
+  // extensions the procedure form fills in - because that data is what makes
+  // each procedure entry unique and there's no canonical definition behind it
+  // to defer to.
+  //
+  // Diagnosis (reasonReference) and CPT (supportingInfo) cross-refs are remapped
+  // through the oldIdToNewIdMap so the plan points at the template's contained
+  // Conditions / CPT Procedures (which were captured above by the diagnoses
+  // and CPT-code sections). At apply time, those refs get rewritten again to
+  // the new live resources within a single FHIR transaction.
+  const procedurePlanMetaTag = chartDataTagSystem('procedure-template-plan');
+  for (const order of procedureOrders) {
+    const planId = uuidV4();
+    const remapReference = (ref: { reference?: string } | undefined): { reference: string } | null => {
+      const oldId = ref?.reference?.split('/')[1];
+      if (!oldId) return null;
+      const newId = oldIdToNewIdMap.get(oldId);
+      if (!newId) return null; // referenced resource isn't in the template (filtered out earlier)
+      const [resourceType] = ref!.reference!.split('/');
+      return { reference: `${resourceType}/${newId}` };
+    };
+    const remappedReasonReferences = (order.reasonReference ?? [])
+      .map(remapReference)
+      .filter((r): r is { reference: string } => r !== null);
+    const remappedSupportingInfo = (order.supportingInfo ?? [])
+      .map(remapReference)
+      .filter((r): r is { reference: string } => r !== null);
+
+    const plan: ServiceRequest = {
+      resourceType: 'ServiceRequest',
+      id: planId,
+      status: 'active',
+      intent: 'plan',
+      subject: { reference: `#${stubPatient.id}` },
+      ...(order.category ? { category: order.category } : {}),
+      ...(order.performerType ? { performerType: order.performerType } : {}),
+      ...(order.bodySite ? { bodySite: order.bodySite } : {}),
+      ...(order.extension && order.extension.length > 0 ? { extension: order.extension } : {}),
+      ...(remappedReasonReferences.length > 0 ? { reasonReference: remappedReasonReferences } : {}),
+      ...(remappedSupportingInfo.length > 0 ? { supportingInfo: remappedSupportingInfo } : {}),
+      meta: {
+        tag: [
+          {
+            system: procedurePlanMetaTag,
+            code: 'procedure-template-plan',
           },
         ],
       },
@@ -355,6 +424,26 @@ export const isValidInHouseLabServiceRequest = (resource: TemplateEncounterResou
     !resourceHasTagSystem(resource, REPEAT_TEST_ORDER_DETAIL_TAG_CONFIG.system) && // we don't want repeat tests included
     !resource.basedOn?.some((basedOn) => basedOn.reference?.startsWith('ServiceRequest/')) && // we don't want reflex tests included either
     resource.instantiatesCanonical?.some((canonical) => canonical.startsWith(AD_CANONICAL_URL_BASE)) === true &&
+    TEMPLATE_INCLUDABLE_SR_STATUSES.has((resource as ServiceRequest).status)
+  );
+};
+
+// Chart-data procedures are stored as ServiceRequest with the 'procedure' meta
+// tag (createProcedureServiceRequest in shared/chart-data uses
+// fillMeta('procedure', 'procedure')). delete-chart-data patches status to
+// 'entered-in-error', and the chart UI hides revoked/entered-in-error
+// procedures - we mirror that filtering here so deleted procedures don't leak
+// into templates.
+export const isValidProcedureServiceRequest = (resource: TemplateEncounterResource): boolean => {
+  if (resource.resourceType !== 'ServiceRequest') return false;
+  const TEMPLATE_INCLUDABLE_SR_STATUSES = new Set<ServiceRequest['status']>([
+    'draft',
+    'active',
+    'on-hold',
+    'completed',
+  ]);
+  return (
+    resourceHasTagSystem(resource, chartDataTagSystem('procedure')) &&
     TEMPLATE_INCLUDABLE_SR_STATUSES.has((resource as ServiceRequest).status)
   );
 };

--- a/packages/zambdas/src/ehr/admin-create-template/index.ts
+++ b/packages/zambdas/src/ehr/admin-create-template/index.ts
@@ -406,19 +406,15 @@ export const filterEntriesToTemplateContent = (
   });
 };
 
+// Orders the provider canceled or marked as a mistake live on as
+// status='revoked' / 'entered-in-error' ServiceRequests on the encounter even
+// though they're hidden from the chart UI. Both lab and procedure capture
+// predicates apply this allow-list so a saved template doesn't accidentally
+// carry deleted entries forward.
+const TEMPLATE_INCLUDABLE_SR_STATUSES = new Set<ServiceRequest['status']>(['draft', 'active', 'on-hold', 'completed']);
+
 export const isValidInHouseLabServiceRequest = (resource: TemplateEncounterResource): boolean => {
   if (resource.resourceType !== 'ServiceRequest') return false;
-
-  // Orders the provider canceled or marked as a mistake live on as
-  // status='revoked' / 'entered-in-error' ServiceRequests on the encounter even
-  // though they're hidden from the chart UI. Skip them so a saved template
-  // doesn't accidentally carry deleted orders forward.
-  const TEMPLATE_INCLUDABLE_SR_STATUSES = new Set<ServiceRequest['status']>([
-    'draft',
-    'active',
-    'on-hold',
-    'completed',
-  ]);
   return (
     !!resource.code?.coding?.some((c) => c.system === IN_HOUSE_TEST_CODE_SYSTEM) &&
     !resourceHasTagSystem(resource, REPEAT_TEST_ORDER_DETAIL_TAG_CONFIG.system) && // we don't want repeat tests included
@@ -436,12 +432,6 @@ export const isValidInHouseLabServiceRequest = (resource: TemplateEncounterResou
 // into templates.
 export const isValidProcedureServiceRequest = (resource: TemplateEncounterResource): boolean => {
   if (resource.resourceType !== 'ServiceRequest') return false;
-  const TEMPLATE_INCLUDABLE_SR_STATUSES = new Set<ServiceRequest['status']>([
-    'draft',
-    'active',
-    'on-hold',
-    'completed',
-  ]);
   return (
     resourceHasTagSystem(resource, chartDataTagSystem('procedure')) &&
     TEMPLATE_INCLUDABLE_SR_STATUSES.has((resource as ServiceRequest).status)

--- a/packages/zambdas/src/ehr/admin-get-template-detail/index.ts
+++ b/packages/zambdas/src/ehr/admin-get-template-detail/index.ts
@@ -14,16 +14,20 @@ import {
   ACCIDENT_TYPE_SYSTEM,
   AdminGetTemplateDetailInput,
   AdminGetTemplateDetailOutput,
+  BODY_SITE_SYSTEM,
   chartDataTagSystem,
   collectKnownExamFields,
   collectKnownRosFields,
   examConfig,
   extractCptCodeModifiersFromCoding,
+  FHIR_EXTENSION,
   getRosFindingStateFromKey,
   getSecret,
   getTag,
   ICD_10_CODE_SYSTEM,
   IN_HOUSE_TEST_CODE_SYSTEM,
+  PERFORMER_TYPE_SYSTEM,
+  PROCEDURE_TYPE_SYSTEM,
   resourceHasTagSystem,
   SecretsKeys,
   TemplateAccidentInfo,
@@ -31,6 +35,7 @@ import {
   TemplateCptCodeInfo,
   TemplateExamFinding,
   TemplateInHouseLabPlanDetail,
+  TemplateProcedurePlan,
   TemplateRosFinding,
 } from 'utils';
 import { checkOrCreateM2MClientToken, topLevelCatch, wrapHandler, ZambdaInput } from '../../shared';
@@ -359,6 +364,100 @@ const performEffect = async (
     };
   });
 
+  // Parse in-office procedure plans. Each plan is a ServiceRequest with intent
+  // 'plan' and the procedure-template-plan meta tag, carrying the procedure
+  // form's data via category/performerType/bodySite plus a stable set of
+  // extensions for the remaining fields. Diagnoses and CPT codes are stored as
+  // cross-references into the template's own contained Conditions and CPT
+  // Procedures, so we look those up here and surface inline {code, display}
+  // tuples for the UI.
+  const procedurePlanTagSystem = chartDataTagSystem('procedure-template-plan');
+  const procedurePlans = contained.filter(
+    (r): r is ServiceRequest =>
+      r.resourceType === 'ServiceRequest' &&
+      (r as ServiceRequest).intent === 'plan' &&
+      resourceHasTagSystem(r, procedurePlanTagSystem)
+  );
+
+  const conditionById = new Map<string, Condition>();
+  for (const c of contained) {
+    if (c.resourceType === 'Condition' && c.id) conditionById.set(c.id, c as Condition);
+  }
+  const cptProcedureById = new Map<string, Procedure>();
+  for (const p of contained) {
+    if (
+      p.resourceType === 'Procedure' &&
+      p.id &&
+      resourceHasTagSystem(p as Procedure, chartDataTagSystem('cpt-code'))
+    ) {
+      cptProcedureById.set(p.id, p as Procedure);
+    }
+  }
+
+  const getExtensionString = (sr: ServiceRequest, url: string): string | undefined =>
+    sr.extension?.find((e) => e.url === url)?.valueString;
+  const getExtensionBoolean = (sr: ServiceRequest, url: string): boolean | undefined =>
+    sr.extension?.find((e) => e.url === url)?.valueBoolean;
+  const getExtensionStrings = (sr: ServiceRequest, url: string): string[] =>
+    (sr.extension ?? []).filter((e) => e.url === url).flatMap((e) => (e.valueString ? [e.valueString] : []));
+  const getCodingCode = (
+    concept: { coding?: { system?: string; code?: string }[] } | undefined,
+    system: string
+  ): string | undefined => concept?.coding?.find((c) => c.system === system)?.code;
+
+  const procedures: TemplateProcedurePlan[] = procedurePlans.map((plan) => {
+    const procedureDiagnoses: TemplateCodeInfo[] = (plan.reasonReference ?? []).flatMap((ref) => {
+      const id = ref.reference?.split('/')[1];
+      if (!id) return [];
+      const cond = conditionById.get(id);
+      if (!cond) return [];
+      const icd = cond.code?.coding?.find((c) => c.system === ICD_10_CODE_SYSTEM) ?? cond.code?.coding?.[0];
+      if (!icd?.code && !icd?.display) return [];
+      return [{ code: icd?.code ?? '', display: icd?.display ?? '' }];
+    });
+    const procedureCptCodes: TemplateCptCodeInfo[] = (plan.supportingInfo ?? []).flatMap((ref) => {
+      const id = ref.reference?.split('/')[1];
+      if (!id) return [];
+      const proc = cptProcedureById.get(id);
+      if (!proc) return [];
+      const coding =
+        proc.code?.coding?.find((c) => c.system === 'http://www.ama-assn.org/go/cpt') ?? proc.code?.coding?.[0];
+      if (!coding?.code && !coding?.display) return [];
+      // Preserve any CPT modifiers stored as Coding.extension on the CPT
+      // Procedure. The standalone CPT Codes section does the same, so a CPT
+      // that the provider modified (e.g. -LT) reads consistently between the
+      // two places it surfaces in the preview.
+      return [
+        {
+          code: coding?.code ?? '',
+          display: coding?.display ?? '',
+          modifiers: extractCptCodeModifiersFromCoding(coding),
+        },
+      ];
+    });
+
+    return {
+      planId: plan.id ?? '',
+      procedureType: getCodingCode(plan.category?.[0], PROCEDURE_TYPE_SYSTEM),
+      performerType: getCodingCode(plan.performerType, PERFORMER_TYPE_SYSTEM),
+      bodySite: getCodingCode(plan.bodySite?.[0], BODY_SITE_SYSTEM),
+      bodySide: getExtensionString(plan, FHIR_EXTENSION.ServiceRequest.bodySide.url),
+      technique: getExtensionStrings(plan, FHIR_EXTENSION.ServiceRequest.technique.url),
+      medicationUsed: getExtensionString(plan, FHIR_EXTENSION.ServiceRequest.medicationUsed.url),
+      suppliesUsed: getExtensionString(plan, FHIR_EXTENSION.ServiceRequest.suppliesUsed.url),
+      procedureDetails: getExtensionString(plan, FHIR_EXTENSION.ServiceRequest.procedureDetails.url),
+      specimenSent: getExtensionBoolean(plan, FHIR_EXTENSION.ServiceRequest.specimenSent.url),
+      complications: getExtensionString(plan, FHIR_EXTENSION.ServiceRequest.complications.url),
+      patientResponse: getExtensionString(plan, FHIR_EXTENSION.ServiceRequest.patientResponse.url),
+      postInstructions: getExtensionString(plan, FHIR_EXTENSION.ServiceRequest.postInstructions.url),
+      timeSpent: getExtensionString(plan, FHIR_EXTENSION.ServiceRequest.timeSpent.url),
+      documentedBy: getExtensionString(plan, FHIR_EXTENSION.ServiceRequest.documentedBy.url),
+      consentObtained: getExtensionBoolean(plan, FHIR_EXTENSION.ServiceRequest.consentObtained.url),
+      diagnoses: procedureDiagnoses,
+      cptCodes: procedureCptCodes,
+    };
+  });
+
   return {
     templateName: templateList.title ?? '',
     templateId: templateList.id!,
@@ -377,6 +476,7 @@ const performEffect = async (
       emCode,
       accident,
       inHouseLabs,
+      procedures,
     },
   };
 };

--- a/packages/zambdas/src/ehr/admin-get-template-detail/index.ts
+++ b/packages/zambdas/src/ehr/admin-get-template-detail/index.ts
@@ -18,6 +18,7 @@ import {
   chartDataTagSystem,
   collectKnownExamFields,
   collectKnownRosFields,
+  CPT_CODE_SYSTEM,
   examConfig,
   extractCptCodeModifiersFromCoding,
   FHIR_EXTENSION,
@@ -379,18 +380,18 @@ const performEffect = async (
       resourceHasTagSystem(r, procedurePlanTagSystem)
   );
 
+  // Build the lookup tables in a single pass so procedure plans' cross-refs
+  // (reasonReference -> Condition, supportingInfo -> CPT Procedure) can resolve
+  // to inline {code, display} tuples in the detail output without scanning
+  // contained twice.
   const conditionById = new Map<string, Condition>();
-  for (const c of contained) {
-    if (c.resourceType === 'Condition' && c.id) conditionById.set(c.id, c as Condition);
-  }
   const cptProcedureById = new Map<string, Procedure>();
-  for (const p of contained) {
-    if (
-      p.resourceType === 'Procedure' &&
-      p.id &&
-      resourceHasTagSystem(p as Procedure, chartDataTagSystem('cpt-code'))
-    ) {
-      cptProcedureById.set(p.id, p as Procedure);
+  const cptCodeTagSystem = chartDataTagSystem('cpt-code');
+  for (const r of contained) {
+    if (!r.id) continue;
+    if (r.resourceType === 'Condition') conditionById.set(r.id, r as Condition);
+    else if (r.resourceType === 'Procedure' && resourceHasTagSystem(r as Procedure, cptCodeTagSystem)) {
+      cptProcedureById.set(r.id, r as Procedure);
     }
   }
 
@@ -420,8 +421,7 @@ const performEffect = async (
       if (!id) return [];
       const proc = cptProcedureById.get(id);
       if (!proc) return [];
-      const coding =
-        proc.code?.coding?.find((c) => c.system === 'http://www.ama-assn.org/go/cpt') ?? proc.code?.coding?.[0];
+      const coding = proc.code?.coding?.find((c) => c.system === CPT_CODE_SYSTEM) ?? proc.code?.coding?.[0];
       if (!coding?.code && !coding?.display) return [];
       // Preserve any CPT modifiers stored as Coding.extension on the CPT
       // Procedure. The standalone CPT Codes section does the same, so a CPT

--- a/packages/zambdas/src/ehr/apply-template/apply-procedures.ts
+++ b/packages/zambdas/src/ehr/apply-template/apply-procedures.ts
@@ -1,0 +1,125 @@
+import { BatchInputPostRequest } from '@oystehr/sdk';
+import { Encounter, List, ServiceRequest } from 'fhir/r4b';
+import { DateTime } from 'luxon';
+import { chartDataTagSystem } from 'utils';
+import { v4 as uuidV4 } from 'uuid';
+
+const PROCEDURE_PLAN_TAG_SYSTEM = chartDataTagSystem('procedure-template-plan');
+const PROCEDURE_META_TAG_SYSTEM = chartDataTagSystem('procedure');
+
+/**
+ * Returns the procedure plan ServiceRequests embedded in a global template's
+ * List.contained.
+ */
+export const findProcedurePlans = (templateList: List): ServiceRequest[] => {
+  return (templateList.contained ?? []).filter(
+    (r): r is ServiceRequest =>
+      r.resourceType === 'ServiceRequest' &&
+      (r as ServiceRequest).intent === 'plan' &&
+      (r.meta?.tag?.some((t) => t.system === PROCEDURE_PLAN_TAG_SYSTEM) ?? false)
+  );
+};
+
+export interface BuildLiveProcedureInput {
+  plan: ServiceRequest;
+  encounter: Encounter;
+  /**
+   * Maps the id of a contained resource on the template ('Condition/xxx',
+   * 'Procedure/xxx', without the resource-type prefix) to the urn:uuid
+   * fullUrl assigned to its newly-created live copy in this apply-template
+   * transaction. References whose target isn't in the map (e.g. its owning
+   * section was set to 'skip') get dropped from the rewritten request.
+   */
+  containedIdToNewFullUrl: ReadonlyMap<string, string>;
+}
+
+export interface BuildLiveProcedureResult {
+  request: BatchInputPostRequest<ServiceRequest>;
+  /** Number of reasonReference entries that couldn't be remapped (target wasn't being created). */
+  droppedReasonReferences: number;
+  /** Number of supportingInfo entries that couldn't be remapped. */
+  droppedSupportingInfo: number;
+}
+
+/**
+ * Builds a POST request for the live procedure ServiceRequest that should be
+ * created when a global template's procedure plan is applied to an encounter.
+ *
+ * The new ServiceRequest reuses the plan's procedure-form payload
+ * (category/performerType/bodySite/extensions) and rewrites
+ * reasonReference / supportingInfo from "template contained-resource ids" into
+ * the urn:uuid fullUrls of the new live Conditions / CPT Procedures the
+ * containing apply-template transaction will also create. Cross-refs whose
+ * target isn't being created (because its section was set to 'skip', or
+ * because the template doesn't carry that resource at all) are dropped rather
+ * than left dangling.
+ *
+ * The result is intended to live in the same FHIR transaction as the referenced
+ * fullUrls so that the references resolve atomically when the transaction
+ * commits.
+ */
+export const buildLiveProcedureRequest = (input: BuildLiveProcedureInput): BuildLiveProcedureResult => {
+  const { plan, encounter, containedIdToNewFullUrl } = input;
+  let droppedReasonReferences = 0;
+  let droppedSupportingInfo = 0;
+
+  const remap = (ref: { reference?: string }, kind: 'reason' | 'support'): { reference: string } | null => {
+    const oldId = ref.reference?.split('/')[1];
+    if (!oldId) {
+      if (kind === 'reason') droppedReasonReferences++;
+      else droppedSupportingInfo++;
+      return null;
+    }
+    const newFullUrl = containedIdToNewFullUrl.get(oldId);
+    if (!newFullUrl) {
+      if (kind === 'reason') droppedReasonReferences++;
+      else droppedSupportingInfo++;
+      return null;
+    }
+    return { reference: newFullUrl };
+  };
+
+  const reasonReference = (plan.reasonReference ?? [])
+    .map((r) => remap(r, 'reason'))
+    .filter((r): r is { reference: string } => r !== null);
+  const supportingInfo = (plan.supportingInfo ?? [])
+    .map((r) => remap(r, 'support'))
+    .filter((r): r is { reference: string } => r !== null);
+
+  const liveProcedure: ServiceRequest = {
+    resourceType: 'ServiceRequest',
+    status: 'completed',
+    intent: 'original-order',
+    subject: encounter.subject!,
+    encounter: { reference: `Encounter/${encounter.id}` },
+    // Recorded as the apply-time author so the chart shows when the template
+    // was applied; the template doesn't carry the original documentation
+    // timestamp.
+    authoredOn: DateTime.now().toISO() ?? undefined,
+    ...(plan.category ? { category: plan.category } : {}),
+    ...(plan.performerType ? { performerType: plan.performerType } : {}),
+    ...(plan.bodySite ? { bodySite: plan.bodySite } : {}),
+    ...(plan.extension && plan.extension.length > 0 ? { extension: plan.extension } : {}),
+    ...(reasonReference.length > 0 ? { reasonReference } : {}),
+    ...(supportingInfo.length > 0 ? { supportingInfo } : {}),
+    meta: {
+      tag: [
+        {
+          system: PROCEDURE_META_TAG_SYSTEM,
+          code: 'procedure',
+        },
+      ],
+    },
+  };
+
+  return {
+    request: {
+      method: 'POST',
+      url: 'ServiceRequest',
+      resource: liveProcedure,
+      fullUrl: `urn:uuid:${uuidV4()}`,
+    },
+    droppedReasonReferences,
+    droppedSupportingInfo,
+  };
+};

--- a/packages/zambdas/src/ehr/apply-template/apply-procedures.ts
+++ b/packages/zambdas/src/ehr/apply-template/apply-procedures.ts
@@ -1,7 +1,7 @@
 import { BatchInputPostRequest } from '@oystehr/sdk';
 import { Encounter, List, ServiceRequest } from 'fhir/r4b';
 import { DateTime } from 'luxon';
-import { chartDataTagSystem } from 'utils';
+import { chartDataTagSystem, resourceHasTagSystem } from 'utils';
 import { v4 as uuidV4 } from 'uuid';
 
 const PROCEDURE_PLAN_TAG_SYSTEM = chartDataTagSystem('procedure-template-plan');
@@ -16,7 +16,7 @@ export const findProcedurePlans = (templateList: List): ServiceRequest[] => {
     (r): r is ServiceRequest =>
       r.resourceType === 'ServiceRequest' &&
       (r as ServiceRequest).intent === 'plan' &&
-      (r.meta?.tag?.some((t) => t.system === PROCEDURE_PLAN_TAG_SYSTEM) ?? false)
+      resourceHasTagSystem(r, PROCEDURE_PLAN_TAG_SYSTEM)
   );
 };
 
@@ -31,14 +31,6 @@ export interface BuildLiveProcedureInput {
    * section was set to 'skip') get dropped from the rewritten request.
    */
   containedIdToNewFullUrl: ReadonlyMap<string, string>;
-}
-
-export interface BuildLiveProcedureResult {
-  request: BatchInputPostRequest<ServiceRequest>;
-  /** Number of reasonReference entries that couldn't be remapped (target wasn't being created). */
-  droppedReasonReferences: number;
-  /** Number of supportingInfo entries that couldn't be remapped. */
-  droppedSupportingInfo: number;
 }
 
 /**
@@ -58,33 +50,18 @@ export interface BuildLiveProcedureResult {
  * fullUrls so that the references resolve atomically when the transaction
  * commits.
  */
-export const buildLiveProcedureRequest = (input: BuildLiveProcedureInput): BuildLiveProcedureResult => {
+export const buildLiveProcedureRequest = (input: BuildLiveProcedureInput): BatchInputPostRequest<ServiceRequest> => {
   const { plan, encounter, containedIdToNewFullUrl } = input;
-  let droppedReasonReferences = 0;
-  let droppedSupportingInfo = 0;
 
-  const remap = (ref: { reference?: string }, kind: 'reason' | 'support'): { reference: string } | null => {
+  const remap = (ref: { reference?: string }): { reference: string } | null => {
     const oldId = ref.reference?.split('/')[1];
-    if (!oldId) {
-      if (kind === 'reason') droppedReasonReferences++;
-      else droppedSupportingInfo++;
-      return null;
-    }
+    if (!oldId) return null;
     const newFullUrl = containedIdToNewFullUrl.get(oldId);
-    if (!newFullUrl) {
-      if (kind === 'reason') droppedReasonReferences++;
-      else droppedSupportingInfo++;
-      return null;
-    }
-    return { reference: newFullUrl };
+    return newFullUrl ? { reference: newFullUrl } : null;
   };
 
-  const reasonReference = (plan.reasonReference ?? [])
-    .map((r) => remap(r, 'reason'))
-    .filter((r): r is { reference: string } => r !== null);
-  const supportingInfo = (plan.supportingInfo ?? [])
-    .map((r) => remap(r, 'support'))
-    .filter((r): r is { reference: string } => r !== null);
+  const reasonReference = (plan.reasonReference ?? []).map(remap).filter((r): r is { reference: string } => r !== null);
+  const supportingInfo = (plan.supportingInfo ?? []).map(remap).filter((r): r is { reference: string } => r !== null);
 
   const liveProcedure: ServiceRequest = {
     resourceType: 'ServiceRequest',
@@ -113,13 +90,9 @@ export const buildLiveProcedureRequest = (input: BuildLiveProcedureInput): Build
   };
 
   return {
-    request: {
-      method: 'POST',
-      url: 'ServiceRequest',
-      resource: liveProcedure,
-      fullUrl: `urn:uuid:${uuidV4()}`,
-    },
-    droppedReasonReferences,
-    droppedSupportingInfo,
+    method: 'POST',
+    url: 'ServiceRequest',
+    resource: liveProcedure,
+    fullUrl: `urn:uuid:${uuidV4()}`,
   };
 };

--- a/packages/zambdas/src/ehr/apply-template/index.ts
+++ b/packages/zambdas/src/ehr/apply-template/index.ts
@@ -11,6 +11,7 @@ import {
   List,
   Observation,
   Procedure,
+  ServiceRequest,
 } from 'fhir/r4b';
 import {
   ApplyTemplateWarning,
@@ -31,6 +32,7 @@ import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../sha
 import { createOystehrClient } from '../../shared/helpers';
 import { getTemplateBaseResources, hasTemplateRelevantTag, isDiagnosisCondition } from '../shared/template-helpers';
 import { applyInHouseLabPlans, canApplyActivityDefinition } from './apply-in-house-labs';
+import { buildLiveProcedureRequest, findProcedurePlans } from './apply-procedures';
 import { validateRequestParameters } from './validateRequestParameters';
 
 interface ComplexValidationOutput {
@@ -205,12 +207,19 @@ const performEffect = async (
   const cptCodesFromLabsToSkip = collectCptCodesFromApplicableActivityDefinitions(applicableInHouseLabAds, actions);
   const createRequests = makeCreateRequests(encounter, templateList, encounterBundle, actions, cptCodesFromLabsToSkip);
 
+  // Procedure plans (ServiceRequests) and CPT Procedures share a single
+  // transaction so the procedure plan's reasonReference / supportingInfo can
+  // resolve via urn:uuid fullUrl to the new Conditions and CPT Procedures
+  // created alongside them. The previous flow put CPT Procedures in a separate
+  // batch which is fine in isolation but breaks the procedure cross-refs.
   const miniTransactionRequests = createRequests.filter((request) => {
     if (request.method === 'POST') {
       return (
         request.resource.resourceType === 'ClinicalImpression' ||
         request.resource.resourceType === 'Condition' ||
-        request.resource.resourceType === 'Communication'
+        request.resource.resourceType === 'Communication' ||
+        request.resource.resourceType === 'Procedure' ||
+        request.resource.resourceType === 'ServiceRequest'
       );
     } else if (request.method === 'PATCH') {
       return true;
@@ -223,18 +232,7 @@ const performEffect = async (
       request.method === 'POST' && request.resource.resourceType === 'Observation'
   );
 
-  const procedureRequests = createRequests.filter(
-    (request): request is BatchInputPostRequest<Procedure> =>
-      request.method === 'POST' && request.resource.resourceType === 'Procedure'
-  );
-
   const createObservationBatches = chunkThings(observationRequests, 5).map((chunk) =>
-    oystehr.fhir.batch({
-      requests: chunk,
-    })
-  );
-
-  const createProcedureBatches = chunkThings(procedureRequests, 5).map((chunk) =>
     oystehr.fhir.batch({
       requests: chunk,
     })
@@ -245,7 +243,7 @@ const performEffect = async (
   });
 
   const [bundles, inHouseLabsResult] = await Promise.all([
-    Promise.all([...deleteBatches, ...createObservationBatches, ...createProcedureBatches, miniTransactionPromise]),
+    Promise.all([...deleteBatches, ...createObservationBatches, miniTransactionPromise]),
     inHouseLabsPromise,
   ]);
 
@@ -311,13 +309,19 @@ export const makeCreateRequests = (
   actions: ResolvedSectionActions,
   cptCodesFromLabsToSkip: Set<string>
 ): Array<
-  | BatchInputPostRequest<Observation | ClinicalImpression | Condition | Communication | Procedure>
+  | BatchInputPostRequest<Observation | ClinicalImpression | Condition | Communication | Procedure | ServiceRequest>
   | BatchInputJSONPatchRequest
 > => {
   const createResourcesRequests: Array<
-    | BatchInputPostRequest<Observation | ClinicalImpression | Condition | Communication | Procedure>
+    | BatchInputPostRequest<Observation | ClinicalImpression | Condition | Communication | Procedure | ServiceRequest>
     | BatchInputJSONPatchRequest
   > = [];
+
+  // Tracks `contained resource id -> urn:uuid fullUrl assigned to its new live
+  // copy in this apply`. Procedure plans use this to rewrite their cross-refs
+  // (reasonReference -> new Condition, supportingInfo -> new CPT Procedure) so
+  // they point at the new resources within this transaction.
+  const containedIdToNewFullUrl = new Map<string, string>();
 
   if (templateList.entry === undefined || templateList.entry.length === 0) {
     console.log('Template has no entries, it will not create anything.');
@@ -527,6 +531,20 @@ export const makeCreateRequests = (
       resource: resourceToCreate,
       fullUrl,
     });
+    if (containedResource.id) {
+      containedIdToNewFullUrl.set(containedResource.id, fullUrl);
+    }
+  }
+
+  // Materialize procedure plans now that every other contained resource has
+  // been turned into a request and assigned a fullUrl. Each plan becomes a
+  // live ServiceRequest whose cross-refs are rewritten to point at the new
+  // resources within this same transaction (see apply-procedures.ts).
+  if (actions.procedures !== 'skip') {
+    for (const plan of findProcedurePlans(templateList)) {
+      const { request } = buildLiveProcedureRequest({ plan, encounter, containedIdToNewFullUrl });
+      createResourcesRequests.push(request);
+    }
   }
 
   const encounterPatchOperations: Operation[] = [];

--- a/packages/zambdas/src/ehr/apply-template/index.ts
+++ b/packages/zambdas/src/ehr/apply-template/index.ts
@@ -542,8 +542,7 @@ export const makeCreateRequests = (
   // resources within this same transaction (see apply-procedures.ts).
   if (actions.procedures !== 'skip') {
     for (const plan of findProcedurePlans(templateList)) {
-      const { request } = buildLiveProcedureRequest({ plan, encounter, containedIdToNewFullUrl });
-      createResourcesRequests.push(request);
+      createResourcesRequests.push(buildLiveProcedureRequest({ plan, encounter, containedIdToNewFullUrl }));
     }
   }
 

--- a/packages/zambdas/test/unit/admin-create-template.test.ts
+++ b/packages/zambdas/test/unit/admin-create-template.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, test } from 'vitest';
 import {
   filterEntriesToTemplateContent,
   isValidInHouseLabServiceRequest,
+  isValidProcedureServiceRequest,
 } from '../../src/ehr/admin-create-template/index';
 import { isInHouseLabRepeatTestCptCode, TemplateEncounterResource } from '../../src/ehr/shared/template-helpers';
 
@@ -308,5 +309,72 @@ describe('filterEntriesToTemplateContent — in-house lab repeat CPT filtering',
     const ids = result.map((r) => r.id);
     expect(ids).not.toContain('proc-repeat');
     expect(ids).toContain('proc-standard');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isValidProcedureServiceRequest — in-office procedure SR capture filter
+// ---------------------------------------------------------------------------
+
+const makeStandardProcedureSR = (id: string, overrides: Partial<ServiceRequest> = {}): ServiceRequest => ({
+  resourceType: 'ServiceRequest',
+  id,
+  status: 'completed',
+  intent: 'original-order',
+  subject: { reference: 'Patient/p1' },
+  meta: { tag: [{ system: chartDataTagSystem('procedure'), code: 'procedure' }] },
+  ...overrides,
+});
+
+describe('isValidProcedureServiceRequest', () => {
+  test('includes a standard completed procedure', () => {
+    expect(isValidProcedureServiceRequest(makeStandardProcedureSR('sr-1'))).toBe(true);
+  });
+
+  test('includes orders with includable statuses: draft, active, on-hold, completed', () => {
+    // Procedures generally save with status='completed' (post-facto records),
+    // but the same inclusion list is used as for in-house labs in case a
+    // procedure workflow ever lands in an intermediate state.
+    for (const status of ['draft', 'active', 'on-hold', 'completed'] as ServiceRequest['status'][]) {
+      expect(isValidProcedureServiceRequest(makeStandardProcedureSR(`sr-${status}`, { status }))).toBe(true);
+    }
+  });
+
+  test('excludes a procedure deleted via delete-chart-data (status=entered-in-error)', () => {
+    // delete-chart-data patches a deleted procedure to entered-in-error rather
+    // than deleting it, and the chart UI hides those by status - filtering them
+    // out here keeps a saved template from carrying deleted procedures forward.
+    const sr = makeStandardProcedureSR('sr-error', { status: 'entered-in-error' });
+    expect(isValidProcedureServiceRequest(sr)).toBe(false);
+  });
+
+  test('excludes a revoked procedure', () => {
+    const sr = makeStandardProcedureSR('sr-revoked', { status: 'revoked' });
+    expect(isValidProcedureServiceRequest(sr)).toBe(false);
+  });
+
+  test('excludes an SR without the procedure meta tag', () => {
+    // An in-house lab SR or any other ServiceRequest without the procedure
+    // chart-data meta tag must not be picked up as a procedure plan.
+    const sr = makeStandardProcedureSR('sr-no-tag', { meta: { tag: [] } });
+    expect(isValidProcedureServiceRequest(sr)).toBe(false);
+  });
+
+  test('excludes an SR whose meta tag system is different (e.g. in-house lab plan)', () => {
+    const sr = makeStandardProcedureSR('sr-lab-tag', {
+      meta: { tag: [{ system: chartDataTagSystem('in-house-lab-template-plan'), code: 'in-house-lab-template-plan' }] },
+    });
+    expect(isValidProcedureServiceRequest(sr)).toBe(false);
+  });
+
+  test('non-ServiceRequest resource returns false', () => {
+    const obs: TemplateEncounterResource = {
+      resourceType: 'Observation',
+      id: 'obs-1',
+      status: 'final',
+      code: {},
+      meta: { tag: [{ system: chartDataTagSystem('procedure'), code: 'procedure' }] },
+    };
+    expect(isValidProcedureServiceRequest(obs)).toBe(false);
   });
 });

--- a/packages/zambdas/test/unit/apply-procedures.test.ts
+++ b/packages/zambdas/test/unit/apply-procedures.test.ts
@@ -77,13 +77,11 @@ describe('buildLiveProcedureRequest', () => {
       'dx-stub-1': 'urn:uuid:dx-new',
       'cpt-stub-1': 'urn:uuid:cpt-new',
     });
-    const { request, droppedReasonReferences, droppedSupportingInfo } = buildLiveProcedureRequest({
+    const request = buildLiveProcedureRequest({
       plan: buildPlan(),
       encounter: buildEncounter(),
       containedIdToNewFullUrl,
     });
-    expect(droppedReasonReferences).toBe(0);
-    expect(droppedSupportingInfo).toBe(0);
     expect(request.method).toBe('POST');
     expect(request.url).toBe('ServiceRequest');
     expect(request.fullUrl).toMatch(/^urn:uuid:/);
@@ -92,20 +90,18 @@ describe('buildLiveProcedureRequest', () => {
     expect(sr.supportingInfo).toEqual([{ reference: 'urn:uuid:cpt-new' }]);
   });
 
-  test('drops references whose target is not in the contained-id map and counts them', () => {
+  test('drops references whose target is not in the contained-id map', () => {
     // Only the CPT is in the map - the diagnosis section was skipped on apply,
     // so its stub id has no new fullUrl. The remap must drop the reasonReference
     // entry rather than leak the template-stub id to the live transaction.
     const containedIdToNewFullUrl = buildContainerMap({
       'cpt-stub-1': 'urn:uuid:cpt-new',
     });
-    const { request, droppedReasonReferences, droppedSupportingInfo } = buildLiveProcedureRequest({
+    const request = buildLiveProcedureRequest({
       plan: buildPlan(),
       encounter: buildEncounter(),
       containedIdToNewFullUrl,
     });
-    expect(droppedReasonReferences).toBe(1);
-    expect(droppedSupportingInfo).toBe(0);
     const sr = request.resource as ServiceRequest;
     // reasonReference shouldn't even appear on the resource when it's empty,
     // so the consumer doesn't have to special-case [] vs undefined later on.
@@ -114,7 +110,7 @@ describe('buildLiveProcedureRequest', () => {
   });
 
   test('sets live subject/encounter and overwrites the template stub references', () => {
-    const { request } = buildLiveProcedureRequest({
+    const request = buildLiveProcedureRequest({
       plan: buildPlan(),
       encounter: buildEncounter(),
       containedIdToNewFullUrl: new Map(),
@@ -129,7 +125,7 @@ describe('buildLiveProcedureRequest', () => {
     // procedure - the live save flow uses 'completed'/'original-order'. Pin
     // those defaults here so a future regression doesn't ship a plan-shape
     // ServiceRequest into the chart.
-    const { request } = buildLiveProcedureRequest({
+    const request = buildLiveProcedureRequest({
       plan: buildPlan(),
       encounter: buildEncounter(),
       containedIdToNewFullUrl: new Map(),
@@ -141,7 +137,7 @@ describe('buildLiveProcedureRequest', () => {
   });
 
   test('tags the new resource with chartDataTagSystem("procedure") so it shows up in get-chart-data', () => {
-    const { request } = buildLiveProcedureRequest({
+    const request = buildLiveProcedureRequest({
       plan: buildPlan(),
       encounter: buildEncounter(),
       containedIdToNewFullUrl: new Map(),
@@ -159,7 +155,7 @@ describe('buildLiveProcedureRequest', () => {
       { url: FHIR_EXTENSION.ServiceRequest.timeSpent.url, valueString: '15 minutes' },
     ];
     const plan = buildPlan({ extension: customExtensions });
-    const { request } = buildLiveProcedureRequest({
+    const request = buildLiveProcedureRequest({
       plan,
       encounter: buildEncounter(),
       containedIdToNewFullUrl: new Map(),
@@ -183,7 +179,7 @@ describe('buildLiveProcedureRequest', () => {
       reasonReference: undefined,
       supportingInfo: undefined,
     });
-    const { request } = buildLiveProcedureRequest({
+    const request = buildLiveProcedureRequest({
       plan: sparsePlan,
       encounter: buildEncounter(),
       containedIdToNewFullUrl: new Map(),

--- a/packages/zambdas/test/unit/apply-procedures.test.ts
+++ b/packages/zambdas/test/unit/apply-procedures.test.ts
@@ -1,0 +1,199 @@
+import { Encounter, Extension, List, ServiceRequest } from 'fhir/r4b';
+import { chartDataTagSystem, FHIR_EXTENSION, PROCEDURE_TYPE_SYSTEM } from 'utils';
+import { describe, expect, test } from 'vitest';
+import { buildLiveProcedureRequest, findProcedurePlans } from '../../src/ehr/apply-template/apply-procedures';
+
+const PROCEDURE_PLAN_TAG = chartDataTagSystem('procedure-template-plan');
+const PROCEDURE_META_TAG = chartDataTagSystem('procedure');
+
+const buildEncounter = (): Encounter => ({
+  resourceType: 'Encounter',
+  id: 'enc-live',
+  status: 'in-progress',
+  class: { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB' },
+  subject: { reference: 'Patient/pat-live' },
+});
+
+const buildPlan = (overrides: Partial<ServiceRequest> = {}): ServiceRequest => ({
+  resourceType: 'ServiceRequest',
+  id: 'plan-1',
+  status: 'active',
+  intent: 'plan',
+  subject: { reference: '#stub-patient' },
+  category: [{ coding: [{ system: PROCEDURE_TYPE_SYSTEM, code: 'splint-application' }] }],
+  performerType: { coding: [{ code: 'provider' }] },
+  bodySite: [{ coding: [{ code: 'wrist' }] }],
+  extension: [
+    { url: FHIR_EXTENSION.ServiceRequest.bodySide.url, valueString: 'Left' },
+    { url: FHIR_EXTENSION.ServiceRequest.technique.url, valueString: 'Closed reduction' },
+    { url: FHIR_EXTENSION.ServiceRequest.consentObtained.url, valueBoolean: true },
+  ],
+  reasonReference: [{ reference: 'Condition/dx-stub-1' }],
+  supportingInfo: [{ reference: 'Procedure/cpt-stub-1' }],
+  meta: { tag: [{ system: PROCEDURE_PLAN_TAG, code: 'procedure-template-plan' }] },
+  ...overrides,
+});
+
+const buildContainerMap = (entries: Record<string, string>): Map<string, string> => new Map(Object.entries(entries));
+
+describe('findProcedurePlans', () => {
+  test('returns only ServiceRequests with intent=plan AND the procedure-template-plan meta tag', () => {
+    const planSr = buildPlan();
+    const otherSr: ServiceRequest = {
+      resourceType: 'ServiceRequest',
+      id: 'sr-other',
+      status: 'active',
+      intent: 'plan',
+      subject: { reference: '#x' },
+      // Different tag system - this is an in-house lab plan, not a procedure plan.
+      meta: { tag: [{ system: chartDataTagSystem('in-house-lab-template-plan'), code: 'in-house-lab-template-plan' }] },
+    };
+    const nonPlanSr: ServiceRequest = {
+      resourceType: 'ServiceRequest',
+      id: 'sr-order',
+      status: 'completed',
+      intent: 'original-order', // not 'plan'
+      subject: { reference: '#x' },
+      meta: { tag: [{ system: PROCEDURE_PLAN_TAG, code: 'procedure-template-plan' }] },
+    };
+    const list: List = {
+      resourceType: 'List',
+      status: 'current',
+      mode: 'working',
+      contained: [planSr, otherSr, nonPlanSr],
+    };
+    expect(findProcedurePlans(list)).toEqual([planSr]);
+  });
+
+  test('returns [] when the template has no contained array', () => {
+    const list: List = { resourceType: 'List', status: 'current', mode: 'working' };
+    expect(findProcedurePlans(list)).toEqual([]);
+  });
+});
+
+describe('buildLiveProcedureRequest', () => {
+  test('rewrites reasonReference and supportingInfo through the contained-id -> fullUrl map', () => {
+    const containedIdToNewFullUrl = buildContainerMap({
+      'dx-stub-1': 'urn:uuid:dx-new',
+      'cpt-stub-1': 'urn:uuid:cpt-new',
+    });
+    const { request, droppedReasonReferences, droppedSupportingInfo } = buildLiveProcedureRequest({
+      plan: buildPlan(),
+      encounter: buildEncounter(),
+      containedIdToNewFullUrl,
+    });
+    expect(droppedReasonReferences).toBe(0);
+    expect(droppedSupportingInfo).toBe(0);
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('ServiceRequest');
+    expect(request.fullUrl).toMatch(/^urn:uuid:/);
+    const sr = request.resource as ServiceRequest;
+    expect(sr.reasonReference).toEqual([{ reference: 'urn:uuid:dx-new' }]);
+    expect(sr.supportingInfo).toEqual([{ reference: 'urn:uuid:cpt-new' }]);
+  });
+
+  test('drops references whose target is not in the contained-id map and counts them', () => {
+    // Only the CPT is in the map - the diagnosis section was skipped on apply,
+    // so its stub id has no new fullUrl. The remap must drop the reasonReference
+    // entry rather than leak the template-stub id to the live transaction.
+    const containedIdToNewFullUrl = buildContainerMap({
+      'cpt-stub-1': 'urn:uuid:cpt-new',
+    });
+    const { request, droppedReasonReferences, droppedSupportingInfo } = buildLiveProcedureRequest({
+      plan: buildPlan(),
+      encounter: buildEncounter(),
+      containedIdToNewFullUrl,
+    });
+    expect(droppedReasonReferences).toBe(1);
+    expect(droppedSupportingInfo).toBe(0);
+    const sr = request.resource as ServiceRequest;
+    // reasonReference shouldn't even appear on the resource when it's empty,
+    // so the consumer doesn't have to special-case [] vs undefined later on.
+    expect(sr.reasonReference).toBeUndefined();
+    expect(sr.supportingInfo).toEqual([{ reference: 'urn:uuid:cpt-new' }]);
+  });
+
+  test('sets live subject/encounter and overwrites the template stub references', () => {
+    const { request } = buildLiveProcedureRequest({
+      plan: buildPlan(),
+      encounter: buildEncounter(),
+      containedIdToNewFullUrl: new Map(),
+    });
+    const sr = request.resource as ServiceRequest;
+    expect(sr.subject?.reference).toBe('Patient/pat-live');
+    expect(sr.encounter?.reference).toBe('Encounter/enc-live');
+  });
+
+  test('emits intent=original-order, status=completed, and a fresh authoredOn timestamp', () => {
+    // The plan's status='active'/intent='plan' would be invalid for a chart
+    // procedure - the live save flow uses 'completed'/'original-order'. Pin
+    // those defaults here so a future regression doesn't ship a plan-shape
+    // ServiceRequest into the chart.
+    const { request } = buildLiveProcedureRequest({
+      plan: buildPlan(),
+      encounter: buildEncounter(),
+      containedIdToNewFullUrl: new Map(),
+    });
+    const sr = request.resource as ServiceRequest;
+    expect(sr.status).toBe('completed');
+    expect(sr.intent).toBe('original-order');
+    expect(sr.authoredOn).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test('tags the new resource with chartDataTagSystem("procedure") so it shows up in get-chart-data', () => {
+    const { request } = buildLiveProcedureRequest({
+      plan: buildPlan(),
+      encounter: buildEncounter(),
+      containedIdToNewFullUrl: new Map(),
+    });
+    const sr = request.resource as ServiceRequest;
+    expect(sr.meta?.tag?.some((t) => t.system === PROCEDURE_META_TAG && t.code === 'procedure')).toBe(true);
+    // It must NOT carry the plan tag - that's a template-only marker.
+    expect(sr.meta?.tag?.some((t) => t.system === PROCEDURE_PLAN_TAG)).toBe(false);
+  });
+
+  test('preserves category, performerType, bodySite, and all extensions verbatim', () => {
+    const customExtensions: Extension[] = [
+      { url: FHIR_EXTENSION.ServiceRequest.medicationUsed.url, valueString: 'Lidocaine 1%' },
+      { url: FHIR_EXTENSION.ServiceRequest.suppliesUsed.url, valueString: 'Splint kit' },
+      { url: FHIR_EXTENSION.ServiceRequest.timeSpent.url, valueString: '15 minutes' },
+    ];
+    const plan = buildPlan({ extension: customExtensions });
+    const { request } = buildLiveProcedureRequest({
+      plan,
+      encounter: buildEncounter(),
+      containedIdToNewFullUrl: new Map(),
+    });
+    const sr = request.resource as ServiceRequest;
+    expect(sr.category).toEqual(plan.category);
+    expect(sr.performerType).toEqual(plan.performerType);
+    expect(sr.bodySite).toEqual(plan.bodySite);
+    expect(sr.extension).toEqual(customExtensions);
+  });
+
+  test('omits optional fields when the plan does not carry them', () => {
+    // A sparse template entry (procedure with only a CPT and no other form
+    // fields) shouldn't end up with empty arrays / undefined extensions on the
+    // resulting ServiceRequest.
+    const sparsePlan = buildPlan({
+      category: undefined,
+      performerType: undefined,
+      bodySite: undefined,
+      extension: undefined,
+      reasonReference: undefined,
+      supportingInfo: undefined,
+    });
+    const { request } = buildLiveProcedureRequest({
+      plan: sparsePlan,
+      encounter: buildEncounter(),
+      containedIdToNewFullUrl: new Map(),
+    });
+    const sr = request.resource as ServiceRequest;
+    expect(sr.category).toBeUndefined();
+    expect(sr.performerType).toBeUndefined();
+    expect(sr.bodySite).toBeUndefined();
+    expect(sr.extension).toBeUndefined();
+    expect(sr.reasonReference).toBeUndefined();
+    expect(sr.supportingInfo).toBeUndefined();
+  });
+});

--- a/packages/zambdas/test/unit/apply-template.test.ts
+++ b/packages/zambdas/test/unit/apply-template.test.ts
@@ -55,6 +55,7 @@ describe('Apply Template - validateRequestParameters', () => {
       cptCodes: 'overwrite',
       emCode: 'skip',
       inHouseLabs: 'append',
+      procedures: 'append',
     };
     const result = validateRequestParameters(createInput({ ...baseBody, sectionActions }));
     expect(result.sectionActions).toEqual(sectionActions);
@@ -91,6 +92,24 @@ describe('Apply Template - validateRequestParameters', () => {
     ).not.toThrow();
     expect(() =>
       validateRequestParameters(createInput({ ...baseBody, sectionActions: { inHouseLabs: 'append' } }))
+    ).not.toThrow();
+  });
+
+  test("rejects 'overwrite' for procedures", () => {
+    // Like in-house labs, procedures are constrained to skip/append - applying
+    // a template should never silently delete a provider's existing procedure
+    // documentation. The validator enforces that constraint by reading
+    // TEMPLATE_SECTIONS_NO_OVERWRITE.
+    const input = createInput({ ...baseBody, sectionActions: { procedures: 'overwrite' } });
+    expect(() => validateRequestParameters(input)).toThrow(/does not support the 'overwrite' action/);
+  });
+
+  test("accepts 'skip' and 'append' for procedures", () => {
+    expect(() =>
+      validateRequestParameters(createInput({ ...baseBody, sectionActions: { procedures: 'skip' } }))
+    ).not.toThrow();
+    expect(() =>
+      validateRequestParameters(createInput({ ...baseBody, sectionActions: { procedures: 'append' } }))
     ).not.toThrow();
   });
 

--- a/packages/zambdas/test/unit/apply-template.test.ts
+++ b/packages/zambdas/test/unit/apply-template.test.ts
@@ -534,3 +534,221 @@ describe('makeCreateRequests — CPT / in-house lab overlap', () => {
     expect(createdCptCodes).toContain('99213');
   });
 });
+
+// ---------------------------------------------------------------------------
+// makeCreateRequests — procedure plans
+// ---------------------------------------------------------------------------
+
+const PROCEDURE_PLAN_TAG_SYSTEM = chartDataTagSystem('procedure-template-plan');
+const PROCEDURE_META_TAG_SYSTEM = chartDataTagSystem('procedure');
+
+const makeProcedurePlan = (id: string, opts: { dxRefIds?: string[]; cptRefIds?: string[] } = {}): ServiceRequest => ({
+  resourceType: 'ServiceRequest',
+  id,
+  status: 'active',
+  intent: 'plan',
+  subject: { reference: '#stub-patient' },
+  category: [{ coding: [{ system: 'https://fhir.ottehr.com/CodeSystem/Procedure/procedure-type', code: 'splint' }] }],
+  reasonReference: (opts.dxRefIds ?? []).map((refId) => ({ reference: `Condition/${refId}` })),
+  supportingInfo: (opts.cptRefIds ?? []).map((refId) => ({ reference: `Procedure/${refId}` })),
+  meta: { tag: [{ system: PROCEDURE_PLAN_TAG_SYSTEM, code: 'procedure-template-plan' }] },
+});
+
+const makeProcedureTemplateList = (resources: Array<Procedure | ServiceRequest | Condition>): List => ({
+  resourceType: 'List',
+  id: 'proc-template',
+  status: 'current',
+  mode: 'working',
+  entry: resources.map((r) => ({ item: { reference: `#${r.id}` } })),
+  contained: [
+    ...resources,
+    {
+      resourceType: 'Encounter',
+      id: 'stub-enc',
+      status: 'unknown',
+      class: { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB' },
+    } as Encounter,
+  ],
+});
+
+const getProcedureServiceRequestPosts = (
+  requests: ReturnType<typeof makeCreateRequests>
+): Array<{ method: 'POST'; url: string; resource: ServiceRequest; fullUrl?: string }> =>
+  requests.filter(
+    (r): r is { method: 'POST'; url: string; resource: ServiceRequest; fullUrl?: string } =>
+      r.method === 'POST' && (r as any).resource?.resourceType === 'ServiceRequest'
+  );
+
+describe('makeCreateRequests — procedure plans', () => {
+  test("procedures='skip' emits no procedure ServiceRequest", () => {
+    const plan = makeProcedurePlan('plan-1');
+    const templateList = makeProcedureTemplateList([plan]);
+    const actions = makeActions({ procedures: 'skip' });
+    const requests = makeCreateRequests(makeSimpleCptEncounter(), templateList, [], actions, new Set());
+    expect(getProcedureServiceRequestPosts(requests)).toHaveLength(0);
+  });
+
+  test("procedures='append' creates one live ServiceRequest per plan, tagged for chart-data", () => {
+    const planA = makeProcedurePlan('plan-a');
+    const planB = makeProcedurePlan('plan-b');
+    const templateList = makeProcedureTemplateList([planA, planB]);
+    const actions = makeActions({ procedures: 'append' });
+    const requests = makeCreateRequests(makeSimpleCptEncounter(), templateList, [], actions, new Set());
+
+    const created = getProcedureServiceRequestPosts(requests);
+    expect(created).toHaveLength(2);
+    for (const req of created) {
+      // Each must be the chart-data shape (completed/original-order/procedure tag)
+      // rather than the plan shape — get-chart-data filters on these.
+      expect(req.resource.status).toBe('completed');
+      expect(req.resource.intent).toBe('original-order');
+      expect(
+        req.resource.meta?.tag?.some((t) => t.system === PROCEDURE_META_TAG_SYSTEM && t.code === 'procedure')
+      ).toBe(true);
+      expect(req.resource.meta?.tag?.some((t) => t.system === PROCEDURE_PLAN_TAG_SYSTEM)).toBe(false);
+      // Cross-section linkage requires the SR's fullUrl to be a urn:uuid so other
+      // resources in the transaction (encounter.diagnosis, etc) could reference it.
+      expect(req.fullUrl).toMatch(/^urn:uuid:/);
+    }
+  });
+
+  test('rewrites reasonReference and supportingInfo to the new fullUrls of the contained diagnoses and CPT Procedures', () => {
+    // The diagnosis Condition and CPT Procedure live in the template's contained
+    // array — when applied they each get a fresh urn:uuid fullUrl in the same
+    // transaction. The procedure plan's cross-refs (Condition/dx-1, Procedure/cpt-1)
+    // must be rewritten to point at those fullUrls so the live procedure links to
+    // the live resources, not the template stub ids.
+    const dxCondition = makeDxCondition('dx-1', 'J02.9');
+    const cptProcedure = makeCptProcedure('cpt-1', '29105');
+    const plan = makeProcedurePlan('plan-1', { dxRefIds: ['dx-1'], cptRefIds: ['cpt-1'] });
+    const templateList: List = {
+      resourceType: 'List',
+      id: 'proc-template',
+      status: 'current',
+      mode: 'working',
+      entry: [{ item: { reference: `#dx-1` } }, { item: { reference: `#cpt-1` } }, { item: { reference: `#plan-1` } }],
+      contained: [
+        dxCondition,
+        cptProcedure,
+        plan,
+        {
+          resourceType: 'Encounter',
+          id: 'stub-enc',
+          status: 'unknown',
+          class: { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB' },
+          diagnosis: [{ condition: { reference: 'Condition/dx-1' } }],
+        } as Encounter,
+      ],
+    };
+    const actions = makeActions({ procedures: 'append', diagnoses: 'append', cptCodes: 'append' });
+    const requests = makeCreateRequests(makeSimpleCptEncounter(), templateList, [], actions, new Set());
+
+    // Find the fullUrls assigned to the new live Condition and CPT Procedure.
+    const dxPostRequest = requests.find(
+      (r): r is { method: 'POST'; resource: Condition; fullUrl?: string; url: string } =>
+        r.method === 'POST' && (r as any).resource?.resourceType === 'Condition'
+    )!;
+    const cptPostRequest = requests.find(
+      (r): r is { method: 'POST'; resource: Procedure; fullUrl?: string; url: string } =>
+        r.method === 'POST' && (r as any).resource?.resourceType === 'Procedure'
+    )!;
+    expect(dxPostRequest.fullUrl).toMatch(/^urn:uuid:/);
+    expect(cptPostRequest.fullUrl).toMatch(/^urn:uuid:/);
+
+    // The procedure SR's refs must match those fullUrls exactly.
+    const procedureSR = getProcedureServiceRequestPosts(requests)[0]!.resource;
+    expect(procedureSR.reasonReference).toEqual([{ reference: dxPostRequest.fullUrl }]);
+    expect(procedureSR.supportingInfo).toEqual([{ reference: cptPostRequest.fullUrl }]);
+  });
+
+  test("dropping diagnoses ('skip') drops the procedure's reasonReference rather than leaking a stub id", () => {
+    // When the diagnoses section is set to skip, the diagnosis Condition isn't
+    // being created in this transaction. The procedure plan's reasonReference
+    // pointed at the template's stub id, which doesn't exist outside the
+    // template - we must drop the ref, not emit a dangling reference.
+    const dxCondition = makeDxCondition('dx-1', 'J02.9');
+    const cptProcedure = makeCptProcedure('cpt-1', '29105');
+    const plan = makeProcedurePlan('plan-1', { dxRefIds: ['dx-1'], cptRefIds: ['cpt-1'] });
+    const templateList: List = {
+      resourceType: 'List',
+      id: 'proc-template',
+      status: 'current',
+      mode: 'working',
+      entry: [{ item: { reference: `#dx-1` } }, { item: { reference: `#cpt-1` } }, { item: { reference: `#plan-1` } }],
+      contained: [
+        dxCondition,
+        cptProcedure,
+        plan,
+        {
+          resourceType: 'Encounter',
+          id: 'stub-enc',
+          status: 'unknown',
+          class: { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB' },
+          diagnosis: [{ condition: { reference: 'Condition/dx-1' } }],
+        } as Encounter,
+      ],
+    };
+    const actions = makeActions({ procedures: 'append', diagnoses: 'skip', cptCodes: 'append' });
+    const requests = makeCreateRequests(makeSimpleCptEncounter(), templateList, [], actions, new Set());
+
+    const procedureSR = getProcedureServiceRequestPosts(requests)[0]!.resource;
+    // reasonReference should be omitted entirely when empty, not present as [].
+    expect(procedureSR.reasonReference).toBeUndefined();
+    // supportingInfo for the CPT is still applied since cptCodes wasn't skipped.
+    const cptPostRequest = requests.find(
+      (r): r is { method: 'POST'; resource: Procedure; fullUrl?: string; url: string } =>
+        r.method === 'POST' && (r as any).resource?.resourceType === 'Procedure'
+    )!;
+    expect(procedureSR.supportingInfo).toEqual([{ reference: cptPostRequest.fullUrl }]);
+  });
+
+  test("dropping cptCodes ('skip') drops the procedure's supportingInfo rather than leaking a stub id", () => {
+    const dxCondition = makeDxCondition('dx-1', 'J02.9');
+    const cptProcedure = makeCptProcedure('cpt-1', '29105');
+    const plan = makeProcedurePlan('plan-1', { dxRefIds: ['dx-1'], cptRefIds: ['cpt-1'] });
+    const templateList: List = {
+      resourceType: 'List',
+      id: 'proc-template',
+      status: 'current',
+      mode: 'working',
+      entry: [{ item: { reference: `#dx-1` } }, { item: { reference: `#cpt-1` } }, { item: { reference: `#plan-1` } }],
+      contained: [
+        dxCondition,
+        cptProcedure,
+        plan,
+        {
+          resourceType: 'Encounter',
+          id: 'stub-enc',
+          status: 'unknown',
+          class: { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB' },
+          diagnosis: [{ condition: { reference: 'Condition/dx-1' } }],
+        } as Encounter,
+      ],
+    };
+    const actions = makeActions({ procedures: 'append', diagnoses: 'append', cptCodes: 'skip' });
+    const requests = makeCreateRequests(makeSimpleCptEncounter(), templateList, [], actions, new Set());
+
+    const procedureSR = getProcedureServiceRequestPosts(requests)[0]!.resource;
+    expect(procedureSR.supportingInfo).toBeUndefined();
+    // reasonReference is preserved since diagnoses wasn't skipped.
+    const dxPostRequest = requests.find(
+      (r): r is { method: 'POST'; resource: Condition; fullUrl?: string; url: string } =>
+        r.method === 'POST' && (r as any).resource?.resourceType === 'Condition'
+    )!;
+    expect(procedureSR.reasonReference).toEqual([{ reference: dxPostRequest.fullUrl }]);
+  });
+
+  test('a sparse procedure plan with no cross-refs still produces a clean ServiceRequest', () => {
+    // Some templates may carry procedures with no diagnoses or CPT codes -
+    // those should still apply without emitting empty reasonReference/[]
+    // arrays on the live SR.
+    const plan = makeProcedurePlan('plan-1');
+    const templateList = makeProcedureTemplateList([plan]);
+    const actions = makeActions({ procedures: 'append' });
+    const requests = makeCreateRequests(makeSimpleCptEncounter(), templateList, [], actions, new Set());
+
+    const procedureSR = getProcedureServiceRequestPosts(requests)[0]!.resource;
+    expect(procedureSR.reasonReference).toBeUndefined();
+    expect(procedureSR.supportingInfo).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the in-house labs template pattern for the in-office Procedures feature, with the linked-structure cross-refs adapted to procedures' shape: a procedure ServiceRequest carries `reasonReference` into encounter diagnosis Conditions and `supportingInfo` into CPT-code Procedures, so the template snapshot has to preserve those links to round-trip.

- `admin-create-template` captures chart procedures (filtered to includable statuses so `entered-in-error`/`revoked` ones don't leak in) and materializes each as a plan ServiceRequest in `List.contained`. The plan preserves the procedure form's full payload — `category` (procedureType), `performerType`, `bodySite`, and the dozen extensions for technique / medication / etc. — and remaps `reasonReference` / `supportingInfo` through `oldIdToNewIdMap` so they point at the template's contained Conditions and CPT Procedures.
- `admin-get-template-detail` parses procedure plans into `TemplateProcedurePlan` with inline `{code, display}` (plus modifiers, matching the in-house labs `TemplateCptCodeInfo` shape) for the linked diagnoses and CPT codes, so the UI never has to walk the FHIR graph.
- `apply-template` materializes procedure plans via a small builder (`apply-procedures.ts`) which rewrites cross-refs through a contained-id → urn:uuid fullUrl map built during `makeCreateRequests`. CPT-Procedure creates moved into the mini-transaction so the procedure plan's `supportingInfo` fullUrls resolve atomically in the same FHIR transaction. References whose target section is set to `skip` get dropped on the rewritten request.
- Section actions: `procedures` added to `TemplateSectionKey`, `TEMPLATE_SECTIONS_IN_ORDER`, and `TEMPLATE_SECTION_DEFAULT_ACTIONS` (default `append`), with the section constrained to skip/append (no overwrite via `TEMPLATE_SECTIONS_NO_OVERWRITE`) so applying a template never silently wipes a provider's existing procedure documentation.
- UI: `TemplatePreviewDialog` and `GlobalTemplateDetailPage` each render a Procedures section. The preview lays out the procedure type as a `subtitle2` subheading with the details left-indented underneath — uppercase-caption "CPT codes" and "Diagnoses" labels above the shared `CodeList` rendering, followed by a compact label/value list of the procedure-form fields the template actually carried (Yes/No for booleans, multi-line content via `whiteSpace: pre-wrap`). The field list is centralised in `src/helpers/templates.ts` so the dialog and admin page stay in sync.

## Test plan

- [x] `cd packages/zambdas && npx vitest run --config ./vitest.config.unit.ts` — 745 tests pass (was 732; +13)
- [x] `cd apps/ehr && npx vitest --config ./vitest.config.component-tests.ts run tests/component/ApplyTemplate.test.tsx` — 18 tests pass (was 16; +2)
- [x] `npx tsc -p packages/zambdas/tsconfig.json --noEmit` — clean
- [x] `npx tsc -p apps/ehr/tsconfig.json --noEmit` — clean
- [x] `npm run lint` — clean across all 10 packages
- [ ] Manual: save a template from a visit with one or more procedures, apply it onto a fresh visit, confirm the procedures appear in the chart with their linked diagnoses and CPT codes
- [ ] Manual: with procedures action set to `skip`, confirm no procedures are created on apply
- [ ] Manual: with diagnoses action set to `skip` and procedures action `append`, confirm the procedure is created but without its `reasonReference` linkage

## Test coverage added

Mirroring the in-house labs work:

- `apply-procedures.test.ts` — 9 unit tests on the procedure-plan builder: reference rewrite, drop semantics when the target section is skipped, intent/status/tag transitions, sparse plan handling.
- `admin-create-template.test.ts` — 7 tests on `isValidProcedureServiceRequest`: includable-status set, exclusion of deleted procedures (`entered-in-error` / `revoked`), the procedure meta-tag requirement, the non-ServiceRequest fallthrough.
- `apply-template.test.ts` — 6 `makeCreateRequests` procedure-plan tests: action propagation, end-to-end cross-ref rewrite into fullUrls in the same transaction, drop semantics when diagnoses/CPT sections are skipped, sparse-plan handling.
- `apply-template.test.ts` — 2 validation tests pin the skip/append-only constraint.
- `ApplyTemplate.test.tsx` — 2 component tests cover the procedure section card (CPT/diagnosis text + form fields visible, Overwrite hidden) and the empty-procedures case where the section is suppressed.

## Open product decisions (from the original handoff doc)

| Question | Resolution |
|---|---|
| Action set: include Overwrite? | **Skip/Append only**, matching in-house labs |
| Default action | **Append** |
| Linked diagnoses (`reasonReference`) and CPT codes (`supportingInfo`) at save? | **Preserve linked structure** — plans carry stub-id refs; apply-template rewrites them through a contained-id → fullUrl map into the same FHIR transaction |
| `ActivityDefinition`? | Skipped — procedures don't reference ADs |
| Status filtering on save | `{ draft, active, on-hold, completed }` (same as in-house labs), filters out the `entered-in-error` state `delete-chart-data` produces |
| Requester / performer | Procedures have no Practitioner requester field; `documentedBy` / `performerType` are free-text codes preserved verbatim |
| In-flight risk | None — procedures are `status='completed'` post-facto records, no specimens or downstream work to lose |

## Notes / known follow-ups

- CPT Procedure POSTs moved from a chunked batch into the mini-transaction so that the procedure plan's `supportingInfo` fullUrls resolve atomically. Transaction size grows with template size; not a failure mode yet for typical templates, worth keeping an eye on if templates with many CPT codes start showing up.

https://claude.ai/code/session_017vAei1vtTc7gfSa6kDUtg8

---
_Generated by [Claude Code](https://claude.ai/code/session_017vAei1vtTc7gfSa6kDUtg8)_