### PR TITLE
Fix e2e flake: side menu clicks blocked by snackbar toasts

### DIFF
--- a/apps/ehr/tests/e2e/page/SideMenu.ts
+++ b/apps/ehr/tests/e2e/page/SideMenu.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 import { dataTestIds } from '../../../src/constants/data-test-ids';
 import { expectHospitalizationPage, HospitalizationPage } from './HospitalizationPage';
 import { expectHpiAndTemplatesPage, HpiAndTemplatesPage } from './HpiAndTemplatesPage';
@@ -26,92 +26,115 @@ export class SideMenu {
     this.#page = page;
   }
 
+  /**
+   * Snackbar toasts anchor to the bottom-left corner of the screen, directly on top of
+   * the lower side menu items, and notistack pauses their auto-hide countdown while the
+   * browser window is blurred — the steady state for parallel headless runs — so a toast
+   * can block a menu item indefinitely. If a normal click can't get through, let pointer
+   * events pass through toasts and try once more; any other overlay (dialog, backdrop)
+   * will still fail the retry.
+   */
+  async #click(locator: Locator): Promise<void> {
+    try {
+      await locator.click({ timeout: 15_000 });
+    } catch {
+      await this.#page.addStyleTag({
+        content: '.notistack-SnackbarContainer, .notistack-SnackbarContainer * { pointer-events: none !important; }',
+      });
+      await locator.click();
+    }
+  }
+
+  async #clickMenuItem(item: string): Promise<void> {
+    await this.#click(this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem(item)));
+  }
+
   async clickInHouseMedications(): Promise<InHouseMedicationsPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('in-house-medication/mar')).click();
+    await this.#clickMenuItem('in-house-medication/mar');
     return expectInHouseMedicationsPage(this.#page);
   }
   async clickInHouseLabs(): Promise<InHouseLabsPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('in-house-lab-orders')).click();
+    await this.#clickMenuItem('in-house-lab-orders');
     return InHouseLabsPage.isOpen(this.#page);
   }
   async clickAllergies(): Promise<AllergiesPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('allergies')).click();
+    await this.#clickMenuItem('allergies');
     return expectAllergiesPage(this.#page);
   }
   async clickMedicalConditions(): Promise<MedicalConditionsPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('medical-conditions')).click();
+    await this.#clickMenuItem('medical-conditions');
     return expectMedicalConditionsPage(this.#page);
   }
   async clickSurgicalHistory(): Promise<SurgicalHistoryPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('surgical-history')).click();
+    await this.#clickMenuItem('surgical-history');
     return expectSurgicalHistoryPage(this.#page);
   }
   async clickHospitalization(): Promise<HospitalizationPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('hospitalization')).click();
+    await this.#clickMenuItem('hospitalization');
     return expectHospitalizationPage(this.#page);
   }
 
   async clickCcAndIntakeNotes(): Promise<PatientInfoPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('cc-and-intake-notes')).click();
+    await this.#clickMenuItem('cc-and-intake-notes');
     return expectPatientInfoPage(this.#page);
   }
 
   async clickVitals(): Promise<VitalsPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('vitals')).click();
+    await this.#clickMenuItem('vitals');
     return expectVitalsPage(this.#page);
   }
 
   async clickHpiAndTemplates(): Promise<HpiAndTemplatesPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('history-of-present-illness-and-templates')).click();
+    await this.#clickMenuItem('history-of-present-illness-and-templates');
     return expectHpiAndTemplatesPage(this.#page);
   }
 
   async clickReviewAndSign(): Promise<InPersonProgressNotePage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('review-and-sign')).click();
+    await this.#clickMenuItem('review-and-sign');
     return expectInPersonProgressNotePage(this.#page);
   }
 
   async clickAssessment(): Promise<InPersonAssessmentPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('assessment')).click();
+    await this.#clickMenuItem('assessment');
     return expectAssessmentPage(this.#page);
   }
 
   async clickExam(): Promise<InPersonExamPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('examination')).click();
+    await this.#clickMenuItem('examination');
     return expectExamPage(this.#page);
   }
 
   async clickProcedures(): Promise<ProceduresPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('procedures')).click();
+    await this.#clickMenuItem('procedures');
     return expectProceduresPage(this.#page);
   }
 
   async clickNursingOrders(): Promise<NursingOrdersPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('nursing-orders')).click();
+    await this.#clickMenuItem('nursing-orders');
     return expectNursingOrdersPage(this.#page);
   }
 
   async clickReviewOfSystems(): Promise<ReviewOfSystemsPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('review-of-systems')).click();
+    await this.#clickMenuItem('review-of-systems');
     return expectReviewOfSystemsPage(this.#page);
   }
 
   async clickScreening(): Promise<ScreeningPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('screening-questions')).click();
+    await this.#clickMenuItem('screening-questions');
     return expectScreeningPage(this.#page);
   }
 
   async clickMedications(): Promise<MedicationsPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('medications')).click();
+    await this.#clickMenuItem('medications');
     return expectMedicationsPage(this.#page);
   }
 
   async clickCompleteIntakeButton(): Promise<void> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.completeIntakeButton).click();
+    await this.#click(this.#page.getByTestId(dataTestIds.sideMenu.completeIntakeButton));
   }
 
   async clickExternalLabs(): Promise<ExternalLabsPage> {
-    await this.#page.getByTestId(dataTestIds.sideMenu.sideMenuItem('external-lab-orders')).click();
+    await this.#clickMenuItem('external-lab-orders');
     return ExternalLabsPage.isOpen(this.#page);
   }
 }


### PR DESCRIPTION
Supposedly a Toast message was blocking the ability for playwright to find the place it wanted to navigate to.

🤖 generated investigation and solution. description below also 🤖 

## Problem

`Order Deletion - Happy Path › Delete in-house medication and verify it is removed from list` flaked in CI ([failing run](https://github.com/masslight/ottehr/actions/runs/27293531075/job/80620896767?pr=8057)). All three retries failed identically at `SideMenu.clickReviewAndSign()` — the menu item was visible, enabled, and stable, but a notistack toast intercepted pointer events for the entire 35s action timeout.

## Root cause

- The EHR's `SnackbarProvider` uses notistack's default **bottom-left** anchor, which sits directly on top of the lower side menu items — and "Review & Sign" is the bottom-most one.
- notistack pauses a toast's 6s auto-hide countdown while the browser window is blurred, which is the steady state in parallel headless CI runs. So the "Medication deleted successfully" toast (plus an error-variant toast visible in the click log) sat over the menu item indefinitely.
- Playwright refuses to click a covered element, so the click retried against the toast until timeout — on every test retry.

## Fix

Route all `SideMenu` clicks (menu items and the Complete Intake button) through a helper that:

1. Tries a normal click first (15s timeout).
2. Only if that fails, injects CSS making snackbar toasts ignore pointer events (`.notistack-SnackbarContainer { pointer-events: none }`), then retries once.

Toasts never legitimately block navigation, so clicking through them matches user intent — while dialogs, backdrops, or any other overlay still fail the retry, so real regressions aren't masked. This hardens every spec that navigates via the side menu, not just the failing one.

## Testing

- ESLint and full EHR `tsc --noEmit` pass.
- Worst case for a blocked click is now 15s + one retry within the 35s action timeout, well inside the 120s test budget.

https://claude.ai/code/session_01VPmSAzSck5D1WeVg8FoXba

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPmSAzSck5D1WeVg8FoXba)_