### PR TITLE
OTR-2997: Improve employers-zambdas test hooks

### DIFF
--- a/packages/zambdas/test/rcm/employers-zambdas.test.ts
+++ b/packages/zambdas/test/rcm/employers-zambdas.test.ts
@@ -1,6 +1,6 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { Organization } from 'fhir/r4b';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 function makeInput(body: Record<string, unknown>): ZambdaInput {
@@ -71,11 +71,11 @@ function makeEmployer(overrides?: Partial<Organization>): Organization {
 }
 
 describe('RCM employer zambdas', () => {
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    vi.resetModules();
-    mockCreateCandidClientIfConfigured.mockReturnValue(null);
-
+  // Import the handlers once. The handlers' only module-scoped state is a cached m2mToken, and
+  // checkOrCreateM2MClientToken is mocked to a constant, so there is nothing to reset between tests.
+  // Re-importing them per-test (with vi.resetModules) forces the whole ../../src/shared barrel to be
+  // reloaded on every test — cold, that reload can exceed the default 10s hook timeout.
+  beforeAll(async () => {
     ({ index: createEmployerHandler } = (await import('../../src/rcm/employers/create-employer/index')) as {
       index: ZambdaHandler;
     });
@@ -85,6 +85,11 @@ describe('RCM employer zambdas', () => {
     ({ index: listEmployersHandler } = (await import('../../src/rcm/employers/list-employers/index')) as {
       index: ZambdaHandler;
     });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateCandidClientIfConfigured.mockReturnValue(null);
   });
 
   it('create-employer creates org and persists Candid payer id when Candid sync succeeds', async () => {


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2997/automated-test-hook-timeout

Wasn't able to reproduce the bug but improved `employers-zambdas.test.ts` beforeEach hook, added beforeAll hook.

> It should not talk to candid from a unit test but probably that is happening ?

Candid wasn't being hit — it's mocked at `employers-zambdas.test.ts`, plus `no-network.setup.ts` blocks egress.