### PR TITLE
fix(ehr): Use SDK for patient search, simply phone check

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/patients-search/usePatientsSearch.ts
+++ b/apps/ehr/src/features/visits/shared/components/patients-search/usePatientsSearch.ts
@@ -1,8 +1,9 @@
-import { useAuth0 } from '@auth0/auth0-react';
-import { Bundle } from 'fhir/r4b';
+import Oystehr, { SearchParam } from '@oystehr/sdk';
+import { Patient } from 'fhir/r4b';
 import { enqueueSnackbar } from 'notistack';
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useApiClients } from 'src/hooks/useAppClients';
 import { SEARCH_CONFIG } from './constants';
 import {
   PartialSearchOptionsState,
@@ -31,37 +32,20 @@ if (!projectId) {
 }
 
 const fetchPatients = async ({
-  searchUrl,
+  oystehr,
+  searchParams,
   setSearchResult,
   setArePatientsLoading,
-  getAccessTokenSilently,
 }: {
-  searchUrl: string;
+  oystehr: Oystehr;
+  searchParams: SearchParam[];
   setSearchResult: React.Dispatch<React.SetStateAction<SearchResult>>;
   setArePatientsLoading: React.Dispatch<React.SetStateAction<boolean>>;
-  getAccessTokenSilently: () => Promise<string>;
 }): Promise<void> => {
   setArePatientsLoading(true);
   try {
-    const token = await getAccessTokenSilently();
+    const patientBundle = await oystehr.fhir.search<Patient>({ resourceType: 'Patient', params: searchParams });
 
-    const headers = {
-      accept: 'application/json',
-      'content-type': 'application/json',
-      Authorization: `Bearer ${token}`,
-      'x-zapehr-project-id': projectId,
-    };
-
-    const response = await fetch(searchUrl, {
-      method: 'GET',
-      headers: headers,
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const patientBundle: Bundle = await response.json();
     const parsedSearchResult = parseSearchResults(patientBundle);
     setSearchResult(parsedSearchResult);
   } catch (error) {
@@ -121,7 +105,7 @@ export const usePatientsSearch = (): {
   resetFilters: () => void;
   search: (params?: PartialSearchOptionsState) => void;
 } => {
-  const { getAccessTokenSilently } = useAuth0();
+  const { oystehr } = useApiClients();
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchResult, setSearchResult] = useState<SearchResult>(emptySearchResult);
   const [arePatientsLoading, setArePatientsLoading] = useState<boolean>(false);
@@ -200,7 +184,7 @@ export const usePatientsSearch = (): {
   useEffect(() => {
     const hasSearchParams = [...searchParams.entries()].length > 0;
 
-    if (hasSearchParams) {
+    if (oystehr && hasSearchParams) {
       const loadPatients = async (): Promise<void> => {
         setArePatientsLoading(true);
         try {
@@ -208,12 +192,16 @@ export const usePatientsSearch = (): {
           const sort: SearchOptionsSort = getSortFromUrl(searchParams);
           const pagination: SearchOptionsPagination = getPaginationFromUrl(searchParams);
 
-          let url = buildSearchQuery(filter);
-          url = addSearchSort(url, sort);
-          url = addSearchPagination(url, pagination);
-          url = `${import.meta.env.VITE_APP_FHIR_API_URL}/${url}`;
+          const queryParams = buildSearchQuery(filter);
+          const sortParams = addSearchSort(sort);
+          const paginationParams = addSearchPagination(pagination);
 
-          await fetchPatients({ searchUrl: url, setSearchResult, setArePatientsLoading, getAccessTokenSilently });
+          await fetchPatients({
+            oystehr,
+            searchParams: [...queryParams, ...sortParams, ...paginationParams],
+            setSearchResult,
+            setArePatientsLoading,
+          });
         } catch {
           setSearchResult(emptySearchResult);
         } finally {
@@ -222,7 +210,7 @@ export const usePatientsSearch = (): {
       };
       void loadPatients();
     }
-  }, [getAccessTokenSilently, searchParams]);
+  }, [oystehr, searchParams]);
 
   return {
     searchResult,

--- a/apps/ehr/src/features/visits/shared/components/patients-search/utils/addSearchPagination.ts
+++ b/apps/ehr/src/features/visits/shared/components/patients-search/utils/addSearchPagination.ts
@@ -1,11 +1,12 @@
+import { SearchParam } from '@oystehr/sdk';
 import { SearchOptionsPagination } from '../types';
 
-export const addSearchPagination = (url: string, pagination: SearchOptionsPagination): string => {
-  const params: string[] = [];
+export const addSearchPagination = (pagination: SearchOptionsPagination): SearchParam[] => {
+  const params: SearchParam[] = [];
 
-  if (pagination.pageSize) params.push(`_count=${pagination.pageSize}`);
-  if (pagination.offset) params.push(`_offset=${pagination.offset}`);
-  params.push('_total=accurate');
+  if (pagination.pageSize) params.push({ name: '_count', value: pagination.pageSize });
+  if (pagination.offset) params.push({ name: '_offset', value: pagination.offset });
+  params.push({ name: '_total', value: 'accurate' });
 
-  return `${url}${url.includes('?') ? '&' : '?'}${params.join('&')}`;
+  return params;
 };

--- a/apps/ehr/src/features/visits/shared/components/patients-search/utils/addSearchSort.ts
+++ b/apps/ehr/src/features/visits/shared/components/patients-search/utils/addSearchSort.ts
@@ -1,7 +1,8 @@
+import { SearchParam } from '@oystehr/sdk';
 import { SearchOptionsSort } from '../types';
 
-export const addSearchSort = (url: string, options: SearchOptionsSort): string => {
-  const params: string[] = [];
+export const addSearchSort = (options: SearchOptionsSort): SearchParam[] => {
+  const params: SearchParam[] = [];
 
   let sortField = '';
   switch (options.field) {
@@ -17,7 +18,7 @@ export const addSearchSort = (url: string, options: SearchOptionsSort): string =
 
   if (options.order === 'desc') sortField = '-' + sortField;
 
-  params.push(`_sort=${sortField},_id`);
+  params.push({ name: '_sort', value: `${sortField},_id` });
 
-  return `${url}${url.includes('?') ? '&' : '?'}${params.join('&')}`;
+  return params;
 };

--- a/apps/ehr/src/features/visits/shared/components/patients-search/utils/buildSearchQuery.ts
+++ b/apps/ehr/src/features/visits/shared/components/patients-search/utils/buildSearchQuery.ts
@@ -1,45 +1,15 @@
+import { SearchParam } from '@oystehr/sdk';
 import { getFriendlyPatientIdSystem } from 'src/features/visits/shared/utils/friendly-patient-id.helper';
 import { SearchOptionsFilters } from '../types';
 
-/**
- * Generates all possible formatting variants for US phone numbers (+1)
- * @param {string} normalizedPhone - Phone number in format +1XXXXXXXXXX
- * @returns {string[]} Array of formatted phone number variants
- */
-const generatePhoneVariants = (normalizedPhone: string): string[] => {
-  // Check if it's a US number (+1 with 11 digits total)
-  const digitsOnly = normalizedPhone.replace(/\D/g, '');
-
-  // Only generate variants for +1 numbers (11 digits starting with 1)
-  if (digitsOnly.length !== 11 || !digitsOnly.startsWith('1')) {
-    return [normalizedPhone];
-  }
-
-  // Extract parts (US format: +1 XXX XXXXXXX)
-  const areaCode = digitsOnly.substring(1, 4);
-  const firstPart = digitsOnly.substring(4, 7);
-  const lastPart = digitsOnly.substring(7);
-
-  const localNumber = `${areaCode}${firstPart}${lastPart}`;
-
-  const variants = [
-    `+1${localNumber}`, // +11234567890 (E.164 - FHIR standard)
-    localNumber, // 1234567890 (most common user input)
-    `(${areaCode}) ${firstPart}-${lastPart}`, // (123) 456-7890 (most common display)
-  ];
-
-  return variants;
-};
-
-export const buildSearchQuery = (filter: Partial<SearchOptionsFilters>): string => {
-  const baseUrl = 'r4/Patient';
-  const params: string[] = [];
+export const buildSearchQuery = (filter: Partial<SearchOptionsFilters>): SearchParam[] => {
+  const params: SearchParam[] = [];
 
   if (filter.location && filter.location !== 'All') {
-    params.push(`_has:Appointment:patient:actor:Location.name:contains=${encodeURIComponent(filter.location)}`);
+    params.push({ name: '_has:Appointment:patient:actor:Location.name:contains', value: filter.location });
   }
-  params.push('_revinclude=Appointment:patient');
-  params.push('_include:iterate=Appointment:actor:Location');
+  params.push({ name: '_revinclude', value: 'Appointment:patient' });
+  params.push({ name: '_include:iterate', value: 'Appointment:actor:Location' });
 
   if (filter.phone) {
     let completedPhone = filter.phone.replace(/\D/g, '');
@@ -52,55 +22,47 @@ export const buildSearchQuery = (filter: Partial<SearchOptionsFilters>): string 
       }
     }
 
-    const phoneVariants = generatePhoneVariants(completedPhone);
-
-    const phoneConditions = phoneVariants
-      .map((variant) => {
-        const encoded = encodeURIComponent(variant);
-        return `phone=${encoded},_has:RelatedPerson:patient:phone=${encoded},_has:RelatedPerson:patient:_has:Person:link:phone=${encoded}`;
-      })
-      .join(',');
-
-    params.push(phoneConditions);
-    params.push('_revinclude=RelatedPerson:patient');
-    params.push('_revinclude:iterate=Person:link');
+    params.push({
+      name: 'phone',
+      value: completedPhone,
+    });
+    params.push({ name: '_revinclude', value: 'RelatedPerson:patient' });
+    params.push({ name: '_revinclude:iterate', value: 'Person:link' });
   }
 
   if (filter.lastName) {
-    params.push(`family:contains=${encodeURIComponent(filter.lastName)}`);
+    params.push({ name: 'family:contains', value: filter.lastName });
   }
   if (filter.givenNames) {
     const names = filter.givenNames.replace(' ', ',');
-    params.push(`given:contains=${encodeURIComponent(names)}`);
+    params.push({ name: 'given:contains', value: names });
   }
 
-  if (filter.status === 'Active') params.push('active=true');
-  else if (filter.status === 'Deceased') params.push('deceased=true');
-  else if (filter.status === 'Inactive') params.push('active=false');
+  if (filter.status === 'Active') params.push({ name: 'active', value: 'true' });
+  else if (filter.status === 'Deceased') params.push({ name: 'deceased', value: 'true' });
+  else if (filter.status === 'Inactive') params.push({ name: 'active', value: 'false' });
 
   if (filter.address) {
-    params.push(`address:contains=${encodeURIComponent(filter.address)}`);
+    params.push({ name: 'address:contains', value: filter.address });
   }
 
-  if (filter.dob) params.push(`birthdate=${encodeURIComponent(filter.dob)}`);
-  if (filter.email) params.push(`email=${encodeURIComponent(filter.email)}`);
+  if (filter.dob) params.push({ name: 'birthdate', value: filter.dob });
+  if (filter.email) params.push({ name: 'email', value: filter.email });
 
   if (filter.pid) {
     const pidValue = filter.pid.trim();
     if (pidValue) {
       const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
       if (uuidRegex.test(pidValue)) {
-        params.push(`_id=${encodeURIComponent(pidValue)}`);
+        params.push({ name: '_id', value: pidValue });
       } else {
         const system = getFriendlyPatientIdSystem();
         if (system) {
-          params.push(`identifier=${encodeURIComponent(`${system}|${pidValue}`)}`);
+          params.push({ name: 'identifier', value: `${system}|${pidValue}` });
         }
       }
     }
   }
 
-  params.push('_total=accurate');
-
-  return `${baseUrl}?${params.join('&')}`;
+  return params;
 };


### PR DESCRIPTION
This PR drops the code that searches for phone number in a large number of places and with a large number of formats. Instead, we will only search on the Patient's `phone` attribute for a single format. This change was made because there's a bug with the current implementation that causes it to already work this way:

<img width="513" height="131" alt="Screenshot 2026-06-29 at 11 38 57 AM" src="https://github.com/user-attachments/assets/93edd2fa-c2d7-416b-928b-a12e02d7335e" />

This query param says "check `Patient.phone` for any of the following exact string values: `%2B...`, `_has:RelatedPerson:patient:phone=%2B...`, `phone=...`, etc". If you read the code it makes it look like they will be added as independent search params but instead they all get sandwiched into one.

Since this situation was already working fine for patient search, we'll drop everything beyond the basic `+1...` comparison.