### PR TITLE
fix(billing): Take any wcompacct coverage

### DIFF
--- a/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
+++ b/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
@@ -570,7 +570,7 @@ export function getClaimCoveragesForEncounter(
             ccov.extension?.find((ccovid) => ccovid.url === SOURCE_IDENTIFIER_SYSTEM)?.valueReference?.reference ===
             wccov.coverage.reference
         );
-        if (wccov.priority === 1) {
+        if (foundClaimCoverage) {
           wcCoverage = foundClaimCoverage;
         }
       });

--- a/packages/zambdas/test/unit/billing/create-billing-claim-from-encounter.test.ts
+++ b/packages/zambdas/test/unit/billing/create-billing-claim-from-encounter.test.ts
@@ -1456,6 +1456,7 @@ describe('create-billing-claim-from-encounter', () => {
       } as unknown as Oystehr;
       const wcAcct = structuredClone({ ...clinicalResources.account });
       wcAcct.type!.coding![0].code = 'WCOMPACCT';
+      delete wcAcct.coverage![0].priority;
       const cvo: ComplexValidationOutput = {
         clinicalResources: {
           accounts: [clinicalResources.account, wcAcct],
@@ -1954,6 +1955,7 @@ describe('create-billing-claim-from-encounter', () => {
       updatedAppointment.serviceCategory![0].coding![0].code = 'workers-comp';
       let updatedAccount = structuredClone(clinicalResources.account);
       updatedAccount.type!.coding![0].code = 'WCOMPACCT';
+      delete updatedAccount.coverage![0].priority;
       let updatedEncounter = structuredClone(clinicalResources.encounter);
       updatedEncounter.extension = [
         {


### PR DESCRIPTION
Workers comp accounts do not set up a `priority`. To keep backwards compatibility and avoid unnecessary clinical changes, this PR just handles this fact and selects one of the workers cop account coverages to use.