### PR TITLE
adds encounter.type to appointment search elements

### DIFF
--- a/packages/zambdas/src/ehr/get-appointments/helpers.ts
+++ b/packages/zambdas/src/ehr/get-appointments/helpers.ts
@@ -48,6 +48,7 @@ export const APPOINTMENT_SEARCH_ELEMENTS = [
   'Encounter.extension',
   'Encounter.location',
   'Encounter.partOf',
+  'Encounter.type',
   'QuestionnaireResponse.id',
   'QuestionnaireResponse.questionnaire',
   'QuestionnaireResponse.encounter',

--- a/packages/zambdas/src/ehr/get-appointments/index.ts
+++ b/packages/zambdas/src/ehr/get-appointments/index.ts
@@ -302,7 +302,7 @@ export const index = wrapHandler('get-appointments', async (input: ZambdaInput):
       if (patientId) patientIds.push(`Patient/${patientId}`);
     } else if (resource.resourceType === 'Patient' && resource.id) {
       patientIdMap[resource.id] = resource as Patient;
-    } else if (resource.resourceType === 'Encounter' && !isAnnotationFollowupEncounter(resource as Encounter)) {
+    } else if (resource.resourceType === 'Encounter' && !isAnnotationFollowupEncounter(resource)) {
       const asEnc = resource as Encounter;
       const apptRef = asEnc.appointment?.[0].reference;
       if (apptRef) {


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-3054/annotation-follow-up-when-annotation-follow-up-is-created-it-shouldnt