### PR TITLE
Issue 7682 / fix. Tracking board. 'Today' should be selected by default after login.

### DIFF
--- a/apps/ehr/src/components/AppointmentsFilters.tsx
+++ b/apps/ehr/src/components/AppointmentsFilters.tsx
@@ -44,6 +44,9 @@ const getVisitTypeToLabel = (): Partial<typeof ALL_VISIT_TYPE_LABELS> => {
 };
 
 export const LOCAL_STORAGE_FILTERS_KEY = 'appointments.filters';
+// `date` is kept in sessionStorage (not localStorage) so it survives in-app navigation but resets
+// to today on a new browser session — closing/reopening the window must not restore a stale date.
+export const SESSION_STORAGE_DATE_KEY = 'appointments.date';
 
 // Filter params owned by this component; any other param (e.g. `tab`) is preserved.
 const FILTER_PARAM_KEYS = ['location', 'visitType', 'serviceCategory', 'date', 'provider'] as const;
@@ -98,9 +101,16 @@ export default function AppointmentsFilters(): ReactElement {
           return next;
         });
         if (values) {
-          localStorage.setItem(LOCAL_STORAGE_FILTERS_KEY, JSON.stringify(values));
+          const { date, ...rest } = values;
+          localStorage.setItem(LOCAL_STORAGE_FILTERS_KEY, JSON.stringify(rest));
+          if (date) {
+            sessionStorage.setItem(SESSION_STORAGE_DATE_KEY, date);
+          } else {
+            sessionStorage.removeItem(SESSION_STORAGE_DATE_KEY);
+          }
         } else {
           localStorage.removeItem(LOCAL_STORAGE_FILTERS_KEY);
+          sessionStorage.removeItem(SESSION_STORAGE_DATE_KEY);
         }
       },
     });
@@ -113,9 +123,10 @@ export default function AppointmentsFilters(): ReactElement {
       return;
     }
 
+    const date = sessionStorage.getItem(SESSION_STORAGE_DATE_KEY) || DateTime.now().toISODate();
     const defaultValues = {
       visitType: Object.keys(visitTypeToLabel),
-      date: DateTime.now().toISODate(),
+      date,
     };
 
     const persistedValues = localStorage.getItem(LOCAL_STORAGE_FILTERS_KEY);
