### PR TITLE
Add TruffleHog secret scanning for Claude Code agents

### DIFF
--- a/.claude/hooks/install-trufflehog.sh
+++ b/.claude/hooks/install-trufflehog.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SessionStart hook: ensure TruffleHog is available for the pre-commit secret scan.
+#
+# Enforcement (blocking on missing tool / found secrets) lives in
+# scan-staged-secrets.sh. This script just does best-effort installation so the
+# block-on-missing policy does not permanently wedge the agent's commits.
+# It must never hard-fail a session: all failures are logged and swallowed.
+
+set -u
+
+# Pin to the same TruffleHog line CI uses (see .github/workflows/lint-and-build.yml).
+TRUFFLEHOG_VERSION="3.82.13"
+DOCKER_IMAGE="ghcr.io/trufflesecurity/trufflehog:${TRUFFLEHOG_VERSION}"
+INSTALL_DIR="${HOME}/.local/bin"
+
+log() { echo "[install-trufflehog] $*" >&2; }
+
+# Already installed? Nothing to do.
+if command -v trufflehog >/dev/null 2>&1; then
+  log "trufflehog already present: $(command -v trufflehog)"
+  exit 0
+fi
+
+# Try the official install script (installs a pinned binary into INSTALL_DIR).
+if command -v curl >/dev/null 2>&1; then
+  mkdir -p "${INSTALL_DIR}"
+  log "installing trufflehog v${TRUFFLEHOG_VERSION} into ${INSTALL_DIR} ..."
+  if curl -fsSL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh \
+      | sh -s -- -b "${INSTALL_DIR}" "v${TRUFFLEHOG_VERSION}" >&2; then
+    if "${INSTALL_DIR}/trufflehog" --version >/dev/null 2>&1; then
+      log "trufflehog binary installed at ${INSTALL_DIR}/trufflehog"
+      exit 0
+    fi
+  fi
+  log "binary install failed or unavailable; will rely on docker fallback at scan time"
+fi
+
+# Fall back to pre-pulling the docker image so the scan hook can use it.
+if command -v docker >/dev/null 2>&1; then
+  log "pre-pulling docker image ${DOCKER_IMAGE} ..."
+  if docker pull "${DOCKER_IMAGE}" >&2 2>&1; then
+    log "docker image ready: ${DOCKER_IMAGE}"
+    exit 0
+  fi
+  log "docker pull failed (network policy?); scan hook will retry on demand"
+fi
+
+log "could not install trufflehog; commits will be BLOCKED until it is available"
+# Do not fail the session — enforcement is the scan hook's job.
+exit 0

