### PR TITLE
disable optimistic locking in front end

### DIFF
--- a/apps/ehr/src/features/visits/shared/stores/appointment/appointment.queries.ts
+++ b/apps/ehr/src/features/visits/shared/stores/appointment/appointment.queries.ts
@@ -728,7 +728,8 @@ export const useSyncERXPatient = ({
         }
 
         try {
-          await tagEncounterAsErxSynced(oystehr, encounter);
+          // optimistic locking causes `If-Match` cors header failures
+          await tagEncounterAsErxSynced(oystehr, encounter, { useOptimisticLocking: false });
         } catch (tagErr) {
           // it's fine if it fails, it'll just try syncing again later
           console.error('Failed to tag encounter as erx-synced: ', tagErr);

--- a/apps/ehr/tests/component/useSyncERXPatient.test.tsx
+++ b/apps/ehr/tests/component/useSyncERXPatient.test.tsx
@@ -112,7 +112,7 @@ describe('useSyncERXPatient', () => {
           },
         ],
       }),
-      { optimisticLockingVersionId: 'v1' }
+      {}
     );
   });
 

--- a/packages/utils/lib/fhir/encounter.test.ts
+++ b/packages/utils/lib/fhir/encounter.test.ts
@@ -264,6 +264,65 @@ describe('eRx sync tag helpers', () => {
       expect(get).not.toHaveBeenCalled();
     });
 
+    it('patches without optimistic locking when disabled', async () => {
+      const patch = vi.fn().mockResolvedValue(undefined);
+      const get = vi.fn();
+      const oystehr = {
+        fhir: {
+          patch,
+          get,
+        },
+      } as unknown as Oystehr;
+
+      await tagEncounterAsErxSynced(
+        oystehr,
+        makeEncounter({
+          id: 'enc-1',
+          meta: {
+            versionId: 'v1',
+          },
+        }),
+        {
+          useOptimisticLocking: false,
+        }
+      );
+
+      expect(patch).toHaveBeenCalledTimes(1);
+      expect(patch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceType: 'Encounter',
+          id: 'enc-1',
+        }),
+        {}
+      );
+      expect(get).not.toHaveBeenCalled();
+    });
+
+    it('does not refresh or retry on failure when optimistic locking is disabled', async () => {
+      const patch = vi.fn().mockRejectedValue(new Error('patch failed'));
+      const get = vi.fn();
+      const oystehr = {
+        fhir: {
+          patch,
+          get,
+        },
+      } as unknown as Oystehr;
+
+      await tagEncounterAsErxSynced(
+        oystehr,
+        makeEncounter({
+          id: 'enc-1',
+          meta: { versionId: 'v1' },
+        }),
+        {
+          useOptimisticLocking: false,
+        }
+      );
+
+      expect(patch).toHaveBeenCalledTimes(1);
+      expect(get).not.toHaveBeenCalled();
+    });
+
     it('does nothing when the encounter is already synced', async () => {
       const patch = vi.fn();
       const oystehr = {

--- a/packages/utils/lib/fhir/encounter.ts
+++ b/packages/utils/lib/fhir/encounter.ts
@@ -382,7 +382,12 @@ export const isEncounterErxSynced = (encounter: Encounter): boolean =>
       tag.system === FHIR_ENCOUNTER_ERX_PATIENT_SYNC_TAG.system && tag.code === FHIR_ENCOUNTER_ERX_PATIENT_SYNC_TAG.code
   ) ?? false;
 
-export const tagEncounterAsErxSynced = async (oystehr: Oystehr, encounter: Encounter): Promise<void> => {
+export const tagEncounterAsErxSynced = async (
+  oystehr: Oystehr,
+  encounter: Encounter,
+  options?: { useOptimisticLocking?: boolean }
+): Promise<void> => {
+  const useOptimisticLocking = options?.useOptimisticLocking ?? true;
   const encounterId = encounter.id;
   if (!encounterId) {
     throw new Error('Cannot tag encounter as eRx-synced: encounter has no id');
@@ -403,10 +408,14 @@ export const tagEncounterAsErxSynced = async (oystehr: Oystehr, encounter: Encou
           id: encounterId,
           operations: [getPatchOperationForNewMetaTag(current, FHIR_ENCOUNTER_ERX_PATIENT_SYNC_TAG)],
         },
-        { optimisticLockingVersionId: current.meta?.versionId }
+        useOptimisticLocking ? { optimisticLockingVersionId: current.meta?.versionId } : {}
       );
       return;
     } catch (patchError) {
+      if (!useOptimisticLocking) {
+        console.warn(`Failed to tag encounter ${encounterId} as eRx-synced`, patchError);
+        return;
+      }
       retries++;
       try {
         current = await oystehr.fhir.get<Encounter>({
@@ -414,7 +423,7 @@ export const tagEncounterAsErxSynced = async (oystehr: Oystehr, encounter: Encou
           id: encounterId,
         });
       } catch (refreshError) {
-        console.warn(`Failed to tag encounter ${encounterId} after ${retries} attempts`, refreshError || patchError);
+        console.warn(`Failed to tag encounter ${encounterId} after ${retries} attempts`, refreshError);
         return;
       }
     }


### PR DESCRIPTION
this was throwing cors errors and ultimately always failing because of the added "If-Match" header