@@ -127,9 +138,7 @@ export default function AppointmentsFilters(): ReactElement {
 
     try {
       const parsed = JSON.parse(persistedValues);
-      // `date` is stripped from storage on logout, so it falls back to today after re-login
-      // while still being preserved across in-app navigation.
-      methods.reset({ ...parsed, date: parsed.date || DateTime.now().toISODate() });
+      methods.reset({ ...parsed, date });
     } catch {
       // Corrupt/legacy localStorage: drop it and fall back to defaults instead of crashing.
       localStorage.removeItem(LOCAL_STORAGE_FILTERS_KEY);

--- a/apps/ehr/src/pages/Logout.tsx
+++ b/apps/ehr/src/pages/Logout.tsx
@@ -1,21 +1,12 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { ReactElement, useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
-import { LOCAL_STORAGE_FILTERS_KEY } from 'src/components/AppointmentsFilters';
+import { SESSION_STORAGE_DATE_KEY } from 'src/components/AppointmentsFilters';
 
-// Drop the persisted tracking board date so it defaults back to today on the next login.
-// Other filters are preserved. Guarded so a corrupted value can't break the logout flow.
+// sessionStorage survives the same-tab logout -> Auth0 round-trip, so the date has to be
+// cleared explicitly here for it to default back to today on the next login.
 function clearPersistedDate(): void {
-  const persistedFilters = localStorage.getItem(LOCAL_STORAGE_FILTERS_KEY);
-  if (!persistedFilters) {
-    return;
-  }
-  try {
-    const { date: _date, ...rest } = JSON.parse(persistedFilters);
-    localStorage.setItem(LOCAL_STORAGE_FILTERS_KEY, JSON.stringify(rest));
-  } catch {
-    localStorage.removeItem(LOCAL_STORAGE_FILTERS_KEY);
-  }
+  sessionStorage.removeItem(SESSION_STORAGE_DATE_KEY);
 }
 
 export default function Logout(): ReactElement {

--- a/apps/ehr/src/pages/Logout.tsx
+++ b/apps/ehr/src/pages/Logout.tsx
@@ -19,19 +19,21 @@ function clearPersistedDate(): void {
 }
 
 export default function Logout(): ReactElement {
-  const { isAuthenticated, logout } = useAuth0();
+  const { isAuthenticated, isLoading, logout } = useAuth0();
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    // Auto-logout navigates here via a full page reload, so wait for Auth0 to rehydrate the
+    // session before acting — otherwise isAuthenticated is briefly false and we'd skip cleanup.
+    if (isLoading || !isAuthenticated) {
       return;
     }
     clearPersistedDate();
     void logout({
       logoutParams: { returnTo: import.meta.env.VITE_APP_OYSTEHR_APPLICATION_REDIRECT_URL, federated: true },
     });
-  }, [isAuthenticated, logout]);
+  }, [isAuthenticated, isLoading, logout]);
 
-  if (!isAuthenticated) {
+  if (!isLoading && !isAuthenticated) {
     return <Navigate to="/" replace />;
   }
 

--- a/apps/ehr/tests/component/AppointmentsFilters.test.tsx
+++ b/apps/ehr/tests/component/AppointmentsFilters.test.tsx
@@ -18,7 +18,10 @@ vi.mock('../../src/components/input/DateInput', () => ({
   DateInput: () => <div data-testid="date-input" />,
 }));
 
-import AppointmentsFilters, { LOCAL_STORAGE_FILTERS_KEY } from '../../src/components/AppointmentsFilters';
+import AppointmentsFilters, {
+  LOCAL_STORAGE_FILTERS_KEY,
+  SESSION_STORAGE_DATE_KEY,
+} from '../../src/components/AppointmentsFilters';
 
 // Surfaces the current query string so assertions can inspect it.
 const SearchProbe = (): ReactNode => {
@@ -40,13 +43,15 @@ const getSearch = (): string => screen.getByTestId('search').textContent ?? '';
 describe('AppointmentsFilters persistence', () => {
   beforeEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
   });
 
   it('restores persisted filters into the URL while preserving the tab param', async () => {
     localStorage.setItem(
       LOCAL_STORAGE_FILTERS_KEY,
-      JSON.stringify({ location: [{ id: 'L1' }], visitType: ['in-person-walk-in'], date: '2026-01-01' })
+      JSON.stringify({ location: [{ id: 'L1' }], visitType: ['in-person-walk-in'] })
     );
+    sessionStorage.setItem(SESSION_STORAGE_DATE_KEY, '2026-01-01');
 
     renderFilters('/visits?tab=in-office');
 
@@ -58,6 +63,22 @@ describe('AppointmentsFilters persistence', () => {
       expect(params.get('location')).toBe('L1');
       expect(params.get('visitType')).toBe('in-person-walk-in');
       expect(params.get('date')).toBe('2026-01-01');
+    });
+  });
+
+  it('defaults the date to today on a fresh session even with other filters persisted', async () => {
+    // A new browser session clears sessionStorage but not localStorage; the stale date in
+    // localStorage (legacy) must be ignored and the date must fall back to today.
+    localStorage.setItem(LOCAL_STORAGE_FILTERS_KEY, JSON.stringify({ location: [{ id: 'L1' }], date: '2020-01-01' }));
+
+    renderFilters('/visits?tab=in-office');
+
+    await waitFor(() => {
+      const params = new URLSearchParams(getSearch());
+      expect(params.get('location')).toBe('L1');
+      // the stale persisted date is dropped in favour of today
+      expect(params.get('date')).not.toBe('2020-01-01');
+      expect(params.get('date')).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2655/tracking-board-today-should-be-selected-by-default-after-login#comment-cfe7ab8a