### PR TITLE
Fix(global temp): preserve multiple procedures when saving as global template

### DIFF
--- a/packages/zambdas/src/ehr/admin-create-template/index.ts
+++ b/packages/zambdas/src/ehr/admin-create-template/index.ts
@@ -128,26 +128,7 @@ const performEffect = async (
     return a.meta.lastUpdated > b.meta.lastUpdated ? -1 : 1;
   });
 
-  const seenTags = new Set<string>();
-  encounterBundle = encounterBundle.filter((resource) => {
-    // Diagnoses are additive (multiple per encounter), so skip deduplication for them.
-    // We identify diagnoses by the `diagnosis` meta tag, NOT by ICD-10 code — Medical Conditions can also
-    // carry ICD-10 codes but they are patient-specific history, not template content.
-    if (isDiagnosisCondition(resource)) return true;
-    const tags = resource?.meta?.tag?.map((tag) => `${tag.system}|${tag.code}`);
-    if (!tags) return true;
-    // CPT codes and patient instructions are additive (multiple per encounter), so skip deduplication for them
-    if (
-      tags.some(
-        (tag) =>
-          tag?.includes(chartDataTagSystem('cpt-code')) || tag?.includes(chartDataTagSystem('patient-instruction'))
-      )
-    )
-      return true;
-    const isDuplicate = tags.some((tag) => seenTags.has(tag!));
-    if (!isDuplicate) tags.forEach((tag) => seenTags.add(tag!));
-    return !isDuplicate;
-  });
+  encounterBundle = deduplicateTemplateResourcesByMetaTag(encounterBundle);
 
   // Capture in-house lab orders on the encounter BEFORE the TEMPLATE_TAG_SYSTEMS
   // filter runs. In-house lab ServiceRequests aren't marked with any chart-data
@@ -377,6 +358,47 @@ const performEffect = async (
     templateName: createdList.title ?? templateName,
     templateId: createdList.id!,
   };
