### PR TITLE
fix(zambdas): de-flake complete-encounters-report integration test

### DIFF
--- a/packages/zambdas/test/integration/complete-encounters-report.test.ts
+++ b/packages/zambdas/test/integration/complete-encounters-report.test.ts
@@ -177,8 +177,7 @@ describe('complete-encounters-report zambda', () => {
           break;
         } catch (error: any) {
           const isConcurrentUpdate =
-            error?.code === APIErrorCode.CONCURRENT_UPDATE ||
-            error?.message?.includes('modified during the operation');
+            error?.code === APIErrorCode.CONCURRENT_UPDATE || error?.message?.includes('modified during the operation');
           if (isConcurrentUpdate && attempt < MAX_ATTEMPTS) {
             await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
             continue;

--- a/packages/zambdas/test/integration/complete-encounters-report.test.ts
+++ b/packages/zambdas/test/integration/complete-encounters-report.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import { Location, Patient, Slot } from 'fhir/r4b';
 import { DateTime } from 'luxon';
 import {
+  APIErrorCode,
   CreateAppointmentInputParams,
   CreateAppointmentResponse,
   getSlugForBookableResource,
@@ -151,15 +152,40 @@ describe('complete-encounters-report zambda', () => {
   /**
    * Advances a walk-in encounter through the required in-person status flow to reach 'completed'.
    * The status machine requires sequential transitions: arrived → intake → ready → provider → discharge → completed
+   *
+   * Each transition is retried on a transient CONCURRENT_UPDATE (4024) error. The
+   * change-in-person-visit-status zambda patches the Encounter with an optimistic lock (If-Match on
+   * the version id). When this test fires the transitions back-to-back, an asynchronous backend
+   * process (e.g. a subscription reacting to the previous status change) can bump the Encounter
+   * version between the zambda's read and its conditional write, producing a 412 that surfaces as
+   * CONCURRENT_UPDATE. The zambda re-reads the Encounter on every call, so re-issuing the transition
+   * after a short backoff picks up the settled version and succeeds.
    */
   const advanceToCompleted = async (encounterId: string): Promise<void> => {
     const statuses: VisitStatusWithoutUnknown[] = ['intake', 'ready', 'provider', 'discharged', 'completed'];
+    const MAX_ATTEMPTS = 5;
+    const RETRY_DELAY_MS = 1_000;
+
     for (const status of statuses) {
-      await oystehr.zambda.execute({
-        id: 'change-in-person-visit-status',
-        encounterId,
-        updatedStatus: status,
-      });
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+          await oystehr.zambda.execute({
+            id: 'change-in-person-visit-status',
+            encounterId,
+            updatedStatus: status,
+          });
+          break;
+        } catch (error: any) {
+          const isConcurrentUpdate =
+            error?.code === APIErrorCode.CONCURRENT_UPDATE ||
+            error?.message?.includes('modified during the operation');
+          if (isConcurrentUpdate && attempt < MAX_ATTEMPTS) {
+            await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+            continue;
+          }
+          throw error;
+        }
+      }
     }
   };
 


### PR DESCRIPTION
We do a bunch of status changes in a row awaiting a zambda call each time but each one performs a mutation in a subscription that can race with the next zambda call supposedly. The tests retry and it works for them. In a production setting you wouldn't want to automatically retry one of these. 

🤖 Claude generated code and description below. 

## Problem

`complete-encounters-report.test.ts` has been flaking in CI (e.g. [run 27154164755](https://github.com/masslight/ottehr/actions/runs/27154164755/job/80152709879), step *"Zambda tests with coverage"*). Two tests failed from **one root cause**:

```
FAIL  complete-encounters-report zambda > returns completed encounters and excludes non-completed ones
OystehrSdkError: The encounter was modified during the operation
 ❯ advanceToCompleted complete-encounters-report.test.ts:158:7
Serialized Error: { code: 4024 }

FAIL  complete-encounters-report zambda > response encounters ... visitStatus is "completed"
AssertionError: expected 0 to be greater than 0
 ❯ complete-encounters-report.test.ts:319:34   expect(ourEncounters.length).toBeGreaterThan(0);
```

## Root cause

`advanceToCompleted` walks the in-person status machine by calling `change-in-person-visit-status` five times back-to-back (`intake → ready → provider → discharged → completed`).

That zambda performs a **read-modify-write under an optimistic lock**: it reads the Encounter, then patches it inside a FHIR transaction with `ifMatch: W/"<versionId>"` (`change-in-person-visit-status/helpers/helpers.ts`). If the Encounter's server-side version no longer matches, FHIR returns **412**, which the helper maps to `CONCURRENT_UPDATE` (4024) — *"The encounter was modified during the operation."*

When the transitions fire at machine speed, an **asynchronous backend process** reacting to the *previous* status change (e.g. discharge outreach, the AI-questionnaire completion that triggers resource creation via subscription) can bump the Encounter version *between* the zambda's read and its conditional write → 412 → 4024 → `advanceToCompleted` throws.

**Cascade:** the throw aborts the test mid-sequence, so the encounter never reaches `completed`. The next test then queries the report, filters to this run's appointments, finds none completed, and fails `expected 0 to be greater than 0`. One race, two red tests — which is why it's intermittent.

## Fix

Retry each status transition on the transient `CONCURRENT_UPDATE` (4024) error with a short backoff. The zambda re-reads the Encounter on every call, so re-issuing the transition picks up the settled version and succeeds.

Scoped intentionally to the **test**, not the zambda: the optimistic lock is deliberate production behavior (it surfaces genuine concurrent edits to real users, who change status at human speed). Auto-retrying server-side would change that contract, so it's left untouched.

## Verification

- Imports verified (`APIErrorCode` is exported from `utils`); `catch (error: any)` and inline `setTimeout` are already-accepted patterns in this test suite.
- Lint and the integration test were **not** run locally (deps not installed in the dev container; the integration test needs a live Oystehr backend + secrets). CI on this branch will exercise it.

https://claude.ai/code/session_019anu6NaksrnNt3quW8i5W2

---
_Generated by [Claude Code](https://claude.ai/code/session_019anu6NaksrnNt3quW8i5W2)_