### PR TITLE
Alex/otr 2825 fix create claim screen

### DIFF
--- a/apps/billing/src/components/claim/DiagnosesEditor.tsx
+++ b/apps/billing/src/components/claim/DiagnosesEditor.tsx
@@ -1,0 +1,58 @@
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { ReactElement } from 'react';
+
+export interface DiagnosisRow {
+  code: string;
+  display: string;
+}
+
+export const emptyDiagnosisRow = (): DiagnosisRow => ({ code: '', display: '' });
+
+interface DiagnosesEditorProps {
+  value: DiagnosisRow[];
+  onChange: (rows: DiagnosisRow[]) => void;
+}
+
+/**
+ * Controlled editor for a claim's diagnosis list. Shared by the create-claim form and the
+ * claim-detail edit experience so the two stay identical. Diagnosis order is the 1-based
+ * `diagnosisSequence` that service lines point at — see {@link ServiceLinesEditor}.
+ */
+export function DiagnosesEditor({ value, onChange }: DiagnosesEditorProps): ReactElement {
+  const setRow = (index: number, field: keyof DiagnosisRow, fieldValue: string): void =>
+    onChange(value.map((row, i) => (i === index ? { ...row, [field]: fieldValue } : row)));
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, maxWidth: 680 }}>
+      {value.map((row, i) => (
+        <Box key={i} sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+          <Typography variant="body2" color="text.secondary" sx={{ width: 16 }}>
+            {i + 1}
+          </Typography>
+          <TextField
+            size="small"
+            label="ICD-10"
+            value={row.code}
+            onChange={(e) => setRow(i, 'code', e.target.value)}
+            sx={{ width: 140 }}
+          />
+          <TextField
+            size="small"
+            label="Description"
+            fullWidth
+            value={row.display}
+            onChange={(e) => setRow(i, 'display', e.target.value)}
+          />
+          <Button size="small" color="error" onClick={() => onChange(value.filter((_, j) => j !== i))}>
+            Remove
+          </Button>
+        </Box>
+      ))}
+      <Box>
+        <Button size="small" onClick={() => onChange([...value, emptyDiagnosisRow()])}>
+          + Add diagnosis
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/billing/src/components/claim/ServiceLinesEditor.tsx
+++ b/apps/billing/src/components/claim/ServiceLinesEditor.tsx
@@ -1,0 +1,152 @@
+import { Box, Button, MenuItem, Select, TextField } from '@mui/material';
+import { ReactElement } from 'react';
+
+export interface ServiceLineRow {
+  cptCode: string;
+  modifiers: string;
+  units: string;
+  charges: string;
+  serviceDate: string;
+  placeOfService: string;
+  diagnosisPointers: number[];
+}
+
+/** A diagnosis as referenced by a service line's `diagnosisPointers` (1-based sequence + its code). */
+export interface DiagnosisPointerOption {
+  sequence: number;
+  code: string;
+}
+
+export const emptyServiceLineRow = (overrides?: Partial<ServiceLineRow>): ServiceLineRow => ({
+  cptCode: '',
+  modifiers: '',
+  units: '1',
+  charges: '',
+  serviceDate: '',
+  placeOfService: '',
+  diagnosisPointers: [],
+  ...overrides,
+});
+
+interface ServiceLinesEditorProps {
+  value: ServiceLineRow[];
+  onChange: (rows: ServiceLineRow[]) => void;
+  /** Diagnoses available for the per-line Dx pointer dropdown (1-based sequence). */
+  diagnoses: DiagnosisPointerOption[];
+  /** Seed date for a newly added line when there's no prior line to copy from. */
+  defaultServiceDate?: string;
+}
+
+/**
+ * Controlled editor for a claim's service lines, including the per-line diagnosis pointers
+ * (CMS-1500 box 24E). Shared by the create-claim form and the claim-detail edit experience.
+ */
+export function ServiceLinesEditor({
+  value,
+  onChange,
+  diagnoses,
+  defaultServiceDate,
+}: ServiceLinesEditorProps): ReactElement {
+  const setRow = <K extends keyof ServiceLineRow>(index: number, field: K, fieldValue: ServiceLineRow[K]): void =>
+    onChange(value.map((row, i) => (i === index ? { ...row, [field]: fieldValue } : row)));
+
+  const dxCode = (sequence: number): string =>
+    diagnoses.find((dx) => dx.sequence === sequence)?.code ?? String(sequence);
+
+  const addRow = (): void =>
+    onChange([
+      ...value,
+      emptyServiceLineRow({
+        serviceDate: value[0]?.serviceDate ?? defaultServiceDate ?? '',
+        placeOfService: value[0]?.placeOfService ?? '',
+        diagnosisPointers: diagnoses.length ? [diagnoses[0].sequence] : [],
+      }),
+    ]);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+      {value.map((row, i) => (
+        <Box key={i} sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+          <TextField
+            size="small"
+            label="CPT"
+            value={row.cptCode}
+            onChange={(e) => setRow(i, 'cptCode', e.target.value)}
+            sx={{ width: 100 }}
+          />
+          <TextField
+            size="small"
+            label="Mod"
+            value={row.modifiers}
+            onChange={(e) => setRow(i, 'modifiers', e.target.value)}
+            sx={{ width: 90 }}
+          />
+          <TextField
+            size="small"
+            label="Units"
+            type="number"
+            value={row.units}
+            onChange={(e) => setRow(i, 'units', e.target.value)}
+            sx={{ width: 80 }}
+          />
+          <TextField
+            size="small"
+            label="Charges"
+            type="number"
+            value={row.charges}
+            onChange={(e) => setRow(i, 'charges', e.target.value)}
+            sx={{ width: 110 }}
+          />
+          <TextField
+            size="small"
+            label="Date"
+            type="date"
+            value={row.serviceDate}
+            onChange={(e) => setRow(i, 'serviceDate', e.target.value)}
+            sx={{ width: 160 }}
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            size="small"
+            label="POS"
+            value={row.placeOfService}
+            onChange={(e) => setRow(i, 'placeOfService', e.target.value)}
+            sx={{ width: 80 }}
+          />
+          <Select
+            multiple
+            size="small"
+            displayEmpty
+            // Clamp to valid sequences so MUI never warns on a pointer whose diagnosis was removed.
+            value={row.diagnosisPointers.filter((p) => diagnoses.some((dx) => dx.sequence === p))}
+            onChange={(e) => setRow(i, 'diagnosisPointers', e.target.value as number[])}
+            renderValue={(selected) =>
+              selected.length ? (
+                selected.map(dxCode).join(', ')
+              ) : (
+                <Box component="span" sx={{ color: 'text.disabled' }}>
+                  Dx
+                </Box>
+              )
+            }
+            sx={{ width: 160 }}
+          >
+            {diagnoses.map((dx) => (
+              <MenuItem key={dx.sequence} value={dx.sequence}>
+                {dx.sequence}: {dx.code}
+              </MenuItem>
+            ))}
+          </Select>
+          <Button size="small" color="error" onClick={() => onChange(value.filter((_, j) => j !== i))}>
+            Remove
+          </Button>
+        </Box>
+      ))}
+      <Box>
+        <Button size="small" onClick={addRow}>
+          + Add service line
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/billing/src/components/input/TextInput.tsx
+++ b/apps/billing/src/components/input/TextInput.tsx
@@ -14,12 +14,6 @@ interface TextInputProps {
   InputLabelProps?: TextFieldProps['InputLabelProps'];
 }
 
-/**
- * react-hook-form-bound text field, mirroring the clinical side's
- * apps/ehr/src/components/input/TextInput.tsx: it registers a `required` rule using the
- * shared REQUIRED_FIELD_ERROR_MESSAGE and renders the error state inline (red + helper text).
- * The `sx`/width is applied to the field itself so it drops into the existing flex layouts.
- */
 export function TextInput({
   name,
   label,

--- a/apps/billing/src/components/input/TextInput.tsx
+++ b/apps/billing/src/components/input/TextInput.tsx
@@ -1,0 +1,56 @@
+import { SxProps, TextField, TextFieldProps, Theme } from '@mui/material';
+import { ReactElement } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { REQUIRED_FIELD_ERROR_MESSAGE } from 'utils';
+
+interface TextInputProps {
+  name: string;
+  label?: string;
+  type?: string;
+  required?: boolean;
+  placeholder?: string;
+  fullWidth?: boolean;
+  sx?: SxProps<Theme>;
+  InputLabelProps?: TextFieldProps['InputLabelProps'];
+}
+
+/**
+ * react-hook-form-bound text field, mirroring the clinical side's
+ * apps/ehr/src/components/input/TextInput.tsx: it registers a `required` rule using the
+ * shared REQUIRED_FIELD_ERROR_MESSAGE and renders the error state inline (red + helper text).
+ * The `sx`/width is applied to the field itself so it drops into the existing flex layouts.
+ */
+export function TextInput({
+  name,
+  label,
+  type,
+  required,
+  placeholder,
+  fullWidth,
+  sx,
+  InputLabelProps,
+}: TextInputProps): ReactElement {
+  const { control } = useFormContext();
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={{ required: required ? REQUIRED_FIELD_ERROR_MESSAGE : false }}
+      render={({ field, fieldState: { error } }) => (
+        <TextField
+          {...field}
+          value={field.value ?? ''}
+          size="small"
+          type={type ?? 'text'}
+          label={label}
+          placeholder={placeholder}
+          error={!!error}
+          helperText={error?.message}
+          fullWidth={fullWidth}
+          InputLabelProps={InputLabelProps}
+          sx={sx}
+        />
+      )}
+    />
+  );
+}

--- a/apps/billing/src/pages/ClaimDetail.tsx
+++ b/apps/billing/src/pages/ClaimDetail.tsx
@@ -48,7 +48,9 @@ import {
   updateBillingResource,
 } from '../api/api';
 import { ClaimStatusFields } from '../components/claim/ClaimStatusFields';
+import { DiagnosesEditor } from '../components/claim/DiagnosesEditor';
 import { EditableSection } from '../components/claim/EditableSection';
+import { ServiceLineRow, ServiceLinesEditor } from '../components/claim/ServiceLinesEditor';
 import { Field } from '../components/Field';
 import { claimStatusValueColor, formatAntCaseString } from '../constants/claimStatus';
 import { useApiClients } from '../hooks/useAppClients';
@@ -1007,9 +1009,6 @@ function DiagnosesSection({
     resetFields();
   }, [resetFields]);
 
-  const setRow = (index: number, field: 'code' | 'display', value: string): void =>
-    setRows((prev) => prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)));
-
   const handleSave = async (): Promise<string | null> => {
     if (rows.some((row) => !row.code.trim())) return 'Each diagnosis needs an ICD-10 code';
     return updateResource('Claim', claim.id, {
@@ -1025,39 +1024,7 @@ function DiagnosesSection({
       title="Diagnoses"
       onSave={handleSave}
       onCancel={resetFields}
-      editForm={
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, maxWidth: 680 }}>
-          {rows.map((row, i) => (
-            <Box key={i} sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-              <Typography variant="body2" color="text.secondary" sx={{ width: 16 }}>
-                {i + 1}
-              </Typography>
-              <TextField
-                size="small"
-                label="ICD-10"
-                value={row.code}
-                onChange={(e) => setRow(i, 'code', e.target.value)}
-                sx={{ width: 140 }}
-              />
-              <TextField
-                size="small"
-                label="Description"
-                fullWidth
-                value={row.display}
-                onChange={(e) => setRow(i, 'display', e.target.value)}
-              />
-              <Button size="small" color="error" onClick={() => setRows((prev) => prev.filter((_, j) => j !== i))}>
-                Remove
-              </Button>
-            </Box>
-          ))}
-          <Box>
-            <Button size="small" onClick={() => setRows((prev) => [...prev, { code: '', display: '' }])}>
-              + Add diagnosis
-            </Button>
-          </Box>
-        </Box>
-      }
+      editForm={<DiagnosesEditor value={rows} onChange={setRows} />}
     >
       {claim.diagnoses.length > 0 ? (
         <>
@@ -1076,16 +1043,6 @@ function DiagnosesSection({
       )}
     </EditableSection>
   );
-}
-
-interface ServiceLineRow {
-  cptCode: string;
-  modifiers: string;
-  units: string;
-  charges: string;
-  serviceDate: string;
-  placeOfService: string;
-  diagnosisPointers: number[];
 }
 
 function ServiceLinesSection({
@@ -1115,23 +1072,6 @@ function ServiceLinesSection({
   useEffect(() => {
     resetFields();
   }, [resetFields]);
-
-  const setRow = <K extends keyof ServiceLineRow>(index: number, field: K, value: ServiceLineRow[K]): void =>
-    setRows((prev) => prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)));
-
-  const addRow = (): void =>
-    setRows((prev) => [
-      ...prev,
-      {
-        cptCode: '',
-        modifiers: '',
-        units: '1',
-        charges: '',
-        serviceDate: claim.serviceLines[0]?.serviceDate ?? claim.created,
-        placeOfService: claim.serviceLines[0]?.placeOfService ?? '',
-        diagnosisPointers: claim.diagnoses.length ? [claim.diagnoses[0].sequence] : [],
-      },
-    ]);
 
   const dxCode = (sequence: number): string =>
     claim.diagnoses.find((dx) => dx.sequence === sequence)?.code ?? String(sequence);
@@ -1168,89 +1108,12 @@ function ServiceLinesSection({
       onSave={handleSave}
       onCancel={resetFields}
       editForm={
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-          {rows.map((row, i) => (
-            <Box key={i} sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-              <TextField
-                size="small"
-                label="CPT"
-                value={row.cptCode}
-                onChange={(e) => setRow(i, 'cptCode', e.target.value)}
-                sx={{ width: 100 }}
-              />
-              <TextField
-                size="small"
-                label="Mod"
-                value={row.modifiers}
-                onChange={(e) => setRow(i, 'modifiers', e.target.value)}
-                sx={{ width: 90 }}
-              />
-              <TextField
-                size="small"
-                label="Units"
-                type="number"
-                value={row.units}
-                onChange={(e) => setRow(i, 'units', e.target.value)}
-                sx={{ width: 80 }}
-              />
-              <TextField
-                size="small"
-                label="Charges"
-                type="number"
-                value={row.charges}
-                onChange={(e) => setRow(i, 'charges', e.target.value)}
-                sx={{ width: 110 }}
-              />
-              <TextField
-                size="small"
-                label="Date"
-                type="date"
-                value={row.serviceDate}
-                onChange={(e) => setRow(i, 'serviceDate', e.target.value)}
-                sx={{ width: 160 }}
-                InputLabelProps={{ shrink: true }}
-              />
-              <TextField
-                size="small"
-                label="POS"
-                value={row.placeOfService}
-                onChange={(e) => setRow(i, 'placeOfService', e.target.value)}
-                sx={{ width: 80 }}
-              />
-              <Select
-                multiple
-                size="small"
-                displayEmpty
-                value={row.diagnosisPointers}
-                onChange={(e) => setRow(i, 'diagnosisPointers', e.target.value as number[])}
-                renderValue={(selected) =>
-                  selected.length ? (
-                    selected.map(dxCode).join(', ')
-                  ) : (
-                    <Box component="span" sx={{ color: 'text.disabled' }}>
-                      Dx
-                    </Box>
-                  )
-                }
-                sx={{ width: 160 }}
-              >
-                {claim.diagnoses.map((dx) => (
-                  <MenuItem key={dx.sequence} value={dx.sequence}>
-                    {dx.sequence}: {dx.code}
-                  </MenuItem>
-                ))}
-              </Select>
-              <Button size="small" color="error" onClick={() => setRows((prev) => prev.filter((_, j) => j !== i))}>
-                Remove
-              </Button>
-            </Box>
-          ))}
-          <Box>
-            <Button size="small" onClick={addRow}>
-              + Add service line
-            </Button>
-          </Box>
-        </Box>
+        <ServiceLinesEditor
+          value={rows}
+          onChange={setRows}
+          diagnoses={claim.diagnoses}
+          defaultServiceDate={claim.created}
+        />
       }
     >
       {claim.serviceLines.length > 0 ? (

--- a/apps/billing/src/pages/CreateClaim.tsx
+++ b/apps/billing/src/pages/CreateClaim.tsx
@@ -4,7 +4,6 @@ import {
   Autocomplete,
   Box,
   Button,
-  Chip,
   CircularProgress,
   Divider,
   FormHelperText,
@@ -13,7 +12,7 @@ import {
   Typography,
 } from '@mui/material';
 import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
-import { Controller, FormProvider, useFieldArray, useForm } from 'react-hook-form';
+import { Controller, FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import {
   BillingCoverageOption,
@@ -36,19 +35,12 @@ import {
   searchBillingProviders as searchBillingProvidersApi,
 } from '../api/api';
 import { ClaimStatusFields } from '../components/claim/ClaimStatusFields';
+import { DiagnosesEditor, DiagnosisRow } from '../components/claim/DiagnosesEditor';
+import { emptyServiceLineRow, ServiceLineRow, ServiceLinesEditor } from '../components/claim/ServiceLinesEditor';
 import { TextInput } from '../components/input/TextInput';
 import { useApiClients } from '../hooks/useAppClients';
 
-interface ServiceLine {
-  cpt: string;
-  modifiers: string;
-  units: number;
-  charges: number;
-}
-
 interface CreateClaimForm {
-  dateOfService: string;
-  pos: { value: string; label: string } | null;
   patient: BillingPatientOption | null;
   patientFirstName: string;
   patientLastName: string;
@@ -67,24 +59,13 @@ interface CreateClaimForm {
   billingName: string;
   billingNpi: string;
   billingTin: string;
-  diagnoses: string[];
-  serviceLines: ServiceLine[];
+  // Diagnoses and service lines reuse the same editors as the claim-detail edit experience;
+  // each service line points at diagnoses by their 1-based position in this list.
+  diagnoses: DiagnosisRow[];
+  serviceLines: ServiceLineRow[];
 }
 
-const POS_OPTIONS = [
-  { value: '11', label: '11 - Office' },
-  { value: '20', label: '20 - Urgent Care' },
-  { value: '21', label: '21 - Inpatient Hospital' },
-  { value: '22', label: '22 - Outpatient Hospital' },
-  { value: '23', label: '23 - Emergency Room' },
-  { value: '02', label: '02 - Telehealth' },
-];
-
-const emptyLine: ServiceLine = { cpt: '', modifiers: '', units: 1, charges: 0 };
-
 const defaultValues: CreateClaimForm = {
-  dateOfService: '',
-  pos: null,
   patient: null,
   patientFirstName: '',
   patientLastName: '',
@@ -104,7 +85,7 @@ const defaultValues: CreateClaimForm = {
   billingNpi: '',
   billingTin: '',
   diagnoses: [],
-  serviceLines: [{ ...emptyLine }],
+  serviceLines: [emptyServiceLineRow()],
 };
 
 export default function CreateClaim(): ReactElement {
@@ -137,20 +118,6 @@ export default function CreateClaim(): ReactElement {
   const [renderingProviders, setRenderingProviders] = useState<BillingProviderOption[]>([]);
   const [locations, setLocations] = useState<BillingLocationOption[]>([]);
   const [billingProviders, setBillingProviders] = useState<BillingProviderOption[]>([]);
-  const [dxInput, setDxInput] = useState('');
-
-  const {
-    fields: serviceLineFields,
-    append,
-    remove,
-  } = useFieldArray({
-    control,
-    name: 'serviceLines',
-    // A claim needs at least one billable line; empty-CPT lines are dropped before submit, so require a real CPT.
-    rules: {
-      validate: (lines) => lines.some((l) => l.cpt.trim()) || 'At least one service line with a CPT code is required',
-    },
-  });
 
   // Watched values used to drive conditional sections / disabled states.
   const selectedPatient = watch('patient');
@@ -158,6 +125,9 @@ export default function CreateClaim(): ReactElement {
   const selectedRenderingProvider = watch('renderingProvider');
   const selectedFacility = watch('facility');
   const selectedBillingProvider = watch('billingProvider');
+  // Diagnoses drive the service-line Dx pointer dropdown — pointers are the 1-based position here.
+  const diagnoses = watch('diagnoses');
+  const diagnosisOptions = diagnoses.map((dx, i) => ({ sequence: i + 1, code: dx.code }));
 
   useEffect(() => {
     return (): void => {
@@ -170,7 +140,7 @@ export default function CreateClaim(): ReactElement {
 
   // After a failed submit, smoothly scroll the first invalid field into view
   // (matches the clinical side, e.g. apps/ehr/src/components/EmployeeInformation/index.tsx).
-  // Covers both RHF fields (Patient, Date of Service) and AR Stage, which render `.Mui-error`.
+  // Covers RHF fields (Patient, providers, diagnoses, service lines) and AR Stage, which render `.Mui-error`.
   useEffect(() => {
     if (Object.keys(errors).length > 0 || arStageError) {
       document.querySelector('.Mui-error')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -312,24 +282,34 @@ export default function CreateClaim(): ReactElement {
         };
       }
 
-      if (data.diagnoses.length) payload.diagnoses = data.diagnoses.map((code) => ({ code }));
-
-      const pos = data.pos?.value;
-      const validLines = data.serviceLines.filter((l) => l.cpt.trim());
-      if (validLines.length) {
-        payload.serviceLines = validLines.map((l) => ({
-          cptCode: l.cpt,
-          units: l.units,
-          charges: l.charges,
-          serviceDate: data.dateOfService,
-          placeOfService: pos || undefined,
-          modifiers: l.modifiers
-            ? l.modifiers
-                .split(',')
-                .map((m) => m.trim())
-                .filter(Boolean)
-            : undefined,
+      // Validation guarantees every diagnosis row has a code, so positions here line up with the
+      // diagnosisPointers below (the backend assigns diagnosisSequence by array order).
+      const diagnoses = data.diagnoses.filter((dx) => dx.code.trim());
+      if (diagnoses.length) {
+        payload.diagnoses = diagnoses.map((dx) => ({
+          code: dx.code.trim(),
+          ...(dx.display.trim() ? { display: dx.display.trim() } : {}),
         }));
+      }
+
+      const validLines = data.serviceLines.filter((l) => l.cptCode.trim());
+      if (validLines.length) {
+        payload.serviceLines = validLines.map((l) => {
+          const modifiers = l.modifiers
+            .split(/[,\s]+/)
+            .map((m) => m.trim())
+            .filter(Boolean);
+          const pointers = l.diagnosisPointers.filter((p) => p >= 1 && p <= diagnoses.length);
+          return {
+            cptCode: l.cptCode.trim(),
+            units: Number(l.units),
+            charges: Number(l.charges),
+            serviceDate: l.serviceDate,
+            ...(l.placeOfService.trim() ? { placeOfService: l.placeOfService.trim() } : {}),
+            ...(modifiers.length ? { modifiers } : {}),
+            ...(pointers.length ? { diagnosisPointers: pointers } : {}),
+          };
+        });
       }
 
       const statusEntries = Object.entries(statuses).filter(([, v]) => v);
@@ -342,7 +322,7 @@ export default function CreateClaim(): ReactElement {
     }
   };
 
-  // Always-enabled Create: RHF validates Patient + Date of Service; AR Stage is checked here since
+  // Always-enabled Create: RHF validates the required fields; AR Stage is checked here since
   // it lives outside the form. On any failure the offending fields turn red and we scroll to the first.
   const handleCreate = handleSubmit(
     async (data) => {
@@ -392,37 +372,6 @@ export default function CreateClaim(): ReactElement {
             {error}
           </Alert>
         )}
-
-        <FormSection label="Claim Information">
-          <Box sx={{ display: 'flex', gap: 2 }}>
-            <TextInput
-              name="dateOfService"
-              type="date"
-              label="Date of Service"
-              required
-              InputLabelProps={{ shrink: true }}
-              sx={{ width: 200 }}
-            />
-            <Controller
-              name="pos"
-              control={control}
-              render={({ field }) => (
-                <Autocomplete
-                  size="small"
-                  options={POS_OPTIONS}
-                  getOptionLabel={(o) => o.label}
-                  value={field.value}
-                  onChange={(_, v) => field.onChange(v)}
-                  renderInput={(params) => <TextField {...params} label="Place of Service" />}
-                  isOptionEqualToValue={(o, v) => o.value === v.value}
-                  sx={{ width: 260 }}
-                />
-              )}
-            />
-          </Box>
-        </FormSection>
-
-        <Divider />
 
         <Box sx={{ py: 2.5 }}>
           <ClaimStatusFields
@@ -719,111 +668,46 @@ export default function CreateClaim(): ReactElement {
           <Controller
             name="diagnoses"
             control={control}
-            rules={{ validate: (v) => (v && v.length > 0) || 'At least one diagnosis is required' }}
-            render={({ field, fieldState: { error: fieldError } }) => {
-              const addDiagnosis = (): void => {
-                const code = dxInput.trim().toUpperCase();
-                if (code && !field.value.includes(code)) {
-                  field.onChange([...field.value, code]);
-                  setDxInput('');
-                }
-              };
-              return (
-                <>
-                  <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
-                    {field.value.map((dx, i) => (
-                      <Chip
-                        key={i}
-                        label={dx}
-                        size="small"
-                        onDelete={() => field.onChange(field.value.filter((_, j) => j !== i))}
-                      />
-                    ))}
-                  </Box>
-                  <Box sx={{ display: 'flex', gap: 1 }}>
-                    <TextField
-                      size="small"
-                      placeholder="ICD-10 (e.g. J06.9)"
-                      value={dxInput}
-                      onChange={(e) => setDxInput(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          e.preventDefault();
-                          addDiagnosis();
-                        }
-                      }}
-                      error={!!fieldError}
-                      helperText={fieldError?.message}
-                      sx={{ width: 200 }}
-                    />
-                    <Button size="small" onClick={addDiagnosis}>
-                      + Add
-                    </Button>
-                  </Box>
-                </>
-              );
+            rules={{
+              validate: (rows) => {
+                if (!rows.length) return 'At least one diagnosis is required';
+                if (rows.some((dx) => !dx.code.trim())) return 'Each diagnosis needs an ICD-10 code';
+                return true;
+              },
             }}
+            render={({ field, fieldState: { error: fieldError } }) => (
+              <>
+                <DiagnosesEditor value={field.value} onChange={field.onChange} />
+                {fieldError && <FormHelperText error>{fieldError.message}</FormHelperText>}
+              </>
+            )}
           />
         </FormSection>
 
         <Divider />
 
         <FormSection label="Service Lines">
-          {serviceLineFields.map((lineField, i) => (
-            <Box key={lineField.id} sx={{ mb: 2 }}>
-              {i > 0 && <Divider sx={{ mb: 2 }} />}
-              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-                <Controller
-                  name={`serviceLines.${i}.cpt`}
-                  control={control}
-                  render={({ field }) => <TextField {...field} size="small" label="CPT" sx={{ width: 100 }} />}
-                />
-                <Controller
-                  name={`serviceLines.${i}.modifiers`}
-                  control={control}
-                  render={({ field }) => <TextField {...field} size="small" label="Mod" sx={{ width: 80 }} />}
-                />
-                <Controller
-                  name={`serviceLines.${i}.units`}
-                  control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      size="small"
-                      label="Units"
-                      type="number"
-                      onChange={(e) => field.onChange(Number(e.target.value))}
-                      sx={{ width: 70 }}
-                    />
-                  )}
-                />
-                <Controller
-                  name={`serviceLines.${i}.charges`}
-                  control={control}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      size="small"
-                      label="Charges"
-                      type="number"
-                      value={field.value || ''}
-                      onChange={(e) => field.onChange(Number(e.target.value))}
-                      sx={{ width: 100 }}
-                    />
-                  )}
-                />
-                {serviceLineFields.length > 1 && (
-                  <Button size="small" color="error" onClick={() => remove(i)}>
-                    Remove
-                  </Button>
-                )}
-              </Box>
-            </Box>
-          ))}
-          <Button size="small" onClick={() => append({ ...emptyLine })}>
-            + Add service line
-          </Button>
-          {errors.serviceLines?.root && <FormHelperText error>{errors.serviceLines.root.message}</FormHelperText>}
+          <Controller
+            name="serviceLines"
+            control={control}
+            rules={{
+              validate: (rows) => {
+                const withCpt = rows.filter((l) => l.cptCode.trim());
+                if (!withCpt.length) return 'At least one service line with a CPT code is required';
+                if (withCpt.some((l) => !l.serviceDate)) return 'Each service line needs a date of service';
+                if (withCpt.some((l) => !(Number(l.units) > 0))) return 'Units must be a positive number';
+                if (withCpt.some((l) => l.charges.trim() === '' || !Number.isFinite(Number(l.charges))))
+                  return 'Charges must be a number';
+                return true;
+              },
+            }}
+            render={({ field, fieldState: { error: fieldError } }) => (
+              <>
+                <ServiceLinesEditor value={field.value} onChange={field.onChange} diagnoses={diagnosisOptions} />
+                {fieldError && <FormHelperText error>{fieldError.message}</FormHelperText>}
+              </>
+            )}
+          />
         </FormSection>
       </Box>
     </FormProvider>

--- a/apps/billing/src/pages/CreateClaim.tsx
+++ b/apps/billing/src/pages/CreateClaim.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
 } from '@mui/material';
 import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
+import { Controller, FormProvider, useFieldArray, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import {
   BillingCoverageOption,
@@ -23,6 +24,7 @@ import {
   CreateBillingClaimInput,
   emptyClaimStatusValues,
   getApiError,
+  REQUIRED_FIELD_ERROR_MESSAGE,
   withArStageInitialization,
 } from 'utils';
 import {
@@ -33,6 +35,7 @@ import {
   searchBillingProviders as searchBillingProvidersApi,
 } from '../api/api';
 import { ClaimStatusFields } from '../components/claim/ClaimStatusFields';
+import { TextInput } from '../components/input/TextInput';
 import { useApiClients } from '../hooks/useAppClients';
 
 interface ServiceLine {
@@ -40,6 +43,32 @@ interface ServiceLine {
   modifiers: string;
   units: number;
   charges: number;
+}
+
+interface CreateClaimForm {
+  dateOfService: string;
+  pos: { value: string; label: string } | null;
+  patient: BillingPatientOption | null;
+  patientFirstName: string;
+  patientLastName: string;
+  patientDob: string;
+  patientGender: string;
+  coverage: BillingCoverageOption | null;
+  subscriberId: string;
+  renderingProvider: BillingProviderOption | null;
+  practFirstName: string;
+  practLastName: string;
+  practNpi: string;
+  facility: BillingLocationOption | null;
+  facilityName: string;
+  facilityNpi: string;
+  facilityAddress: string;
+  billingProvider: BillingProviderOption | null;
+  billingName: string;
+  billingNpi: string;
+  billingTin: string;
+  diagnoses: string[];
+  serviceLines: ServiceLine[];
 }
 
 const POS_OPTIONS = [
@@ -53,6 +82,32 @@ const POS_OPTIONS = [
 
 const emptyLine: ServiceLine = { cpt: '', modifiers: '', units: 1, charges: 0 };
 
+const defaultValues: CreateClaimForm = {
+  dateOfService: '',
+  pos: null,
+  patient: null,
+  patientFirstName: '',
+  patientLastName: '',
+  patientDob: '',
+  patientGender: '',
+  coverage: null,
+  subscriberId: '',
+  renderingProvider: null,
+  practFirstName: '',
+  practLastName: '',
+  practNpi: '',
+  facility: null,
+  facilityName: '',
+  facilityNpi: '',
+  facilityAddress: '',
+  billingProvider: null,
+  billingName: '',
+  billingNpi: '',
+  billingTin: '',
+  diagnoses: [],
+  serviceLines: [{ ...emptyLine }],
+};
+
 export default function CreateClaim(): ReactElement {
   const navigate = useNavigate();
   const { oystehrZambda } = useApiClients();
@@ -61,43 +116,38 @@ export default function CreateClaim(): ReactElement {
   const locTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const billingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const methods = useForm<CreateClaimForm>({ defaultValues });
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors, isSubmitting },
+  } = methods;
 
+  // API-level error shown in the top alert (kept separate from field validation).
+  const [error, setError] = useState<string | null>(null);
+  // Claim status indicators live outside RHF (managed by the ClaimStatusFields component).
+  const [statuses, setStatuses] = useState<ClaimStatusValues>(emptyClaimStatusValues);
+  // AR Stage is required but isn't an RHF field, so we surface its error after a submit attempt.
+  const [arStageError, setArStageError] = useState(false);
+
+  // Autocomplete search results — UI state, not form values.
   const [patients, setPatients] = useState<BillingPatientOption[]>([]);
   const [coverages, setCoverages] = useState<BillingCoverageOption[]>([]);
   const [renderingProviders, setRenderingProviders] = useState<BillingProviderOption[]>([]);
   const [locations, setLocations] = useState<BillingLocationOption[]>([]);
   const [billingProviders, setBillingProviders] = useState<BillingProviderOption[]>([]);
-
-  const [selectedPatient, setSelectedPatient] = useState<BillingPatientOption | null>(null);
-  const [selectedCoverage, setSelectedCoverage] = useState<BillingCoverageOption | null>(null);
-  const [selectedRenderingProvider, setSelectedRenderingProvider] = useState<BillingProviderOption | null>(null);
-  const [selectedFacility, setSelectedFacility] = useState<BillingLocationOption | null>(null);
-  const [selectedBillingProvider, setSelectedBillingProvider] = useState<BillingProviderOption | null>(null);
-
-  const [subscriberId, setSubscriberId] = useState('');
-  const [dateOfService, setDateOfService] = useState('');
-  const [selectedPos, setSelectedPos] = useState<{ value: string; label: string } | null>(null);
-  const [diagnoses, setDiagnoses] = useState<string[]>([]);
   const [dxInput, setDxInput] = useState('');
-  const [serviceLines, setServiceLines] = useState<ServiceLine[]>([{ ...emptyLine }]);
-  const [statuses, setStatuses] = useState<ClaimStatusValues>(emptyClaimStatusValues);
 
-  // Override fields — populated from selection, editable by user
-  const [patientFirstName, setPatientFirstName] = useState('');
-  const [patientLastName, setPatientLastName] = useState('');
-  const [patientDob, setPatientDob] = useState('');
-  const [patientGender, setPatientGender] = useState('');
-  const [practFirstName, setPractFirstName] = useState('');
-  const [practLastName, setPractLastName] = useState('');
-  const [practNpi, setPractNpi] = useState('');
-  const [facilityName, setFacilityName] = useState('');
-  const [facilityNpi, setFacilityNpi] = useState('');
-  const [facilityAddress, setFacilityAddress] = useState('');
-  const [billingName, setBillingName] = useState('');
-  const [billingNpi, setBillingNpi] = useState('');
-  const [billingTin, setBillingTin] = useState('');
+  const { fields: serviceLineFields, append, remove } = useFieldArray({ control, name: 'serviceLines' });
+
+  // Watched values used to drive conditional sections / disabled states.
+  const selectedPatient = watch('patient');
+  const selectedRenderingProvider = watch('renderingProvider');
+  const selectedFacility = watch('facility');
+  const selectedBillingProvider = watch('billingProvider');
+  const diagnoses = watch('diagnoses');
 
   useEffect(() => {
     return (): void => {
@@ -107,6 +157,15 @@ export default function CreateClaim(): ReactElement {
       if (billingTimer.current) clearTimeout(billingTimer.current);
     };
   }, []);
+
+  // After a failed submit, smoothly scroll the first invalid field into view
+  // (matches the clinical side, e.g. apps/ehr/src/components/EmployeeInformation/index.tsx).
+  // Covers both RHF fields (Patient, Date of Service) and AR Stage, which render `.Mui-error`.
+  useEffect(() => {
+    if (Object.keys(errors).length > 0 || arStageError) {
+      document.querySelector('.Mui-error')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [errors, arStageError]);
 
   const searchPatients = useCallback(
     async (query?: string): Promise<void> => {
@@ -173,30 +232,12 @@ export default function CreateClaim(): ReactElement {
     searchTimer.current = setTimeout(() => void searchPatients(query || undefined), 300);
   };
 
-  const handlePatientSelect = (_: unknown, value: BillingPatientOption | null): void => {
-    setSelectedPatient(value);
-    setSelectedCoverage(null);
-    setCoverages([]);
-    setSubscriberId('');
-    setPatientFirstName(value?.firstName ?? '');
-    setPatientLastName(value?.lastName ?? '');
-    setPatientDob(value?.dob ?? '');
-    setPatientGender(value?.gender ?? '');
-    if (value?.id) void fetchCoverages(value.id);
-  };
-
   const addDiagnosis = (): void => {
     const code = dxInput.trim().toUpperCase();
     if (code && !diagnoses.includes(code)) {
-      setDiagnoses([...diagnoses, code]);
+      setValue('diagnoses', [...diagnoses, code]);
       setDxInput('');
     }
-  };
-
-  const updateLine = (i: number, field: keyof ServiceLine, value: string | number): void => {
-    const updated = [...serviceLines];
-    updated[i] = { ...updated[i], [field]: value };
-    setServiceLines(updated);
   };
 
   const handleStatusChange = (field: ClaimStatusFieldKey, value: string): void => {
@@ -205,80 +246,83 @@ export default function CreateClaim(): ReactElement {
       // Entering an AR Stage initializes that stage's progress status (mirrors the server rule).
       return field === 'arStage' ? { ...next, ...withArStageInitialization(next) } : next;
     });
+    // Clear the AR Stage error as soon as a stage is chosen (never raise it outside a submit attempt).
+    if (field === 'arStage' && value) setArStageError(false);
   };
 
-  const canSave = selectedPatient && dateOfService && statuses.arStage;
-
-  const handleSave = async (): Promise<void> => {
-    if (!oystehrZambda || !selectedPatient || !dateOfService || !statuses.arStage) return;
-    if (!selectedPatient.id) {
+  const onValid = async (data: CreateClaimForm): Promise<void> => {
+    if (!oystehrZambda || !data.patient) return;
+    if (!data.patient.id) {
       setError('Selected patient is missing an id');
       return;
     }
-    setSaving(true);
     setError(null);
     try {
-      const payload: Record<string, unknown> = { patientId: selectedPatient.id };
+      const payload: Record<string, unknown> = { patientId: data.patient.id };
 
       // Patient overrides — only send fields that differ from original
       const patOverrides: Record<string, string> = {};
-      if (patientFirstName && patientFirstName !== selectedPatient.firstName) patOverrides.firstName = patientFirstName;
-      if (patientLastName && patientLastName !== selectedPatient.lastName) patOverrides.lastName = patientLastName;
-      if (patientDob && patientDob !== selectedPatient.dob) patOverrides.dob = patientDob;
-      if (patientGender && patientGender !== selectedPatient.gender) patOverrides.gender = patientGender;
+      if (data.patientFirstName && data.patientFirstName !== data.patient.firstName)
+        patOverrides.firstName = data.patientFirstName;
+      if (data.patientLastName && data.patientLastName !== data.patient.lastName)
+        patOverrides.lastName = data.patientLastName;
+      if (data.patientDob && data.patientDob !== data.patient.dob) patOverrides.dob = data.patientDob;
+      if (data.patientGender && data.patientGender !== data.patient.gender) patOverrides.gender = data.patientGender;
       if (Object.keys(patOverrides).length) payload.patientOverrides = patOverrides;
 
-      if (selectedCoverage) {
-        payload.coverageId = selectedCoverage.id;
-        if (subscriberId && subscriberId !== selectedCoverage.subscriberId) {
-          payload.coverageOverrides = { subscriberId };
+      if (data.coverage) {
+        payload.coverageId = data.coverage.id;
+        if (data.subscriberId && data.subscriberId !== data.coverage.subscriberId) {
+          payload.coverageOverrides = { subscriberId: data.subscriberId };
         }
       }
 
-      if (selectedRenderingProvider) {
+      if (data.renderingProvider) {
         const overrides: Record<string, string> = {};
-        if (practFirstName && practFirstName !== selectedRenderingProvider.firstName)
-          overrides.firstName = practFirstName;
-        if (practLastName && practLastName !== selectedRenderingProvider.lastName) overrides.lastName = practLastName;
-        if (practNpi && practNpi !== selectedRenderingProvider.npi) overrides.npi = practNpi;
+        if (data.practFirstName && data.practFirstName !== data.renderingProvider.firstName)
+          overrides.firstName = data.practFirstName;
+        if (data.practLastName && data.practLastName !== data.renderingProvider.lastName)
+          overrides.lastName = data.practLastName;
+        if (data.practNpi && data.practNpi !== data.renderingProvider.npi) overrides.npi = data.practNpi;
         payload.renderingProvider = {
-          id: selectedRenderingProvider.id,
-          type: selectedRenderingProvider.kind === 'organization' ? 'Organization' : 'Practitioner',
+          id: data.renderingProvider.id,
+          type: data.renderingProvider.kind === 'organization' ? 'Organization' : 'Practitioner',
           ...(Object.keys(overrides).length ? { overrides } : {}),
         };
       }
 
-      if (selectedFacility) {
-        payload.facilityId = selectedFacility.id;
+      if (data.facility) {
+        payload.facilityId = data.facility.id;
         const facOverrides: Record<string, string> = {};
-        if (facilityName && facilityName !== selectedFacility.name) facOverrides.name = facilityName;
-        if (facilityNpi && facilityNpi !== selectedFacility.npi) facOverrides.npi = facilityNpi;
-        if (facilityAddress && facilityAddress !== selectedFacility.address) facOverrides.address = facilityAddress;
+        if (data.facilityName && data.facilityName !== data.facility.name) facOverrides.name = data.facilityName;
+        if (data.facilityNpi && data.facilityNpi !== data.facility.npi) facOverrides.npi = data.facilityNpi;
+        if (data.facilityAddress && data.facilityAddress !== data.facility.address)
+          facOverrides.address = data.facilityAddress;
         if (Object.keys(facOverrides).length) payload.facilityOverrides = facOverrides;
       }
 
-      if (selectedBillingProvider) {
+      if (data.billingProvider) {
         const overrides: Record<string, string> = {};
-        if (billingName && billingName !== selectedBillingProvider.name) overrides.name = billingName;
-        if (billingNpi && billingNpi !== selectedBillingProvider.npi) overrides.npi = billingNpi;
-        if (billingTin && billingTin !== selectedBillingProvider.taxId) overrides.tin = billingTin;
+        if (data.billingName && data.billingName !== data.billingProvider.name) overrides.name = data.billingName;
+        if (data.billingNpi && data.billingNpi !== data.billingProvider.npi) overrides.npi = data.billingNpi;
+        if (data.billingTin && data.billingTin !== data.billingProvider.taxId) overrides.tin = data.billingTin;
         payload.billingProvider = {
-          id: selectedBillingProvider.id,
-          type: selectedBillingProvider.kind === 'organization' ? 'Organization' : 'Practitioner',
+          id: data.billingProvider.id,
+          type: data.billingProvider.kind === 'organization' ? 'Organization' : 'Practitioner',
           ...(Object.keys(overrides).length ? { overrides } : {}),
         };
       }
 
-      if (diagnoses.length) payload.diagnoses = diagnoses.map((code) => ({ code }));
+      if (data.diagnoses.length) payload.diagnoses = data.diagnoses.map((code) => ({ code }));
 
-      const pos = selectedPos?.value;
-      const validLines = serviceLines.filter((l) => l.cpt.trim());
+      const pos = data.pos?.value;
+      const validLines = data.serviceLines.filter((l) => l.cpt.trim());
       if (validLines.length) {
         payload.serviceLines = validLines.map((l) => ({
           cptCode: l.cpt,
           units: l.units,
           charges: l.charges,
-          serviceDate: dateOfService,
+          serviceDate: data.dateOfService,
           placeOfService: pos || undefined,
           modifiers: l.modifiers
             ? l.modifiers
@@ -292,441 +336,451 @@ export default function CreateClaim(): ReactElement {
       const statusEntries = Object.entries(statuses).filter(([, v]) => v);
       if (statusEntries.length) payload.statuses = Object.fromEntries(statusEntries);
 
-      const data = await createBillingClaim(oystehrZambda, payload as CreateBillingClaimInput);
-      if (data.claimId) navigate(`/claims/${data.claimId}`);
+      const result = await createBillingClaim(oystehrZambda, payload as CreateBillingClaimInput);
+      if (result.claimId) navigate(`/claims/${result.claimId}`);
     } catch (err) {
       setError(getApiError({ error: err, defaultError: 'Failed to create claim' }));
-    } finally {
-      setSaving(false);
     }
   };
 
+  // Always-enabled Create: RHF validates Patient + Date of Service; AR Stage is checked here since
+  // it lives outside the form. On any failure the offending fields turn red and we scroll to the first.
+  const handleCreate = handleSubmit(
+    async (data) => {
+      if (!statuses.arStage) {
+        setArStageError(true);
+        return;
+      }
+      setArStageError(false);
+      await onValid(data);
+    },
+    () => {
+      setArStageError(!statuses.arStage);
+    }
+  );
+
   return (
-    <Box sx={{ p: 3 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <IconButton size="small" onClick={() => navigate('/claims')}>
-            <ArrowBackIcon fontSize="small" />
-          </IconButton>
-          <Typography variant="h6" color="primary.dark" fontWeight={600}>
-            Create a Claim
-          </Typography>
-        </Box>
-        <Box sx={{ display: 'flex', gap: 1 }}>
-          <Button size="small" onClick={() => navigate('/claims')}>
-            Cancel
-          </Button>
-          <Button
-            size="small"
-            variant="contained"
-            startIcon={saving ? <CircularProgress size={14} /> : <SaveIcon fontSize="small" />}
-            onClick={handleSave}
-            disabled={saving || !canSave}
-          >
-            {saving ? 'Creating...' : 'Create'}
-          </Button>
-        </Box>
-      </Box>
-
-      <Divider />
-      {error && (
-        <Alert severity="error" sx={{ mt: 2 }}>
-          {error}
-        </Alert>
-      )}
-
-      <FormSection label="Claim Information">
-        <Box sx={{ display: 'flex', gap: 2 }}>
-          <TextField
-            size="small"
-            type="date"
-            label="Date of Service"
-            value={dateOfService}
-            onChange={(e) => setDateOfService(e.target.value)}
-            InputLabelProps={{ shrink: true }}
-            sx={{ width: 200 }}
-          />
-          <Autocomplete
-            size="small"
-            options={POS_OPTIONS}
-            getOptionLabel={(o) => o.label}
-            value={selectedPos}
-            onChange={(_, v) => setSelectedPos(v)}
-            renderInput={(params) => <TextField {...params} label="Place of Service" />}
-            isOptionEqualToValue={(o, v) => o.value === v.value}
-            sx={{ width: 260 }}
-          />
-        </Box>
-      </FormSection>
-
-      <Divider />
-
-      <Box sx={{ py: 2.5 }}>
-        <ClaimStatusFields values={statuses} onChange={handleStatusChange} requireArStage title="Claim Status" />
-      </Box>
-
-      <Divider />
-
-      <FormSection label="Patient">
-        <Autocomplete
-          options={patients}
-          value={selectedPatient}
-          onChange={handlePatientSelect}
-          onInputChange={(_, val, reason) => {
-            if (reason === 'input') handlePatientSearch(val);
-          }}
-          onOpen={() => void searchPatients()}
-          filterOptions={(x) => x}
-          getOptionLabel={(o) => o.name || `${o.firstName} ${o.lastName}`}
-          renderOption={(props, o) => (
-            <Box component="li" {...props} key={o.id}>
-              <Box>
-                <Typography variant="body2" fontWeight={500}>
-                  {o.name || `${o.firstName} ${o.lastName}`}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  DOB: {o.dob} | {o.gender}
-                </Typography>
-              </Box>
-            </Box>
-          )}
-          renderInput={(params) => <TextField {...params} label="Search Patient" size="small" />}
-          isOptionEqualToValue={(o, v) => o.id === v.id}
-          sx={{ mb: selectedPatient ? 2 : 0 }}
-        />
-        {selectedPatient && (
-          <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
-            <TextField
+    <FormProvider {...methods}>
+      <Box sx={{ p: 3 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <IconButton size="small" onClick={() => navigate('/claims')}>
+              <ArrowBackIcon fontSize="small" />
+            </IconButton>
+            <Typography variant="h6" color="primary.dark" fontWeight={600}>
+              Create a Claim
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button size="small" onClick={() => navigate('/claims')}>
+              Cancel
+            </Button>
+            <Button
               size="small"
-              label="First Name"
-              value={patientFirstName}
-              onChange={(e) => setPatientFirstName(e.target.value)}
-              sx={{ flex: 1, minWidth: 160 }}
-            />
-            <TextField
-              size="small"
-              label="Last Name"
-              value={patientLastName}
-              onChange={(e) => setPatientLastName(e.target.value)}
-              sx={{ flex: 1, minWidth: 160 }}
-            />
-            <TextField
-              size="small"
+              variant="contained"
+              startIcon={isSubmitting ? <CircularProgress size={14} /> : <SaveIcon fontSize="small" />}
+              onClick={handleCreate}
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? 'Creating...' : 'Create'}
+            </Button>
+          </Box>
+        </Box>
+
+        <Divider />
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        <FormSection label="Claim Information">
+          <Box sx={{ display: 'flex', gap: 2 }}>
+            <TextInput
+              name="dateOfService"
               type="date"
-              label="Date of Birth"
-              value={patientDob}
-              onChange={(e) => setPatientDob(e.target.value)}
+              label="Date of Service"
+              required
               InputLabelProps={{ shrink: true }}
-              sx={{ width: 160 }}
+              sx={{ width: 200 }}
             />
-            <TextField
-              size="small"
-              label="Gender"
-              value={patientGender}
-              onChange={(e) => setPatientGender(e.target.value)}
-              sx={{ width: 120 }}
-            />
-          </Box>
-        )}
-      </FormSection>
-
-      <Divider />
-
-      <FormSection label="Insurance / Coverage">
-        <Autocomplete
-          options={coverages}
-          value={selectedCoverage}
-          onChange={(_, v) => {
-            setSelectedCoverage(v);
-            if (v) setSubscriberId(v.subscriberId);
-          }}
-          getOptionLabel={(o) => `${o.payorName} — ${o.subscriberId}`}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Select Coverage"
-              size="small"
-              placeholder={selectedPatient ? 'Choose coverage...' : 'Select a patient first'}
-            />
-          )}
-          isOptionEqualToValue={(o, v) => o.id === v.id}
-          disabled={!selectedPatient}
-          sx={{ mb: 2 }}
-        />
-        <TextField
-          label="Member / Subscriber ID"
-          size="small"
-          fullWidth
-          value={subscriberId}
-          onChange={(e) => setSubscriberId(e.target.value)}
-        />
-      </FormSection>
-
-      <Divider />
-
-      <FormSection label="Rendering Provider">
-        <Autocomplete
-          options={renderingProviders}
-          value={selectedRenderingProvider}
-          onChange={(_, v) => {
-            setSelectedRenderingProvider(v);
-            setPractFirstName(v?.firstName ?? '');
-            setPractLastName(v?.lastName ?? '');
-            setPractNpi(v?.npi ?? '');
-          }}
-          onInputChange={(_, val, reason) => {
-            if (reason === 'input') searchRenderingProviders(val || undefined);
-          }}
-          onOpen={() => searchRenderingProviders()}
-          filterOptions={(x) => x}
-          getOptionLabel={(o) => o.name || `${o.firstName} ${o.lastName}`}
-          renderOption={(props, o) => (
-            <Box component="li" {...props} key={o.id}>
-              <Box>
-                <Typography variant="body2" fontWeight={500}>
-                  {o.name || `${o.firstName} ${o.lastName}`}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  NPI: {o.npi}
-                </Typography>
-              </Box>
-            </Box>
-          )}
-          renderInput={(p) => <TextField {...p} size="small" label="Choose Rendering Provider" />}
-          isOptionEqualToValue={(o, v) => o.id === v.id}
-          sx={{ mb: selectedRenderingProvider ? 2 : 0 }}
-        />
-        {selectedRenderingProvider && (
-          <Box sx={{ display: 'flex', gap: 2 }}>
-            <TextField
-              size="small"
-              label="First Name"
-              value={practFirstName}
-              onChange={(e) => setPractFirstName(e.target.value)}
-              sx={{ flex: 1 }}
-            />
-            <TextField
-              size="small"
-              label="Last Name"
-              value={practLastName}
-              onChange={(e) => setPractLastName(e.target.value)}
-              sx={{ flex: 1 }}
-            />
-            <TextField
-              size="small"
-              label="NPI"
-              value={practNpi}
-              onChange={(e) => setPractNpi(e.target.value)}
-              sx={{ width: 160 }}
-            />
-          </Box>
-        )}
-      </FormSection>
-
-      <Divider />
-
-      <FormSection label="Service Facility">
-        <Autocomplete
-          options={locations}
-          value={selectedFacility}
-          onChange={(_, v) => {
-            setSelectedFacility(v);
-            setFacilityName(v?.name ?? '');
-            setFacilityNpi(v?.npi ?? '');
-            setFacilityAddress(v?.address ?? '');
-          }}
-          onInputChange={(_, val, reason) => {
-            if (reason === 'input') searchLocations(val || undefined);
-          }}
-          onOpen={() => searchLocations()}
-          filterOptions={(x) => x}
-          getOptionLabel={(o) => o.name}
-          renderOption={(props, o) => (
-            <Box component="li" {...props} key={o.id}>
-              <Box>
-                <Typography variant="body2" fontWeight={500}>
-                  {o.name}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  NPI: {o.npi} | {o.address}
-                </Typography>
-              </Box>
-            </Box>
-          )}
-          renderInput={(p) => <TextField {...p} size="small" label="Choose Service Facility" />}
-          isOptionEqualToValue={(o, v) => o.id === v.id}
-          sx={{ mb: selectedFacility ? 2 : 0 }}
-        />
-        {selectedFacility && (
-          <Box sx={{ display: 'flex', gap: 2 }}>
-            <TextField
-              size="small"
-              label="Facility Name"
-              value={facilityName}
-              onChange={(e) => setFacilityName(e.target.value)}
-              sx={{ flex: 1 }}
-            />
-            <TextField
-              size="small"
-              label="NPI"
-              value={facilityNpi}
-              onChange={(e) => setFacilityNpi(e.target.value)}
-              sx={{ width: 160 }}
-            />
-            <TextField
-              size="small"
-              label="Address"
-              value={facilityAddress}
-              onChange={(e) => setFacilityAddress(e.target.value)}
-              sx={{ flex: 1 }}
-            />
-          </Box>
-        )}
-      </FormSection>
-
-      <Divider />
-
-      <FormSection label="Billing Provider">
-        <Autocomplete
-          options={billingProviders}
-          value={selectedBillingProvider}
-          onChange={(_, v) => {
-            setSelectedBillingProvider(v);
-            setBillingName(v?.name ?? '');
-            setBillingNpi(v?.npi ?? '');
-            setBillingTin(v?.taxId ?? '');
-          }}
-          onInputChange={(_, val, reason) => {
-            if (reason === 'input') searchBillingProviders(val || undefined);
-          }}
-          onOpen={() => searchBillingProviders()}
-          filterOptions={(x) => x}
-          getOptionLabel={(o) => o.name}
-          renderOption={(props, o) => (
-            <Box component="li" {...props} key={o.id}>
-              <Box>
-                <Typography variant="body2" fontWeight={500}>
-                  {o.name}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  NPI: {o.npi} | TIN: {o.taxId}
-                </Typography>
-              </Box>
-            </Box>
-          )}
-          renderInput={(p) => <TextField {...p} size="small" label="Choose Billing Provider" />}
-          isOptionEqualToValue={(o, v) => o.id === v.id}
-          sx={{ mb: selectedBillingProvider ? 2 : 0 }}
-        />
-        {selectedBillingProvider && (
-          <Box sx={{ display: 'flex', gap: 2 }}>
-            <TextField
-              size="small"
-              label="Name"
-              value={billingName}
-              onChange={(e) => setBillingName(e.target.value)}
-              sx={{ flex: 1 }}
-            />
-            <TextField
-              size="small"
-              label="NPI"
-              value={billingNpi}
-              onChange={(e) => setBillingNpi(e.target.value)}
-              sx={{ width: 160 }}
-            />
-            <TextField
-              size="small"
-              label="TIN"
-              value={billingTin}
-              onChange={(e) => setBillingTin(e.target.value)}
-              sx={{ width: 160 }}
-            />
-          </Box>
-        )}
-      </FormSection>
-
-      <Divider />
-
-      <FormSection label="Diagnoses">
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
-          {diagnoses.map((dx, i) => (
-            <Chip key={i} label={dx} size="small" onDelete={() => setDiagnoses(diagnoses.filter((_, j) => j !== i))} />
-          ))}
-        </Box>
-        <Box sx={{ display: 'flex', gap: 1 }}>
-          <TextField
-            size="small"
-            placeholder="ICD-10 (e.g. J06.9)"
-            value={dxInput}
-            onChange={(e) => setDxInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                addDiagnosis();
-              }
-            }}
-            sx={{ width: 200 }}
-          />
-          <Button size="small" onClick={addDiagnosis}>
-            + Add
-          </Button>
-        </Box>
-      </FormSection>
-
-      <Divider />
-
-      <FormSection label="Service Lines">
-        {serviceLines.map((line, i) => (
-          <Box key={i} sx={{ mb: 2 }}>
-            {i > 0 && <Divider sx={{ mb: 2 }} />}
-            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-              <TextField
-                size="small"
-                label="CPT"
-                value={line.cpt}
-                onChange={(e) => updateLine(i, 'cpt', e.target.value)}
-                sx={{ width: 100 }}
-              />
-              <TextField
-                size="small"
-                label="Mod"
-                value={line.modifiers}
-                onChange={(e) => updateLine(i, 'modifiers', e.target.value)}
-                sx={{ width: 80 }}
-              />
-              <TextField
-                size="small"
-                label="Units"
-                type="number"
-                value={line.units}
-                onChange={(e) => updateLine(i, 'units', Number(e.target.value))}
-                sx={{ width: 70 }}
-              />
-              <TextField
-                size="small"
-                label="Charges"
-                type="number"
-                value={line.charges || ''}
-                onChange={(e) => updateLine(i, 'charges', Number(e.target.value))}
-                sx={{ width: 100 }}
-              />
-              {serviceLines.length > 1 && (
-                <Button
+            <Controller
+              name="pos"
+              control={control}
+              render={({ field }) => (
+                <Autocomplete
                   size="small"
-                  color="error"
-                  onClick={() => setServiceLines(serviceLines.filter((_, j) => j !== i))}
-                >
-                  Remove
-                </Button>
+                  options={POS_OPTIONS}
+                  getOptionLabel={(o) => o.label}
+                  value={field.value}
+                  onChange={(_, v) => field.onChange(v)}
+                  renderInput={(params) => <TextField {...params} label="Place of Service" />}
+                  isOptionEqualToValue={(o, v) => o.value === v.value}
+                  sx={{ width: 260 }}
+                />
               )}
-            </Box>
+            />
           </Box>
-        ))}
-        <Button size="small" onClick={() => setServiceLines([...serviceLines, { ...emptyLine }])}>
-          + Add service line
-        </Button>
-      </FormSection>
-    </Box>
+        </FormSection>
+
+        <Divider />
+
+        <Box sx={{ py: 2.5 }}>
+          <ClaimStatusFields
+            values={statuses}
+            onChange={handleStatusChange}
+            requireArStage={arStageError}
+            title="Claim Status"
+          />
+        </Box>
+
+        <Divider />
+
+        <FormSection label="Patient">
+          <Controller
+            name="patient"
+            control={control}
+            rules={{ required: REQUIRED_FIELD_ERROR_MESSAGE }}
+            render={({ field, fieldState: { error: fieldError } }) => (
+              <Autocomplete
+                options={patients}
+                value={field.value}
+                onChange={(_, value) => {
+                  field.onChange(value);
+                  setValue('coverage', null);
+                  setCoverages([]);
+                  setValue('subscriberId', '');
+                  setValue('patientFirstName', value?.firstName ?? '');
+                  setValue('patientLastName', value?.lastName ?? '');
+                  setValue('patientDob', value?.dob ?? '');
+                  setValue('patientGender', value?.gender ?? '');
+                  if (value?.id) void fetchCoverages(value.id);
+                }}
+                onInputChange={(_, val, reason) => {
+                  if (reason === 'input') handlePatientSearch(val);
+                }}
+                onOpen={() => void searchPatients()}
+                filterOptions={(x) => x}
+                getOptionLabel={(o) => o.name || `${o.firstName} ${o.lastName}`}
+                renderOption={(props, o) => (
+                  <Box component="li" {...props} key={o.id}>
+                    <Box>
+                      <Typography variant="body2" fontWeight={500}>
+                        {o.name || `${o.firstName} ${o.lastName}`}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        DOB: {o.dob} | {o.gender}
+                      </Typography>
+                    </Box>
+                  </Box>
+                )}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Search Patient"
+                    size="small"
+                    error={!!fieldError}
+                    helperText={fieldError?.message}
+                  />
+                )}
+                isOptionEqualToValue={(o, v) => o.id === v.id}
+                sx={{ mb: field.value ? 2 : 0 }}
+              />
+            )}
+          />
+          {selectedPatient && (
+            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+              <TextInput name="patientFirstName" label="First Name" sx={{ flex: 1, minWidth: 160 }} />
+              <TextInput name="patientLastName" label="Last Name" sx={{ flex: 1, minWidth: 160 }} />
+              <TextInput
+                name="patientDob"
+                type="date"
+                label="Date of Birth"
+                InputLabelProps={{ shrink: true }}
+                sx={{ width: 160 }}
+              />
+              <TextInput name="patientGender" label="Gender" sx={{ width: 120 }} />
+            </Box>
+          )}
+        </FormSection>
+
+        <Divider />
+
+        <FormSection label="Insurance / Coverage">
+          <Controller
+            name="coverage"
+            control={control}
+            render={({ field }) => (
+              <Autocomplete
+                options={coverages}
+                value={field.value}
+                onChange={(_, v) => {
+                  field.onChange(v);
+                  if (v) setValue('subscriberId', v.subscriberId);
+                }}
+                getOptionLabel={(o) => `${o.payorName} — ${o.subscriberId}`}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Select Coverage"
+                    size="small"
+                    placeholder={selectedPatient ? 'Choose coverage...' : 'Select a patient first'}
+                  />
+                )}
+                isOptionEqualToValue={(o, v) => o.id === v.id}
+                disabled={!selectedPatient}
+                sx={{ mb: 2 }}
+              />
+            )}
+          />
+          <TextInput name="subscriberId" label="Member / Subscriber ID" fullWidth />
+        </FormSection>
+
+        <Divider />
+
+        <FormSection label="Rendering Provider">
+          <Controller
+            name="renderingProvider"
+            control={control}
+            render={({ field }) => (
+              <Autocomplete
+                options={renderingProviders}
+                value={field.value}
+                onChange={(_, v) => {
+                  field.onChange(v);
+                  setValue('practFirstName', v?.firstName ?? '');
+                  setValue('practLastName', v?.lastName ?? '');
+                  setValue('practNpi', v?.npi ?? '');
+                }}
+                onInputChange={(_, val, reason) => {
+                  if (reason === 'input') searchRenderingProviders(val || undefined);
+                }}
+                onOpen={() => searchRenderingProviders()}
+                filterOptions={(x) => x}
+                getOptionLabel={(o) => o.name || `${o.firstName} ${o.lastName}`}
+                renderOption={(props, o) => (
+                  <Box component="li" {...props} key={o.id}>
+                    <Box>
+                      <Typography variant="body2" fontWeight={500}>
+                        {o.name || `${o.firstName} ${o.lastName}`}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        NPI: {o.npi}
+                      </Typography>
+                    </Box>
+                  </Box>
+                )}
+                renderInput={(p) => <TextField {...p} size="small" label="Choose Rendering Provider" />}
+                isOptionEqualToValue={(o, v) => o.id === v.id}
+                sx={{ mb: field.value ? 2 : 0 }}
+              />
+            )}
+          />
+          {selectedRenderingProvider && (
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <TextInput name="practFirstName" label="First Name" sx={{ flex: 1 }} />
+              <TextInput name="practLastName" label="Last Name" sx={{ flex: 1 }} />
+              <TextInput name="practNpi" label="NPI" sx={{ width: 160 }} />
+            </Box>
+          )}
+        </FormSection>
+
+        <Divider />
+
+        <FormSection label="Service Facility">
+          <Controller
+            name="facility"
+            control={control}
+            render={({ field }) => (
+              <Autocomplete
+                options={locations}
+                value={field.value}
+                onChange={(_, v) => {
+                  field.onChange(v);
+                  setValue('facilityName', v?.name ?? '');
+                  setValue('facilityNpi', v?.npi ?? '');
+                  setValue('facilityAddress', v?.address ?? '');
+                }}
+                onInputChange={(_, val, reason) => {
+                  if (reason === 'input') searchLocations(val || undefined);
+                }}
+                onOpen={() => searchLocations()}
+                filterOptions={(x) => x}
+                getOptionLabel={(o) => o.name}
+                renderOption={(props, o) => (
+                  <Box component="li" {...props} key={o.id}>
+                    <Box>
+                      <Typography variant="body2" fontWeight={500}>
+                        {o.name}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        NPI: {o.npi} | {o.address}
+                      </Typography>
+                    </Box>
+                  </Box>
+                )}
+                renderInput={(p) => <TextField {...p} size="small" label="Choose Service Facility" />}
+                isOptionEqualToValue={(o, v) => o.id === v.id}
+                sx={{ mb: field.value ? 2 : 0 }}
+              />
+            )}
+          />
+          {selectedFacility && (
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <TextInput name="facilityName" label="Facility Name" sx={{ flex: 1 }} />
+              <TextInput name="facilityNpi" label="NPI" sx={{ width: 160 }} />
+              <TextInput name="facilityAddress" label="Address" sx={{ flex: 1 }} />
+            </Box>
+          )}
+        </FormSection>
+
+        <Divider />
+
+        <FormSection label="Billing Provider">
+          <Controller
+            name="billingProvider"
+            control={control}
+            render={({ field }) => (
+              <Autocomplete
+                options={billingProviders}
+                value={field.value}
+                onChange={(_, v) => {
+                  field.onChange(v);
+                  setValue('billingName', v?.name ?? '');
+                  setValue('billingNpi', v?.npi ?? '');
+                  setValue('billingTin', v?.taxId ?? '');
+                }}
+                onInputChange={(_, val, reason) => {
+                  if (reason === 'input') searchBillingProviders(val || undefined);
+                }}
+                onOpen={() => searchBillingProviders()}
+                filterOptions={(x) => x}
+                getOptionLabel={(o) => o.name}
+                renderOption={(props, o) => (
+                  <Box component="li" {...props} key={o.id}>
+                    <Box>
+                      <Typography variant="body2" fontWeight={500}>
+                        {o.name}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        NPI: {o.npi} | TIN: {o.taxId}
+                      </Typography>
+                    </Box>
+                  </Box>
+                )}
+                renderInput={(p) => <TextField {...p} size="small" label="Choose Billing Provider" />}
+                isOptionEqualToValue={(o, v) => o.id === v.id}
+                sx={{ mb: field.value ? 2 : 0 }}
+              />
+            )}
+          />
+          {selectedBillingProvider && (
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <TextInput name="billingName" label="Name" sx={{ flex: 1 }} />
+              <TextInput name="billingNpi" label="NPI" sx={{ width: 160 }} />
+              <TextInput name="billingTin" label="TIN" sx={{ width: 160 }} />
+            </Box>
+          )}
+        </FormSection>
+
+        <Divider />
+
+        <FormSection label="Diagnoses">
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
+            {diagnoses.map((dx, i) => (
+              <Chip
+                key={i}
+                label={dx}
+                size="small"
+                onDelete={() =>
+                  setValue(
+                    'diagnoses',
+                    diagnoses.filter((_, j) => j !== i)
+                  )
+                }
+              />
+            ))}
+          </Box>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <TextField
+              size="small"
+              placeholder="ICD-10 (e.g. J06.9)"
+              value={dxInput}
+              onChange={(e) => setDxInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  addDiagnosis();
+                }
+              }}
+              sx={{ width: 200 }}
+            />
+            <Button size="small" onClick={addDiagnosis}>
+              + Add
+            </Button>
+          </Box>
+        </FormSection>
+
+        <Divider />
+
+        <FormSection label="Service Lines">
+          {serviceLineFields.map((lineField, i) => (
+            <Box key={lineField.id} sx={{ mb: 2 }}>
+              {i > 0 && <Divider sx={{ mb: 2 }} />}
+              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                <Controller
+                  name={`serviceLines.${i}.cpt`}
+                  control={control}
+                  render={({ field }) => <TextField {...field} size="small" label="CPT" sx={{ width: 100 }} />}
+                />
+                <Controller
+                  name={`serviceLines.${i}.modifiers`}
+                  control={control}
+                  render={({ field }) => <TextField {...field} size="small" label="Mod" sx={{ width: 80 }} />}
+                />
+                <Controller
+                  name={`serviceLines.${i}.units`}
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      size="small"
+                      label="Units"
+                      type="number"
+                      onChange={(e) => field.onChange(Number(e.target.value))}
+                      sx={{ width: 70 }}
+                    />
+                  )}
+                />
+                <Controller
+                  name={`serviceLines.${i}.charges`}
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      size="small"
+                      label="Charges"
+                      type="number"
+                      value={field.value || ''}
+                      onChange={(e) => field.onChange(Number(e.target.value))}
+                      sx={{ width: 100 }}
+                    />
+                  )}
+                />
+                {serviceLineFields.length > 1 && (
+                  <Button size="small" color="error" onClick={() => remove(i)}>
+                    Remove
+                  </Button>
+                )}
+              </Box>
+            </Box>
+          ))}
+          <Button size="small" onClick={() => append({ ...emptyLine })}>
+            + Add service line
+          </Button>
+        </FormSection>
+      </Box>
+    </FormProvider>
   );
 }
 

--- a/apps/billing/src/pages/CreateClaim.tsx
+++ b/apps/billing/src/pages/CreateClaim.tsx
@@ -59,8 +59,6 @@ interface CreateClaimForm {
   billingName: string;
   billingNpi: string;
   billingTin: string;
-  // Diagnoses and service lines reuse the same editors as the claim-detail edit experience;
-  // each service line points at diagnoses by their 1-based position in this list.
   diagnoses: DiagnosisRow[];
   serviceLines: ServiceLineRow[];
 }
@@ -138,9 +136,7 @@ export default function CreateClaim(): ReactElement {
     };
   }, []);
 
-  // After a failed submit, smoothly scroll the first invalid field into view
-  // (matches the clinical side, e.g. apps/ehr/src/components/EmployeeInformation/index.tsx).
-  // Covers RHF fields (Patient, providers, diagnoses, service lines) and AR Stage, which render `.Mui-error`.
+  // After a failed submit, smoothly scroll the first invalid field into view.
   useEffect(() => {
     if (Object.keys(errors).length > 0 || arStageError) {
       document.querySelector('.Mui-error')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -295,6 +291,8 @@ export default function CreateClaim(): ReactElement {
       const validLines = data.serviceLines.filter((l) => l.cptCode.trim());
       if (validLines.length) {
         payload.serviceLines = validLines.map((l) => {
+          // Split the free-text modifiers field on any run of commas and/or whitespace
+          // so "25, 59" and "25 59" both yield ["25", "59"].
           const modifiers = l.modifiers
             .split(/[,\s]+/)
             .map((m) => m.trim())
@@ -322,8 +320,6 @@ export default function CreateClaim(): ReactElement {
     }
   };
 
-  // Always-enabled Create: RHF validates the required fields; AR Stage is checked here since
-  // it lives outside the form. On any failure the offending fields turn red and we scroll to the first.
   const handleCreate = handleSubmit(
     async (data) => {
       if (!statuses.arStage) {

--- a/apps/billing/src/pages/CreateClaim.tsx
+++ b/apps/billing/src/pages/CreateClaim.tsx
@@ -7,6 +7,7 @@ import {
   Chip,
   CircularProgress,
   Divider,
+  FormHelperText,
   IconButton,
   TextField,
   Typography,
@@ -138,7 +139,18 @@ export default function CreateClaim(): ReactElement {
   const [billingProviders, setBillingProviders] = useState<BillingProviderOption[]>([]);
   const [dxInput, setDxInput] = useState('');
 
-  const { fields: serviceLineFields, append, remove } = useFieldArray({ control, name: 'serviceLines' });
+  const {
+    fields: serviceLineFields,
+    append,
+    remove,
+  } = useFieldArray({
+    control,
+    name: 'serviceLines',
+    // A claim needs at least one billable line; empty-CPT lines are dropped before submit, so require a real CPT.
+    rules: {
+      validate: (lines) => lines.some((l) => l.cpt.trim()) || 'At least one service line with a CPT code is required',
+    },
+  });
 
   // Watched values used to drive conditional sections / disabled states.
   const selectedPatient = watch('patient');
@@ -146,7 +158,6 @@ export default function CreateClaim(): ReactElement {
   const selectedRenderingProvider = watch('renderingProvider');
   const selectedFacility = watch('facility');
   const selectedBillingProvider = watch('billingProvider');
-  const diagnoses = watch('diagnoses');
 
   useEffect(() => {
     return (): void => {
@@ -229,14 +240,6 @@ export default function CreateClaim(): ReactElement {
   const handlePatientSearch = (query: string): void => {
     if (searchTimer.current) clearTimeout(searchTimer.current);
     searchTimer.current = setTimeout(() => void searchPatients(query || undefined), 300);
-  };
-
-  const addDiagnosis = (): void => {
-    const code = dxInput.trim().toUpperCase();
-    if (code && !diagnoses.includes(code)) {
-      setValue('diagnoses', [...diagnoses, code]);
-      setDxInput('');
-    }
   };
 
   const handleStatusChange = (field: ClaimStatusFieldKey, value: string): void => {
@@ -542,7 +545,8 @@ export default function CreateClaim(): ReactElement {
           <Controller
             name="renderingProvider"
             control={control}
-            render={({ field }) => (
+            rules={{ required: REQUIRED_FIELD_ERROR_MESSAGE }}
+            render={({ field, fieldState: { error: fieldError } }) => (
               <Autocomplete
                 options={renderingProviders}
                 value={field.value}
@@ -570,7 +574,15 @@ export default function CreateClaim(): ReactElement {
                     </Box>
                   </Box>
                 )}
-                renderInput={(p) => <TextField {...p} size="small" label="Choose Rendering Provider" />}
+                renderInput={(p) => (
+                  <TextField
+                    {...p}
+                    size="small"
+                    label="Choose Rendering Provider"
+                    error={!!fieldError}
+                    helperText={fieldError?.message}
+                  />
+                )}
                 isOptionEqualToValue={(o, v) => o.id === v.id}
                 sx={{ mb: field.value ? 2 : 0 }}
               />
@@ -591,7 +603,8 @@ export default function CreateClaim(): ReactElement {
           <Controller
             name="facility"
             control={control}
-            render={({ field }) => (
+            rules={{ required: REQUIRED_FIELD_ERROR_MESSAGE }}
+            render={({ field, fieldState: { error: fieldError } }) => (
               <Autocomplete
                 options={locations}
                 value={field.value}
@@ -619,7 +632,15 @@ export default function CreateClaim(): ReactElement {
                     </Box>
                   </Box>
                 )}
-                renderInput={(p) => <TextField {...p} size="small" label="Choose Service Facility" />}
+                renderInput={(p) => (
+                  <TextField
+                    {...p}
+                    size="small"
+                    label="Choose Service Facility"
+                    error={!!fieldError}
+                    helperText={fieldError?.message}
+                  />
+                )}
                 isOptionEqualToValue={(o, v) => o.id === v.id}
                 sx={{ mb: field.value ? 2 : 0 }}
               />
@@ -640,7 +661,8 @@ export default function CreateClaim(): ReactElement {
           <Controller
             name="billingProvider"
             control={control}
-            render={({ field }) => (
+            rules={{ required: REQUIRED_FIELD_ERROR_MESSAGE }}
+            render={({ field, fieldState: { error: fieldError } }) => (
               <Autocomplete
                 options={billingProviders}
                 value={field.value}
@@ -668,7 +690,15 @@ export default function CreateClaim(): ReactElement {
                     </Box>
                   </Box>
                 )}
-                renderInput={(p) => <TextField {...p} size="small" label="Choose Billing Provider" />}
+                renderInput={(p) => (
+                  <TextField
+                    {...p}
+                    size="small"
+                    label="Choose Billing Provider"
+                    error={!!fieldError}
+                    helperText={fieldError?.message}
+                  />
+                )}
                 isOptionEqualToValue={(o, v) => o.id === v.id}
                 sx={{ mb: field.value ? 2 : 0 }}
               />
@@ -686,39 +716,54 @@ export default function CreateClaim(): ReactElement {
         <Divider />
 
         <FormSection label="Diagnoses">
-          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
-            {diagnoses.map((dx, i) => (
-              <Chip
-                key={i}
-                label={dx}
-                size="small"
-                onDelete={() =>
-                  setValue(
-                    'diagnoses',
-                    diagnoses.filter((_, j) => j !== i)
-                  )
+          <Controller
+            name="diagnoses"
+            control={control}
+            rules={{ validate: (v) => (v && v.length > 0) || 'At least one diagnosis is required' }}
+            render={({ field, fieldState: { error: fieldError } }) => {
+              const addDiagnosis = (): void => {
+                const code = dxInput.trim().toUpperCase();
+                if (code && !field.value.includes(code)) {
+                  field.onChange([...field.value, code]);
+                  setDxInput('');
                 }
-              />
-            ))}
-          </Box>
-          <Box sx={{ display: 'flex', gap: 1 }}>
-            <TextField
-              size="small"
-              placeholder="ICD-10 (e.g. J06.9)"
-              value={dxInput}
-              onChange={(e) => setDxInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                  addDiagnosis();
-                }
-              }}
-              sx={{ width: 200 }}
-            />
-            <Button size="small" onClick={addDiagnosis}>
-              + Add
-            </Button>
-          </Box>
+              };
+              return (
+                <>
+                  <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
+                    {field.value.map((dx, i) => (
+                      <Chip
+                        key={i}
+                        label={dx}
+                        size="small"
+                        onDelete={() => field.onChange(field.value.filter((_, j) => j !== i))}
+                      />
+                    ))}
+                  </Box>
+                  <Box sx={{ display: 'flex', gap: 1 }}>
+                    <TextField
+                      size="small"
+                      placeholder="ICD-10 (e.g. J06.9)"
+                      value={dxInput}
+                      onChange={(e) => setDxInput(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          addDiagnosis();
+                        }
+                      }}
+                      error={!!fieldError}
+                      helperText={fieldError?.message}
+                      sx={{ width: 200 }}
+                    />
+                    <Button size="small" onClick={addDiagnosis}>
+                      + Add
+                    </Button>
+                  </Box>
+                </>
+              );
+            }}
+          />
         </FormSection>
 
         <Divider />
@@ -778,6 +823,7 @@ export default function CreateClaim(): ReactElement {
           <Button size="small" onClick={() => append({ ...emptyLine })}>
             + Add service line
           </Button>
+          {errors.serviceLines?.root && <FormHelperText error>{errors.serviceLines.root.message}</FormHelperText>}
         </FormSection>
       </Box>
     </FormProvider>

--- a/apps/billing/src/pages/CreateClaim.tsx
+++ b/apps/billing/src/pages/CreateClaim.tsx
@@ -54,7 +54,6 @@ interface CreateClaimForm {
   patientDob: string;
   patientGender: string;
   coverage: BillingCoverageOption | null;
-  subscriberId: string;
   renderingProvider: BillingProviderOption | null;
   practFirstName: string;
   practLastName: string;
@@ -91,7 +90,6 @@ const defaultValues: CreateClaimForm = {
   patientDob: '',
   patientGender: '',
   coverage: null,
-  subscriberId: '',
   renderingProvider: null,
   practFirstName: '',
   practLastName: '',
@@ -144,6 +142,7 @@ export default function CreateClaim(): ReactElement {
 
   // Watched values used to drive conditional sections / disabled states.
   const selectedPatient = watch('patient');
+  const selectedCoverage = watch('coverage');
   const selectedRenderingProvider = watch('renderingProvider');
   const selectedFacility = watch('facility');
   const selectedBillingProvider = watch('billingProvider');
@@ -272,9 +271,6 @@ export default function CreateClaim(): ReactElement {
 
       if (data.coverage) {
         payload.coverageId = data.coverage.id;
-        if (data.subscriberId && data.subscriberId !== data.coverage.subscriberId) {
-          payload.coverageOverrides = { subscriberId: data.subscriberId };
-        }
       }
 
       if (data.renderingProvider) {
@@ -449,7 +445,6 @@ export default function CreateClaim(): ReactElement {
                   field.onChange(value);
                   setValue('coverage', null);
                   setCoverages([]);
-                  setValue('subscriberId', '');
                   setValue('patientFirstName', value?.firstName ?? '');
                   setValue('patientLastName', value?.lastName ?? '');
                   setValue('patientDob', value?.dob ?? '');
@@ -514,10 +509,7 @@ export default function CreateClaim(): ReactElement {
               <Autocomplete
                 options={coverages}
                 value={field.value}
-                onChange={(_, v) => {
-                  field.onChange(v);
-                  if (v) setValue('subscriberId', v.subscriberId);
-                }}
+                onChange={(_, v) => field.onChange(v)}
                 getOptionLabel={(o) => `${o.payorName} — ${o.subscriberId}`}
                 renderInput={(params) => (
                   <TextField
@@ -533,7 +525,15 @@ export default function CreateClaim(): ReactElement {
               />
             )}
           />
-          <TextInput name="subscriberId" label="Member / Subscriber ID" fullWidth />
+          {selectedCoverage && (
+            <TextField
+              label="Member / Subscriber ID"
+              value={selectedCoverage.subscriberId}
+              size="small"
+              fullWidth
+              InputProps={{ readOnly: true }}
+            />
+          )}
         </FormSection>
 
         <Divider />

--- a/apps/billing/tests/component/CreateClaim.test.tsx
+++ b/apps/billing/tests/component/CreateClaim.test.tsx
@@ -45,10 +45,10 @@ describe('CreateClaim — required-field validation', () => {
 
     fireEvent.click(createButton);
 
-    // Patient, Date of Service, Rendering Provider, Service Facility, and Billing Provider are all
-    // required RHF fields → shared "This field is required" message (≥5).
+    // Patient, Rendering Provider, Service Facility, and Billing Provider are all required RHF
+    // fields → shared "This field is required" message (≥4). Date of service is now per service line.
     const requiredMessages = await screen.findAllByText('This field is required');
-    expect(requiredMessages.length).toBeGreaterThanOrEqual(5);
+    expect(requiredMessages.length).toBeGreaterThanOrEqual(4);
 
     // Diagnoses and Service Lines have their own validation messages.
     expect(screen.getByText('At least one diagnosis is required')).toBeInTheDocument();
@@ -59,5 +59,22 @@ describe('CreateClaim — required-field validation', () => {
 
     // Nothing should have been submitted.
     expect(createBillingClaimMock).not.toHaveBeenCalled();
+  });
+
+  it('exposes diagnoses added in the shared editor as Dx pointers on a service line', async () => {
+    renderCreateClaim();
+
+    // Both shared editors (same components as the claim-detail edit experience) render.
+    expect(screen.getByRole('button', { name: '+ Add service line' })).toBeInTheDocument();
+
+    // Add a diagnosis and give it an ICD-10 code via the shared DiagnosesEditor.
+    fireEvent.click(screen.getByRole('button', { name: '+ Add diagnosis' }));
+    fireEvent.change(screen.getByLabelText('ICD-10'), { target: { value: 'J06.9' } });
+
+    // The default service line's Dx dropdown now offers that diagnosis at sequence 1.
+    const dxSelect = screen.getAllByRole('combobox').find((el) => el.textContent === 'Dx');
+    expect(dxSelect).toBeDefined();
+    fireEvent.mouseDown(dxSelect!);
+    expect(await screen.findByRole('option', { name: '1: J06.9' })).toBeInTheDocument();
   });
 });

--- a/apps/billing/tests/component/CreateClaim.test.tsx
+++ b/apps/billing/tests/component/CreateClaim.test.tsx
@@ -45,9 +45,14 @@ describe('CreateClaim — required-field validation', () => {
 
     fireEvent.click(createButton);
 
-    // Patient + Date of Service are required RHF fields → shared "This field is required" message.
+    // Patient, Date of Service, Rendering Provider, Service Facility, and Billing Provider are all
+    // required RHF fields → shared "This field is required" message (≥5).
     const requiredMessages = await screen.findAllByText('This field is required');
-    expect(requiredMessages.length).toBeGreaterThanOrEqual(2);
+    expect(requiredMessages.length).toBeGreaterThanOrEqual(5);
+
+    // Diagnoses and Service Lines have their own validation messages.
+    expect(screen.getByText('At least one diagnosis is required')).toBeInTheDocument();
+    expect(screen.getByText('At least one service line with a CPT code is required')).toBeInTheDocument();
 
     // AR Stage (outside RHF) turns red with its own "Required" placeholder only after the click.
     expect(screen.getByText('Required')).toBeInTheDocument();

--- a/apps/billing/tests/component/CreateClaim.test.tsx
+++ b/apps/billing/tests/component/CreateClaim.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import CreateClaim from '../../src/pages/CreateClaim';
+
+// createBillingClaim must be observable across the vi.mock hoist boundary.
+const { createBillingClaimMock } = vi.hoisted(() => ({ createBillingClaimMock: vi.fn() }));
+
+vi.mock('../../src/api/api', () => ({
+  createBillingClaim: createBillingClaimMock,
+  getPatientCoverages: vi.fn(),
+  searchBillingLocations: vi.fn(),
+  searchBillingPatients: vi.fn(),
+  searchBillingProviders: vi.fn(),
+}));
+
+vi.mock('../../src/hooks/useAppClients', () => ({
+  useApiClients: () => ({ oystehrZambda: {} }),
+}));
+
+function renderCreateClaim(): ReactElement {
+  return render(
+    <MemoryRouter>
+      <CreateClaim />
+    </MemoryRouter>
+  ) as unknown as ReactElement;
+}
+
+describe('CreateClaim — required-field validation', () => {
+  beforeAll(() => {
+    // jsdom doesn't implement scrollIntoView, which the scroll-to-error effect calls.
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  beforeEach(() => {
+    createBillingClaimMock.mockReset();
+  });
+
+  it('keeps Create enabled and surfaces required errors instead of submitting when the form is empty', async () => {
+    renderCreateClaim();
+
+    const createButton = screen.getByRole('button', { name: 'Create' });
+    expect(createButton).toBeEnabled();
+
+    fireEvent.click(createButton);
+
+    // Patient + Date of Service are required RHF fields → shared "This field is required" message.
+    const requiredMessages = await screen.findAllByText('This field is required');
+    expect(requiredMessages.length).toBeGreaterThanOrEqual(2);
+
+    // AR Stage (outside RHF) turns red with its own "Required" placeholder only after the click.
+    expect(screen.getByText('Required')).toBeInTheDocument();
+
+    // Nothing should have been submitted.
+    expect(createBillingClaimMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/utils/lib/types/data/billing/billing.schemas.ts
+++ b/packages/utils/lib/types/data/billing/billing.schemas.ts
@@ -181,12 +181,6 @@ export const CreateBillingClaimInputSchema = z.object({
     .strict()
     .optional(),
   coverageId: nonEmptyString.optional(),
-  coverageOverrides: z
-    .object({
-      subscriberId: nonEmptyString.optional(),
-    })
-    .strict()
-    .optional(),
   renderingProvider: z
     .object({
       id: nonEmptyString,

--- a/packages/zambdas/src/billing/create-billing-claim/index.ts
+++ b/packages/zambdas/src/billing/create-billing-claim/index.ts
@@ -106,7 +106,6 @@ async function createWorkingCopies(
 
   if (originals.coverage) {
     const copy = prepareWorkingCopy<Coverage>(originals.coverage, originals.coverage.id!);
-    if (params.coverageOverrides?.subscriberId) copy.subscriberId = params.coverageOverrides.subscriberId;
     copy.beneficiary = { reference: patientUrn };
     copy.subscriber = { reference: patientUrn };
     // payor is an Oystehr payer list URL kept from the original coverage


### PR DESCRIPTION
Stacked on alex/claim-status. 

Fixes validation of the form so create button is always enabled and fields light up red with an explanation of what's wrong if you try to submit without a valid form.

Also:
* makes all the fields required.
* removes the ability to enter only the member ID part of a Coverage
* reuses the service line component from the edit claim experience instead of the separate less useful one that was on create claim.

🤖 generated the code.