### PR TITLE
fix(OTR-2257): use MUI Checkbox for standard bright blue styling

### DIFF
--- a/apps/ehr/src/features/in-house-labs/components/create/InHouseLabSelect.tsx
+++ b/apps/ehr/src/features/in-house-labs/components/create/InHouseLabSelect.tsx
@@ -1,6 +1,4 @@
-import CheckBoxIcon from '@mui/icons-material/CheckBox';
-import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
-import { FormControl, InputLabel, ListItemText, MenuItem, Select } from '@mui/material';
+import { Checkbox, FormControl, InputLabel, ListItemText, MenuItem, Select } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { dataTestIds } from 'src/constants/data-test-ids';
 import { DataEntryTestItem } from 'utils';
@@ -87,16 +85,12 @@ export const InHouseLabSelect: React.FC<InHouseLabSelectProps> = ({
           PaperProps: { 'data-testid': dataTestIds.orderInHouseLabPage.testTypeList },
         }}
       >
-        {availableTests.map((test) => {
-          const selected = pendingTestNames.includes(test.name);
-          const SelectionIcon = selected ? CheckBoxIcon : CheckBoxOutlineBlankIcon;
-          return (
-            <MenuItem key={`${test.name}-${test.adId}`} value={test.name}>
-              <SelectionIcon fontSize="small" style={{ marginRight: 8, padding: 9, boxSizing: 'content-box' }} />
-              <ListItemText primary={test.name} />
-            </MenuItem>
-          );
-        })}
+        {availableTests.map((test) => (
+          <MenuItem key={`${test.name}-${test.adId}`} value={test.name}>
+            <Checkbox checked={pendingTestNames.includes(test.name)} />
+            <ListItemText primary={test.name} />
+          </MenuItem>
+        ))}
       </Select>
     </FormControl>
   );


### PR DESCRIPTION
## Summary
- Replaces raw `CheckBoxIcon`/`CheckBoxOutlineBlankIcon` icon components with MUI's `Checkbox` component in the in-house lab test multi-select dropdown
- `Checkbox` automatically applies the theme's primary blue color when checked, matching the standard checkbox design used elsewhere in the app

## Test plan
- [ ] Open the in-house labs order creation page
- [ ] Open the test dropdown — verify checkboxes appear in standard bright blue when selected
- [ ] Verify multi-select behavior (stay open, close on outside click) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)