### PR TITLE
fix(billing): Use correct HCPCS and modifier systems in billing app

### DIFF
--- a/packages/utils/lib/helpers/rcm/constants.ts
+++ b/packages/utils/lib/helpers/rcm/constants.ts
@@ -23,8 +23,9 @@ export const CODE_SYSTEM_CLAIM_INFORMATION_CATEGORY = 'http://terminology.hl7.or
 export const CODE_SYSTEM_ACT_CODE_V3 = 'http://terminology.hl7.org/CodeSystem/v3-ActCode';
 export const CODE_SYSTEM_ICD_9 = 'http://hl7.org/fhir/sid/icd-9-cm';
 export const CODE_SYSTEM_ICD_10 = 'http://hl7.org/fhir/sid/icd-10-cm';
-export const CODE_SYSTEM_CPT = 'http://www.ama-assn.org/go/cpt';
-export const CODE_SYSTEM_HCPCS = 'http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets';
+export const CODE_SYSTEM_CPT = 'http://www.ama-assn.org/go/cpt'; // used by both Ottehr and Oystehr
+export const CODE_SYSTEM_HCPCS = 'http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets'; // used by Ottehr clinical in-house meds
+export const CODE_SYSTEM_HL7_HCPCS = 'http://terminology.hl7.org/CodeSystem/HCPCS'; // used by Oystehr RCM
 export const CODE_SYSTEM_NDC = 'http://hl7.org/fhir/sid/ndc';
 export const CODE_SYSTEM_CMS_PLACE_OF_SERVICE =
   'http://www.cms.gov/Medicare/Coding/place-of-service-codes/Place_of_Service_Code_Set.html';

