### PR TITLE
OTR-2462: enforce NPI for NPI-gated actions in zambdas

### DIFF
--- a/packages/zambdas/src/ehr/create-update-medication-order/index.ts
+++ b/packages/zambdas/src/ehr/create-update-medication-order/index.ts
@@ -40,6 +40,7 @@ import {
   checkOrCreateM2MClientToken,
   createClinicalOystehrClient,
   getMyPractitionerId,
+  requirePractitionerNPI,
   wrapHandler,
   ZambdaInput,
 } from '../../shared';
@@ -123,6 +124,10 @@ async function performEffect(
       id: orderId,
     };
   } else if (orderData) {
+    // Ordering (creating) an in-house medication order is an NPI-gated action — block callers without
+    // an NPI (e.g. Clinician role). Administering / changing the status of an existing order (handled by
+    // the branches above) stays allowed, since that is a routine nurse/MA task.
+    await requirePractitionerNPI(oystehr, practitionerIdCalledZambda);
     const medicationAdministrationId = await createOrder(
       oystehr,
       orderData,

--- a/packages/zambdas/src/ehr/lab/external/create-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/external/create-lab-order/index.ts
@@ -7,7 +7,12 @@ import {
   getSecret,
   SecretsKeys,
 } from 'utils';
-import { checkOrCreateM2MClientToken, getMyPractitionerId, wrapHandler } from '../../../../shared';
+import {
+  assertPractitionerHasNPI,
+  checkOrCreateM2MClientToken,
+  getMyPractitionerId,
+  wrapHandler,
+} from '../../../../shared';
 import { createClinicalOystehrClient } from '../../../../shared/helpers';
 import { ZambdaInput } from '../../../../shared/types';
 import { buildExternalLabOrderRequests } from './build-order';
@@ -47,6 +52,9 @@ export const index = wrapHandler('create-lab-order', async (input: ZambdaInput):
     resourceType: 'Practitioner',
     id: curUserPractitionerId,
   });
+
+  // Ordering an external lab is an NPI-gated action — block callers without an NPI (e.g. Clinician role).
+  assertPractitionerHasNPI(currentUserPractitioner);
 
   console.log('>>> this is the encounter,', JSON.stringify(encounter, undefined, 2));
   const attendingPractitionerId = getAttendingPractitionerId(encounter);

--- a/packages/zambdas/src/ehr/lab/external/submit-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/external/submit-lab-order/index.ts
@@ -13,7 +13,13 @@ import {
   SubmitLabOrderOutput,
   userMe,
 } from 'utils';
-import { checkOrCreateM2MClientToken, createClinicalOystehrClient, wrapHandler, ZambdaInput } from '../../../../shared';
+import {
+  checkOrCreateM2MClientToken,
+  createClinicalOystehrClient,
+  requirePractitionerNPI,
+  wrapHandler,
+  ZambdaInput,
+} from '../../../../shared';
 import {
   getBundledOrderResources,
   makeOrderFormsAndDocRefs,
@@ -41,6 +47,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
   const userToken = input.headers.Authorization.replace('Bearer ', '');
   const currentUser = await userMe(userToken, secrets);
+
+  // Submitting an external lab order is an NPI-gated action — block callers without an NPI (e.g. Clinician role).
+  await requirePractitionerNPI(oystehr, currentUser.profile.replace('Practitioner/', ''));
 
   const now = DateTime.now();
 

--- a/packages/zambdas/src/ehr/lab/external/submit-lab-order/index.ts
+++ b/packages/zambdas/src/ehr/lab/external/submit-lab-order/index.ts
@@ -10,6 +10,7 @@ import {
   getPatchBinary,
   getPatientFriendlyId,
   MANUAL_EXTERNAL_LAB_ORDER_CATEGORY_CODING,
+  removePrefix,
   SubmitLabOrderOutput,
   userMe,
 } from 'utils';
@@ -49,7 +50,11 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   const currentUser = await userMe(userToken, secrets);
 
   // Submitting an external lab order is an NPI-gated action — block callers without an NPI (e.g. Clinician role).
-  await requirePractitionerNPI(oystehr, currentUser.profile.replace('Practitioner/', ''));
+  const currentUserPractitionerId = removePrefix('Practitioner/', currentUser.profile);
+  if (!currentUserPractitionerId) {
+    throw EXTERNAL_LAB_ERROR('User submitting this external lab order must have a Practitioner resource linked');
+  }
+  await requirePractitionerNPI(oystehr, currentUserPractitionerId);
 
   const now = DateTime.now();
 

--- a/packages/zambdas/src/ehr/radiology/create-order/index.ts
+++ b/packages/zambdas/src/ehr/radiology/create-order/index.ts
@@ -47,6 +47,7 @@ import {
   userMe,
 } from 'utils';
 import {
+  assertPractitionerHasNPI,
   checkOrCreateM2MClientToken,
   createClinicalOystehrClient,
   fillMeta,
@@ -129,6 +130,9 @@ const performEffect = async (
     resourceType: 'Practitioner',
     id: practitionerRelativeReference.split('/')[1],
   });
+
+  // Ordering imaging is an NPI-gated action — block callers without an NPI (e.g. Clinician role).
+  assertPractitionerHasNPI(ourPractitioner);
 
   // Create the order in FHIR
   const ourServiceRequest = await writeOurServiceRequest(body, practitionerRelativeReference, oystehr);

--- a/packages/zambdas/src/ehr/sign-appointment/index.ts
+++ b/packages/zambdas/src/ehr/sign-appointment/index.ts
@@ -22,7 +22,13 @@ import {
   visitStatusToFhirAppointmentStatusMap,
   visitStatusToFhirEncounterStatusMap,
 } from 'utils';
-import { checkOrCreateM2MClientToken, getMyPractitionerId, wrapHandler, ZambdaInput } from '../../shared';
+import {
+  checkOrCreateM2MClientToken,
+  getMyPractitionerId,
+  requirePractitionerNPI,
+  wrapHandler,
+  ZambdaInput,
+} from '../../shared';
 import { createProvenanceForEncounter } from '../../shared/createProvenanceForEncounter';
 import { createPublishExcuseNotesOps } from '../../shared/createPublishExcuseNotesOps';
 import { createClinicalOystehrClient } from '../../shared/helpers';
@@ -56,6 +62,10 @@ export const performEffect = async (
   }
 ): Promise<SignAppointmentResponse> => {
   const { appointmentId, encounterId, timezone, supervisorApprovalEnabled, userToken, secrets } = params;
+
+  // Signing / co-signing a note is an NPI-gated action. Block callers whose Practitioner has no NPI
+  // (e.g. the Clinician role) — this also stops the downstream claim submission the sign kicks off.
+  await requirePractitionerNPI(oystehr, await getMyPractitionerId(userToken, secrets));
 
   const visitResources = await getAppointmentAndRelatedResources(oystehr, appointmentId, true, encounterId);
   if (!visitResources) {

--- a/packages/zambdas/src/ehr/sign-appointment/index.ts
+++ b/packages/zambdas/src/ehr/sign-appointment/index.ts
@@ -15,6 +15,7 @@ import {
   getSkipEmailTaskInput,
   getTaskResource,
   isAnnotationFollowupEncounter,
+  removePrefix,
   SignAppointmentInput,
   SignAppointmentResponse,
   TaskIndicator,
@@ -22,13 +23,7 @@ import {
   visitStatusToFhirAppointmentStatusMap,
   visitStatusToFhirEncounterStatusMap,
 } from 'utils';
-import {
-  checkOrCreateM2MClientToken,
-  getMyPractitionerId,
-  requirePractitionerNPI,
-  wrapHandler,
-  ZambdaInput,
-} from '../../shared';
+import { checkOrCreateM2MClientToken, requirePractitionerNPI, wrapHandler, ZambdaInput } from '../../shared';
 import { createProvenanceForEncounter } from '../../shared/createProvenanceForEncounter';
 import { createPublishExcuseNotesOps } from '../../shared/createPublishExcuseNotesOps';
 import { createClinicalOystehrClient } from '../../shared/helpers';
@@ -63,9 +58,16 @@ export const performEffect = async (
 ): Promise<SignAppointmentResponse> => {
   const { appointmentId, encounterId, timezone, supervisorApprovalEnabled, userToken, secrets } = params;
 
+  // Resolve the acting user once up front and reuse it below, rather than calling userMe repeatedly.
+  const currentUser = await userMe(userToken, secrets);
+  const practitionerId = removePrefix('Practitioner/', currentUser.profile);
+  if (!practitionerId) {
+    throw new Error("Can't resolve the Practitioner resource id attached to the current user");
+  }
+
   // Signing / co-signing a note is an NPI-gated action. Block callers whose Practitioner has no NPI
   // (e.g. the Clinician role) — this also stops the downstream claim submission the sign kicks off.
-  await requirePractitionerNPI(oystehr, await getMyPractitionerId(userToken, secrets));
+  await requirePractitionerNPI(oystehr, practitionerId);
 
   const visitResources = await getAppointmentAndRelatedResources(oystehr, appointmentId, true, encounterId);
   if (!visitResources) {
@@ -94,8 +96,12 @@ export const performEffect = async (
   if (isFollowup) {
     // For follow-up encounters: only update encounter status and create PDF (no appointment updates, no email)
     if (currentStatus) {
-      const userId = await getMyPractitionerId(userToken, secrets);
-      await changeFollowupEncounterStatusToCompleted(oystehr, userId, visitResources, supervisorApprovalEnabled);
+      await changeFollowupEncounterStatusToCompleted(
+        oystehr,
+        practitionerId,
+        visitResources,
+        supervisorApprovalEnabled
+      );
     }
     console.debug(`Follow-up encounter status has been changed.`);
 
@@ -117,8 +123,7 @@ export const performEffect = async (
   } else {
     // For regular encounters: keep existing behavior
     if (currentStatus) {
-      const user = await userMe(userToken, secrets);
-      await changeStatusToCompleted(oystehr, user, visitResources, supervisorApprovalEnabled);
+      await changeStatusToCompleted(oystehr, currentUser, visitResources, supervisorApprovalEnabled);
     }
     console.debug(`Status has been changed.`);
 

--- a/packages/zambdas/src/shared/auth.ts
+++ b/packages/zambdas/src/shared/auth.ts
@@ -1,7 +1,8 @@
 import Oystehr, { User } from '@oystehr/sdk';
-import { Patient, RelatedPerson } from 'fhir/r4b';
+import { Patient, Practitioner, RelatedPerson } from 'fhir/r4b';
 import { decodeJwt } from 'jose';
 import {
+  getNPIIdentifier,
   getPatientsForUser,
   getSecret,
   NOT_AUTHORIZED,
@@ -45,6 +46,29 @@ export const requireUserWithRole = async (
 
 export const requireAdminUser = async (userToken: string, secrets: Secrets | null): Promise<void> => {
   await requireUserWithRole(userToken, secrets, [RoleType.Administrator]);
+};
+
+/**
+ * Throws NOT_AUTHORIZED unless the given Practitioner has an NPI identifier.
+ *
+ * NPI-gated actions (signing/co-signing notes, e-prescribing, ordering external labs & imaging,
+ * submitting claims under a provider NPI, and ordering in-house medications) must be performed
+ * only by a user whose Practitioner carries an NPI. The clinical zambdas run their FHIR writes
+ * under an M2M token, so the caller's Oystehr access policy does not gate them — this check is the
+ * backend enforcement point that blocks non-NPI roles such as Clinician from reaching these actions
+ * via a direct API call.
+ */
+export const assertPractitionerHasNPI = (practitioner: Practitioner): void => {
+  if (!getNPIIdentifier(practitioner)?.value) {
+    throw NOT_AUTHORIZED;
+  }
+};
+
+/** Reads the Practitioner and asserts it has an NPI. See {@link assertPractitionerHasNPI}. */
+export const requirePractitionerNPI = async (oystehr: Oystehr, practitionerId: string): Promise<Practitioner> => {
+  const practitioner = await oystehr.fhir.get<Practitioner>({ resourceType: 'Practitioner', id: practitionerId });
+  assertPractitionerHasNPI(practitioner);
+  return practitioner;
 };
 
 export async function getPersonForPatient(patientID: string, oystehr: Oystehr): Promise<RelatedPerson | undefined> {

--- a/packages/zambdas/test/helpers/integration-global-setup.ts
+++ b/packages/zambdas/test/helpers/integration-global-setup.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'crypto';
 import { Patient, Practitioner } from 'fhir/r4b';
 import { Server } from 'http';
 import type { AddressInfo } from 'net';
-import { M2MClientMockType, RoleType } from 'utils';
+import { FHIR_IDENTIFIER_NPI, M2MClientMockType, RoleType } from 'utils';
 import type { TestProject } from 'vitest/node';
 import app from '../../src/local-server/index';
 import { getAuth0Token } from '../../src/shared';
@@ -104,6 +104,9 @@ async function provisionSharedClient(
             name: [{ given: ['Integration'], family: 'TestsProvider' }],
             birthDate: '1990-01-01',
             telecom: [{ system: 'phone', value: '+11231231234', use: 'mobile' }],
+            // NPI is required for NPI-gated actions (sign, external labs, imaging, in-house med orders).
+            // The shared provider fixture stands in for a full Provider, so give it a (valid) NPI.
+            identifier: [{ system: FHIR_IDENTIFIER_NPI, value: '1234567893' }],
           },
           runId
         ) as Practitioner

--- a/packages/zambdas/test/unit/require-practitioner-npi.test.ts
+++ b/packages/zambdas/test/unit/require-practitioner-npi.test.ts
@@ -1,0 +1,76 @@
+import Oystehr from '@oystehr/sdk';
+import { Practitioner } from 'fhir/r4b';
+import { FHIR_IDENTIFIER_NPI, NOT_AUTHORIZED } from 'utils';
+import { describe, expect, it } from 'vitest';
+import { assertPractitionerHasNPI, requirePractitionerNPI } from '../../src/shared/auth';
+
+// Backend enforcement for NPI-gated actions (sign/co-sign notes, e-prescribe, external labs &
+// imaging orders, claim submission, in-house medication orders). A user without an NPI on their
+// Practitioner (e.g. the Clinician role) must be rejected with NOT_AUTHORIZED.
+
+const practitionerWithNPI: Practitioner = {
+  resourceType: 'Practitioner',
+  id: 'p-with-npi',
+  identifier: [{ system: FHIR_IDENTIFIER_NPI, value: '1234567893' }],
+};
+
+const practitionerWithoutNPI: Practitioner = {
+  resourceType: 'Practitioner',
+  id: 'p-without-npi',
+};
+
+const practitionerWithOtherIdentifierOnly: Practitioner = {
+  resourceType: 'Practitioner',
+  id: 'p-other-id',
+  identifier: [{ system: 'http://example.com/some-other-id', value: 'abc' }],
+};
+
+const practitionerWithEmptyNPIValue: Practitioner = {
+  resourceType: 'Practitioner',
+  id: 'p-empty-npi',
+  identifier: [{ system: FHIR_IDENTIFIER_NPI, value: '' }],
+};
+
+const expectNotAuthorized = (fn: () => unknown): void => {
+  let thrown: unknown;
+  try {
+    fn();
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).toEqual(NOT_AUTHORIZED);
+};
+
+describe('assertPractitionerHasNPI', () => {
+  it('passes when the practitioner has an NPI identifier', () => {
+    expect(() => assertPractitionerHasNPI(practitionerWithNPI)).not.toThrow();
+  });
+
+  it('throws NOT_AUTHORIZED when there is no identifier at all', () => {
+    expectNotAuthorized(() => assertPractitionerHasNPI(practitionerWithoutNPI));
+  });
+
+  it('throws NOT_AUTHORIZED when the only identifier is not an NPI', () => {
+    expectNotAuthorized(() => assertPractitionerHasNPI(practitionerWithOtherIdentifierOnly));
+  });
+
+  it('throws NOT_AUTHORIZED when the NPI identifier has an empty value', () => {
+    expectNotAuthorized(() => assertPractitionerHasNPI(practitionerWithEmptyNPIValue));
+  });
+});
+
+describe('requirePractitionerNPI', () => {
+  const makeOystehr = (practitioner: Practitioner): Oystehr =>
+    ({ fhir: { get: async () => practitioner } }) as unknown as Oystehr;
+
+  it('reads the practitioner and returns it when it has an NPI', async () => {
+    const result = await requirePractitionerNPI(makeOystehr(practitionerWithNPI), 'p-with-npi');
+    expect(result).toBe(practitionerWithNPI);
+  });
+
+  it('rejects with NOT_AUTHORIZED when the practitioner has no NPI', async () => {
+    await expect(requirePractitionerNPI(makeOystehr(practitionerWithoutNPI), 'p-without-npi')).rejects.toEqual(
+      NOT_AUTHORIZED
+    );
+  });
+});

--- a/scripts/e2e-test-setup.ts
+++ b/scripts/e2e-test-setup.ts
@@ -5,7 +5,9 @@ import { FhirResource, HealthcareService, Location, Practitioner, Schedule } fro
 import fs from 'fs';
 import {
   allLicensesForPractitioner,
+  FHIR_IDENTIFIER_NPI,
   FULL_DAY_SCHEDULE,
+  getNPIIdentifier,
   makeQualificationForPractitioner,
   SCHEDULE_EXTENSION_URL,
   TIMEZONE_EXTENSION_URL,
@@ -266,12 +268,13 @@ async function getLocationsForTesting(ehrZambdaEnv: Record<string, string>): Pro
   };
 }
 
-async function setTestEhrUserCredentials(ehrConfig: EhrConfig): Promise<void> {
-  if (!isVirtualEnabled) {
-    console.warn('No virtual locations configured — skipping telemed practitioner setup');
-    return;
-  }
+// The e2e provider stands in for a full Provider. NPI-gated actions (sign/co-sign, external labs &
+// imaging orders, in-house medication orders) are enforced in the zambdas via requirePractitionerNPI, so
+// without an NPI on file every ordering and signing spec fails — the zambda returns NOT_AUTHORIZED and
+// the EHR also disables the affected buttons. Same value the shared integration-test provider uses.
+const TEST_PRACTITIONER_NPI = '1234567893';
 
+async function setTestEhrUserCredentials(ehrConfig: EhrConfig): Promise<void> {
   console.log(`Setting up test EHR provider credentials`);
   const oystehr = await getToken(ehrConfig, ehrConfig.AUTH0_CLIENT_TESTS, ehrConfig.AUTH0_SECRET_TESTS);
 
@@ -301,30 +304,48 @@ async function setTestEhrUserCredentials(ehrConfig: EhrConfig): Promise<void> {
     throw Error('e2e test user profile practitioner not found');
   }
 
-  const firstDefaultVirtualLocation = virtualDefaultLocations[0];
+  const updates: Partial<Practitioner> = {};
 
-  const licenses = allLicensesForPractitioner(practitioner);
-  const qualification = practitioner.qualification || [];
-  if (!licenses.find((license) => license.state === firstDefaultVirtualLocation.state)) {
-    qualification.push(
-      makeQualificationForPractitioner({
-        state: firstDefaultVirtualLocation.state,
-        number: '1234567890',
-        code: 'MD',
-        active: true,
-      })
-    );
+  // Not telemed-specific, so this runs even when no virtual locations are configured.
+  if (!getNPIIdentifier(practitioner)?.value) {
+    console.log(`Adding NPI to e2e test practitioner ${practitioner.id}`);
+    updates.identifier = [
+      ...(practitioner.identifier ?? []),
+      { system: FHIR_IDENTIFIER_NPI, value: TEST_PRACTITIONER_NPI },
+    ];
+  }
 
-    try {
-      await oystehr.fhir.update<Practitioner>({
-        id: practitioner.id!,
-        ...practitioner,
-        qualification,
-      });
-    } catch (error) {
-      console.error('Error updating e2e test practitioner qualifications', error);
-      throw error;
+  if (isVirtualEnabled) {
+    const firstDefaultVirtualLocation = virtualDefaultLocations[0];
+    const licenses = allLicensesForPractitioner(practitioner);
+    if (!licenses.find((license) => license.state === firstDefaultVirtualLocation.state)) {
+      updates.qualification = [
+        ...(practitioner.qualification ?? []),
+        makeQualificationForPractitioner({
+          state: firstDefaultVirtualLocation.state,
+          number: '1234567890',
+          code: 'MD',
+          active: true,
+        }),
+      ];
     }
+  } else {
+    console.warn('No virtual locations configured — skipping telemed practitioner license setup');
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return;
+  }
+
+  try {
+    await oystehr.fhir.update<Practitioner>({
+      ...practitioner,
+      id: practitioner.id!,
+      ...updates,
+    });
+  } catch (error) {
+    console.error('Error updating e2e test practitioner credentials', error);
+    throw error;
   }
 }
 


### PR DESCRIPTION
Add assertPractitionerHasNPI / requirePractitionerNPI to shared/auth and
call them in the clinical zambdas that perform NPI-gated actions, so a
non-NPI user (e.g. the upcoming Clinician role) hitting these endpoints
directly gets NOT_AUTHORIZED rather than relying on the UI hiding buttons:

- sign-appointment (also blocks the claim submission it kicks off)
- external lab: create-lab-order, submit-lab-order
- radiology: create-order
- create-update-medication-order: only the create/order path; administering
  or changing status of an existing order stays allowed (routine nurse task)

Give the shared integration-test provider Practitioner an NPI so the existing
sign / medication-order integration tests keep passing, and add unit tests for
the new helpers.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>