### PR TITLE
OTR-1038: Increase patient screen table row counts to 20

### DIFF
--- a/apps/ehr/src/components/PatientEncountersGrid.tsx
+++ b/apps/ehr/src/components/PatientEncountersGrid.tsx
@@ -149,7 +149,7 @@ export const PatientEncountersGrid: FC<PatientEncountersGridProps> = (props) => 
   const [sortField, setSortField] = useState<SortField>('dateTime');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(5);
+  const [rowsPerPage, setRowsPerPage] = useState(20);
 
   const { oystehrZambda } = useApiClients();
   const navigate = useNavigate();
@@ -551,7 +551,7 @@ export const PatientEncountersGrid: FC<PatientEncountersGridProps> = (props) => 
       </TableContainer>
 
       <TablePagination
-        rowsPerPageOptions={[5]}
+        rowsPerPageOptions={[20]}
         component="div"
         count={filtered.length}
         rowsPerPage={rowsPerPage}

--- a/apps/ehr/src/features/visits/shared/components/patient/PatientFollowupEncountersGrid.tsx
+++ b/apps/ehr/src/features/visits/shared/components/patient/PatientFollowupEncountersGrid.tsx
@@ -221,7 +221,7 @@ export const PatientFollowupEncountersGrid: FC<PatientEncountersGridProps> = (pr
         initialState={{
           pagination: {
             paginationModel: {
-              pageSize: 5,
+              pageSize: 20,
             },
           },
           sorting: {
@@ -232,7 +232,7 @@ export const PatientFollowupEncountersGrid: FC<PatientEncountersGridProps> = (pr
         loading={loading}
         pagination
         disableColumnMenu
-        pageSizeOptions={[5]}
+        pageSizeOptions={[20]}
         disableRowSelectionOnClick
         sx={{
           border: 0,

--- a/packages/utils/lib/types/data/in-house/in-house.constants.ts
+++ b/packages/utils/lib/types/data/in-house/in-house.constants.ts
@@ -159,7 +159,7 @@ export const SPECIMEN_COLLECTION_SOURCE_SYSTEM = 'https://hl7.org/fhir/R4B/value
 // todo we will use this while the entry is free text
 export const SPECIMEN_COLLECTION_CUSTOM_SOURCE_SYSTEM = 'http://ottehr.org/fhir/StructureDefinition/specimen-source';
 
-export const DEFAULT_IN_HOUSE_LABS_ITEMS_PER_PAGE = 10;
+export const DEFAULT_IN_HOUSE_LABS_ITEMS_PER_PAGE = 20;
 
 export const REPEATABLE_TEXT_EXTENSION_CONFIG = {
   url: 'http://ottehr.org/fhir/StructureDefinition/in-house-lab-repeatable-test',

--- a/packages/utils/lib/types/data/labs/labs.constants.ts
+++ b/packages/utils/lib/types/data/labs/labs.constants.ts
@@ -194,7 +194,7 @@ export const OYSTEHR_LAB_API_BASE = 'https://labs-api.zapehr.com/v1';
 export const OYSTEHR_LAB_ORDERABLE_ITEM_SEARCH_API = `${OYSTEHR_LAB_API_BASE}/orderableItem`;
 export const OYSTEHR_SUBMIT_LAB_API = `${OYSTEHR_LAB_API_BASE}/submit`;
 
-export const DEFAULT_LABS_ITEMS_PER_PAGE = 10;
+export const DEFAULT_LABS_ITEMS_PER_PAGE = 20;
 
 export const EMPTY_PAGINATION: Pagination = {
   currentPageIndex: 0,

--- a/packages/zambdas/src/ehr/radiology/order-list/index.ts
+++ b/packages/zambdas/src/ehr/radiology/order-list/index.ts
@@ -36,7 +36,7 @@ export interface ValidatedInput {
   callerAccessToken: string;
 }
 
-export const DEFAULT_RADIOLOGY_ITEMS_PER_PAGE = 10;
+export const DEFAULT_RADIOLOGY_ITEMS_PER_PAGE = 20;
 
 // Lifting up value to outside of the handler allows it to stay in memory across warm lambda invocations
 let m2mToken: string;


### PR DESCRIPTION
## Summary
- **Visits** (`PatientEncountersGrid`): default `rowsPerPage` state 5 → 20, `rowsPerPageOptions` updated to match
- **Patient Follow-ups** (`PatientFollowupEncountersGrid`): DataGrid `pageSize` 5 → 20, `pageSizeOptions` updated to match
- **Labs** (`DEFAULT_LABS_ITEMS_PER_PAGE` in `utils`): 10 → 20
- **In-House Labs** (`DEFAULT_IN_HOUSE_LABS_ITEMS_PER_PAGE` in `utils`): 10 → 20
- **Radiology** (`DEFAULT_RADIOLOGY_ITEMS_PER_PAGE` in zambda): 10 → 20

## Test plan
- [ ] Open a patient detail page with >10 visits — verify 20 rows shown in Visits tab before pagination kicks in
- [ ] Open Follow-ups tab — verify 20 rows shown
- [ ] Open Labs tab — verify up to 20 orders shown per page
- [ ] Open In-House Labs tab — verify up to 20 orders shown per page
- [ ] Open Radiology tab — verify up to 20 orders shown per page

🤖 Generated with [Claude Code](https://claude.com/claude-code)