### PR TITLE
fix(get-paperwork): return clean 400 when appointment is not found

### DIFF
--- a/packages/zambdas/src/patient/paperwork/get-paperwork/index.ts
+++ b/packages/zambdas/src/patient/paperwork/get-paperwork/index.ts
@@ -10,6 +10,7 @@ import {
   QuestionnaireResponse,
 } from 'fhir/r4b';
 import {
+  APPOINTMENT_NOT_FOUND_ERROR,
   AppointmentSummary,
   AvailableLocationInformation,
   checkEncounterIsVirtual,
@@ -163,10 +164,11 @@ export const index = wrapHandler('get-paperwork', async (input: ZambdaInput): Pr
     return resource.resourceType == 'QuestionnaireResponse';
   }) as QuestionnaireResponse;
 
-  const missingResources: string[] = [];
   if (!appointment) {
-    missingResources.push('Appointment');
+    throw APPOINTMENT_NOT_FOUND_ERROR;
   }
+
+  const missingResources: string[] = [];
   if (!encounter) {
     missingResources.push('Encounter');
   }


### PR DESCRIPTION
## Summary
- UUID format validation was already in place via `z.string().uuid()` in `validateRequestParameters.ts` (throws `INVALID_INPUT_ERROR` → 400, no Sentry)
- The gap: a valid UUID pointing to a non-existent appointment fell through to a plain `new Error(...)` on the missing-resources check, which triggered `sendErrors` (Sentry) and returned a 500
- This PR lifts the appointment-not-found check out of the generic missing-resources block and throws `APPOINTMENT_NOT_FOUND_ERROR` (an `APIError`) instead — returning a clean 400 that bypasses Sentry, since a missing appointment is almost certainly a user/copy-paste error rather than a server problem

The remaining missing-resources check (Encounter, Location, Patient, QuestionnaireResponse) still throws a plain `Error` → 500 → Sentry, because those represent real data integrity issues that warrant investigation.

Closes [OTR-2493](https://linear.app/zapehr/issue/OTR-2493/add-uuid-validation-for-appointment-id-passed-to-get-paperwork)

## Test plan
- [ ] Pass a syntactically invalid UUID (e.g. `"not-a-uuid"`) → should get 400 with `INVALID_INPUT` code (unchanged)
- [ ] Pass a valid UUID that doesn't match any appointment → should get 400 with `APPOINTMENT_NOT_FOUND` code (was 500 before)
- [ ] Pass a valid appointment UUID → paperwork loads normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)