### PR TITLE
Fix(global temp): procedure Dx not applied when same Dx already on encounter

### DIFF
--- a/packages/zambdas/src/ehr/apply-template/index.ts
+++ b/packages/zambdas/src/ehr/apply-template/index.ts
@@ -535,6 +535,26 @@ export const makeCreateRequests = (
     ) {
       const isDuplicate = isDuplicateDiagnosis(resourceToCreate, encounterDiagnosesConditions);
 
+      // QA-caught case: a procedure's linked Dx is also on the encounter
+      // already (the user added it manually, or it carried over from a
+      // previous apply). The standalone dedup below would silently fall
+      // through and POST a duplicate orphan Condition, and the procedure's
+      // reasonReference would resolve to that orphan via fullUrl. The chart's
+      // procedure card looks up its linked Dx via encounter.diagnosis, so the
+      // orphan never shows up. Skip the create entirely and redirect any
+      // procedure refs to the existing Condition so the procedure links to
+      // the Dx that's actually on the chart. The redirect stores the bare id
+      // in the contained-id map; downstream createProcedureServiceRequest's
+      // formatLinkedRef adds the Condition/ prefix (urn:uuid values are passed
+      // through verbatim for FHIR-transaction fullUrl resolution).
+      if (isDuplicate && isClaimedByProcedure && containedResource.id) {
+        const existingCondition = encounterDiagnosesConditions.find((c) => isDuplicateDiagnosis(resourceToCreate, [c]));
+        if (existingCondition?.id) {
+          containedIdToNewFullUrl.set(containedResource.id, existingCondition.id);
+          continue;
+        }
+      }
+
       // we should only add to encounter diagnoses after a dedupe when appending, to ensure the template doesn't add Dx already on the chart
       if ((!isDuplicate && effectiveAction === 'append') || effectiveAction === 'overwrite') {
         const diagnosisToAdd = templateEncounterDiagnoses?.find((d) => {

--- a/packages/zambdas/src/ehr/apply-template/index.ts
+++ b/packages/zambdas/src/ehr/apply-template/index.ts
@@ -535,18 +535,6 @@ export const makeCreateRequests = (
     ) {
       const isDuplicate = isDuplicateDiagnosis(resourceToCreate, encounterDiagnosesConditions);
 
-      // QA-caught case: a procedure's linked Dx is also on the encounter
-      // already (the user added it manually, or it carried over from a
-      // previous apply). The standalone dedup below would silently fall
-      // through and POST a duplicate orphan Condition, and the procedure's
-      // reasonReference would resolve to that orphan via fullUrl. The chart's
-      // procedure card looks up its linked Dx via encounter.diagnosis, so the
-      // orphan never shows up. Skip the create entirely and redirect any
-      // procedure refs to the existing Condition so the procedure links to
-      // the Dx that's actually on the chart. The redirect stores the bare id
-      // in the contained-id map; downstream createProcedureServiceRequest's
-      // formatLinkedRef adds the Condition/ prefix (urn:uuid values are passed
-      // through verbatim for FHIR-transaction fullUrl resolution).
       if (isDuplicate && isClaimedByProcedure && containedResource.id) {
         const existingCondition = encounterDiagnosesConditions.find((c) => isDuplicateDiagnosis(resourceToCreate, [c]));
         if (existingCondition?.id) {

--- a/packages/zambdas/test/unit/apply-template.test.ts
+++ b/packages/zambdas/test/unit/apply-template.test.ts
@@ -837,20 +837,7 @@ describe('makeCreateRequests — procedure plans', () => {
     expect(dxPostRequest, 'Dx should NOT be created when procedures is also skipped').toBeUndefined();
   });
 
-  test("procedures='append' + a procedure's Dx is already on the encounter: procedure links to the existing Condition (QA regression)", () => {
-    // QA reported: when a chart already has the same Dx that a template
-    // procedure was linked to (e.g. the user added it manually before
-    // applying the template), the procedure ends up with no Dx attached.
-    //
-    // Root cause: the standalone dedup recognized the duplicate and skipped
-    // pushing it to encounter.diagnosis, but still POSTed a new (orphan)
-    // Condition. The procedure's reasonReference resolved to that orphan via
-    // fullUrl. The chart's procedure card looks up linked Dx through
-    // encounter.diagnosis, so the orphan never showed.
-    //
-    // Fix: when the duplicate is procedure-claimed, redirect the procedure's
-    // ref to the existing Condition's literal reference instead of creating
-    // an orphan. Verify the procedure links to the existing Condition by id.
+  test("procedures='append' + a procedure's Dx is already on the encounter: procedure links to the existing Condition", () => {
     const templateList = makeLinkedProcedureTemplate();
     const actions = makeActions({ procedures: 'append', diagnoses: 'append', cptCodes: 'append' });
     const claimedByProcedures = collectContainedIdsClaimedByProcedures(templateList, actions.procedures);

--- a/packages/zambdas/test/unit/apply-template.test.ts
+++ b/packages/zambdas/test/unit/apply-template.test.ts
@@ -837,6 +837,62 @@ describe('makeCreateRequests — procedure plans', () => {
     expect(dxPostRequest, 'Dx should NOT be created when procedures is also skipped').toBeUndefined();
   });
 
+  test("procedures='append' + a procedure's Dx is already on the encounter: procedure links to the existing Condition (QA regression)", () => {
+    // QA reported: when a chart already has the same Dx that a template
+    // procedure was linked to (e.g. the user added it manually before
+    // applying the template), the procedure ends up with no Dx attached.
+    //
+    // Root cause: the standalone dedup recognized the duplicate and skipped
+    // pushing it to encounter.diagnosis, but still POSTed a new (orphan)
+    // Condition. The procedure's reasonReference resolved to that orphan via
+    // fullUrl. The chart's procedure card looks up linked Dx through
+    // encounter.diagnosis, so the orphan never showed.
+    //
+    // Fix: when the duplicate is procedure-claimed, redirect the procedure's
+    // ref to the existing Condition's literal reference instead of creating
+    // an orphan. Verify the procedure links to the existing Condition by id.
+    const templateList = makeLinkedProcedureTemplate();
+    const actions = makeActions({ procedures: 'append', diagnoses: 'append', cptCodes: 'append' });
+    const claimedByProcedures = collectContainedIdsClaimedByProcedures(templateList, actions.procedures);
+
+    // Encounter already carries the same Dx (J02.9) the template procedure
+    // is linked to. The Condition is on encounter.diagnosis.
+    const existingDxCondition = makeDxCondition('existing-dx-1', 'J02.9');
+    const encounterWithExistingDx = makeDxEncounter('enc-1', [{ conditionId: 'existing-dx-1' }]);
+
+    const requests = makeCreateRequests(
+      encounterWithExistingDx,
+      templateList,
+      [existingDxCondition],
+      actions,
+      new Set(),
+      claimedByProcedures
+    );
+
+    // No new Condition POST for the duplicate Dx (no orphan).
+    const newConditionPosts = requests.filter(
+      (r): r is { method: 'POST'; resource: Condition; fullUrl?: string; url: string } =>
+        r.method === 'POST' && (r as any).resource?.resourceType === 'Condition'
+    );
+    expect(
+      newConditionPosts,
+      'Duplicate Dx should be redirected to the existing Condition, not POSTed as an orphan'
+    ).toHaveLength(0);
+
+    // The procedure's reasonReference is a literal reference to the existing
+    // Condition (Condition/existing-dx-1), not a urn:uuid fullUrl.
+    const procedureSR = getProcedureServiceRequestPosts(requests)[0]!.resource;
+    expect(procedureSR.reasonReference).toEqual([{ reference: 'Condition/existing-dx-1' }]);
+
+    // encounter.diagnosis is unchanged — the existing entry stays put, no
+    // duplicate gets pushed.
+    const dxPatch = getEncounterDiagnosisPatchOperations(requests);
+    if (dxPatch && (dxPatch.op === 'add' || dxPatch.op === 'replace')) {
+      expect(dxPatch.value).toHaveLength(1);
+      expect(dxPatch.value[0]).toMatchObject({ condition: { reference: 'Condition/existing-dx-1' } });
+    }
+  });
+
   test('a sparse procedure plan with no cross-refs still produces a clean ServiceRequest', () => {
     // Some templates may carry procedures with no diagnoses or CPT codes -
     // those should still apply without emitting empty reasonReference/[]


### PR DESCRIPTION
We have to link the procedure's codes to the codes already in the chart (assessment page).

🤖 generated code. 🤖 description below.

## Summary

A global template carries a procedure linked to Dx X. The provider books a visit, adds Dx X manually on the Assessment tab, then applies the template. **Expected:** the applied procedure shows Dx X linked to it. **Actual:** the procedure shows no Dx.

**Root cause:** the apply-template Dx dedup correctly recognizes the duplicate and skips pushing it to `encounter.diagnosis` (we don't want two entries for the same ICD code), but the loop still POSTs the template's Condition as an orphan. The procedure plan's `reasonReference` then gets rewritten via fullUrl to that orphan. The chart's procedure card looks up linked Dx through `encounter.diagnosis`, so the orphan never shows up and the procedure renders with no Dx attached.

**Fix:** when the duplicate is procedure-claimed (so the redirect is actually consequential), skip POSTing the duplicate Condition and write the existing Condition's bare id into `containedIdToNewFullUrl`. Downstream `createProcedureServiceRequest`'s `formatLinkedRef` prepends `Condition/` and the procedure ends up referencing the existing Condition that's already on `encounter.diagnosis` — the chart's procedure card resolves it correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vAei1vtTc7gfSa6kDUtg8)_