### PR TITLE
fix(OTR-2110): format pharmacy ZIP code and phone number for display

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/review-tab/components/PrescribedMedicationsContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/components/PrescribedMedicationsContainer.tsx
@@ -57,7 +57,7 @@ export const PrescribedMedicationsContainer: FC = () => {
                   pharmacy.city,
                   pharmacy.state,
                   pharmacy.zipCode ? formatZipcodeForDisplay(pharmacy.zipCode) : undefined,
-                  pharmacy.phone ? formatPhoneNumberDisplay(pharmacy.phone) : undefined,
+                  formatPhoneNumberDisplay(pharmacy.phone),
                 ]
                   .filter(Boolean)
                   .join(', ')}

--- a/apps/ehr/src/features/visits/shared/components/review-tab/components/PrescribedMedicationsContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/components/PrescribedMedicationsContainer.tsx
@@ -2,6 +2,7 @@ import { Box, Typography } from '@mui/material';
 import { useQueries } from '@tanstack/react-query';
 import { FC } from 'react';
 import { useApiClients } from 'src/hooks/useAppClients';
+import { formatPhoneNumberDisplay, formatZipcodeForDisplay } from 'utils';
 import { useChartFields } from '../../../hooks/useChartFields';
 import { PrescribedMedicationReviewItem } from './PrescribedMedicationReviewItem';
 
@@ -55,8 +56,8 @@ export const PrescribedMedicationsContainer: FC = () => {
                   pharmacy.address2,
                   pharmacy.city,
                   pharmacy.state,
-                  pharmacy.zipCode,
-                  pharmacy.phone,
+                  pharmacy.zipCode ? formatZipcodeForDisplay(pharmacy.zipCode) : undefined,
+                  pharmacy.phone ? formatPhoneNumberDisplay(pharmacy.phone) : undefined,
                 ]
                   .filter(Boolean)
                   .join(', ')}

--- a/packages/zambdas/src/shared/pdf/helpers/pharmacy.ts
+++ b/packages/zambdas/src/shared/pdf/helpers/pharmacy.ts
@@ -13,7 +13,7 @@ export const toPharmacyInfo = (pharmacy: ErxGetPharmacyResponse): pharmacyInfo =
   ]
     .filter(Boolean)
     .join(', '),
-  phone: pharmacy.phone ? formatPhoneNumberDisplay(pharmacy.phone) : undefined,
+  phone: formatPhoneNumberDisplay(pharmacy.phone),
 });
 
 export const groupPrescriptionsByPharmacy = (

--- a/packages/zambdas/src/shared/pdf/helpers/pharmacy.ts
+++ b/packages/zambdas/src/shared/pdf/helpers/pharmacy.ts
@@ -1,13 +1,19 @@
 import { ErxGetPharmacyResponse } from '@oystehr/sdk';
-import { PrescribedMedicationDTO } from 'utils';
+import { formatPhoneNumberDisplay, formatZipcodeForDisplay, PrescribedMedicationDTO } from 'utils';
 import { pharmacyInfo } from '../types';
 
 export const toPharmacyInfo = (pharmacy: ErxGetPharmacyResponse): pharmacyInfo => ({
   name: pharmacy.name,
-  address: [pharmacy.address1, pharmacy.address2, pharmacy.city, pharmacy.state, pharmacy.zipCode]
+  address: [
+    pharmacy.address1,
+    pharmacy.address2,
+    pharmacy.city,
+    pharmacy.state,
+    pharmacy.zipCode ? formatZipcodeForDisplay(pharmacy.zipCode) : undefined,
+  ]
     .filter(Boolean)
     .join(', '),
-  phone: pharmacy.phone,
+  phone: pharmacy.phone ? formatPhoneNumberDisplay(pharmacy.phone) : undefined,
 });
 
 export const groupPrescriptionsByPharmacy = (


### PR DESCRIPTION
## Summary
- Formats the pharmacy ZIP code using `formatZipcodeForDisplay` (e.g. `123456789` → `12345-6789`)
- Formats the pharmacy phone number using `formatPhoneNumberDisplay` (e.g. `1234567890` → `(123) 456-7890`)
- Applied in both the UI (`PrescribedMedicationsContainer`) and PDF generation (`toPharmacyInfo` helper)

## Test plan
- [ ] Open a visit with an eRx prescription that has a dispensing pharmacy
- [ ] Verify the pharmacy phone displays as `(XXX) XXX-XXXX` in the progress note UI
- [ ] Verify the ZIP code displays as `XXXXX-XXXX` (9-digit) or `XXXXX` (5-digit)
- [ ] Generate a progress note PDF and discharge summary PDF — verify the same formatting applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)