### PR TITLE
tweak(billing): Restrict copyable fields; stop copying extension

### DIFF
--- a/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
+++ b/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
@@ -554,11 +554,11 @@ export function copyCoverageAndSubscriber(
   copy.beneficiary = uuidOrUrnReference('Patient', patientUuidOrUrn);
   // Subscriber is patient by default, check for contained RelatedPerson
   let subscriberId = patientUuidOrUrn;
-  if (copy.subscriber?.reference?.startsWith('#') && copy.contained && copy.contained.length > 0) {
+  if (coverage.subscriber?.reference?.startsWith('#') && coverage.contained && coverage.contained.length > 0) {
     // Subscriber is contained on the coverage
-    const containedSubscriber = copy.contained.find(
+    const containedSubscriber = coverage.contained.find(
       (contained): contained is RelatedPerson =>
-        contained.id === copy.subscriber?.reference?.replace('#', '') && contained.resourceType === 'RelatedPerson'
+        contained.id === coverage.subscriber?.reference?.replace('#', '') && contained.resourceType === 'RelatedPerson'
     );
     if (containedSubscriber) {
       const subscriber = workingCopy
@@ -574,7 +574,6 @@ export function copyCoverageAndSubscriber(
       });
       order.push('relatedperson');
       subscriberId = subscriber.id;
-      copy.contained = copy.contained.filter((contained) => contained.id !== containedSubscriber.id);
     }
   } else if (coverageSubscriber) {
     // Subscriber was found and passed in to the function

--- a/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
+++ b/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
@@ -72,6 +72,7 @@ import {
 import {
   BILLING_RESOURCE_TAG,
   BILLING_WORKING_COPY_TAG,
+  BillingFhirResource,
   createBillingClient,
   CURRENT_STATUS_TAG_SYSTEM,
   findRef,
@@ -85,18 +86,6 @@ export interface CreateClaimFromEncounterParams extends CreateBillingClaimFromEn
 }
 
 export type ComplexValidationOutput = { clinicalResources: ClinicalResources; billingResources: BillingResources };
-
-// Type alias for resources relevant to billing
-type BillingFhirResource =
-  | Patient
-  | Coverage
-  | Practitioner
-  | Organization
-  | Location
-  | Person
-  | Claim
-  | Account
-  | RelatedPerson;
 
 type CoverageRefs = { coverageRef: Reference; payorRef: Reference }[];
 type EncounterType = 'uc' | 'wc' | 'occmed' | 'auto';
@@ -176,12 +165,12 @@ export async function performEffect(
   // Create or update main billing patient from clinical patient
   let mainPatient = billingResources.mainPatient;
   if (!mainPatient) {
-    mainPatient = prepareCopy(clinicalResources.patient, clinicalResources.patient.id!);
+    mainPatient = prepareCopy<Patient>(clinicalResources.patient, clinicalResources.patient.id!);
     mainPatient.id = 'urn:uuid:main-patient';
     requests.push({ method: 'POST', url: '/Patient', resource: mainPatient, fullUrl: mainPatient.id });
     order.push('patient');
   } else {
-    const updatedMainPatient = prepareCopy(clinicalResources.patient, clinicalResources.patient.id!);
+    const updatedMainPatient = prepareCopy<Patient>(clinicalResources.patient, clinicalResources.patient.id!);
     updatedMainPatient.id = mainPatient.id;
     try {
       deepStrictEqual(mainPatient, updatedMainPatient);
@@ -503,7 +492,7 @@ export function getClaimCoveragesForEncounter(
 }
 
 export function copyAccount(account: Account, patientId: string, billingCoverages?: Coverage[]): Account {
-  const copy = prepareCopy(account, account.id!);
+  const copy = prepareCopy<Account>(account, account.id!);
   copy.subject = [uuidOrUrnReference('Patient', patientId)];
   if (billingCoverages?.length) {
     copy.coverage = account.coverage
@@ -559,7 +548,9 @@ export function copyCoverageAndSubscriber(
   const requests: CreateClaimFromEncounterRequests = [];
   const order: string[] = [];
   const cleanedCoverageId = coverage.id?.replace('urn:uuid:', '');
-  const copy = workingCopy ? prepareWorkingCopy(coverage, coverage.id!) : prepareCopy(coverage, coverage.id!);
+  const copy = workingCopy
+    ? prepareWorkingCopy<Coverage>(coverage, coverage.id!)
+    : prepareCopy<Coverage>(coverage, coverage.id!);
   copy.beneficiary = uuidOrUrnReference('Patient', patientUuidOrUrn);
   // Subscriber is patient by default, check for contained RelatedPerson
   let subscriberId = patientUuidOrUrn;
@@ -570,7 +561,9 @@ export function copyCoverageAndSubscriber(
         contained.id === copy.subscriber?.reference?.replace('#', '') && contained.resourceType === 'RelatedPerson'
     );
     if (containedSubscriber) {
-      const subscriber = workingCopy ? prepareWorkingCopy(containedSubscriber) : prepareCopy(containedSubscriber);
+      const subscriber = workingCopy
+        ? prepareWorkingCopy<RelatedPerson>(containedSubscriber)
+        : prepareCopy<RelatedPerson>(containedSubscriber);
       subscriber.id = `urn:uuid:${workingCopy ? 'claim' : 'billing'}-coverage-rp-${cleanedCoverageId}`;
       subscriber.patient = uuidOrUrnReference('Patient', patientUuidOrUrn);
       requests.push({
@@ -586,8 +579,8 @@ export function copyCoverageAndSubscriber(
   } else if (coverageSubscriber) {
     // Subscriber was found and passed in to the function
     const subscriber = workingCopy
-      ? prepareWorkingCopy(coverageSubscriber, coverageSubscriber.id!)
-      : prepareCopy(coverageSubscriber, coverageSubscriber.id!);
+      ? prepareWorkingCopy<RelatedPerson>(coverageSubscriber, coverageSubscriber.id!)
+      : prepareCopy<RelatedPerson>(coverageSubscriber, coverageSubscriber.id!);
     subscriber.id = `urn:uuid:${workingCopy ? 'claim' : 'billing'}-coverage-rp-${cleanedCoverageId}`;
     requests.push({
       method: 'POST',

--- a/packages/zambdas/src/billing/create-billing-claim/index.ts
+++ b/packages/zambdas/src/billing/create-billing-claim/index.ts
@@ -95,13 +95,13 @@ async function createWorkingCopies(
   const order: string[] = [];
 
   const patientUrn = `urn:uuid:${randomUUID()}`;
-  let patientCopy = prepareWorkingCopy(originals.patient, originals.patient.id!);
+  let patientCopy = prepareWorkingCopy<Patient>(originals.patient, originals.patient.id!);
   patientCopy = applyPatientOverrides(patientCopy, params.patientOverrides);
   requests.push({ method: 'POST', url: '/Patient', resource: patientCopy, fullUrl: patientUrn });
   order.push('patient');
 
   if (originals.coverage) {
-    const copy = prepareWorkingCopy(originals.coverage, originals.coverage.id!);
+    const copy = prepareWorkingCopy<Coverage>(originals.coverage, originals.coverage.id!);
     if (params.coverageOverrides?.subscriberId) copy.subscriberId = params.coverageOverrides.subscriberId;
     copy.beneficiary = { reference: patientUrn };
     copy.subscriber = { reference: patientUrn };
@@ -111,13 +111,13 @@ async function createWorkingCopies(
   }
 
   if (originals.practitioner) {
-    let copy = prepareWorkingCopy(originals.practitioner, originals.practitioner.id!);
+    let copy = prepareWorkingCopy<Practitioner>(originals.practitioner, originals.practitioner.id!);
     copy = applyPractitionerOverrides(copy, params.practitionerOverrides);
     requests.push({ method: 'POST', url: '/Practitioner', resource: copy });
     order.push('practitioner');
   }
   if (originals.facility) {
-    const copy = prepareWorkingCopy(originals.facility, originals.facility.id!);
+    const copy = prepareWorkingCopy<Location>(originals.facility, originals.facility.id!);
     if (params.facilityOverrides?.name) copy.name = params.facilityOverrides.name;
     if (params.facilityOverrides?.npi) applyNpiOverride(copy, params.facilityOverrides.npi);
     if (params.facilityOverrides?.address) {
@@ -127,7 +127,7 @@ async function createWorkingCopies(
     order.push('facility');
   }
   if (originals.billingProvider) {
-    const copy = prepareWorkingCopy(originals.billingProvider, originals.billingProvider.id!);
+    const copy = prepareWorkingCopy<Organization>(originals.billingProvider, originals.billingProvider.id!);
     if (params.billingProviderOverrides?.name) copy.name = params.billingProviderOverrides.name;
     if (params.billingProviderOverrides?.npi) applyNpiOverride(copy, params.billingProviderOverrides.npi);
     if (params.billingProviderOverrides?.tin) applyTinOverride(copy, params.billingProviderOverrides.tin);

--- a/packages/zambdas/src/billing/create-billing-working-copy/index.ts
+++ b/packages/zambdas/src/billing/create-billing-working-copy/index.ts
@@ -3,7 +3,7 @@ import { APIGatewayProxyResult } from 'aws-lambda';
 import { FhirResource } from 'fhir/r4b';
 import { FHIR_RESOURCE_NOT_FOUND } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
-import { createBillingClient, prepareWorkingCopy } from '../shared';
+import { CopyableBillingResource, createBillingClient, prepareWorkingCopy } from '../shared';
 import { CreateWorkingCopyParams, validateRequestParameters } from './validateRequestParameters';
 
 let m2mToken: string;
@@ -22,7 +22,7 @@ async function performEffect(
   oystehr: Oystehr,
   params: CreateWorkingCopyParams
 ): Promise<{ id: string | undefined; resourceType: string }> {
-  const searchResult = await oystehr.fhir.search<FhirResource>({
+  const searchResult = await oystehr.fhir.search<CopyableBillingResource>({
     resourceType: params.resourceType,
     params: [{ name: '_id', value: params.resourceId }],
   });

--- a/packages/zambdas/src/billing/shared.ts
+++ b/packages/zambdas/src/billing/shared.ts
@@ -1,7 +1,31 @@
 import Oystehr from '@oystehr/sdk';
-import { Claim, DomainResource, HumanName, Organization, Patient, Practitioner, Resource } from 'fhir/r4b';
+import {
+  Account,
+  Claim,
+  Coverage,
+  HumanName,
+  Location,
+  Organization,
+  Patient,
+  Person,
+  Practitioner,
+  RelatedPerson,
+  Resource,
+} from 'fhir/r4b';
 import { convertFhirNameToDisplayName, isPayerUrl, Secrets } from 'utils';
 import { createOystehrClient } from '../shared/helpers';
+
+// Type alias for resources relevant to billing
+export type BillingFhirResource =
+  | Patient
+  | Coverage
+  | Practitioner
+  | Organization
+  | Location
+  | Person
+  | Claim
+  | Account
+  | RelatedPerson;
 
 export const BILLING_RESOURCE_TAG = {
   system: 'https://ottehr.com/billing/resource-type',
@@ -94,16 +118,25 @@ export function fhirName(resource?: Patient | Practitioner): string {
   return name ? convertFhirNameToDisplayName(name) : '';
 }
 
-// Clone a billing resource into a working copy: strips id, tags it, adds source identifier.
-export function prepareWorkingCopy<T extends Resource>(resource: T, originalId?: string): T {
+/**
+ * Clone a billing resource into a working copy: strips id, tags it, adds source identifier.
+ */
+export function prepareWorkingCopy<T extends CopyableBillingResource>(resource: CRT<T>, originalId?: string): CRT<T> {
   const copy = prepareCopy<T>(resource, originalId);
   copy.meta = { tag: [BILLING_WORKING_COPY_TAG] };
   return copy;
 }
 
-// Clone a billing resource into a working copy: strips id, tags it, adds source identifier.
-export function prepareCopy<T extends DomainResource>(resource: T, originalId?: string): T {
-  const copy: T = structuredClone(resource);
+/**
+ * Clone a billing resource into a working copy: strips id, tags it, adds source identifier.
+ */
+export function prepareCopy<T extends CopyableBillingResource>(resource: CRT<T>, originalId?: string): CRT<T> {
+  const propHolder: Partial<Writable<CRT<T>>> = {};
+  const resourceProps = copyableProps(resource);
+  for (const prop of resourceProps) {
+    propHolder[prop] = resource[prop];
+  }
+  const copy: CRT<T> = structuredClone(propHolder) as CRT<T>;
   delete copy.id;
   const existing = (copy.extension ?? []).filter((ext) => ext.url !== SOURCE_IDENTIFIER_SYSTEM);
   copy.extension = [
@@ -120,6 +153,44 @@ export function prepareCopy<T extends DomainResource>(resource: T, originalId?: 
       : []),
   ];
   return copy;
+}
+
+/**
+ * Map of resource types and their valid properties
+ */
+type ResourceProperties<Resources extends BillingFhirResource> = { [R in Resources as R['resourceType']]: (keyof R)[] };
+/**
+ * Billing resources that are eligible to be copied
+ */
+export type CopyableBillingResource = Exclude<BillingFhirResource, Claim | Person>;
+/**
+ * Extracts the specific billing resource out of the union type
+ */
+type CRT<T extends CopyableBillingResource> = Extract<CopyableBillingResource, { resourceType: T['resourceType'] }>;
+/**
+ * List of copyable properties for each resource type
+ */
+const CopyableProperties: ResourceProperties<CopyableBillingResource> = {
+  Account: ['resourceType', 'status', 'type', 'subject', 'guarantor', 'coverage'],
+  Coverage: ['resourceType', 'status', 'subscriber', 'beneficiary', 'payor', 'subscriberId', 'relationship', 'class'],
+  Location: ['resourceType', 'address', 'description', 'name', 'telecom', 'type'],
+  Organization: ['resourceType', 'active', 'address', 'contact', 'name', 'telecom', 'type'],
+  Patient: ['resourceType', 'name', 'active', 'gender', 'address', 'telecom', 'birthDate'],
+  Practitioner: ['resourceType', 'active', 'address', 'birthDate', 'gender', 'name', 'qualification', 'telecom'],
+  RelatedPerson: ['resourceType', 'name', 'birthDate', 'gender', 'patient', 'address', 'relationship'],
+} as const;
+/**
+ * Helper to remove readonly from fields
+ */
+type Writable<T> = { -readonly [K in keyof T]: T[K] };
+/**
+ * Helper to handle types for CopyableProperties
+ * @param r
+ * @returns
+ */
+function copyableProps<R extends CopyableBillingResource>(r: CRT<R>): (keyof CRT<R>)[] {
+  const props = CopyableProperties[r.resourceType];
+  return props as (keyof CRT<R>)[];
 }
 
 // Resolve FHIR reference like "Patient/uuid-12345" from resource array.

--- a/packages/zambdas/src/billing/shared.ts
+++ b/packages/zambdas/src/billing/shared.ts
@@ -134,7 +134,9 @@ export function prepareCopy<T extends CopyableBillingResource>(resource: CRT<T>,
   const propHolder: Partial<Writable<CRT<T>>> = {};
   const resourceProps = copyableProps(resource);
   for (const prop of resourceProps) {
-    propHolder[prop] = resource[prop];
+    if (resource[prop]) {
+      propHolder[prop] = resource[prop];
+    }
   }
   const copy: CRT<T> = structuredClone(propHolder) as CRT<T>;
   delete copy.id;

--- a/packages/zambdas/test/unit/billing/create-billing-claim-from-encounter.test.ts
+++ b/packages/zambdas/test/unit/billing/create-billing-claim-from-encounter.test.ts
@@ -757,7 +757,6 @@ describe('create-billing-claim-from-encounter', () => {
               "beneficiary": {
                 "reference": "urn:uuid:patient",
               },
-              "contained": [],
               "extension": [
                 {
                   "url": "https://ottehr.com/billing/source-resource",
@@ -829,7 +828,6 @@ describe('create-billing-claim-from-encounter', () => {
               "beneficiary": {
                 "reference": "urn:uuid:claim-patient",
               },
-              "contained": [],
               "extension": [
                 {
                   "url": "https://ottehr.com/billing/source-resource",

--- a/packages/zambdas/test/unit/billing/prepare-copy.test.ts
+++ b/packages/zambdas/test/unit/billing/prepare-copy.test.ts
@@ -2,6 +2,7 @@ import { Coverage, DomainResource, Extension, Location, Organization, Patient, P
 import { describe, expect, it } from 'vitest';
 import {
   BILLING_WORKING_COPY_TAG,
+  CopyableBillingResource,
   prepareCopy,
   prepareWorkingCopy,
   SOURCE_IDENTIFIER_SYSTEM,
@@ -20,7 +21,7 @@ const withoutCopyFields = (r: Resource): Record<string, unknown> => {
   return clone;
 };
 
-const cases: { resourceType: string; resource: Resource }[] = [
+const cases: { resourceType: string; resource: CopyableBillingResource }[] = [
   {
     resourceType: 'Patient',
     resource: {
@@ -61,27 +62,29 @@ describe('prepareWorkingCopy', () => {
   describe.each(cases)('for $resourceType', ({ resourceType, resource }) => {
     it('tags the copy as a billing working copy (so list views exclude it)', () => {
       // Only the working-copy tag is set explicitly; the workspace SDK client adds BILLING_RESOURCE_TAG on write.
-      expect(prepareWorkingCopy(resource, ORIGINAL_ID).meta?.tag).toEqual([BILLING_WORKING_COPY_TAG]);
+      expect(prepareWorkingCopy<typeof resource>(resource, ORIGINAL_ID).meta?.tag).toEqual([BILLING_WORKING_COPY_TAG]);
     });
 
     it('drops the original id so create() makes a new resource', () => {
-      expect(prepareWorkingCopy(resource, ORIGINAL_ID).id).toBeUndefined();
+      expect(prepareWorkingCopy<typeof resource>(resource, ORIGINAL_ID).id).toBeUndefined();
     });
 
     it('links back to the original via a source identifier', () => {
-      expect(extensionsOf(prepareWorkingCopy(resource, ORIGINAL_ID))).toContainEqual({
+      expect(extensionsOf(prepareWorkingCopy<typeof resource>(resource, ORIGINAL_ID))).toContainEqual({
         url: SOURCE_IDENTIFIER_SYSTEM,
         valueReference: { reference: `${resourceType}/${ORIGINAL_ID}` },
       });
     });
 
     it('preserves every other field unchanged', () => {
-      expect(withoutCopyFields(prepareWorkingCopy(resource, ORIGINAL_ID))).toEqual(withoutCopyFields(resource));
+      expect(withoutCopyFields(prepareWorkingCopy<typeof resource>(resource, ORIGINAL_ID))).toEqual(
+        withoutCopyFields(resource)
+      );
     });
 
     it('does not mutate the original', () => {
       const before = structuredClone(resource);
-      prepareWorkingCopy(resource, ORIGINAL_ID);
+      prepareWorkingCopy<typeof resource>(resource, ORIGINAL_ID);
       expect(resource).toEqual(before);
     });
   });
@@ -89,9 +92,9 @@ describe('prepareWorkingCopy', () => {
   describe('extension list handling', () => {
     const otherId = { url: 'https://example.org/external-id', valueString: 'EXT-1' };
 
-    it('preserves existing non-source identifiers', () => {
+    it('does not preserve existing non-source identifiers', () => {
       const patient: Patient = { resourceType: 'Patient', id: ORIGINAL_ID, extension: [{ ...otherId }] };
-      expect(extensionsOf(prepareWorkingCopy(patient, ORIGINAL_ID))).toContainEqual(otherId);
+      expect(extensionsOf(prepareWorkingCopy<typeof patient>(patient, ORIGINAL_ID))).not.toContainEqual(otherId);
     });
 
     it('creates the identifier list when the original has none', () => {
@@ -102,7 +105,7 @@ describe('prepareWorkingCopy', () => {
         beneficiary: { reference: 'Patient/p1' },
         payor: [{ reference: 'Organization/o1' }],
       };
-      expect(extensionsOf(prepareWorkingCopy(coverage, ORIGINAL_ID))).toEqual([
+      expect(extensionsOf(prepareWorkingCopy<typeof coverage>(coverage, ORIGINAL_ID))).toEqual([
         { url: SOURCE_IDENTIFIER_SYSTEM, valueReference: { reference: `Coverage/${ORIGINAL_ID}` } },
       ]);
     });
@@ -113,7 +116,7 @@ describe('prepareWorkingCopy', () => {
         id: ORIGINAL_ID,
         extension: [{ url: SOURCE_IDENTIFIER_SYSTEM, valueReference: { reference: 'Patient/stale' } }, { ...otherId }],
       };
-      const sources = extensionsOf(prepareWorkingCopy(patient, ORIGINAL_ID)).filter(
+      const sources = extensionsOf(prepareWorkingCopy<typeof patient>(patient, ORIGINAL_ID)).filter(
         (i) => i.url === SOURCE_IDENTIFIER_SYSTEM
       );
       expect(sources).toEqual([
@@ -136,27 +139,29 @@ describe('prepareCopy', () => {
   describe.each(cases)('for $resourceType', ({ resourceType, resource }) => {
     it('does not tag the copy as a working copy', () => {
       // Only the working-copy tag is set explicitly; the workspace SDK client adds BILLING_RESOURCE_TAG on write.
-      expect(prepareCopy(resource, ORIGINAL_ID).meta?.tag).toBeUndefined();
+      expect(prepareCopy<typeof resource>(resource, ORIGINAL_ID).meta?.tag).toBeUndefined();
     });
 
     it('drops the original id so create() makes a new resource', () => {
-      expect(prepareWorkingCopy(resource, ORIGINAL_ID).id).toBeUndefined();
+      expect(prepareCopy<typeof resource>(resource, ORIGINAL_ID).id).toBeUndefined();
     });
 
     it('links back to the original via a source identifier', () => {
-      expect(extensionsOf(prepareWorkingCopy(resource, ORIGINAL_ID))).toContainEqual({
+      expect(extensionsOf(prepareCopy<typeof resource>(resource, ORIGINAL_ID))).toContainEqual({
         url: SOURCE_IDENTIFIER_SYSTEM,
         valueReference: { reference: `${resourceType}/${ORIGINAL_ID}` },
       });
     });
 
     it('preserves every other field unchanged', () => {
-      expect(withoutCopyFields(prepareWorkingCopy(resource, ORIGINAL_ID))).toEqual(withoutCopyFields(resource));
+      expect(withoutCopyFields(prepareCopy<typeof resource>(resource, ORIGINAL_ID))).toEqual(
+        withoutCopyFields(resource)
+      );
     });
 
     it('does not mutate the original', () => {
       const before = structuredClone(resource);
-      prepareWorkingCopy(resource, ORIGINAL_ID);
+      prepareCopy<typeof resource>(resource, ORIGINAL_ID);
       expect(resource).toEqual(before);
     });
   });


### PR DESCRIPTION
Restricts copyable fields for each resource. This includes no longer copying `meta`, `identifier`, or `extension` for any resources.