### PR TITLE
feat(reports): add "Telerad Orders" column to completed encounter report (OTR-2714)

### DIFF
--- a/apps/ehr/src/pages/reports/CompleteEncounters.tsx
+++ b/apps/ehr/src/pages/reports/CompleteEncounters.tsx
@@ -49,6 +49,7 @@ interface CompleteEncounterRow {
   attendingProvider?: string;
   visitType?: string;
   reason?: string;
+  teleradiologyOrdersSent: number;
 }
 
 type DateRangeFilter =
@@ -246,6 +247,7 @@ const useCompleteEncounters = (
             attendingProvider: encounter.attendingProvider,
             visitType: encounter.visitType,
             reason: encounter.reason,
+            teleradiologyOrdersSent: encounter.teleradiologyOrdersSent,
           };
         });
 
@@ -298,6 +300,7 @@ const useCompleteEncounters = (
           attendingProvider: encounter.attendingProvider,
           visitType: encounter.visitType,
           reason: encounter.reason,
+          teleradiologyOrdersSent: encounter.teleradiologyOrdersSent,
         };
       });
 
@@ -550,6 +553,13 @@ export default function CompleteEncounters(): React.ReactElement {
       {
         field: 'reason',
         headerName: 'Reason',
+        width: 200,
+        sortable: true,
+      },
+      {
+        field: 'teleradiologyOrdersSent',
+        headerName: 'Telerad Orders',
+        type: 'number',
         width: 200,
         sortable: true,
       },

--- a/packages/utils/lib/types/api/incomplete-encounters-report.types.ts
+++ b/packages/utils/lib/types/api/incomplete-encounters-report.types.ts
@@ -21,6 +21,10 @@ export interface IncompleteEncounterItem {
   attendingProvider?: string;
   visitType?: string;
   reason?: string;
+  // Number of radiology orders on this encounter that have actually been transmitted to a
+  // teleradiology group for an external read (i.e. carry the has-been-sent-to-teleradiology
+  // extension). Usually 0 or 1, but can be higher when multiple orders were sent.
+  teleradiologyOrdersSent: number;
 }
 
 export interface IncompleteEncountersReportZambdaOutput {

--- a/packages/zambdas/src/ehr/incomplete-encounters-report/index.ts
+++ b/packages/zambdas/src/ehr/incomplete-encounters-report/index.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { Appointment, Encounter, Location, Patient, Practitioner } from 'fhir/r4b';
+import { Appointment, Encounter, Location, Patient, Practitioner, ServiceRequest } from 'fhir/r4b';
 import {
   getAttendingPractitionerId,
   getInPersonVisitStatus,
@@ -11,6 +11,7 @@ import {
   isTelemedAppointment,
   OTTEHR_MODULE,
   Secrets,
+  SERVICE_REQUEST_HAS_BEEN_SENT_TO_TELERADIOLOGY_EXTENSION_URL,
 } from 'utils';
 import { checkOrCreateM2MClientToken, createOystehrClient, wrapHandler, ZambdaInput } from '../../shared';
 import { validateRequestParameters } from './validateRequestParameters';
@@ -39,7 +40,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
   // Search for appointments within the date range with proper pagination
   // Fetch all appointments, encounters, patients, locations, and practitioners with proper FHIR pagination
-  let allResources: (Appointment | Encounter | Patient | Location | Practitioner)[] = [];
+  let allResources: (Appointment | Encounter | Patient | Location | Practitioner | ServiceRequest)[] = [];
   let offset = 0;
   const pageSize = 1000;
 
@@ -77,6 +78,13 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
       value: 'Encounter:participant:Practitioner',
     },
     {
+      // Pull ServiceRequests (radiology orders, etc.) attached to the revincluded Encounters so we
+      // can count those that were sent to a teleradiology group for an external read. `:iterate`
+      // because ServiceRequest references the Encounter, which is itself revincluded from Appointment.
+      name: '_revinclude:iterate',
+      value: 'ServiceRequest:encounter',
+    },
+    {
       name: '_sort',
       value: 'date',
     },
@@ -86,7 +94,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     },
   ];
 