--- a/.claude/hooks/scan-staged-secrets.sh
+++ b/.claude/hooks/scan-staged-secrets.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) hook: scan staged changes for secrets before a `git commit`.
+#
+# Behaviour (see .claude/settings.json):
+#   - Only acts on commands that run `git commit`. Everything else is a no-op.
+#   - Scans the staged files with TruffleHog (binary, or docker fallback).
+#   - DENIES the commit if a verified secret is found.
+#   - DENIES the commit if TruffleHog cannot be run at all (block-on-failure).
+#   - Stays silent (exit 0, no output) when clean, so normal permission flow
+#     and the user's approval prompts are preserved.
+#
+# A Claude hook cannot be bypassed with `git commit --no-verify` — it runs
+# before the command executes, unlike git's own hooks.
+
+set -u
+
+# Pin to the same TruffleHog line CI uses (see .github/workflows/lint-and-build.yml).
+TRUFFLEHOG_VERSION="3.82.13"
+DOCKER_IMAGE="ghcr.io/trufflesecurity/trufflehog:${TRUFFLEHOG_VERSION}"
+
+# Which TruffleHog result buckets block a commit. Default is strict on purpose
+# (the point of this guard is to catch an agent's mistakes):
+#   verified   - credential confirmed live via an API call
+#   unknown    - verification attempted but indeterminate (e.g. network blocked,
+#                which is the common case in the agent's restricted environment)
+#   unverified - regex match that failed/has no verifier (e.g. private keys)
+# CI uses --only-verified to avoid false positives at PR scale; for a local
+# pre-commit guard we err toward over-blocking. Relax via the env var, e.g.
+# OTTEHR_TRUFFLEHOG_RESULTS=verified,unknown  or  =verified.
+TRUFFLEHOG_RESULTS="${OTTEHR_TRUFFLEHOG_RESULTS:-verified,unknown,unverified}"
+
+# --- helpers ---------------------------------------------------------------
+
+# Emit a PreToolUse "deny" decision and exit. Arg 1 is a human-readable reason.
+deny() {
+  local reason="$1"
+  # Sanitise for embedding in a JSON string literal.
+  reason="${reason//\\/\\\\}"
+  reason="${reason//\"/\'}"
+  reason="${reason//$'\n'/ }"
+  reason="${reason//$'\t'/ }"
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "$reason"
+  exit 0
+}
+
+# Extract a JSON field from stdin payload. Prefers jq, falls back to python3.
+json_field() {
+  local field="$1" payload="$2"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$payload" | jq -r "$field // empty" 2>/dev/null
+  elif command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$payload" | python3 -c '
+import json, sys
+path = sys.argv[1].lstrip(".").split(".")
+try:
+    obj = json.load(sys.stdin)
+    for p in path:
+        obj = obj.get(p, "") if isinstance(obj, dict) else ""
+    print(obj if isinstance(obj, str) else "")
+except Exception:
+    print("")
+' "$field"
+  fi
+}
+
+# --- read hook input -------------------------------------------------------
+
+PAYLOAD="$(cat)"
+COMMAND="$(json_field '.tool_input.command' "$PAYLOAD")"
+CWD="$(json_field '.cwd' "$PAYLOAD")"
+[ -n "$CWD" ] || CWD="$PWD"
+
+# Only care about `git commit`. Be liberal about surrounding syntax
+# (cd ... && git commit, flags, etc.), but ignore dry runs.
+case "$COMMAND" in
+  *"git commit"*) : ;;
+  *) exit 0 ;;
+esac
+case "$COMMAND" in
+  *"--dry-run"*) exit 0 ;;
+esac
+
+# --- locate repo and staged files -----------------------------------------
+
+REPO_ROOT="$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null)"
+[ -n "$REPO_ROOT" ] || exit 0  # not a git repo; let the command proceed/fail on its own
+
+# Staged, non-deleted files (NUL-separated; paths relative to repo root).
+mapfile -d '' -t STAGED < <(git -C "$REPO_ROOT" diff --cached --name-only --diff-filter=ACMR -z)
+[ "${#STAGED[@]}" -gt 0 ] || exit 0  # nothing staged to scan
+
+# --- run TruffleHog --------------------------------------------------------
+
+TMP_OUT="$(mktemp)"
+trap 'rm -f "$TMP_OUT"' EXIT
+status=0
+
+if command -v trufflehog >/dev/null 2>&1; then
+  ( cd "$REPO_ROOT" && trufflehog filesystem "${STAGED[@]}" \
+      --results="$TRUFFLEHOG_RESULTS" --fail --no-update ) >"$TMP_OUT" 2>&1
+  status=$?
+elif command -v docker >/dev/null 2>&1; then
+  if docker run --rm -v "$REPO_ROOT":/repo -w /repo "$DOCKER_IMAGE" \
+      filesystem "${STAGED[@]}" --results="$TRUFFLEHOG_RESULTS" --fail --no-update \
+      >"$TMP_OUT" 2>&1; then
+    status=0
+  else
+    status=$?
+  fi
+else
+  deny "TruffleHog secret scan could not run: neither the trufflehog binary nor docker is available. Commit blocked (block-on-failure policy). Install trufflehog (see .claude/hooks/install-trufflehog.sh) and retry."
+fi
+
+# TruffleHog --fail exits 183 when results are found. Treat any non-zero exit
+# as a block, since under block-on-failure a scanner error must not pass.
+if [ "$status" -ne 0 ]; then
+  findings="$(grep -iE 'Found (verified|unverified)|Detector Type|Raw result' "$TMP_OUT" | head -n 20)"
+  [ -n "$findings" ] || findings="$(head -n 20 "$TMP_OUT")"
+  deny "TruffleHog detected potential secrets in staged files OR failed to run (exit ${status}). Commit blocked. Remove the secret(s) and use a secrets manager / env vars instead. Scanner output: ${findings}"
+fi
+
+# Clean: stay silent so normal permission handling proceeds.
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/install-trufflehog.sh",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/scan-staged-secrets.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,9 @@ terraform.json
 .test-appointment-id
 .playwright-mcp
 
