### PR TITLE
fix(e2e): derive payment locations test target from the table instead of IaC config

### DIFF
--- a/apps/ehr/tests/e2e/specs/admin/paymentLocations.spec.ts
+++ b/apps/ehr/tests/e2e/specs/admin/paymentLocations.spec.ts
@@ -1,32 +1,10 @@
 import { BrowserContext, Page, test } from '@playwright/test';
-import { isLocationVirtual } from 'utils';
-import locationsSpec from '../../../../../../config/oystehr/locations-and-schedules.json' assert { type: 'json' };
 import {
   expectPaymentLocationDetailPage,
   expectPaymentLocationsPage,
   PaymentLocationDetailPage,
   PaymentLocationsPage,
 } from '../../page/PaymentLocationsPage';
-
-function findFirstLocationName(): string {
-  const entries = Object.values((locationsSpec as { fhirResources: Record<string, any> }).fhirResources);
-  let inPerson: string | undefined;
-  let telemed: string | undefined;
-  for (const entry of entries) {
-    const resource = entry.resource;
-    if (resource?.resourceType !== 'Location' || !resource.name) continue;
-    if (isLocationVirtual(resource)) {
-      telemed ??= resource.name;
-    } else {
-      inPerson ??= resource.name;
-    }
-  }
-  if (inPerson) return inPerson;
-  if (telemed) return telemed;
-  throw new Error(
-    'Expected locations-and-schedules.json to contain at least one named Location resource, but none were found.'
-  );
-}
 
 let page: Page;
 let context: BrowserContext;
@@ -43,7 +21,9 @@ test.afterAll(async () => {
 
 let paymentLocationsPage: PaymentLocationsPage;
 let detailPage: PaymentLocationDetailPage;
-const TARGET_LOCATION = findFirstLocationName();
+// Location names are self-service editable (not terraform-managed), so seeded names from
+// config can drift in shared environments. Use whatever location the table actually lists.
+let targetLocation: string;
 
 test.describe.configure({ mode: 'serial' });
 
@@ -58,33 +38,40 @@ test.describe('Payment Locations Admin', () => {
     const rowCount = await paymentLocationsPage.getLocationRows();
     test.skip(rowCount === 0, 'No payment locations available to test');
 
-    await paymentLocationsPage.searchLocations(TARGET_LOCATION);
-    await paymentLocationsPage.verifyLocationVisible(TARGET_LOCATION);
+    targetLocation = await paymentLocationsPage.getFirstLocationName();
+    test.skip(!targetLocation, 'First listed location has no name to search for');
+
+    await paymentLocationsPage.searchLocations(targetLocation);
+    await paymentLocationsPage.verifyLocationVisible(targetLocation);
     await paymentLocationsPage.searchLocations('');
   });
 
   test('search filters locations correctly', async () => {
-    await paymentLocationsPage.searchLocations(TARGET_LOCATION);
-    await paymentLocationsPage.verifyLocationVisible(TARGET_LOCATION);
+    test.skip(!targetLocation, 'No target location available');
+
+    await paymentLocationsPage.searchLocations(targetLocation);
+    await paymentLocationsPage.verifyLocationVisible(targetLocation);
 
     // Search for nonexistent location
     await paymentLocationsPage.searchLocations('ZZZZNONEXISTENT');
-    await paymentLocationsPage.verifyLocationNotVisible(TARGET_LOCATION);
+    await paymentLocationsPage.verifyLocationNotVisible(targetLocation);
 
     // Clear search
     await paymentLocationsPage.searchLocations('');
   });
 
   test('click on a location row navigates to detail page', async () => {
-    await paymentLocationsPage.searchLocations(TARGET_LOCATION);
-    await paymentLocationsPage.clickLocationByName(TARGET_LOCATION);
+    test.skip(!targetLocation, 'No target location available');
+
+    await paymentLocationsPage.searchLocations(targetLocation);
+    await paymentLocationsPage.clickLocationByName(targetLocation);
     detailPage = await expectPaymentLocationDetailPage(page);
   });
 
   test('detail page shows location name and sections', async () => {
     test.skip(!detailPage, 'Detail page not loaded');
 
-    await detailPage.verifyLocationName(TARGET_LOCATION);
+    await detailPage.verifyLocationName(targetLocation);
     await detailPage.verifyContactAndAddressSection();
     await detailPage.verifyBreadcrumbs();
   });


### PR DESCRIPTION
Location names became self service configurable but this e2e test was depending on an exact Location name to be there. Changing it to use any Location that's available which should work fine.

🤖 generated code, 🤖 description below.

## Problem

`paymentLocations.spec.ts › verify locations are listed and target location exists` is failing across many PRs (whenever CI load-balances onto the `e2e` environment), e.g. [this run](https://github.com/masslight/ottehr/actions/runs/27241111262/job/80445423897?pr=7740).

The spec derived its target location name ("New York") from `config/oystehr/locations-and-schedules.json`. Since OTR-2505 (#7701) added `managedFields: ["identifier"]` to the seeded Locations, terraform no longer reconciles `name`/`address`/`status` on them — those fields are intentionally self-service editable via the new Schedule General tab. Once the "New York" location drifted in the shared `e2e` project, the per-run terraform apply stopped restoring it, so every run on that environment fails the lookup. Runs on `e2e2` pass (verified by comparing job logs), confirming environment drift rather than a code regression.

## Fix

Make the spec independent of seeded names: capture the first location actually listed in the Payment Locations table (via the existing `getFirstLocationName()` page-object method) and use it as the target for the search/filter/detail-page/breadcrumb tests, with skip guards when the table is empty or the first row has no name.

Capturing the name once and searching by name keeps the test stable even if other suites insert locations mid-run.

## Notes

- The `e2e` environment's "New York" location is still drifted; worth restoring to config values if anything else assumes seeded state, but this spec no longer cares.
- `employees.spec.ts › Deactivating employee success` fails on both `e2e` and `e2e2` — separate issue, not addressed here.

## Verification

- `npx eslint tests/e2e/specs/admin/paymentLocations.spec.ts` — clean
- `npx tsc --noEmit` (apps/ehr) — clean

https://claude.ai/code/session_014iehQwxfzwm6aLXYgGuXbG

---
_Generated by [Claude Code](https://claude.ai/code/session_014iehQwxfzwm6aLXYgGuXbG)_