### PR TITLE
feat(OTR-1175): Show toast when clinical task is assigned

### DIFF
--- a/apps/ehr/src/features/visits/in-person/hooks/useTasks.ts
+++ b/apps/ehr/src/features/visits/in-person/hooks/useTasks.ts
@@ -199,7 +199,7 @@ export const useAssignTask = (): UseMutationResult<void, Error, AssignTaskReques
         queryKey: [GET_TASKS_KEY],
         exact: false,
       });
-      enqueueSnackbar('Task assigned successfully and moved to Pending status.', { variant: 'success' });
+      enqueueSnackbar('Task assigned successfully and moved to In Progress status.', { variant: 'success' });
     },
   });
 };

--- a/apps/ehr/src/features/visits/in-person/hooks/useTasks.ts
+++ b/apps/ehr/src/features/visits/in-person/hooks/useTasks.ts
@@ -3,6 +3,7 @@ import { useMutation, UseMutationResult, useQuery, useQueryClient, UseQueryResul
 import { Operation } from 'fast-json-patch';
 import { Encounter, Reference, Task as FhirTask, TaskInput } from 'fhir/r4b';
 import { DateTime } from 'luxon';
+import { enqueueSnackbar } from 'notistack';
 import { useApiClients } from 'src/hooks/useAppClients';
 import {
   chooseJson,
@@ -198,6 +199,7 @@ export const useAssignTask = (): UseMutationResult<void, Error, AssignTaskReques
         queryKey: [GET_TASKS_KEY],
         exact: false,
       });
+      enqueueSnackbar('Task assigned successfully and moved to Pending status.', { variant: 'success' });
     },
   });
 };


### PR DESCRIPTION
## Summary
- Adds a success toast notification after a task is assigned, displaying: "Task assigned successfully and moved to Pending status."
- Fires for both "Assign me" and "Assign to someone else" flows via the `useAssignTask` hook's `onSuccess` callback

## Test plan
- [ ] Assign a clinical task to yourself via "Assign me" — confirm toast appears at the bottom of the screen
- [ ] Assign a clinical task to someone else via "Assign to someone else" — confirm toast appears

Closes OTR-1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)