--- a/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
+++ b/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
@@ -40,6 +40,8 @@ import {
   claimStatusValuesToTags,
   CODE_SYSTEM_CMS_PLACE_OF_SERVICE,
   CODE_SYSTEM_CPT_MODIFIER,
+  CODE_SYSTEM_HCPCS,
+  CODE_SYSTEM_HL7_HCPCS,
   CODE_SYSTEM_OYSTEHR_CLAIM_PROCEDURE_MODIFIER,
   CODE_SYSTEM_OYSTEHR_RCM_CMS1500_REFERRING_PROVIDER_TYPE,
   CODE_SYSTEM_PROCESS_PRIORITY,
@@ -1182,13 +1184,24 @@ function buildClaim(resources: ClaimResources): Claim {
     priority: { coding: [{ system: CODE_SYSTEM_PROCESS_PRIORITY, code: 'normal' }] },
     item: resources.procedures
       ? resources.procedures.map<ClaimItem>((p, i) => {
+          const procedureCode = assertDefined(p.code, 'Procedure code');
+          // Swap Ottehr's custom HCPCS code system for HL7's
+          procedureCode.coding = [
+            ...(procedureCode.coding ?? [])
+              .filter((coding) => coding.system === CODE_SYSTEM_HCPCS)
+              .map((coding) => ({
+                ...coding,
+                system: CODE_SYSTEM_HL7_HCPCS,
+              })),
+            ...(procedureCode.coding ?? []).filter((coding) => coding.system !== CODE_SYSTEM_HCPCS),
+          ];
           const amount = getPriceForProcedure(p, resources.chargeMaster);
           total += amount;
           return {
             sequence: i + 1,
             careTeamSequence: resources.renderingProvider ? [1] : undefined,
             diagnosisSequence: resources.diagnoses ? [1] : undefined,
-            productOrService: assertDefined(p.code, 'Procedure code'),
+            productOrService: procedureCode,
             modifier: p.code?.coding?.[0].extension
               ?.flatMap<CodeableConcept | undefined>((ext) =>
                 ext.url === EXTENSION_URL_CPT_MODIFIER

--- a/packages/zambdas/src/billing/create-billing-claim/index.ts
+++ b/packages/zambdas/src/billing/create-billing-claim/index.ts
@@ -17,9 +17,9 @@ import {
   claimStatusValuesToTags,
   CODE_SYSTEM_CLAIM_TYPE,
   CODE_SYSTEM_CMS_PLACE_OF_SERVICE,
-  CODE_SYSTEM_HCPCS,
+  CODE_SYSTEM_HL7_HCPCS,
   CODE_SYSTEM_ICD_10,
-  CODE_SYSTEM_OYSTEHR_RCM_CMS1500_PROCEDURE_MODIFIER,
+  CODE_SYSTEM_OYSTEHR_CLAIM_PROCEDURE_MODIFIER,
   CODE_SYSTEM_OYSTEHR_RCM_CMS1500_REFERRING_PROVIDER_TYPE,
   CODE_SYSTEM_PROCESS_PRIORITY,
   FHIR_RESOURCE_NOT_FOUND,
@@ -247,11 +247,11 @@ function buildClaim(copies: OriginalResources, params: CreateClaimParams): Claim
       careTeamSequence: copies.renderingProvider ? [1] : undefined,
       diagnosisSequence: buildDiagnosisSequence(line.diagnosisPointers, diagnosisCount),
       productOrService: {
-        coding: [{ system: CODE_SYSTEM_HCPCS, code: line.cptCode }],
+        coding: [{ system: CODE_SYSTEM_HL7_HCPCS, code: line.cptCode }],
       },
       modifier: line.modifiers?.length
         ? line.modifiers.map((m) => ({
-            coding: [{ system: CODE_SYSTEM_OYSTEHR_RCM_CMS1500_PROCEDURE_MODIFIER, code: m }],
+            coding: [{ system: CODE_SYSTEM_OYSTEHR_CLAIM_PROCEDURE_MODIFIER, code: m }],
           }))
         : undefined,
       servicedPeriod: { start: line.serviceDate },

--- a/packages/zambdas/src/billing/update-billing-claim/index.ts
+++ b/packages/zambdas/src/billing/update-billing-claim/index.ts
@@ -8,9 +8,9 @@ import {
   clearClaimPlanType,
   CODE_SYSTEM_CLAIM_TYPE,
   CODE_SYSTEM_CMS_PLACE_OF_SERVICE,
-  CODE_SYSTEM_HCPCS,
+  CODE_SYSTEM_HL7_HCPCS,
   CODE_SYSTEM_ICD_10,
-  CODE_SYSTEM_OYSTEHR_RCM_CMS1500_PROCEDURE_MODIFIER,
+  CODE_SYSTEM_OYSTEHR_CLAIM_PROCEDURE_MODIFIER,
   CODE_SYSTEM_OYSTEHR_RCM_CMS1500_REFERRING_PROVIDER_TYPE,
   CODE_SYSTEM_SERVICE_CATEGORY_TAG_SYSTEM,
   FHIR_RESOURCE_NOT_FOUND,
@@ -256,10 +256,10 @@ async function attachClaimResources(
       sequence: i + 1,
       careTeamSequence: hasRenderingProvider ? [1] : undefined,
       diagnosisSequence: buildDiagnosisSequence(line.diagnosisPointers, diagnosisCount),
-      productOrService: { coding: [{ system: CODE_SYSTEM_HCPCS, code: line.cptCode }] },
+      productOrService: { coding: [{ system: CODE_SYSTEM_HL7_HCPCS, code: line.cptCode }] },
       modifier: line.modifiers?.length
         ? line.modifiers.map((m) => ({
-            coding: [{ system: CODE_SYSTEM_OYSTEHR_RCM_CMS1500_PROCEDURE_MODIFIER, code: m }],
+            coding: [{ system: CODE_SYSTEM_OYSTEHR_CLAIM_PROCEDURE_MODIFIER, code: m }],
           }))
         : undefined,
       servicedPeriod: { start: line.serviceDate },

--- a/packages/zambdas/test/unit/billing/create-billing-claim-from-encounter.test.ts
+++ b/packages/zambdas/test/unit/billing/create-billing-claim-from-encounter.test.ts
@@ -28,6 +28,8 @@ import {
   CODE_SYSTEM_CMS_PLACE_OF_SERVICE,
   CODE_SYSTEM_CPT,
   CODE_SYSTEM_CPT_MODIFIER,
+  CODE_SYSTEM_HCPCS,
+  CODE_SYSTEM_HL7_HCPCS,
   CODE_SYSTEM_PROCESS_PRIORITY,
   CODE_SYSTEM_SERVICE_CATEGORY_CODES,
   CODE_SYSTEM_SERVICE_CATEGORY_TAG_SYSTEM,
@@ -2747,6 +2749,146 @@ describe('create-billing-claim-from-encounter', () => {
                       },
                     ],
                   },
+                  net: {
+                    currency: 'USD',
+                    value: 0,
+                  },
+                  quantity: { value: 1, unit: 'UN' },
+                },
+              ],
+            },
+          },
+        ]),
+      });
+    });
+    it('swaps Oystehr-invalid HCPCS system URL for HL7 system URL', async () => {
+      const txFn = vi.fn().mockResolvedValue({
+        entry: [
+          { resource: { resourceType: 'Patient', id: 'billing-patient' } },
+          { resource: { resourceType: 'Patient', id: 'claim-patient' } },
+          { resource: { resourceType: 'RelatedPerson', id: 'billing-subscriber' } },
+          { resource: { resourceType: 'Coverage', id: 'billing-coverage' } },
+          { resource: { resourceType: 'Account', id: 'billing-account' } },
+          { resource: { resourceType: 'RelatedPerson', id: 'claim-subscriber' } },
+          { resource: { resourceType: 'Coverage', id: 'claim-coverage' } },
+          { resource: { resourceType: 'Person', id: 'billing-person' } },
+          { resource: { resourceType: 'Basic', id: 'billing-service-basic' } },
+          { resource: { resourceType: 'Claim', id: 'claim' } },
+        ],
+      });
+      const billingOystehr = {
+        fhir: { transaction: txFn },
+        rcm: { constructPayerUrl: vi.fn().mockReturnValue('https://rcm-api.zapehr.com/v1/payer/payer-123') },
+      } as unknown as Oystehr;
+      const cvo: ComplexValidationOutput = {
+        clinicalResources: {
+          accounts: [clinicalResources.account],
+          appointment: clinicalResources.appointment,
+          billingProvider: clinicalResources.billingProvider,
+          coverages: [clinicalResources.coverage],
+          diagnoses: [...clinicalResources.conditions],
+          encounter: clinicalResources.encounter,
+          location: clinicalResources.location,
+          patient: clinicalResources.patient,
+          payors: [oystehrResources.payor],
+          practitioners: [clinicalResources.practitioner],
+          procedures: [
+            {
+              ...clinicalResources.procedure,
+              code: {
+                coding: [
+                  {
+                    system: CODE_SYSTEM_HCPCS,
+                    code: '12345',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        billingResources: {
+          accounts: [],
+          billingProvider: undefined,
+          coverages: [],
+          mainPatient: undefined,
+          person: undefined,
+          practitioners: [],
+          renderingProvider: undefined,
+          serviceFacility: undefined,
+          subscribers: [],
+          billingService: undefined,
+        },
+      };
+      const result = await performEffect(billingOystehr, cvo);
+      expect(result.claimId).toEqual('claim');
+      expect(txFn).toHaveBeenCalledWith({
+        requests: expect.arrayContaining([
+          {
+            method: 'POST',
+            url: '/Claim',
+            resource: {
+              resourceType: 'Claim',
+              identifier: [
+                { system: ottehrIdentifierSystem('claim-encounter-id'), value: 'encounter-123' },
+                { system: ottehrIdentifierSystem('claim-appointment-id'), value: 'appointment-123' },
+              ],
+              status: 'draft',
+              meta: {
+                tag: [
+                  { system: CURRENT_STATUS_TAG_SYSTEM, code: 'open' },
+                  { system: CODE_SYSTEM_CLAIM_TYPE, code: CODE_SYSTEM_CLAIM_TYPE_CODES.professional },
+                  { system: CODE_SYSTEM_SERVICE_CATEGORY_TAG_SYSTEM, code: 'urgent-care' },
+                  { system: CLAIM_STATUS_TAG_SYSTEMS.arStage, code: AR_STAGE.insurancePayer },
+                  { system: CLAIM_STATUS_TAG_SYSTEMS.insuranceArStatus, code: 'created' },
+                ],
+              },
+              type: { coding: [{ system: CODE_SYSTEM_CLAIM_TYPE, code: CODE_SYSTEM_CLAIM_TYPE_CODES.professional }] },
+              use: 'claim',
+              created: expect.any(String),
+              extension: getDefaultClaimSubmissionExtensions(),
+              patient: {
+                reference: 'urn:uuid:claim-patient',
+              },
+              provider: { display: 'Unknown' },
+              facility: undefined,
+              insurer: { reference: 'https://rcm-api.zapehr.com/v1/payer/payer-123' },
+              insurance: [
+                {
+                  sequence: 1,
+                  focal: true,
+                  coverage: { reference: 'urn:uuid:claim-coverage-billing-coverage-coverage-123' },
+                },
+              ],
+              careTeam: undefined,
+              diagnosis: [
+                { sequence: 1, diagnosisCodeableConcept: clinicalResources.conditions[0].code },
+                { sequence: 2, diagnosisCodeableConcept: clinicalResources.conditions[1].code },
+              ],
+              priority: { coding: [{ system: CODE_SYSTEM_PROCESS_PRIORITY, code: 'normal' }] },
+              total: {
+                currency: 'USD',
+                value: 0,
+              },
+              item: [
+                {
+                  sequence: 1,
+                  careTeamSequence: undefined,
+                  diagnosisSequence: [1],
+                  productOrService: {
+                    coding: [
+                      {
+                        // It has been swapped
+                        system: CODE_SYSTEM_HL7_HCPCS,
+                        code: '12345',
+                      },
+                    ],
+                  },
+                  modifier: undefined,
+                  servicedPeriod: {
+                    start: expect.any(String),
+                    end: undefined,
+                  },
+                  locationCodeableConcept: undefined,
                   net: {
                     currency: 'USD',
                     value: 0,


### PR DESCRIPTION
Three changes:

1. Use HL7 HCPCS code system URL in create and update claim endpoints. This is what is expected by Oystehr RCM.
2. Use Oystehr-RCM-approved modifier code system URL in create and update claim endpoints.
3. Map procedure codes from Ottehr's HCPCS code system URL to HL7's in create-billing-claim-from-encounter.