-.claude
+# Ignore personal Claude Code config, but track the shared agent hooks/settings.
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+.claude/settings.local.json
 scripts/setup/project/setup-progress.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,3 +161,12 @@ Feature flags are defined in `packages/utils/lib/ottehr-config/feature-flags/ind
 - Pre-commit hook runs `lint-staged`
 - A custom git merge driver resolves `package.json`/`package-lock.json` version conflicts by picking the higher version—run `./scripts/setup-git-merge-driver.sh` to install it
 - `config/` and `apps/ehr/tests/e2e-utils/seed-data/` use the "ours" merge strategy to preserve local versions during upstream merges
+
+## Secret Scanning (Claude Code agents)
+
+Claude Code sessions in this repo run a TruffleHog secret scan before any `git commit`, mirroring CI's TruffleHog check. This is configured via Claude Code hooks in `.claude/settings.json` (it does **not** affect human developers' commits or the husky/lint-staged hook):
+
+- **`.claude/hooks/install-trufflehog.sh`** — `SessionStart` hook; installs the pinned `trufflehog` binary (falls back to the docker image) so the scan can run.
+- **`.claude/hooks/scan-staged-secrets.sh`** — `PreToolUse(Bash)` hook; on any `git commit`, scans the staged files with TruffleHog and **denies** the commit if a secret is found. It also denies (block-on-failure) if TruffleHog cannot run at all. Cannot be bypassed with `git commit --no-verify`.
+
+By default the scan blocks on `verified`, `unknown`, and `unverified` findings (strict, to catch agent mistakes even when the network can't verify a credential). Relax it for a session with `OTTEHR_TRUFFLEHOG_RESULTS=verified,unknown` (or `=verified` to match CI exactly) if false positives block legitimate commits.


### PR DESCRIPTION
I'm still reviewing this don't review it yet please.

🤖 generated and 🤖 description below.

## Summary

Adds Claude Code hooks to automatically scan staged files for secrets before any `git commit`, mirroring the TruffleHog check that runs in CI. This prevents Claude Code agents from accidentally committing credentials while preserving the normal workflow for human developers.

## Changes

- **`.claude/hooks/scan-staged-secrets.sh`** — `PreToolUse(Bash)` hook that runs before `git commit` commands. Scans staged files with TruffleHog and denies the commit if any secrets are found (verified, unknown, or unverified by default). Also blocks if TruffleHog cannot run at all (block-on-failure policy). Cannot be bypassed with `git commit --no-verify`.

- **`.claude/hooks/install-trufflehog.sh`** — `SessionStart` hook that installs the pinned TruffleHog binary (v3.82.13, matching CI) into `~/.local/bin`, with a fallback to pre-pulling the Docker image if the binary install fails. Runs best-effort only; failures are logged but do not block the session.

- **`.claude/settings.json`** — New Claude Code configuration file that registers both hooks. Tracked in git so all agents use the same secret scanning policy.

- **`.gitignore`** — Updated to track `.claude/settings.json` and `.claude/hooks/` while ignoring personal agent config (`.claude/*` except the shared files and `.claude/settings.local.json`).

- **`CLAUDE.md`** — Added "Secret Scanning (Claude Code agents)" section documenting the hooks, their behavior, and how to relax the scan strictness if needed (via `OTTEHR_TRUFFLEHOG_RESULTS` env var).

## Implementation Details

- The scan hook extracts the git command from the Claude hook payload, only acts on `git commit` (ignoring dry runs), and uses `git diff --cached` to find staged files.
- TruffleHog is invoked with `--results=verified,unknown,unverified` by default (strict, to catch agent mistakes even when the network can't verify credentials). CI uses `--only-verified` to avoid false positives at scale; agents err toward over-blocking.
- The hook stays silent on success (exit 0, no output) so normal Claude permission flow and user approval prompts are preserved.
- Both hooks pin to TruffleHog v3.82.13 to match CI's version.

https://claude.ai/code/session_01VyahB5TTKdrspN1an2GYkm