### PR TITLE
ci: don't fail automated-tests when Coveralls upload errors

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -120,6 +120,7 @@ jobs:
           flag-name: spec
           parallel: true
           file: ./packages/spec/coverage/lcov.info
+          fail-on-error: false
 
       - name: Upload test-utils coverage to Coveralls
         if: ${{ !cancelled() && hashFiles('packages/test-utils/coverage/lcov.info') != '' }}
@@ -128,6 +129,7 @@ jobs:
           flag-name: test-utils
           parallel: true
           file: ./packages/test-utils/coverage/lcov.info
+          fail-on-error: false
 
       - name: Upload deploy coverage to Coveralls
         if: ${{ !cancelled() && hashFiles('deploy/coverage/lcov.info') != '' }}
@@ -136,6 +138,7 @@ jobs:
           flag-name: deploy
           parallel: true
           file: ./deploy/coverage/lcov.info
+          fail-on-error: false
 
       - name: Upload utils coverage to Coveralls
         if: ${{ !cancelled() && hashFiles('packages/utils/coverage/lcov.info') != '' }}
@@ -144,6 +147,7 @@ jobs:
           flag-name: utils
           parallel: true
           file: ./packages/utils/coverage/lcov.info
+          fail-on-error: false
 
       - name: Upload zambdas coverage to Coveralls
         if: ${{ !cancelled() && hashFiles('packages/zambdas/coverage/integration/lcov.info') != '' }}
@@ -152,6 +156,7 @@ jobs:
           flag-name: zambdas
           parallel: true
           file: ./packages/zambdas/coverage/integration/lcov.info
+          fail-on-error: false
 
       - name: Upload EHR unit coverage to Coveralls
         if: ${{ !cancelled() && hashFiles('apps/ehr/coverage/unit/lcov.info') != '' }}
@@ -160,6 +165,7 @@ jobs:
           flag-name: ehr-unit
           parallel: true
           file: ./apps/ehr/coverage/unit/lcov.info
+          fail-on-error: false
 
       - name: Upload EHR component coverage to Coveralls
         if: ${{ !cancelled() && hashFiles('apps/ehr/coverage/component/lcov.info') != '' }}
@@ -168,6 +174,7 @@ jobs:
           flag-name: ehr-component
           parallel: true
           file: ./apps/ehr/coverage/component/lcov.info
+          fail-on-error: false
 
       - name: Upload intake unit coverage to Coveralls
         if: ${{ !cancelled() && hashFiles('apps/intake/coverage/unit/lcov.info') != '' }}
@@ -176,6 +183,7 @@ jobs:
           flag-name: intake-unit
           parallel: true
           file: ./apps/intake/coverage/unit/lcov.info
+          fail-on-error: false
 
       - name: Upload intake component coverage to Coveralls
         if: ${{ !cancelled() && hashFiles('apps/intake/coverage/component/lcov.info') != '' }}
@@ -184,6 +192,7 @@ jobs:
           flag-name: intake-component
           parallel: true
           file: ./apps/intake/coverage/component/lcov.info
+          fail-on-error: false
 
       - name: Coveralls parallel finished
         if: ${{ !cancelled() }}
@@ -191,6 +200,7 @@ jobs:
         with:
           parallel-finished: true
           carryforward: "spec,test-utils,deploy,utils,zambdas,ehr-unit,ehr-component,intake-unit,intake-component"
+          fail-on-error: false
 
       - name: Set GitHub Commit Status
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
🤖 generated change and description. i reviewed it.

## Problem

The `automated-tests` job sometimes fails even when every test passes, purely because it can't upload coverage to Coveralls. When `coveralls.io` returns a 500/502, the upload step exits non-zero and the whole job is marked failed.

Example: [run 28241470944 / job 83669811590](https://github.com/masslight/ottehr/actions/runs/28241470944/job/83669811590?pr=8410). The logs show the `Upload EHR unit coverage to Coveralls` step posting to `coveralls.io/api/v1/jobs` and getting back a `Bad Gateway (502)` / `Oops, something went wrong (500)` page:

```
🚀 Posting coverage data to https://coveralls.io/api/v1/jobs
HTTP error:
Error: Bad Gateway (502)
...
##[error]Process completed with exit code 1.
```

All tests had passed, and the final `Coveralls parallel finished` webhook even succeeded — but the job's conclusion was `failure` because that one upload step exited 1. (The remaining steps still ran because they use `!cancelled()`, which is why the rest of the run looks green.)

## Cause

`coverallsapp/github-action` defaults to `fail-on-error: true`, so any transient Coveralls outage propagates a non-zero exit code from the upload step and fails the job.

## Fix

Set `fail-on-error: false` on every Coveralls invocation in `automated-tests.yml` — the nine `Upload … coverage to Coveralls` steps and the `Coveralls parallel finished` webhook step. This is the action's documented input for exactly this situation: the error is still logged (and surfaced as a step annotation), but the step exits 0, so coverage upload becomes best-effort and the job's result reflects the **test outcome** rather than Coveralls' availability.

## Notes

- No change to test execution, coverage generation, or which reports get uploaded — only how upload failures are handled.
- Coveralls failures remain visible in the step logs/annotations; they just no longer block CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rhDMEs7Ld147Y3QUZmqts

---
_Generated by [Claude Code](https://claude.ai/code/session_017rhDMEs7Ld147Y3QUZmqts)_