### PR TITLE
Fix(in house labs): fix circular dependency

### DIFF
--- a/packages/utils/lib/types/data/appointments/appointments.types.ts
+++ b/packages/utils/lib/types/data/appointments/appointments.types.ts
@@ -12,8 +12,9 @@ import {
   RelatedPerson,
 } from 'fhir/r4b';
 import { z } from 'zod';
+import { PARTICIPATION_CODE_SYSTEM } from '../../../fhir/constants';
 import { OTTEHR_MODULE } from '../../../fhir/moduleIdentification';
-import { FhirAppointmentType, PARTICIPATION_CODE_SYSTEM, ProviderTypeCode, Secrets } from '../../../main';
+import { Secrets } from '../../../secrets';
 import {
   AppointmentAttendanceType,
   AppointmentMessaging,
@@ -22,6 +23,8 @@ import {
   VisitStatusHistoryEntry,
   VisitStatusLabel,
 } from '../../api';
+import { ProviderTypeCode } from '../../api/practitioner.types';
+import { FhirAppointmentType } from '../../common';
 
 export interface GetPastVisitsResponse {
   appointments: AppointmentInformationIntake[];


### PR DESCRIPTION
Courtesy of Claude:
 The problem was the path through the module graph, not the symbols themselves:

  Before:
  main.ts → export * from './types' → types/index.ts → types/api/index.ts → appointments.types.ts → import from '../../../main'
  That last edge closes a cycle back to main.ts. When Node starts evaluating main.ts, it begins re-exporting ./fhir and ./types. While traversing ./types it reaches appointments.types.ts, which immediately asks
  for main.ts again. Node hands back the partially-evaluated main.ts — and at that moment fhir/constants.ts may not have run yet, so PARTICIPATION_CODE_SYSTEM comes back as undefined. It gets baked into
  PRACTITIONER_CODINGS as a permanent undefined.

  After:
  appointments.types.ts → import from '../../../fhir/constants'
  appointments.types.ts → import from '../../../secrets'
  appointments.types.ts → import from '../../common'
  appointments.types.ts → import from '../../api/practitioner.types'
  None of those files import from main.ts or from types/data/appointments/, so there's no cycle. Each one is a leaf (or close to it) in the module graph — by the time appointments.types.ts runs, all four values
  are already fully initialized.
 
  The short version: the symbols were always correct at their source. The bug was that fetching them through main.ts meant you were reading from a module that was still mid-evaluation. Fetching them directly from
  where they're defined sidesteps that entirely.