-  let searchBundle = await oystehr.fhir.search<Appointment | Encounter | Patient | Location | Practitioner>({
+  let searchBundle = await oystehr.fhir.search<
+    Appointment | Encounter | Patient | Location | Practitioner | ServiceRequest
+  >({
     resourceType: 'Appointment',
     params: [...baseSearchParams, { name: '_offset', value: offset.toString() }],
   });
@@ -110,7 +120,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     pageCount++;
     console.log(`Fetching page ${pageCount} of incomplete encounters...`);
 
-    searchBundle = await oystehr.fhir.search<Appointment | Encounter | Patient | Location | Practitioner>({
+    searchBundle = await oystehr.fhir.search<
+      Appointment | Encounter | Patient | Location | Practitioner | ServiceRequest
+    >({
       resourceType: 'Appointment',
       params: [...baseSearchParams, { name: '_offset', value: offset.toString() }],
     });
@@ -176,6 +188,30 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     if (practitioner.id) {
       practitionerMap.set(practitioner.id, practitioner);
     }
+  });
+
+  // Count, per encounter, the radiology orders that have actually been transmitted to a
+  // teleradiology group for an external read. The has-been-sent-to-teleradiology extension is only
+  // present on radiology ServiceRequests, so its presence alone is a sufficient signal.
+  const serviceRequests = allResources.filter(
+    (resource): resource is ServiceRequest => resource.resourceType === 'ServiceRequest'
+  );
+  const teleradiologyOrdersSentByEncounterId = new Map<string, number>();
+  serviceRequests.forEach((serviceRequest) => {
+    const sentToTeleradiology = serviceRequest.extension?.some(
+      (ext) => ext.url === SERVICE_REQUEST_HAS_BEEN_SENT_TO_TELERADIOLOGY_EXTENSION_URL
+    );
+    if (!sentToTeleradiology) {
+      return;
+    }
+    const encounterId = serviceRequest.encounter?.reference?.replace('Encounter/', '');
+    if (!encounterId) {
+      return;
+    }
+    teleradiologyOrdersSentByEncounterId.set(
+      encounterId,
+      (teleradiologyOrdersSentByEncounterId.get(encounterId) ?? 0) + 1
+    );
   });
 
   // Filter encounters based on encounterStatus parameter
@@ -246,6 +282,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
       attendingProvider: attendingProviderName,
       visitType,
       reason: encounter.reasonCode?.[0]?.text || appointment?.appointmentType?.text || '',
+      teleradiologyOrdersSent: encounter.id ? teleradiologyOrdersSentByEncounterId.get(encounter.id) ?? 0 : 0,
     };
   });
 


### PR DESCRIPTION
## Summary
Adds a **Telerad Orders** column to the Complete Encounters report. Per encounter, it counts the radiology orders that have actually been transmitted to a teleradiology group for an external read — i.e. `ServiceRequest`s carrying the `has-been-sent-to-teleradiology` extension. Usually `0`/`1`, higher when multiple orders were sent.

## Changes
- **`incomplete-encounters-report` zambda** — adds `_revinclude:iterate ServiceRequest:encounter` to the appointment search, then counts, per encounter, the `ServiceRequest`s whose `extension` includes `SERVICE_REQUEST_HAS_BEEN_SENT_TO_TELERADIOLOGY_EXTENSION_URL`, returning `teleradiologyOrdersSent`. (That extension only appears on radiology orders, so its presence alone is a sufficient signal.)
- **types** — `teleradiologyOrdersSent: number` added to `IncompleteEncounterItem`.
- **`CompleteEncounters.tsx`** — maps the field in **both** transform paths (single-request and batched) and adds a numeric `Telerad Orders` column.

## How "sent to teleradiology" is detected
A radiology order is a `ServiceRequest`; when it's transmitted to a teleradiology group for an external read, the `pacs-poll` service stamps it with the `has-been-sent-to-teleradiology` extension (set after a clinician clicks "Send for Final Read"). There is no performer/Organization naming the group — the extension is the signal. The extension persists, so completed encounters report correctly.

## Verification
- Lint + typecheck clean (no new errors).
- Verified the local zambda returns the field for every row.
- **End-to-end proof:** temporarily added the extension to one radiology order whose encounter is in the report → its count went **0 → 1**; removing it returned it to **0** (test data reverted). Confirms the column is correct.
- In current synthetic data the count is `0` everywhere because no order has progressed through the external-PACS workflow that sets the extension — expected, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)