### PR TITLE
ci: print per-suite test run summary in PR CI

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -107,11 +107,15 @@ jobs:
           fi
 
       - name: Spec tests with coverage
-        run: npx turbo run test:ci test:unit:ci test:component:ci --concurrency=5 --output-logs=errors-only --continue=always
+        run: npx turbo run test:ci test:unit:ci test:component:ci --concurrency=5 --output-logs=errors-only --continue=always --summarize
         env:
           ENV: ${{ steps.env.outputs.environment }}
           CI: true
           NODE_OPTIONS: "--max-old-space-size=8192"
+
+      - name: Test run summary
+        if: ${{ !cancelled() }}
+        run: node ./scripts/print-test-run-summary.mjs
 
       - name: Upload spec coverage to Coveralls
         if: ${{ !cancelled() && hashFiles('packages/spec/coverage/lcov.info') != '' }}

--- a/scripts/print-test-run-summary.mjs
+++ b/scripts/print-test-run-summary.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Prints a concise, one-line-per-suite summary of the most recent `turbo --summarize` run.
+// Turbo's `--output-logs=errors-only` hides successful/cached output, which makes it hard
+// to tell from CI logs which test suites actually ran versus were restored from cache.
+// This reads the run summary JSON turbo writes to `.turbo/runs/` and prints, per suite,
+// whether it executed or was a cache hit, its status, and how long it took.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const RUNS_DIR = '.turbo/runs';
+
+function latestSummaryFile() {
+  let entries;
+  try {
+    entries = readdirSync(RUNS_DIR).filter((f) => f.endsWith('.json'));
+  } catch {
+    return null;
+  }
+  if (entries.length === 0) return null;
+  return entries
+    .map((f) => join(RUNS_DIR, f))
+    .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs)[0];
+}
+
+const file = latestSummaryFile();
+if (!file) {
+  console.log('No turbo run summary found in .turbo/runs — nothing to report.');
+  process.exit(0);
+}
+
+const summary = JSON.parse(readFileSync(file, 'utf8'));
+const tasks = summary.tasks ?? [];
+
+const fmtDuration = (ms) => {
+  if (typeof ms !== 'number' || Number.isNaN(ms)) return '?';
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
+};
+
+let failed = 0;
+let executed = 0;
+let cached = 0;
+
+console.log('::group::Test suite run summary');
+console.log(`Suites: ${tasks.length}`);
+console.log('');
+
+const lines = tasks
+  .slice()
+  .sort((a, b) => (a.taskId || '').localeCompare(b.taskId || ''))
+  .map((t) => {
+    const taskId = t.taskId ?? `${t.package ?? '?'}#${t.task ?? '?'}`;
+    const exitCode = t.execution?.exitCode;
+    const cacheHit = t.cache?.status === 'HIT';
+    const ok = exitCode === 0 || exitCode === undefined;
+
+    if (!ok) failed++;
+    else if (cacheHit) cached++;
+    else executed++;
+
+    const icon = ok ? '✓' : '✗';
+    const source = cacheHit ? 'cached' : 'executed';
+    let timing;
+    if (cacheHit && typeof t.cache?.timeSaved === 'number') {
+      timing = `saved ${fmtDuration(t.cache.timeSaved)}`;
+    } else if (t.execution?.startTime && t.execution?.endTime) {
+      timing = fmtDuration(t.execution.endTime - t.execution.startTime);
+    } else {
+      timing = '';
+    }
+    return `${icon} ${taskId} — ${source}${timing ? ` (${timing})` : ''}`;
+  });
+
+for (const line of lines) console.log(line);
+
+console.log('');
+console.log(`Totals: ${executed} executed, ${cached} cached, ${failed} failed`);
+console.log('::endgroup::');
+
+if (failed > 0) {
+  console.log(`::error::${failed} test suite(s) failed — see the "Spec tests with coverage" step for details.`);
+}


### PR DESCRIPTION
It's hard to tell which tests run. This adds a quiet step that announces what happened with successes. 

🤖 generated, 🤖 description below.

## Problem

The **Spec tests with coverage** step in `automated-tests.yml` runs turbo with `--output-logs=errors-only`. That hides all successful and cache-restored output, so the CI logs don't show which test suites actually ran versus which were served from cache. The caching is great for speed, but it makes the run opaque.

## Change

- Add `--summarize` to the turbo run, which writes a machine-readable run summary to `.turbo/runs/*.json` (per-task cache status and exit codes).
- Add a **Test run summary** step (runs even on failure via `if: !cancelled()`) backed by `scripts/print-test-run-summary.mjs`, which prints **one line per suite**: whether it executed or was a cache hit (with time saved), pass/fail status, and timing. Failures are also surfaced as GitHub Actions `::error::` annotations.

Example output:

```
✓ @ottehr/spec#test:ci — executed (4.3s)
✓ @ottehr/utils#test:ci — cached (saved 8.2s)
✗ ehr#test:component:ci — executed (0ms)

Totals: 1 executed, 1 cached, 1 failed
```

The script is defensive against missing fields and exits 0 — the existing test step still owns actual CI pass/fail. Opening this against `develop` to see the live output in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014iVAbgY98jKtRdwqiTu6ut)_