### PR TITLE
Hide delete button on completed medication orders

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/medication-administration/medication-editable-card/MedicationCardView.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/medication-administration/medication-editable-card/MedicationCardView.tsx
@@ -179,7 +179,7 @@ export const MedicationCardView: React.FC<MedicationCardViewProps> = ({
             onClick={onStatusSelect}
             status={selectedStatus}
           />
-          {!isReadOnly && onDelete && (
+          {!isReadOnly && onDelete && type !== 'completed-edit' && (
             <ButtonRounded onClick={onDelete} variant="outlined" color="error" size="large">
               Delete Order
             </ButtonRounded>


### PR DESCRIPTION
## Summary
- Removes the "Delete Order" button from the `DispenseFooter` in `MedicationCardView` when the order type is `completed-edit`
- Matches existing behavior in `OrderFooter`, which already gates the delete button on order type

## Test plan
- [ ] Open a medication order that has been administered (completed)
- [ ] Confirm "Delete Order" button is no longer shown in the footer
- [ ] Open a pending or in-progress medication order and confirm "Delete Order" is still shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)