### PR TITLE
fix(medications): trim whitespace-only dose in shared CurrentMedicationsCard

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/medical-history-tab/CurrentMedications/CurrentMedicationsCard.tsx
+++ b/apps/ehr/src/features/visits/shared/components/medical-history-tab/CurrentMedications/CurrentMedicationsCard.tsx
@@ -36,15 +36,16 @@ export const CurrentMedicationsCard: FC = () => {
       const strength = selection.medication.strength;
       const nameAlreadyHasStrength = strength && medName.toLowerCase().includes(strength.toLowerCase());
       const displayName = nameAlreadyHasStrength || !strength ? medName : `${medName} (${strength})`;
+      const trimmedDose = selection.dose?.trim() || undefined;
       const doseIsRedundantWithStrength =
-        selection.dose && strength && strength.toLowerCase() === selection.dose.toLowerCase();
+        trimmedDose && strength && strength.toLowerCase() === trimmedDose.toLowerCase();
       try {
         const success = await onSubmit({
           name: displayName,
           id: selection.medication.id?.toString(),
           type: selection.type ?? 'scheduled',
           intakeInfo: {
-            dose: doseIsRedundantWithStrength ? undefined : selection.dose ?? undefined,
+            dose: doseIsRedundantWithStrength ? undefined : trimmedDose,
             date: selection.date,
             patientCouldNotConfirmDosage: selection.patientCouldNotConfirmDosage || undefined,
           },


### PR DESCRIPTION
## Summary
- The in-person `Medications.tsx` path was fixed in bdbb29bec to trim the dose field before saving, preventing a whitespace-only entry from reaching FHIR as an empty string
- `CurrentMedicationsCard.tsx` (shared component used by the telemed path) had the same bug and was missed in that fix
- This PR applies the identical one-line trim to `CurrentMedicationsCard.tsx`

The error being fixed: `OystehrFHIRError: Invalid empty string at MedicationStatement.dosage[0].text`

Closes [OTR-2610](https://linear.app/zapehr/issue/OTR-2610/error-when-adding-current-medication)

## Test plan
- [ ] Add a current medication via the **telemed** visit flow
- [ ] Enter only a space in the "Recent dose amount and units" field and save — should succeed without error
- [ ] Confirm a fully empty dose field also saves successfully
- [ ] Confirm a valid dose (e.g. "10mg") saves and displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)