### PR TITLE
Revert "tweak: Move secret from oystehr to billing (#8543)"

### DIFF
--- a/config/billing-app-core/secrets.json
+++ b/config/billing-app-core/secrets.json
@@ -1,9 +1,0 @@
-{
-  "schema-version": "2025-09-25",
-  "secrets": {
-    "BILLING_INTEGRATION_FEATURE_FLAG": {
-      "name": "BILLING_INTEGRATION",
-      "value": "#{var/BILLING_INTEGRATION}"
-    }
-  }
-}

--- a/config/oystehr-core/secrets.json
+++ b/config/oystehr-core/secrets.json
@@ -145,6 +145,10 @@
     "POSTGRID_API_KEY": {
       "name": "POSTGRID_API_KEY",
       "value": "#{var/POSTGRID_API_KEY}"
+    },
+    "BILLING_INTEGRATION_FEATURE_FLAG": {
+      "name": "BILLING_INTEGRATION",
+      "value": "#{var/BILLING_INTEGRATION}"
     }
   }
 }

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -85,23 +85,8 @@ module "oystehr" {
   environment                 = var.environment
 }
 
-module "billing_app" {
-  source = "./billing_app"
-
-  project_id                   = var.project_id
-  environment                  = var.environment
-  is_local                     = local.is_local
-  aws_profile                  = var.aws_profile
-  not_local_env_resource_count = local.not_local_env_resource_count
-
-  billing_bucket_name = var.billing_bucket_name
-  billing_domain      = var.billing_domain
-  billing_cert_domain = var.billing_cert_domain
-  ehr_app_url         = var.ehr_domain == null ? "http://localhost:4002" : "https://${var.ehr_domain}"
-}
-
 module "ottehr_apps" {
-  depends_on  = [module.oystehr, module.infra, module.billing_app]
+  depends_on  = [module.oystehr, module.infra]
   source      = "./ottehr_apps"
   environment = var.environment
   is_local    = local.is_local
@@ -147,7 +132,7 @@ module "ottehr_apps" {
     SENTRY_ENV                    = var.environment
     SENTRY_TAGS                   = module.oystehr.sentry_tags
   }
-  zambda_secrets_for_local_server = merge(module.oystehr.zambda_secrets_for_local_server, module.billing_app.zambda_secrets_for_local_server)
+  zambda_secrets_for_local_server = module.oystehr.zambda_secrets_for_local_server
 }
 
 module "apps_upload" {
@@ -161,4 +146,19 @@ module "apps_upload" {
   patient_portal_cdn_distribution_id = one(module.infra[*].patient_portal_cdn_distribution_id)
   ehr_hash                           = one(module.ottehr_apps[*].ehr_hash)
   patient_portal_hash                = one(module.ottehr_apps[*].patient_portal_hash)
+}
+
+module "billing_app" {
+  source = "./billing_app"
+
+  project_id                   = var.project_id
+  environment                  = var.environment
+  is_local                     = local.is_local
+  aws_profile                  = var.aws_profile
+  not_local_env_resource_count = local.not_local_env_resource_count
+
+  billing_bucket_name = var.billing_bucket_name
+  billing_domain      = var.billing_domain
+  billing_cert_domain = var.billing_cert_domain
+  ehr_app_url         = var.ehr_domain == null ? "http://localhost:4002" : "https://${var.ehr_domain}"
 }

--- a/packages/spec/src/schema-20250925.test.ts
+++ b/packages/spec/src/schema-20250925.test.ts
@@ -125,7 +125,6 @@ describe('Schema20250925 generate()', () => {
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spec-test-'));
-    await fs.mkdir(path.join(tmpDir, 'oystehr'));
   });
 
   afterEach(async () => {
@@ -145,10 +144,10 @@ describe('Schema20250925 generate()', () => {
         },
       };
 
-      const schema = new Schema20250925([spec], {}, `${tmpDir}/oystehr`, '/zambdas');
+      const schema = new Schema20250925([spec], {}, tmpDir, '/zambdas');
       await schema.generate();
 
-      const outputsContent = await fs.readFile(path.join(`${tmpDir}/oystehr`, 'outputs.tf.json'), 'utf8');
+      const outputsContent = await fs.readFile(path.join(tmpDir, 'outputs.tf.json'), 'utf8');
       const outputs = JSON.parse(outputsContent);
 
       expect(outputs.locals.zambda_secrets_for_local_server).toBeDefined();

--- a/packages/spec/src/schema-20250925.ts
+++ b/packages/spec/src/schema-20250925.ts
@@ -408,13 +408,7 @@ export class Schema20250925 implements Schema<Spec20250925> {
       const staticSecretRefs = Object.keys(this.resources.secrets)
         .map((name) => `"${name}": oystehr_secret.${name}.value`)
         .join(', ');
-      const zambdaSecretsExpr = `\${merge({for k, v in ${
-        outputsOutFile.includes('oystehr/') ? 'oystehr_secret.sendgrid_template_ids' : '{}'
-      } : k => v.value}, ${
-        outputsOutFile.includes('oystehr/')
-          ? 'length(oystehr_secret.sendgrid_send_email_api_key) > 0 ? {"SENDGRID_SEND_EMAIL_API_KEY": one(oystehr_secret.sendgrid_send_email_api_key[*].value)} : {}'
-          : '{}'
-      }, {${staticSecretRefs}})}`;
+      const zambdaSecretsExpr = `\${merge({for k, v in oystehr_secret.sendgrid_template_ids : k => v.value}, length(oystehr_secret.sendgrid_send_email_api_key) > 0 ? {"SENDGRID_SEND_EMAIL_API_KEY": one(oystehr_secret.sendgrid_send_email_api_key[*].value)} : {}, {${staticSecretRefs}})}`;
       outputDirectives.locals['zambda_secrets_for_local_server'] = { value: zambdaSecretsExpr };
       outputDirectives.output['zambda_secrets_for_local_server'] = {
         value: '${local.zambda_secrets_for_local_server.value}',


### PR DESCRIPTION
This reverts commit e1bc92962bee279b66df91e9cf79b071bb751586.

Reverting this because if we only run billing deploy, there will be duplicate secrets and the deploy will fail.