### PR TITLE
feat(OTR-2668): Bold both metric & imperial values for vitals

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/vitals/components/VitalsHistoryEntry.tsx
+++ b/apps/ehr/src/features/visits/shared/components/vitals/components/VitalsHistoryEntry.tsx
@@ -60,11 +60,7 @@ export const VitalHistoryElement: React.FC<VitalHistoryElementProps> = ({
           {observationValueElements.map((value, index) => {
             if (typeof value === 'string') {
               return (
-                <Typography
-                  key={index}
-                  component="span"
-                  sx={{ fontWeight: index === 0 ? 'bold' : 'normal', color: lineColor }}
-                >
+                <Typography key={index} component="span" sx={{ fontWeight: 'bold', color: lineColor }}>
                   {value}
                 </Typography>
               );


### PR DESCRIPTION
## Summary
- Bold all vital value elements in history entries, including the imperial conversion (e.g., both `60 C` and `≈ 140 F` are now bold)

## Test plan
- [ ] View a vital history entry with a temperature or weight reading — confirm both the metric and imperial values are bold
- [ ] Confirm alert (critical/abnormal) vitals still display correctly with bold values

Closes OTR-2668

🤖 Generated with [Claude Code](https://claude.com/claude-code)