### PR TITLE
fix: mock ui-components/lib/utils/heic directly in FileInput test

### DIFF
--- a/apps/intake/tests/component/FileInput.test.tsx
+++ b/apps/intake/tests/component/FileInput.test.tsx
@@ -14,6 +14,13 @@ vi.mock('browser-image-compression', () => ({
   default: vi.fn(async (file: File) => file),
 }));
 
+// FileInput/index.tsx imports convertHeicToJpegIfNeeded via a relative path
+// (../../../../utils/heic), not the ui-components barrel, so we must mock the
+// resolved module path directly.
+vi.mock('ui-components/lib/utils/heic', () => ({
+  convertHeicToJpegIfNeeded: vi.fn(async (file: File) => file),
+}));
+
 vi.mock('ui-components', async () => {
   const actual = await vi.importActual<typeof import('ui-components')>('ui-components');
   return {


### PR DESCRIPTION
FileInput/index.tsx imports convertHeicToJpegIfNeeded from a relative path (../../../../utils/heic), not the ui-components barrel export. The existing vi.mock('ui-components', ...) therefore never intercepted the actual import, causing the real dynamic import('heic-to') to run in jsdom — slow enough to race against waitFor's default timeout.

Add vi.mock('ui-components/lib/utils/heic', ...) which resolves to the same module path that FileInput uses internally, ensuring the stub is applied before the file-change handler fires.

Fixes: test "compresses images exactly at the threshold" in apps/intake/tests/component/FileInput.test.tsx:99

Parent run: https://github.com/masslight/hosted-ottehr-builds/actions/runs/29909304782