### PR TITLE
fix(e2e): scope service category dropdown click to listbox option

### DIFF
--- a/apps/ehr/tests/e2e/page/AddPatientPage.ts
+++ b/apps/ehr/tests/e2e/page/AddPatientPage.ts
@@ -142,7 +142,7 @@ export class AddPatientPage {
       await expect(dropdown).toContainText(serviceCategory);
     } else {
       await dropdown.click();
-      await this.#page.getByText(serviceCategory).click();
+      await this.#page.getByRole('option', { name: serviceCategory }).click();
     }
   }
 }


### PR DESCRIPTION
🤖 generated.

getByText() matched both the combobox displayed value and the open listbox option, triggering Playwright strict mode violation when 2 elements resolved. Switching to getByRole('option') scopes the click to the listbox option only.

Fixes: https://github.com/masslight/hosted-ottehr-builds/actions/runs/29405024664
Failing test: apps/ehr/tests/e2e/page/AddPatientPage.ts:145