### PR TITLE
Billing app. Validate that city in addresses is at least 2 characters long

### DIFF
--- a/apps/billing/src/components/AddressFields.tsx
+++ b/apps/billing/src/components/AddressFields.tsx
@@ -42,7 +42,13 @@ export function AddressFields({ requireFullZip }: { requireFullZip?: boolean }):
       <Controller
         name="city"
         control={control}
-        rules={{ required: REQUIRED_FIELD_ERROR_MESSAGE }}
+        rules={{
+          required: REQUIRED_FIELD_ERROR_MESSAGE,
+          validate: (value) => {
+            if (value.length < 2) return 'Must be least 2 chars long';
+            return true;
+          },
+        }}
         render={({ field, fieldState: { error: fieldError } }) => (
           <TextField
             label="City *"


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2955/claim-submission-requires-that-city-in-addresses-be-at-least-2