### PR TITLE
ci: bump automated-tests runner from 4 to 8 cores

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   automated-tests:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 40
     permissions:
       id-token: write # Required for OIDC


### PR DESCRIPTION
Reduce flakiness caused by resource constraints on the PR CI automated-tests job by moving from ubuntu-latest-4-cores to ubuntu-latest-8-cores.


Claude-Session: https://claude.ai/code/session_01Rg9G535CzP3A6G4aoJ9KsK