### PR TITLE
fix(ci): cap turbo concurrency to stop OOM-killed lint-and-build runs

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -102,7 +102,13 @@ jobs:
 
       - name: Build
         if: ${{ !contains(github.event.pull_request.body, '/skip-build-and-lint') }}
-        run: npm run build
+        # Cap turbo concurrency: with the default (10), several type-aware
+        # ESLint processes (~3GB RSS each) overlap with tsc + vite builds and
+        # peak memory exceeds the 16GB on the 4-core runner, killing the
+        # runner agent ("The operation was canceled", tasks SIGTERMed).
+        # Profiled on a 4-core/16GB box: default = 13.4GB peak @ 7m05s;
+        # --concurrency=3 = 8.8GB peak @ 6m45s (no wall-time cost at 4 cores).
+        run: npm run build -- --concurrency=3
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"
 


### PR DESCRIPTION
🤖 generated fix and description. But i've got direct experience setting concurrency limits for turbo to make jobs succeed on smaller runners before, so I'm familiar with this approach.

## Problem

The `lint-and-build` job on the 4-core (16GB) runner has been failing intermittently over the past week. Failing runs (e.g. [29413293171](https://github.com/masslight/ottehr/actions/runs/29413293171), [29397944927](https://github.com/masslight/ottehr/actions/runs/29397944927)) die ~3–4 minutes in with `tsc` / `vite build` receiving SIGTERM across multiple workspaces simultaneously, followed by `##[error]The operation was canceled.` — the signature of the runner agent itself being killed by memory exhaustion, not a build error.

## Root cause

`npm run build` runs `turbo build lint` — 22 tasks at turbo's **default concurrency of 10**:

- ESLint is type-aware (`parserOptions.project` + `no-floating-promises`), so each workspace's lint builds a full TS program in memory: **~3.0–3.7GB RSS per process** on the large workspaces
- `ehr`/`intake`/`utils`/`ui-components` builds each spawn **two** node processes (`concurrently "tsc" "vite build"`); vite peaks at 2.4–3.2GB
- every process gets `--max-old-space-size=8192`, so V8 GCs lazily

Profiled on a 4-core/15GB machine (same spec as the runner), the job peaks at **13.4GB** — right at the edge once the runner agent and OS are added. Which tasks hit the turbo cache varies per PR, so on unlucky runs all the heavy uncached tasks start at once and the runner OOMs; that's why failures are intermittent. A checkout from two weeks ago profiles essentially the same (13.8GB peak), so this isn't a sudden regression — the job has been at the cliff for a while and recent source growth (~56k lines, no dependency changes) tipped it over.

## Fix

Cap turbo at `--concurrency=3` in the workflow's Build step:

| Configuration | Wall time | Peak memory |
|---|---|---|
| default (concurrency 10) | 7m05s | 13.4GB |
| `--concurrency=3` | 6m45s | **8.8GB** |

It's not just safer — it's slightly **faster**, because 4 cores were already oversubscribed (load average 13); parallelism beyond the core count was pure memory cost. Note that a burst of 3 tasks is still up to ~6 node processes when build tasks spawn tsc+vite pairs, which is why 3 (not 4) is the right cap. All 22 tasks pass with this configuration.

Scoped to the workflow only (not the root `package.json` script) so developers on larger machines keep full parallelism. Avoids moving to the 8-core runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkeY1ySe2qKSh4ud31qotS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkeY1ySe2qKSh4ud31qotS)_