### PR TITLE
OTR-2462: gate NPI-only actions in the EHR UI on NPI presence

### DIFF
--- a/apps/ehr/src/components/navigation/UserMenu.tsx
+++ b/apps/ehr/src/components/navigation/UserMenu.tsx
@@ -35,7 +35,10 @@ export const UserMenu: FC = () => {
   const [anchorElement, setAnchorElement] = useState<HTMLElement | null>(null);
   const [pendingReviewOpen, setPendingReviewOpen] = useState<boolean>(false);
   const user = useEvolveUser();
-  const userIsProvider = user?.hasRole([RoleType.Provider]);
+  // eRX enrollment/notifications require an NPI (DoseSpot). The provider notifications bell is a
+  // general, visit-linked inbox — not NPI-gated — so keep it on a role check.
+  const userHasNPI = user?.hasNPI;
+  const showProviderNotifications = user?.hasRole([RoleType.Provider]);
 
   const practitioner = user?.profileResource;
 
@@ -104,7 +107,7 @@ export const UserMenu: FC = () => {
     <>
       <CommandPaletteSearchButton sx={{ mr: 2 }} />
       <UnsolicitedResultsIcon />
-      {userIsProvider && <ProviderNotifications />}
+      {showProviderNotifications && <ProviderNotifications />}
       <ListItem disablePadding sx={{ width: 'fit-content' }}>
         <ListItemButton onClick={(event: MouseEvent<HTMLElement>) => setAnchorElement(event.currentTarget)}>
           <ListItemAvatar sx={{ minWidth: 'auto', mr: { xs: '0', sm: 2 } }}>
@@ -131,7 +134,7 @@ export const UserMenu: FC = () => {
           </Box>
         </MenuItem>
         <Divider />
-        {isPractitionerEnrollmentChecked && userIsProvider && !practitionerEnrollmentStatus?.identityVerified && (
+        {isPractitionerEnrollmentChecked && userHasNPI && !practitionerEnrollmentStatus?.identityVerified && (
           <>
             {practitionerMissingFields.length > 0 && (
               <Box sx={{ display: 'flex', alignItems: 'center', maxWidth: 300, gap: 1, padding: '6px 16px' }}>

--- a/apps/ehr/src/features/external-labs/pages/CreateExternalLabOrder.tsx
+++ b/apps/ehr/src/features/external-labs/pages/CreateExternalLabOrder.tsx
@@ -36,6 +36,7 @@ import {
   useChartData,
   useSaveChartData,
 } from 'src/features/visits/shared/stores/appointment/appointment.store';
+import useEvolveUser from 'src/hooks/useEvolveUser';
 import { useDebounce } from 'src/shared/hooks/useDebounce';
 import {
   APIErrorCode,
@@ -123,6 +124,8 @@ export const CreateExternalLabOrder: React.FC<CreateExternalLabOrdersProps> = ()
   );
   const [labOrgIdsForSelectedOffice, setLabOrgIdsForSelectedOffice] = useState<string>('');
   const [isOrderingDisabled, setIsOrderingDisabled] = useState<boolean>(false);
+  // Ordering external labs is NPI-gated — block users without an NPI on file (e.g. the Clinician role).
+  const hasNPI = useEvolveUser()?.hasNPI ?? false;
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<CreateLabPaymentMethod | ''>(
     draft.selectedPaymentMethod ?? formStateDefaults.selectedPaymentMethod
   );
@@ -760,7 +763,7 @@ export const CreateExternalLabOrder: React.FC<CreateExternalLabOrdersProps> = ()
                 <Grid item xs={6} display="flex" justifyContent="flex-end">
                   <LoadingButton
                     data-testid={dataTestIds.externalLabs.createPg.createExternalLabOrderBtn}
-                    disabled={isOrderingDisabled}
+                    disabled={isOrderingDisabled || !hasNPI}
                     loading={submitting}
                     type="submit"
                     variant="contained"
@@ -769,6 +772,13 @@ export const CreateExternalLabOrder: React.FC<CreateExternalLabOrdersProps> = ()
                     Order
                   </LoadingButton>
                 </Grid>
+                {!hasNPI && (
+                  <Grid item xs={12} sx={{ textAlign: 'right', paddingTop: 1 }}>
+                    <Typography sx={{ color: theme.palette.error.main }}>
+                      You need an NPI on file to order external labs
+                    </Typography>
+                  </Grid>
+                )}
                 {Array.isArray(error) &&
                   error.length > 0 &&
                   error.map((msg, idx) => (

--- a/apps/ehr/src/features/radiology/components/RadiologyOrderFormShared.tsx
+++ b/apps/ehr/src/features/radiology/components/RadiologyOrderFormShared.tsx
@@ -323,7 +323,8 @@ export const RadiologyOrderFormActions: React.FC<{
   onCancel?: () => void;
   cancelUrl?: string;
   clearFormButton?: React.ReactNode;
-}> = ({ appointmentId, submitting, submitLabel, errors, onCancel, cancelUrl, clearFormButton }) => {
+  disabled?: boolean;
+}> = ({ appointmentId, submitting, submitLabel, errors, onCancel, cancelUrl, clearFormButton, disabled }) => {
   const navigate = useNavigate();
   const theme = useTheme();
   return (
@@ -347,6 +348,7 @@ export const RadiologyOrderFormActions: React.FC<{
         <LoadingButton
           data-testid={dataTestIds.radiologyPage.submitOrderButton}
           loading={submitting}
+          disabled={disabled}
           type="submit"
           variant="contained"
           sx={{ borderRadius: '50px', textTransform: 'none', fontWeight: 600 }}

--- a/apps/ehr/src/features/radiology/pages/CreateExternalRadiologyOrder.tsx
+++ b/apps/ehr/src/features/radiology/pages/CreateExternalRadiologyOrder.tsx
@@ -18,6 +18,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import DetailPageContainer from 'src/features/common/DetailPageContainer';
 import { getRadiologyExternalOrderDetailsUrl, getRadiologyUrl } from 'src/features/visits/in-person/routing/helpers';
 import { useAppointmentData } from 'src/features/visits/shared/stores/appointment/appointment.store';
+import useEvolveUser from 'src/hooks/useEvolveUser';
 import { InputMask } from 'ui-components';
 import {
   DiagnosisDTO,
@@ -62,6 +63,7 @@ export const CreateExternalRadiologyOrder: React.FC<CreateExternalRadiologyOrder
   const { oystehrZambda } = useApiClients();
   const navigate = useNavigate();
   const { id: appointmentIdFromUrl } = useParams();
+  const hasNPI = useEvolveUser()?.hasNPI ?? false;
   const isEditMode = !!initialOrder;
   const [error, setError] = useState<string[] | undefined>(undefined);
   const [submitting, setSubmitting] = useState<boolean>(false);
@@ -319,7 +321,8 @@ export const CreateExternalRadiologyOrder: React.FC<CreateExternalRadiologyOrder
                   appointmentId={appointmentIdFromUrl || ''}
                   submitting={submitting}
                   submitLabel={isEditMode ? 'Save & Print' : 'Order & Print'}
-                  errors={error}
+                  disabled={!hasNPI}
+                  errors={hasNPI ? error : [...(error ?? []), 'You need an NPI on file to order imaging']}
                   cancelUrl={
                     initialOrder
                       ? getRadiologyExternalOrderDetailsUrl(appointmentIdFromUrl || '', initialOrder.serviceRequestId)

--- a/apps/ehr/src/features/radiology/pages/CreateRadiologyOrder.tsx
+++ b/apps/ehr/src/features/radiology/pages/CreateRadiologyOrder.tsx
@@ -147,6 +147,8 @@ export const CreateRadiologyOrder: React.FC<CreateRadiologyOrdersProps> = () => 
   const [confirmOverwriteOpen, setConfirmOverwriteOpen] = useState(false);
   const currentUser = useEvolveUser();
   const isAdmin = currentUser?.hasRole([RoleType.Administrator, RoleType.CustomerSupport]) ?? false;
+  // Ordering imaging is NPI-gated — block users without an NPI on file (e.g. the Clinician role).
+  const hasNPI = currentUser?.hasNPI ?? false;
 
   // Quick pick handlers
   const onQuickPickSelect = (quickPick: RadiologyQuickPickData): void => {
@@ -379,7 +381,8 @@ export const CreateRadiologyOrder: React.FC<CreateRadiologyOrdersProps> = () => 
                   appointmentId={appointmentIdFromUrl || ''}
                   submitting={submitting}
                   submitLabel="Order"
-                  errors={error}
+                  disabled={!hasNPI}
+                  errors={hasNPI ? error : [...(error ?? []), 'You need an NPI on file to order imaging']}
                   onCancel={() => {
                     if (encounter.id) clearDraft(encounter.id);
                   }}

--- a/apps/ehr/src/features/visits/in-person/components/medication-administration/OrderButton.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/medication-administration/OrderButton.tsx
@@ -1,7 +1,8 @@
-import { SxProps } from '@mui/material';
+import { SxProps, Tooltip } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import useEvolveUser from 'src/hooks/useEvolveUser';
 import { getNewMedicationOrderUrl } from '../../routing/helpers';
 import { ButtonRounded } from '../RoundedButton';
 
@@ -14,6 +15,9 @@ interface OrderButtonProps {
 export const OrderButton: React.FC<OrderButtonProps> = ({ size = 'medium', sx, dataTestId }) => {
   const navigate = useNavigate();
   const { id: appointmentId } = useParams();
+  // Ordering in-house medications is NPI-gated — a user without an NPI (e.g. the Clinician role) can
+  // still administer existing orders, but cannot create new ones.
+  const hasNPI = useEvolveUser()?.hasNPI ?? false;
 
   const onClick = (): void => {
     if (!appointmentId) {
@@ -24,19 +28,24 @@ export const OrderButton: React.FC<OrderButtonProps> = ({ size = 'medium', sx, d
   };
 
   return (
-    <ButtonRounded
-      variant="contained"
-      color="primary"
-      size={size}
-      onClick={onClick}
-      sx={{
-        py: 1,
-        px: 5,
-        ...sx,
-      }}
-      data-testid={dataTestId}
-    >
-      Order
-    </ButtonRounded>
+    <Tooltip title={hasNPI ? '' : 'You need an NPI on file to order in-house medications'}>
+      <span>
+        <ButtonRounded
+          variant="contained"
+          color="primary"
+          size={size}
+          disabled={!hasNPI}
+          onClick={onClick}
+          sx={{
+            py: 1,
+            px: 5,
+            ...sx,
+          }}
+          data-testid={dataTestId}
+        >
+          Order
+        </ButtonRounded>
+      </span>
+    </Tooltip>
   );
 };

--- a/apps/ehr/src/features/visits/in-person/pages/InHouseOrderNew.tsx
+++ b/apps/ehr/src/features/visits/in-person/pages/InHouseOrderNew.tsx
@@ -1,5 +1,6 @@
 import { Stack } from '@mui/material';
 import React, { useLayoutEffect, useRef } from 'react';
+import useEvolveUser from 'src/hooks/useEvolveUser';
 import { InHouseOrderNewBreadcrumbs } from '../components/breadcrumbs/InHouseOrderNewBreadcrumbs';
 import { InfoAlert } from '../components/InfoAlert';
 import { MedicationWarnings } from '../components/medication-administration/medication-details/MedicationWarnings';
@@ -9,6 +10,10 @@ import { PageHeader } from '../components/medication-administration/PageHeader';
 
 export const InHouseOrderNew: React.FC = () => {
   const scrollToRef = useRef<HTMLHeadingElement>(null);
+  // Ordering in-house medications is NPI-gated. Guard the page itself so a user without an NPI
+  // (e.g. the Clinician role) reaching it directly by URL sees a permission message rather than the
+  // order form; administering existing orders remains available elsewhere.
+  const hasNPI = useEvolveUser()?.hasNPI ?? false;
 
   useLayoutEffect(() => {
     scrollToRef.current?.scrollIntoView({ behavior: 'auto', block: 'start' });
@@ -18,10 +23,16 @@ export const InHouseOrderNew: React.FC = () => {
       <span ref={scrollToRef} />
       <InHouseOrderNewBreadcrumbs />
       <PageHeader title="Order Medication" variant="h3" component="h1" />
-      <InfoAlert text="Make sure an AssociatedDx is selected first in the Assessment menu item." />
-      <MedicationWarnings />
-      <EditableMedicationCard type="order-new" />
-      <MedicationHistoryList />
+      {hasNPI ? (
+        <>
+          <InfoAlert text="Make sure an AssociatedDx is selected first in the Assessment menu item." />
+          <MedicationWarnings />
+          <EditableMedicationCard type="order-new" />
+          <MedicationHistoryList />
+        </>
+      ) : (
+        <InfoAlert text="You need an NPI on file to order in-house medications." />
+      )}
     </Stack>
   );
 };

--- a/apps/ehr/src/features/visits/shared/components/plan-tab/ERxContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/plan-tab/ERxContainer.tsx
@@ -24,7 +24,7 @@ import { PageTitle } from 'src/features/visits/shared/components/PageTitle';
 import { useGetErxConfigQuery } from 'src/features/visits/telemed/hooks/useGetErxConfig';
 import { useApiClients } from 'src/hooks/useAppClients';
 import useEvolveUser from 'src/hooks/useEvolveUser';
-import { ERX_MEDICATION_META_TAG_CODE, formatDateToMDYWithTime, RoleType } from 'utils';
+import { ERX_MEDICATION_META_TAG_CODE, formatDateToMDYWithTime } from 'utils';
 import { RoundedButton } from '../../../../../components/RoundedButton';
 import { useChartFields } from '../../hooks/useChartFields';
 import { useGetAppointmentAccessibility } from '../../hooks/useGetAppointmentAccessibility';
@@ -198,15 +198,15 @@ export const ERxContainer: FC<ERxContainerProps> = ({ showHeader = true }) => {
           </Stack>
           <Tooltip
             placement="top"
-            title="You don't have the necessary role to access ERX. Please contact your administrator."
-            open={openTooltip && !isReadOnly && !user?.hasRole([RoleType.Provider])}
+            title="You need an NPI on file to access eRX. Please contact your administrator."
+            open={openTooltip && !isReadOnly && !user?.hasNPI}
             onClose={handleCloseTooltip}
             onOpen={handleOpenTooltip}
           >
             <Stack>
               {isERXOpen && erxStatus !== ERXStatus.LOADING ? (
                 <RoundedButton
-                  disabled={isReadOnly || !user?.hasRole([RoleType.Provider])}
+                  disabled={isReadOnly || !user?.hasNPI}
                   variant="contained"
                   onClick={() => {
                     setIsERXOpen(false);
@@ -217,10 +217,7 @@ export const ERxContainer: FC<ERxContainerProps> = ({ showHeader = true }) => {
               ) : (
                 <RoundedButton
                   disabled={
-                    isReadOnly ||
-                    erxStatus === ERXStatus.LOADING ||
-                    !user?.hasRole([RoleType.Provider]) ||
-                    !erxConfigData?.configured
+                    isReadOnly || erxStatus === ERXStatus.LOADING || !user?.hasNPI || !erxConfigData?.configured
                   }
                   variant="contained"
                   onClick={() => onNewOrderClick()}

--- a/apps/ehr/src/features/visits/shared/components/review-tab/ReviewAndSignButton.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/ReviewAndSignButton.tsx
@@ -73,7 +73,9 @@ export const ReviewAndSignButton: FC<ReviewAndSignButtonProps> = ({ onSigned }) 
   });
 
   const apiClient = useOystehrAPIClient();
-  const practitioner = useEvolveUser()?.profileResource;
+  const evolveUser = useEvolveUser();
+  const practitioner = evolveUser?.profileResource;
+  const hasNPI = evolveUser?.hasNPI ?? false;
 
   const { mutateAsync: signAppointment, isPending: isSignLoading } = useSignAppointmentMutation();
   const [openTooltip, setOpenTooltip] = useState(false);
@@ -120,7 +122,16 @@ export const ReviewAndSignButton: FC<ReviewAndSignButtonProps> = ({ onSigned }) 
   const errorMessage = useMemo(() => {
     const messages: string[] = [];
 
-    if (completed || isFollowup) {
+    if (completed) {
+      return messages;
+    }
+
+    // Signing / co-signing a note is NPI-gated — block users without an NPI (e.g. the Clinician role).
+    if (!hasNPI) {
+      messages.push('You need an NPI on file to sign');
+    }
+
+    if (isFollowup) {
       return messages;
     }
 
@@ -192,6 +203,7 @@ export const ReviewAndSignButton: FC<ReviewAndSignButtonProps> = ({ onSigned }) 
     return messages;
   }, [
     completed,
+    hasNPI,
     inPersonStatus,
     primaryDiagnosis,
     medicalDecision,

--- a/apps/ehr/src/hooks/useEvolveUser.tsx
+++ b/apps/ehr/src/hooks/useEvolveUser.tsx
@@ -27,6 +27,12 @@ export interface EvolveUser extends User {
   userInitials: string;
   lastLogin: string | undefined;
   hasRole: (role: RoleType[]) => boolean;
+  /**
+   * Whether the user's Practitioner has an NPI on file. NPI-gated actions (sign/co-sign a note,
+   * e-prescribe, order external labs & imaging, submit claims, order in-house medications) are
+   * hidden/disabled when this is false — e.g. for the Clinician role, which has no NPI.
+   */
+  hasNPI: boolean;
 }
 
 interface EvolveUserState {
@@ -53,6 +59,8 @@ export default function useEvolveUser(): EvolveUser | undefined {
       profile?.name?.[0]?.given?.[0] &&
       profile?.name?.[0]?.family
   );
+
+  const hasNPI = Boolean(profile && getNPIIdentifier(profile)?.value);
 
   const userRoles = user?.roles;
   const hasRole = useCallback(
@@ -144,10 +152,11 @@ export default function useEvolveUser(): EvolveUser | undefined {
         profileResource: profile,
         isProviderHasEverythingToBeEnrolled,
         hasRole,
+        hasNPI,
       };
     }
     return undefined;
-  }, [hasRole, isProviderHasEverythingToBeEnrolled, lastLogin, profile, user, userInitials, userName]);
+  }, [hasNPI, hasRole, isProviderHasEverythingToBeEnrolled, lastLogin, profile, user, userInitials, userName]);
 }
 
 // const MINUTE = 1000 * 60; // For Credentials Sync

--- a/apps/ehr/tests/component/CreateExternalLabOrder.draft.test.tsx
+++ b/apps/ehr/tests/component/CreateExternalLabOrder.draft.test.tsx
@@ -34,6 +34,10 @@ vi.mock('src/features/visits/shared/hooks/useOystehrAPIClient', () => ({
   useOystehrAPIClient: () => ({}),
 }));
 
+vi.mock('src/hooks/useEvolveUser', () => ({
+  default: () => ({ hasNPI: true, hasRole: () => false }),
+}));
+
 vi.mock('src/features/visits/shared/stores/appointment/appointment.store', () => ({
   useAppointmentData: () => ({
     encounter: { id: 'enc-external-test' },


### PR DESCRIPTION
Add hasNPI to useEvolveUser and hide/disable the NPI-gated actions for any
user without an NPI on file (e.g. the upcoming Clinician role), each with a
clear "NPI required" message:

- eRX: ERxContainer + the eRX enrollment/notifications entry in UserMenu
  (was gated on the Provider role; now gated on NPI presence)
- Review & Sign: adds an NPI requirement to ReviewAndSignButton, including
  follow-up notes
- External lab order: CreateExternalLabOrder submit
- Imaging order: CreateRadiologyOrder (RadiologyOrderFormActions gains an
  optional disabled prop)
- In-house medication ordering: the Order button and the order-new page.
  Administering / changing status of existing orders is untouched, since
  that is a routine nurse/MA task, not an NPI-gated order.

Mock useEvolveUser in the external-lab draft component test now that the
page reads the hook.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>