### PR TITLE
Trying to fix payment type for WC visits in candid claims sync process

### DIFF
--- a/packages/zambdas/src/shared/candid.ts
+++ b/packages/zambdas/src/shared/candid.ts
@@ -129,22 +129,18 @@ const CANDID_CASH_PAY_PAYER = 'Cash Pay';
 
 /**
  * Whether the claim should bill a single "Cash Pay" payer instead of insurance. This is true for
- * self-pay visits, and for employer-paid visits only when the visit is occupational medicine. The
+ * self-pay visits, and for employer-paid visits only when the visit is occupational medicine or worker compensation. The
  * payment variant comes from the encounter (the authoritative billing signal chosen during paperwork).
  * Note an occupational-medicine *service category* visit can still be insurance-pay, so the service
  * category must not be used on its own to make this decision; it only gates the employer variant.
- *
- * WC visits always use their WC insurance coverage regardless of the payment variant. A WC patient
- * without general insurance may select "I will pay without insurance" on the payment page (which sets
- * paymentVariant = selfPay), but the WC insurer — not Cash Pay — is the correct billing vehicle.
  */
 const shouldUseCashPayCoverage = (encounter: Encounter, appointment: Appointment): boolean => {
-  if (isAppointmentWorkersComp(appointment)) {
-    return false;
-  }
   const paymentVariant = getPaymentVariantFromEncounter(encounter);
   if (paymentVariant === PaymentVariant.selfPay) {
     return true;
+  }
+  if (isAppointmentWorkersComp(appointment)) {
+    return false;
   }
   if (paymentVariant === PaymentVariant.employer) {
     return isAppointmentOccupationalMedicine(appointment);
@@ -1255,14 +1251,10 @@ export async function createEncounterFromAppointment(
   }
 
   // here we're setting claim type (self-pay or insurance-pay), if nothing provided it'll be insurance-pay
-  // WC visits always bill through WC insurance, so they are always InsurancePay even when the
-  // encounter's paymentVariant is selfPay (a WC patient without general insurance selects
-  // "I will pay without insurance" on the payment page, which sets selfPay, but the WC insurer
-  // is still the responsible party for the claim).
   const packageEncounter = visitResources.encounter;
   const paymentVariantFromEncounter = getPaymentVariantFromEncounter(packageEncounter);
   const candidResponsibleParty: ResponsiblePartyType =
-    !isAppointmentWorkersComp(visitResources.appointment) && paymentVariantFromEncounter === PaymentVariant.selfPay
+    paymentVariantFromEncounter === PaymentVariant.selfPay
       ? ResponsiblePartyType.SelfPay
       : ResponsiblePartyType.InsurancePay;
   if (candidResponsibleParty && candidEncounterId) {


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2918/candid-wc-insurance-isnt-shown-for-wc-visits-if-general-insurance-isnt