### PR TITLE
enable bucket deletion per env

### DIFF
--- a/config/oystehr-core/buckets.json
+++ b/config/oystehr-core/buckets.json
@@ -3,87 +3,87 @@
   "buckets": {
     "VISIT_NOTES": {
       "name": "#{var/PROJECT_ID}-visit-notes",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "CONSENT_FORMS": {
       "name": "#{var/PROJECT_ID}-consent-forms",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "PRIVACY_POLICY": {
       "name": "#{var/PROJECT_ID}-privacy-policy",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "INSURANCE_CARDS": {
       "name": "#{var/PROJECT_ID}-insurance-cards",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "PHOTO_ID_CARDS": {
       "name": "#{var/PROJECT_ID}-photo-id-cards",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "PATIENT_PHOTOS": {
       "name": "#{var/PROJECT_ID}-patient-photos",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "SCHOOL_WORK_NOTES": {
       "name": "#{var/PROJECT_ID}-school-work-notes",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "SCHOOL_WORK_NOTE_TEMPLATES": {
       "name": "#{var/PROJECT_ID}-school-work-note-templates",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "AUDIO-RECORDINGS": {
       "name": "#{var/PROJECT_ID}-audio-recordings",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "LABS": {
       "name": "#{var/PROJECT_ID}-labs",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "RECEIPTS": {
       "name": "#{var/PROJECT_ID}-receipts",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "PAPERWORK": {
       "name": "#{var/PROJECT_ID}-exported-questionnaires",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "DISCHARGE_SUMMARIES": {
       "name": "#{var/PROJECT_ID}-discharge-summaries",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "INVOICEABLE_PATIENTS_REPORTS": {
       "name": "#{var/PROJECT_ID}-invoiceable-patients-reports",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "STATEMENTS": {
       "name": "#{var/PROJECT_ID}-statements",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "PATIENT_EDUCATION": {
       "name": "#{var/PROJECT_ID}-patient-education",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "PATIENT_EDUCATION_ADMIN": {
       "name": "#{var/PROJECT_ID}-patient-education-admin",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "RADIOLOGY_REPORTS": {
       "name": "#{var/PROJECT_ID}-radiology-reports",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "LEGACY_DATA": {
       "name": "#{var/PROJECT_ID}-legacy-data",
-      "removalPolicy": "delete"
+      "retainInEnvironments": []
     },
     "PATIENT_DOCS_CUSTOM_FOLDERS": {
       "name": "#{var/PROJECT_ID}-patient-docs-custom-folders",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     },
     "MEDICAL_RECORD_EXPORTS": {
       "name": "#{var/PROJECT_ID}-medical-record-exports",
-      "removalPolicy": "retain"
+      "retainInEnvironments": ["production", "staging", "demo"]
     }
   }
 }

--- a/deploy/.terraform.lock.hcl
+++ b/deploy/.terraform.lock.hcl
@@ -114,24 +114,27 @@ provider "registry.terraform.io/hashicorp/null" {
 }
 
 provider "registry.terraform.io/masslight/oystehr" {
-  version     = "0.0.21"
-  constraints = "0.0.21"
+  version     = "0.0.22"
+  constraints = "0.0.22"
   hashes = [
-    "h1:HLk2RE/q7znovnDkEVzpaINXbbvRFILp1wCjnZlc548=",
-    "h1:RmBXa95pjv2kuT7yGQoTG6hM9/LmzLrEpRrF9kM/jdc=",
-    "zh:0236aac8cb53d20332134495ff5d69a56b0fbb75458ff21ce5bb5eaccdd2afcd",
-    "zh:03eae39113cdd84a108605503bdb84c5c6a1b611996fd7c061e8c67f00ca7509",
-    "zh:041b56beec90e5663df8ac4f23014591c06f15d9ee1dfc17ae271488c3820c5c",
+    "h1:AbifNERdArgePlD/Xh/lj3HfIpxM3+LCYFr448WcmV4=",
+    "h1:SI53vgnTm8ew58xPB1bz5DUEUP4p5AVo3emSFVkYChs=",
+    "h1:WKGvOnSwh8xVJThr07N9mAZXXDDIjH0A0isMnuzy0BA=",
+    "h1:tmoCJab8YjKjUIzMerYuxn0TpcExdkNR6+2c17Ng3Ao=",
+    "h1:wEtRFe/rJf+CGHFGX1jBv+gtfuR0Jebguf+h1xDfBzw=",
+    "zh:0b93e640c4691d6947d31c7c2600b8c1a3ba703792943721d3bb9da93fefcb28",
     "zh:0dde99e7b343fa01f8eefc378171fb8621bedb20f59157d6cc8e3d46c738105f",
-    "zh:2a04a1a6aa2c3e13b4f23305c725cdfb659fc7e3d21b9a7dbc6cb5eb7cdc6a73",
-    "zh:3a8182b9a83a43706594a6c2dd8c2ea58f164cb458dbb77ec29b0ca414dd92ab",
-    "zh:3bc8487645afd1db2ec8aa009cb067fa2e5199000dcc75f866a63f1f5a397ca4",
-    "zh:4dc3dae586789790f5adb96d3c53a4f1e212674e6bf0a7fe5050a0f67ccd1614",
-    "zh:7a052683247bde5725aaf5e7a73096768360557f34e39badd75b3b44b4dc781a",
-    "zh:8335a0d59828b167616210333b15b209f45642db788406698f6f3a8ace6d241b",
-    "zh:9162128524365ccb0fc6a11ca10c678c760d55df9b4fb85f66c84d481cc3d9b7",
-    "zh:9a2bb81a22204b78000a7828b06e18db8216f2d66acb75947a82ff64b0bea0f1",
-    "zh:bf491967e839f28954624dadfe99d140a086ffd0dccfa49a9b301f5bc7db81aa",
-    "zh:d675ee62b6f53a6504481abaa6f5555d4f277a1c1d9ea77889cfa9f909198a4e",
+    "zh:23f37f47b819e35de3502385139cb16d6896c725e4f72f4da84066a529b60123",
+    "zh:5b4010c84197695b0048ee75b5f75f138c7f9820d5036c9dcec42f0ee92f068b",
+    "zh:7720f5a08849f4ebb62721604ee9610ceaaba090619c0a72ecf58e194e8eaa3f",
+    "zh:81a1f371598d06d7e8dee4cf7e0b9d6363f00f234b515b0a05a31e7c9f0619fb",
+    "zh:834e14351a4608eafa629abc127cfd144525e9c5f64af54d3423db5e4828d84a",
+    "zh:966749c7e34bd6c87ef3b24c9e039d879c9acf18ab53c6013279b1dfc9638d2d",
+    "zh:a83dc0658b2aac00fbb78c0259d1a08bc74623b1e1d5a1078801c31a6cd49d01",
+    "zh:a871e3ccb6f3d454641c4cd105abb3a935c50d951578ada51a375d59e0a3a013",
+    "zh:c55db2cb12ef7a79818b26eb0d81ecae476bb95802ec1f86660abce5004d6d35",
+    "zh:cdb8516452f222dfa975fa7438c6ee594015a3861f3dc3f7ed95eb5e9a338149",
+    "zh:ce6ab4611d774609d2cec09eeec21e5c2777b956c92c0279bf78a8a1954fa37a",
+    "zh:e8c5050539c46ba26abdb99f7d03459d33c8bb647827147ecfd888e9586efbae",
   ]
 }

--- a/deploy/billing_app/main.tf
+++ b/deploy/billing_app/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     oystehr = {
       source  = "registry.terraform.io/masslight/oystehr"
-      version = "0.0.21"
+      version = "0.0.22"
     }
   }
 }

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -17,7 +17,8 @@ terraform {
       version = "~> 2.0"
     }
     oystehr = {
-      source = "registry.terraform.io/masslight/oystehr"
+      source  = "registry.terraform.io/masslight/oystehr"
+      version = "0.0.22"
     }
     aws = {
       source = "hashicorp/aws"

--- a/deploy/oystehr/main.tf
+++ b/deploy/oystehr/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     oystehr = {
       source  = "registry.terraform.io/masslight/oystehr"
-      version = "0.0.21"
+      version = "0.0.22"
     }
   }
 }

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -179,6 +179,11 @@ field means `delete` in every environment. Generation throws if buckets are defi
 deletable. The legacy single-value `removalPolicy` field is no longer supported — generation
 throws if a bucket still uses it, forcing migration to `retainInEnvironments`.
 
+Deletable buckets (those `delete`d in the current environment) are also generated with
+`force_destroy = true`, so `terraform destroy` empties and removes the bucket even when it
+still holds objects; retained buckets get `force_destroy = false`. `force_destroy` requires the
+`oystehr` provider at version `0.0.22` or later.
+
 ## Zambda Configuration
 
 Example zambda spec:

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -176,7 +176,8 @@ protects buckets in production-like environments while letting lower/ephemeral e
 freely destroy and recreate buckets (e.g. across branch switches). An empty list or a missing
 field means `delete` in every environment. Generation throws if buckets are defined but
 `ENVIRONMENT` is not set, so a misconfigured environment can never silently mark buckets
-deletable.
+deletable. The legacy single-value `removalPolicy` field is no longer supported — generation
+throws if a bucket still uses it, forcing migration to `retainInEnvironments`.
 
 ## Zambda Configuration
 

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -174,10 +174,11 @@ Example bucket spec:
 `retain`ed when the current `ENVIRONMENT` is in the list, and `delete`d everywhere else. This
 protects buckets in production-like environments while letting lower/ephemeral environments
 freely destroy and recreate buckets (e.g. across branch switches). An empty list or a missing
-field means `delete` in every environment. Generation throws if buckets are defined but
-`ENVIRONMENT` is not set, so a misconfigured environment can never silently mark buckets
-deletable. The legacy single-value `removalPolicy` field is no longer supported — generation
-throws if a bucket still uses it, forcing migration to `retainInEnvironments`.
+field means `delete` in every environment, and it must be an array of environment name strings.
+Generation also throws if buckets are defined but `ENVIRONMENT` is not set, so a misconfigured
+environment can never silently mark buckets deletable. The legacy single-value `removalPolicy` field
+is no longer supported — generation throws if a bucket still uses it, forcing migration to
+`retainInEnvironments`.
 
 Deletable buckets (those `delete`d in the current environment) are generated with
 `force_destroy = true`, so `terraform destroy` empties and removes the bucket even when it

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -179,10 +179,9 @@ field means `delete` in every environment. Generation throws if buckets are defi
 deletable. The legacy single-value `removalPolicy` field is no longer supported — generation
 throws if a bucket still uses it, forcing migration to `retainInEnvironments`.
 
-Deletable buckets (those `delete`d in the current environment) are also generated with
+Deletable buckets (those `delete`d in the current environment) are generated with
 `force_destroy = true`, so `terraform destroy` empties and removes the bucket even when it
-still holds objects; retained buckets get `force_destroy = false`. `force_destroy` requires the
-`oystehr` provider at version `0.0.22` or later.
+still holds objects. `force_destroy` requires the `oystehr` provider at version `0.0.22` or later.
 
 ## Zambda Configuration
 

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -154,6 +154,30 @@ When deploying to `local`, both `config/oystehr/zambdas.json` AND `config/oysteh
 
 When deploying to `production`, only `config/oystehr/zambdas.json` is used (no env-specific folder).
 
+## Bucket Configuration
+
+Example bucket spec:
+
+```json
+{
+  "schema-version": "2025-09-25",
+  "buckets": {
+    "MY_BUCKET": {
+      "name": "#{var/PROJECT_ID}-my-bucket",
+      "retainInEnvironments": ["production", "staging", "demo"]
+    }
+  }
+}
+```
+
+`retainInEnvironments` controls the generated `removal_policy` per environment: the bucket is
+`retain`ed when the current `ENVIRONMENT` is in the list, and `delete`d everywhere else. This
+protects buckets in production-like environments while letting lower/ephemeral environments
+freely destroy and recreate buckets (e.g. across branch switches). An empty list or a missing
+field means `delete` in every environment. Generation throws if buckets are defined but
+`ENVIRONMENT` is not set, so a misconfigured environment can never silently mark buckets
+deletable.
+
 ## Zambda Configuration
 
 Example zambda spec:

--- a/packages/spec/src/schema-20250925.test.ts
+++ b/packages/spec/src/schema-20250925.test.ts
@@ -304,5 +304,30 @@ describe('Schema20250925 generate()', () => {
 
       await expect(schema.generate()).rejects.toThrow('ENVIRONMENT must be set to resolve bucket removal policies');
     });
+
+    it('deletes in every environment when retainInEnvironments is omitted', async () => {
+      const spec = {
+        path: 'buckets.json',
+        spec: {
+          'schema-version': '2025-09-25',
+          buckets: {
+            MY_BUCKET: {
+              name: '#{var/PROJECT_ID}-my-bucket',
+            },
+          },
+        },
+      };
+      const schema = new Schema20250925(
+        [spec],
+        {
+          ENVIRONMENT: 'production',
+        },
+        tmpDir,
+        '/zambdas'
+      );
+      await schema.generate();
+
+      expect((await readBucket()).removal_policy).toBe('delete');
+    });
   });
 });

--- a/packages/spec/src/schema-20250925.test.ts
+++ b/packages/spec/src/schema-20250925.test.ts
@@ -364,5 +364,32 @@ describe('Schema20250925 generate()', () => {
         'Bucket "MY_BUCKET" uses the removed "removalPolicy" field; use "retainInEnvironments" instead'
       );
     });
+
+    it('throws when retainInEnvironments is not an array of strings', async () => {
+      const spec = {
+        path: 'buckets.json',
+        spec: {
+          'schema-version': '2025-09-25',
+          buckets: {
+            MY_BUCKET: {
+              name: '#{var/PROJECT_ID}-my-bucket',
+              retainInEnvironments: 'production',
+            },
+          },
+        },
+      };
+      const schema = new Schema20250925(
+        [spec],
+        {
+          ENVIRONMENT: 'production',
+        },
+        tmpDir,
+        '/zambdas'
+      );
+
+      await expect(schema.generate()).rejects.toThrow(
+        'Bucket "MY_BUCKET" has an invalid "retainInEnvironments"; expected an array of environment name strings'
+      );
+    });
   });
 });

--- a/packages/spec/src/schema-20250925.test.ts
+++ b/packages/spec/src/schema-20250925.test.ts
@@ -237,7 +237,7 @@ describe('Schema20250925 generate()', () => {
       },
     });
 
-    const readBucket = async (): Promise<{ name: string; removal_policy: string; force_destroy: boolean }> => {
+    const readBucket = async (): Promise<{ name: string; removal_policy: string; force_destroy?: boolean }> => {
       const content = await fs.readFile(path.join(tmpDir, 'buckets.tf.json'), 'utf8');
       return JSON.parse(content).resource.oystehr_z3_bucket.MY_BUCKET;
     };
@@ -255,7 +255,7 @@ describe('Schema20250925 generate()', () => {
 
       const bucket = await readBucket();
       expect(bucket.removal_policy).toBe('retain');
-      expect(bucket.force_destroy).toBe(false);
+      expect(bucket.force_destroy).toBeUndefined();
     });
 
     it('deletes the bucket when the current environment is not in retainInEnvironments', async () => {

--- a/packages/spec/src/schema-20250925.test.ts
+++ b/packages/spec/src/schema-20250925.test.ts
@@ -329,5 +329,32 @@ describe('Schema20250925 generate()', () => {
 
       expect((await readBucket()).removal_policy).toBe('delete');
     });
+
+    it('throws when a bucket uses the removed removalPolicy field', async () => {
+      const spec = {
+        path: 'buckets.json',
+        spec: {
+          'schema-version': '2025-09-25',
+          buckets: {
+            MY_BUCKET: {
+              name: '#{var/PROJECT_ID}-my-bucket',
+              removalPolicy: 'retain',
+            },
+          },
+        },
+      };
+      const schema = new Schema20250925(
+        [spec],
+        {
+          ENVIRONMENT: 'production',
+        },
+        tmpDir,
+        '/zambdas'
+      );
+
+      await expect(schema.generate()).rejects.toThrow(
+        'Bucket "MY_BUCKET" uses the removed "removalPolicy" field; use "retainInEnvironments" instead'
+      );
+    });
   });
 });

--- a/packages/spec/src/schema-20250925.test.ts
+++ b/packages/spec/src/schema-20250925.test.ts
@@ -237,7 +237,7 @@ describe('Schema20250925 generate()', () => {
       },
     });
 
-    const readBucket = async (): Promise<{ name: string; removal_policy: string }> => {
+    const readBucket = async (): Promise<{ name: string; removal_policy: string; force_destroy: boolean }> => {
       const content = await fs.readFile(path.join(tmpDir, 'buckets.tf.json'), 'utf8');
       return JSON.parse(content).resource.oystehr_z3_bucket.MY_BUCKET;
     };
@@ -253,7 +253,9 @@ describe('Schema20250925 generate()', () => {
       );
       await schema.generate();
 
-      expect((await readBucket()).removal_policy).toBe('retain');
+      const bucket = await readBucket();
+      expect(bucket.removal_policy).toBe('retain');
+      expect(bucket.force_destroy).toBe(false);
     });
 
     it('deletes the bucket when the current environment is not in retainInEnvironments', async () => {
@@ -267,7 +269,9 @@ describe('Schema20250925 generate()', () => {
       );
       await schema.generate();
 
-      expect((await readBucket()).removal_policy).toBe('delete');
+      const bucket = await readBucket();
+      expect(bucket.removal_policy).toBe('delete');
+      expect(bucket.force_destroy).toBe(true);
     });
 
     it('deletes in every environment when retainInEnvironments is empty', async () => {
@@ -281,7 +285,9 @@ describe('Schema20250925 generate()', () => {
       );
       await schema.generate();
 
-      expect((await readBucket()).removal_policy).toBe('delete');
+      const bucket = await readBucket();
+      expect(bucket.removal_policy).toBe('delete');
+      expect(bucket.force_destroy).toBe(true);
     });
 
     it('resolves #{var/...} references in the bucket name', async () => {
@@ -327,7 +333,9 @@ describe('Schema20250925 generate()', () => {
       );
       await schema.generate();
 
-      expect((await readBucket()).removal_policy).toBe('delete');
+      const bucket = await readBucket();
+      expect(bucket.removal_policy).toBe('delete');
+      expect(bucket.force_destroy).toBe(true);
     });
 
     it('throws when a bucket uses the removed removalPolicy field', async () => {

--- a/packages/spec/src/schema-20250925.test.ts
+++ b/packages/spec/src/schema-20250925.test.ts
@@ -215,4 +215,94 @@ describe('Schema20250925 generate()', () => {
       expect(value).toContain('local.zambda_secrets_for_local_server');
     });
   });
+
+  describe('buckets', () => {
+    const bucketSpecRetainingIn = (
+      retainInEnvironments: string[]
+    ): {
+      path: string;
+      spec: {
+        [key: string]: unknown;
+      };
+    } => ({
+      path: 'buckets.json',
+      spec: {
+        'schema-version': '2025-09-25',
+        buckets: {
+          MY_BUCKET: {
+            name: '#{var/PROJECT_ID}-my-bucket',
+            retainInEnvironments,
+          },
+        },
+      },
+    });
+
+    const readBucket = async (): Promise<{ name: string; removal_policy: string }> => {
+      const content = await fs.readFile(path.join(tmpDir, 'buckets.tf.json'), 'utf8');
+      return JSON.parse(content).resource.oystehr_z3_bucket.MY_BUCKET;
+    };
+
+    it('retains the bucket when the current environment is in retainInEnvironments', async () => {
+      const schema = new Schema20250925(
+        [bucketSpecRetainingIn(['production'])],
+        {
+          ENVIRONMENT: 'production',
+        },
+        tmpDir,
+        '/zambdas'
+      );
+      await schema.generate();
+
+      expect((await readBucket()).removal_policy).toBe('retain');
+    });
+
+    it('deletes the bucket when the current environment is not in retainInEnvironments', async () => {
+      const schema = new Schema20250925(
+        [bucketSpecRetainingIn(['production'])],
+        {
+          ENVIRONMENT: 'local',
+        },
+        tmpDir,
+        '/zambdas'
+      );
+      await schema.generate();
+
+      expect((await readBucket()).removal_policy).toBe('delete');
+    });
+
+    it('deletes in every environment when retainInEnvironments is empty', async () => {
+      const schema = new Schema20250925(
+        [bucketSpecRetainingIn([])],
+        {
+          ENVIRONMENT: 'production',
+        },
+        tmpDir,
+        '/zambdas'
+      );
+      await schema.generate();
+
+      expect((await readBucket()).removal_policy).toBe('delete');
+    });
+
+    it('resolves #{var/...} references in the bucket name', async () => {
+      const schema = new Schema20250925(
+        [bucketSpecRetainingIn(['production'])],
+        {
+          ENVIRONMENT: 'production',
+          PROJECT_ID: 'proj-123',
+        },
+        tmpDir,
+        '/zambdas'
+      );
+      await schema.generate();
+
+      expect((await readBucket()).name).toBe('proj-123-my-bucket');
+    });
+
+    it('throws when buckets are defined but ENVIRONMENT is not set', async () => {
+      const schema = new Schema20250925([bucketSpecRetainingIn(['production'])], {}, tmpDir, '/zambdas');
+
+      await expect(schema.generate()).rejects.toThrow('ENVIRONMENT must be set to resolve bucket removal policies');
+    });
+  });
 });

--- a/packages/spec/src/schema-20250925.ts
+++ b/packages/spec/src/schema-20250925.ts
@@ -202,10 +202,14 @@ export class Schema20250925 implements Schema<Spec20250925> {
     const bucketResources: { resource: { oystehr_z3_bucket: { [key: string]: any } } } = {
       resource: { oystehr_z3_bucket: {} },
     };
+    if (Object.keys(this.resources.buckets).length && !this.vars.ENVIRONMENT) {
+      throw new Error('ENVIRONMENT must be set to resolve bucket removal policies');
+    }
     for (const [bucketName, bucket] of Object.entries(this.resources.buckets)) {
+      const retainInEnvironments: string[] = bucket.retainInEnvironments ?? [];
       bucketResources.resource.oystehr_z3_bucket[bucketName] = {
         name: this.getValue(bucket.name, this.resources),
-        removal_policy: this.getValue(bucket.removalPolicy, this.resources),
+        removal_policy: retainInEnvironments.includes(this.vars.ENVIRONMENT) ? 'retain' : 'delete',
       };
     }
     if (Object.keys(bucketResources.resource.oystehr_z3_bucket).length) {

--- a/packages/spec/src/schema-20250925.ts
+++ b/packages/spec/src/schema-20250925.ts
@@ -211,7 +211,13 @@ export class Schema20250925 implements Schema<Spec20250925> {
           `Bucket "${bucketName}" uses the removed "removalPolicy" field; use "retainInEnvironments" instead`
         );
       }
-      const retainInEnvironments: string[] = bucket.retainInEnvironments ?? [];
+      const rawRetain: unknown = bucket.retainInEnvironments ?? [];
+      if (!Array.isArray(rawRetain) || rawRetain.some((env) => typeof env !== 'string')) {
+        throw new Error(
+          `Bucket "${bucketName}" has an invalid "retainInEnvironments"; expected an array of environment name strings`
+        );
+      }
+      const retainInEnvironments: string[] = rawRetain;
       const shouldRetain = retainInEnvironments.includes(this.vars.ENVIRONMENT);
       bucketResources.resource.oystehr_z3_bucket[bucketName] = {
         name: this.getValue(bucket.name, this.resources),

--- a/packages/spec/src/schema-20250925.ts
+++ b/packages/spec/src/schema-20250925.ts
@@ -212,9 +212,11 @@ export class Schema20250925 implements Schema<Spec20250925> {
         );
       }
       const retainInEnvironments: string[] = bucket.retainInEnvironments ?? [];
+      const shouldRetain = retainInEnvironments.includes(this.vars.ENVIRONMENT);
       bucketResources.resource.oystehr_z3_bucket[bucketName] = {
         name: this.getValue(bucket.name, this.resources),
-        removal_policy: retainInEnvironments.includes(this.vars.ENVIRONMENT) ? 'retain' : 'delete',
+        removal_policy: shouldRetain ? 'retain' : 'delete',
+        force_destroy: shouldRetain ? undefined : true,
       };
     }
     if (Object.keys(bucketResources.resource.oystehr_z3_bucket).length) {

--- a/packages/spec/src/schema-20250925.ts
+++ b/packages/spec/src/schema-20250925.ts
@@ -206,6 +206,11 @@ export class Schema20250925 implements Schema<Spec20250925> {
       throw new Error('ENVIRONMENT must be set to resolve bucket removal policies');
     }
     for (const [bucketName, bucket] of Object.entries(this.resources.buckets)) {
+      if ('removalPolicy' in bucket) {
+        throw new Error(
+          `Bucket "${bucketName}" uses the removed "removalPolicy" field; use "retainInEnvironments" instead`
+        );
+      }
       const retainInEnvironments: string[] = bucket.retainInEnvironments ?? [];
       bucketResources.resource.oystehr_z3_bucket[bucketName] = {
         name: this.getValue(bucket.name, this.resources),


### PR DESCRIPTION
[evidently this won't fix "bucket already exists" errors](https://github.com/masslight/ottehr/actions/runs/28598158719/job/84801336576?pr=8503#step:13:968) but hopefully this shouldn't happen when this fix is applied to all envs

tested and working locally