+};
+
+// Drops chart-data resources that duplicate a previously-seen meta tag
+// (system|code pair). Used at the top of template creation to coalesce
+// stale or re-saved chart entries down to the most recent one.
+//
+// Some chart-data sections legitimately have multiple resources sharing the
+// same meta tag - they're list-shaped, with each new entry adding to the
+// collection rather than replacing the previous one. Those are exempted:
+//
+//   - Diagnoses (identified by the 'diagnosis' meta tag, NOT by ICD-10 code:
+//     Medical Conditions also carry ICD-10 codes but are patient-specific
+//     history, not template content).
+//   - CPT codes.
+//   - Patient instructions.
+//   - In-office procedures (each procedure ServiceRequest carries the same
+//     'procedure' meta tag, so without this exemption a chart with N
+//     procedures would get coalesced down to one).
+//
+// Caller is responsible for any other sorting / shaping of the resource list.
+export const deduplicateTemplateResourcesByMetaTag = (
+  resources: TemplateEncounterResource[]
+): TemplateEncounterResource[] => {
+  const seenTags = new Set<string>();
+  return resources.filter((resource) => {
+    if (isDiagnosisCondition(resource)) return true;
+    const tags = resource?.meta?.tag?.map((tag) => `${tag.system}|${tag.code}`);
+    if (!tags) return true;
+    if (
+      tags.some(
+        (tag) =>
+          tag?.includes(chartDataTagSystem('cpt-code')) ||
+          tag?.includes(chartDataTagSystem('patient-instruction')) ||
+          tag?.includes(chartDataTagSystem('procedure'))
+      )
+    )
+      return true;
+    const isDuplicate = tags.some((tag) => seenTags.has(tag!));
+    if (!isDuplicate) tags.forEach((tag) => seenTags.add(tag!));
+    return !isDuplicate;
+  });
 };
 
 export const filterEntriesToTemplateContent = (

--- a/packages/zambdas/test/unit/admin-create-template.test.ts
+++ b/packages/zambdas/test/unit/admin-create-template.test.ts
@@ -7,6 +7,7 @@ import {
 } from 'utils';
 import { describe, expect, test } from 'vitest';
 import {
+  deduplicateTemplateResourcesByMetaTag,
   filterEntriesToTemplateContent,
   isValidInHouseLabServiceRequest,
   isValidProcedureServiceRequest,
@@ -376,5 +377,97 @@ describe('isValidProcedureServiceRequest', () => {
       meta: { tag: [{ system: chartDataTagSystem('procedure'), code: 'procedure' }] },
     };
     expect(isValidProcedureServiceRequest(obs)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deduplicateTemplateResourcesByMetaTag — additive-section preservation
+// ---------------------------------------------------------------------------
+
+const makeProcedureSR = (id: string): ServiceRequest => ({
+  resourceType: 'ServiceRequest',
+  id,
+  status: 'completed',
+  intent: 'original-order',
+  subject: { reference: 'Patient/p1' },
+  meta: { tag: [{ system: chartDataTagSystem('procedure'), code: 'procedure' }] },
+});
+
+const makeCptProcedure = (id: string): Procedure => ({
+  resourceType: 'Procedure',
+  id,
+  status: 'completed',
+  subject: { reference: 'Patient/p1' },
+  meta: { tag: [{ system: chartDataTagSystem('cpt-code'), code: 'cpt-code' }] },
+  code: { coding: [{ system: 'http://www.ama-assn.org/go/cpt', code: '29105' }] },
+});
+
+const makePatientInstruction = (id: string): TemplateEncounterResource =>
+  ({
+    resourceType: 'Communication',
+    id,
+    status: 'completed',
+    meta: { tag: [{ system: chartDataTagSystem('patient-instruction'), code: 'patient-instruction' }] },
+  }) as unknown as TemplateEncounterResource;
+
+describe('deduplicateTemplateResourcesByMetaTag', () => {
+  test('preserves multiple in-office procedure ServiceRequests (additive section)', () => {
+    // Regression: chart-data procedures all carry the same 'procedure' meta
+    // tag, so without the additive exemption they'd collapse down to one
+    // procedure plan in the template (QA caught this for templates saved off
+    // charts with multiple procedures documented).
+    const resources: TemplateEncounterResource[] = [
+      makeProcedureSR('proc-1'),
+      makeProcedureSR('proc-2'),
+      makeProcedureSR('proc-3'),
+    ];
+    const result = deduplicateTemplateResourcesByMetaTag(resources);
+    expect(result.map((r) => r.id)).toEqual(['proc-1', 'proc-2', 'proc-3']);
+  });
+
+  test('preserves multiple CPT-code Procedures and patient-instruction Communications', () => {
+    const resources: TemplateEncounterResource[] = [
+      makeCptProcedure('cpt-1'),
+      makeCptProcedure('cpt-2'),
+      makePatientInstruction('instr-1'),
+      makePatientInstruction('instr-2'),
+    ];
+    const result = deduplicateTemplateResourcesByMetaTag(resources);
+    expect(result.map((r) => r.id)).toEqual(['cpt-1', 'cpt-2', 'instr-1', 'instr-2']);
+  });
+
+  test('preserves multiple diagnosis Conditions (identified by diagnosis tag, not ICD-10 code)', () => {
+    const resources: TemplateEncounterResource[] = [makeDxCondition('dx-1'), makeDxCondition('dx-2')];
+    const result = deduplicateTemplateResourcesByMetaTag(resources);
+    expect(result.map((r) => r.id)).toEqual(['dx-1', 'dx-2']);
+  });
+
+  test('coalesces non-additive resources that share a meta tag (keeps the first one seen)', () => {
+    // Single-resource sections (e.g. HPI's chief-complaint Condition) shouldn't
+    // accumulate duplicates - if two resources share the same system|code, the
+    // first wins. (The caller sorts by lastUpdated DESC before passing in, so
+    // "first" means most-recent.)
+    const hpi1: TemplateEncounterResource = {
+      resourceType: 'Condition',
+      id: 'hpi-1',
+      meta: { tag: [{ system: chartDataTagSystem('chief-complaint'), code: 'chief-complaint' }] },
+      subject: { reference: 'Patient/p1' },
+    } as TemplateEncounterResource;
+    const hpi2: TemplateEncounterResource = { ...hpi1, id: 'hpi-2' } as TemplateEncounterResource;
+    const result = deduplicateTemplateResourcesByMetaTag([hpi1, hpi2]);
+    expect(result.map((r) => r.id)).toEqual(['hpi-1']);
+  });
+
+  test('keeps resources with no meta tags', () => {
+    // Defensive: a resource with no tags doesn't have a fingerprint to dedup
+    // against; pass it through.
+    const enc: TemplateEncounterResource = {
+      resourceType: 'Encounter',
+      id: 'enc-1',
+      status: 'in-progress',
+      class: { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB' },
+    };
+    const result = deduplicateTemplateResourcesByMetaTag([enc]);
+    expect(result.map((r) => r.id)).toEqual(['enc-1']);
   });
 });


### PR DESCRIPTION
The fix is actually a one liner. But we lifted up a function and added some test coverage that indicates it will work correctly when trying to put multiple procedures in 1 template. 

🤖  generated. 🤖 description below.

## Summary

QA found that saving a chart as a global template when the chart has two or more procedures only carries **one** procedure plan into the template. Root cause: the `encounterBundle` dedup at the top of `admin-create-template` coalesces resources by their `meta.tag.system|code` pair on the assumption that resources sharing the same tag are stale revisions of the same entry. Chart-data procedure ServiceRequests all carry the same `'procedure'` meta tag (via `fillMeta('procedure', 'procedure')`), so the second procedure onwards was treated as a duplicate and dropped before `procedureOrders` captured them.

CPT codes and patient instructions already have this exact shape and were explicitly exempted from the dedup because they're list-shaped sections. Procedures belong in the same camp — added `chartDataTagSystem('procedure')` to the exemption.

Also pulled the dedup filter out of `performEffect` into a named export (`deduplicateTemplateResourcesByMetaTag`) so the regression can be pinned with a focused unit test instead of only catching it via an end-to-end test of the full zambda.

## Test plan

- [x] `cd packages/zambdas && npx vitest run --config ./vitest.config.unit.ts test/unit/admin-create-template.test.ts` — 37 tests pass (was 32; +5)
- [x] Full zambda suite (`npx vitest run --config ./vitest.config.unit.ts`) — 873 pass
- [x] `npx tsc -p packages/zambdas/tsconfig.json --noEmit` — clean (one unrelated pre-existing error in `harvest/index.ts:4159` that reproduces on unmodified `develop`)
- [ ] Manual: save a template from a chart with 2+ procedures, open the template detail page, confirm all procedures appear; apply the template onto a fresh visit and confirm all procedures land

## Test coverage added

5 tests under a new `deduplicateTemplateResourcesByMetaTag` describe block:

- **`preserves multiple in-office procedure ServiceRequests (additive section)`** — pins the regression.
- `preserves multiple CPT-code Procedures and patient-instruction Communications` — pins the existing additive sections so they don't regress alongside.
- `preserves multiple diagnosis Conditions (identified by diagnosis tag, not ICD-10 code)` — diagnoses use a special-case predicate; covered separately.
- `coalesces non-additive resources that share a meta tag (keeps the first one seen)` — single-resource sections like HPI still dedup as before.
- `keeps resources with no meta tags` — defensive pass-through for things like the Encounter resource.

## Note on the "all-or-nothing" UX

QA also mentioned that the apply-template UI doesn't let you pick which individual procedures to apply — the Skip/Append toggle applies to all procedures in the section. That's the intended design across every list-shaped section in templates today (Diagnoses, CPT Codes, In-House Lab Orders, Patient Instructions, Procedures all behave this way). Per-entry selection would be a larger UX change across all of them; not in scope for this hotfix.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vAei1vtTc7gfSa6kDUtg8)_