### PR TITLE
fix(e2e): remove flaky networkidle wait from FeeSchedulePage navigation

### DIFF
--- a/apps/ehr/tests/e2e/page/FeeSchedulePage.ts
+++ b/apps/ehr/tests/e2e/page/FeeSchedulePage.ts
@@ -7,13 +7,16 @@ export class FeeSchedulePage {
   constructor(private page: Page) {}
 
   async goto(feeScheduleId: string): Promise<void> {
+    // NOTE: Do not wait for 'networkidle' here. The EHR runs continuous
+    // background polling / React Query refetches, so the network never goes
+    // idle and the wait reliably times out (the cause of the nightly fee
+    // schedule flakiness). Callers wait on concrete elements instead
+    // (e.g. waitForProcedureCodesLoaded), which is the deterministic signal.
     await this.page.goto(`/admin/fee-schedule/${feeScheduleId}`);
-    await this.page.waitForLoadState('networkidle');
   }
 
   async gotoChargeMaster(chargeMasterId: string): Promise<void> {
     await this.page.goto(`/admin/charge-masters/${chargeMasterId}`);
-    await this.page.waitForLoadState('networkidle');
   }
 
   async waitForProcedureCodesLoaded(): Promise<void> {


### PR DESCRIPTION
## Problem

The nightly fee schedule e2e tests (`feeScheduleAdmin.spec.ts`) intermittently fail/flake. Every failure has the same root cause, e.g. from the June 3 nightly run:

```
TimeoutError: page.waitForLoadState: Timeout 35000ms exceeded.
  at FeeSchedulePage.goto (e2e/page/FeeSchedulePage.ts:11)
> 11 |     await this.page.waitForLoadState('networkidle');
```

Affected tests included `prevents adding duplicate code+modifier`, `allows adding same code with different modifier`, `upload CSV deduplicates rows` (failed all 3 attempts), and `search filters procedure codes`.

## Root cause

`FeeSchedulePage.goto()` waited for `'networkidle'`. The EHR runs continuous background polling and React Query refetches, so the network never reaches `networkidle` and the wait burns the full `navigationTimeout` (35s) before timing out. This is timing-dependent, which is why it flakes under load rather than failing consistently. Notably, the rest of the e2e suite's page objects don't use `networkidle` — only the newest admin ones do.

## Fix

Remove the `networkidle` wait from `goto()` / `gotoChargeMaster()`. It was redundant: every caller immediately follows with `waitForProcedureCodesLoaded()`, which clicks the tab and asserts the Add button is visible — a deterministic readiness signal that matches the convention used by the rest of the e2e page objects.

## Notes

`EmployersPage.ts`, `PaymentLocationsPage.ts`, and `paymentLocations.spec.ts` carry the same anti-pattern and are likely to flake next; left out of scope here but can be addressed in a follow-up.

https://claude.ai/code/session_01DvVdEJPfyDsECQZWcgkaPm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvVdEJPfyDsECQZWcgkaPm)_