### PR TITLE
fix(OTR-1086): name follow-up visit note "Patient Follow-up Note" in patient documents

### DIFF
--- a/packages/zambdas/src/subscriptions/task/sub-visit-note-pdf-and-email/index.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-visit-note-pdf-and-email/index.ts
@@ -169,6 +169,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
         oystehrToken
       );
       if (!patient?.id) throw new Error(`No patient has been found for encounter: ${encounter.id}`);
+      if (isPDFOnlyTask) {
+        pdfInfo.title = 'Patient Follow-up Note';
+      }
       console.log(`Creating visit note pdf docRef`);
       await makeVisitNotePdfDocumentReference(
         oystehr,


### PR DESCRIPTION
## Summary
- Follow-up visit notes were being saved to patient documents with the title `VisitNote.pdf` (displayed as "Visit note"), same as regular visit notes
- After the PDF is uploaded, if the encounter is a follow-up, override `pdfInfo.title` to `'Patient Follow-up Note'` before creating the FHIR DocumentReference — the title is what the patient documents UI displays

## Test plan
- [ ] Complete a follow-up visit note and check patient documents — title should show "Patient Follow-up Note"
- [ ] Complete a regular visit note and check patient documents — title should be unchanged

Closes OTR-1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)