### PR TITLE
Issue 8311. Sub harvest paperwork page throwing FHIR constraint issue on extension as 500

### DIFF
--- a/packages/utils/lib/fhir/patientMasterRecord.buildExtensionObject.test.ts
+++ b/packages/utils/lib/fhir/patientMasterRecord.buildExtensionObject.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PATIENT_ETHNICITY_URL, PATIENT_INDIVIDUAL_PRONOUNS_URL, PATIENT_RACE_URL } from '../types/constants';
+import { buildExtensionObject } from './patientMasterRecord';
+
+describe('buildExtensionObject', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('builds a fully-populated coding for a mapped race value', () => {
+    const ext = buildExtensionObject(PATIENT_RACE_URL, 'White');
+    expect(ext).toEqual({
+      url: PATIENT_RACE_URL,
+      valueCodeableConcept: {
+        coding: [{ system: 'http://terminology.hl7.org/CodeSystem/v3-Race', code: '2106-3', display: 'White' }],
+      },
+    });
+  });
+
+  // Regression for OTR-2856: an unmapped coded value used to produce coding: [{}]
+  // (all fields undefined → empty object), violating FHIR ele-1 and 500-ing the harvest.
+  it('returns undefined (no empty coding) for an unmapped race value', () => {
+    const ext = buildExtensionObject(PATIENT_RACE_URL, 'Other Race');
+    expect(ext).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  it('never emits a coding with an empty object for any unmapped coded value', () => {
+    for (const url of [PATIENT_RACE_URL, PATIENT_ETHNICITY_URL, PATIENT_INDIVIDUAL_PRONOUNS_URL]) {
+      const ext = buildExtensionObject(url, 'definitely-not-a-mapping-key');
+      // either skipped entirely, or — if ever built — must not contain an empty coding entry
+      const coding = ext?.valueCodeableConcept?.coding ?? [];
+      expect(coding.every((c) => Object.keys(c).length > 0)).toBe(true);
+      expect(ext).toBeUndefined();
+    }
+  });
+
+  it('still maps known values for other coded extensions (ethnicity, pronouns)', () => {
+    expect(
+      buildExtensionObject(PATIENT_ETHNICITY_URL, 'Not Hispanic or Latino')?.valueCodeableConcept?.coding?.[0]
+    ).toMatchObject({ code: '2186-5', display: 'Not Hispanic or Latino' });
+    expect(
+      buildExtensionObject(PATIENT_INDIVIDUAL_PRONOUNS_URL, 'She/her')?.valueCodeableConcept?.coding?.[0]
+    ).toMatchObject({ code: 'LA29519-8', display: 'She/her' });
+  });
+});

--- a/packages/utils/lib/fhir/patientMasterRecord.ts
+++ b/packages/utils/lib/fhir/patientMasterRecord.ts
@@ -347,18 +347,26 @@ export function buildExtensionObject(url: string, value: string): Extension | un
     case 'valueCodeableConcept': {
       const mapping = CODEABLE_CONCEPT_MAPPINGS[url as keyof typeof CODEABLE_CONCEPT_MAPPINGS];
       if (mapping) {
-        const valueMapping = mapping[value as keyof typeof mapping] as Coding;
-        extensionValue = {
-          valueCodeableConcept: {
-            coding: [
-              {
-                system: valueMapping?.system,
-                code: valueMapping?.code,
-                display: valueMapping?.display,
-              },
-            ],
-          },
-        };
+        const valueMapping = mapping[value as keyof typeof mapping] as Coding | undefined;
+        // Only build the coding when the value is a known mapping key. An unmapped value
+        // would otherwise produce a coding of all-undefined fields that serializes to an
+        // empty `{}` — which violates FHIR constraint ele-1 and fails the whole patch.
+        // Leaving extensionValue undefined makes the caller skip this field entirely.
+        if (valueMapping) {
+          extensionValue = {
+            valueCodeableConcept: {
+              coding: [
+                {
+                  system: valueMapping.system,
+                  code: valueMapping.code,
+                  display: valueMapping.display,
+                },
+              ],
+            },
+          };
+        } else {
+          console.warn(`buildExtensionObject: no mapping for ${url} value "${value}"; skipping extension`);
+        }
       }
       break;
     }


### PR DESCRIPTION
#8311

On the demo environment the crash was triggered by `patient-race = "Other Race"`, which is not one of the six `RACE_MAPPING` keys. The value comes from a custom demo/seed data generator (synthetic patients) — we could not locate the source of that generator. Regardless of the source, the harvest should not crash on a value outside the mapping.

#### Fix
`buildExtensionObject` now only builds the coding when the value is a known mapping key. An unmapped value leaves the extension unset (skipped by the existing `if (!extensionValue) return undefined` guard) and emits a `console.warn` with the URL and value so future drift is visible instead of silent. Applies to all five coded extensions: race, ethnicity, pronouns, gender identity, sexual orientation.