### PR TITLE
OTR-2462: grant the Clinician role general EHR access

### DIFF
--- a/apps/ehr/src/App.tsx
+++ b/apps/ehr/src/App.tsx
@@ -102,6 +102,7 @@ const PRIMARY_EHR_STAFF_ROLES = [
   RoleType.Staff,
   RoleType.Manager,
   RoleType.Provider,
+  RoleType.Clinician,
   RoleType.CustomerSupport,
 ];
 

--- a/apps/ehr/src/components/navigation/Navbar.tsx
+++ b/apps/ehr/src/components/navigation/Navbar.tsx
@@ -78,7 +78,9 @@ export default function Navbar(): ReactElement | null {
       if (user.hasRole([RoleType.Staff])) {
         navItems = { ...navItems, ...staffNavbarItems };
       }
-      if (user.hasRole([RoleType.Provider])) {
+      // Clinicians get the same navigation as Providers; the NPI-gated actions within those pages are
+      // disabled separately based on NPI presence.
+      if (user.hasRole([RoleType.Provider, RoleType.Clinician])) {
         navItems = { ...navItems, ...providerNavbarItems };
       }
       if (user.hasRole([RoleType.CustomerSupport])) {

--- a/apps/ehr/src/components/navigation/UserMenu.tsx
+++ b/apps/ehr/src/components/navigation/UserMenu.tsx
@@ -38,7 +38,7 @@ export const UserMenu: FC = () => {
   // eRX enrollment/notifications require an NPI (DoseSpot). The provider notifications bell is a
   // general, visit-linked inbox — not NPI-gated — so keep it on a role check.
   const userHasNPI = user?.hasNPI;
-  const showProviderNotifications = user?.hasRole([RoleType.Provider]);
+  const showProviderNotifications = user?.hasRole([RoleType.Provider, RoleType.Clinician]);
 
   const practitioner = user?.profileResource;
 

--- a/apps/ehr/src/constants/data-test-ids.ts
+++ b/apps/ehr/src/constants/data-test-ids.ts
@@ -700,6 +700,10 @@ export const dataTestIds = {
     pencilIconButton: 'EditOutlinedIcon',
   },
 
+  updateMedicationPage: {
+    medicationDatabaseAlert: 'medication-database-alert',
+  },
+
   editNoteDialog: {
     cancelButton: 'edit-note-dialog-cancel-button',
     proceedButton: 'edit-note-dialog-proceed-button',

--- a/apps/ehr/src/features/visits/shared/components/medical-history-tab/CurrentMedications/ExternalRxSuggestions.tsx
+++ b/apps/ehr/src/features/visits/shared/components/medical-history-tab/CurrentMedications/ExternalRxSuggestions.tsx
@@ -35,7 +35,8 @@ interface ExternalRxSuggestionsProps {
 }
 
 export const ExternalRxSuggestions: FC<ExternalRxSuggestionsProps> = ({ chartedMedications, onSelectMedication }) => {
-  const { isLoading, isAvailable, externalMedications } = useExternalMedicationHistory(chartedMedications);
+  const { isLoading, isAvailable, isPermissionDenied, externalMedications } =
+    useExternalMedicationHistory(chartedMedications);
   const [expanded, setExpanded] = useState(false);
   // Track medication IDs that were just clicked (optimistic hide).
   const [addedIds, setAddedIds] = useState<Set<number>>(new Set());
@@ -150,7 +151,9 @@ export const ExternalRxSuggestions: FC<ExternalRxSuggestionsProps> = ({ chartedM
           </Box>
         ) : !isAvailable ? (
           <Typography variant="body2" color="text.secondary">
-            Not available
+            {isPermissionDenied
+              ? 'Not available — your role does not have access to external medication history.'
+              : 'Not available'}
           </Typography>
         ) : visibleMedications.length === 0 ? (
           <Typography variant="body2" color="text.secondary">

--- a/apps/ehr/src/features/visits/shared/hooks/useExternalMedicationHistory.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useExternalMedicationHistory.ts
@@ -1,6 +1,7 @@
 import { ErxGetMedicationHistoryResponse, ErxSearchMedicationsResponse } from '@oystehr/sdk';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
+import { isPermissionDeniedError } from 'src/helpers/apiErrors';
 import { useApiClients } from 'src/hooks/useAppClients';
 import { MedicationDTO } from 'utils';
 import { ExtractObjectType } from '../stores/appointment/appointment.queries';
@@ -30,6 +31,8 @@ export interface UseExternalMedicationHistoryResult {
   isAvailable: boolean;
   externalMedications: ExternalMedication[];
   error: Error | null;
+  /** True when the history is unavailable because the signed-in user's role cannot read eRx data. */
+  isPermissionDenied: boolean;
 }
 
 // Mock data for development/testing — remove when real eRx data is available
@@ -234,7 +237,10 @@ export const useExternalMedicationHistory = (
       try {
         const history = await oystehr.erx.getMedicationHistory({ patientId });
         if (history.length > 0) return history;
-      } catch {
+      } catch (error) {
+        // Surface a permission denial instead of swallowing it: the user's role simply cannot read eRx
+        // history, so it must not be reported as "history hasn't arrived yet" and polled forever.
+        if (isPermissionDeniedError(error)) throw error;
         /* fall through to mock data in sandbox */
       }
       // In sandbox environments, fall back to stub data when no real data is available
@@ -243,10 +249,11 @@ export const useExternalMedicationHistory = (
     },
     enabled: !!oystehr && !!patientId,
     staleTime: 5 * 60 * 1000,
-    retry: 1,
+    retry: (failureCount, error) => !isPermissionDeniedError(error) && failureCount < 1,
     // Poll every 10s while the eRx service is still populating history.
-    // Once data arrives, stop polling.
+    // Once data arrives — or once we know this user isn't allowed to read it — stop polling.
     refetchInterval: (query) => {
+      if (isPermissionDeniedError(query.state.error)) return false;
       const data = query.state.data;
       if (!data || data.length === 0) return 10_000;
       return false;
@@ -335,5 +342,6 @@ export const useExternalMedicationHistory = (
     isAvailable: !historyError,
     externalMedications,
     error: historyError ?? null,
+    isPermissionDenied: isPermissionDeniedError(historyError),
   };
 };

--- a/apps/ehr/src/features/visits/shared/stores/appointment/appointment.queries.ts
+++ b/apps/ehr/src/features/visits/shared/stores/appointment/appointment.queries.ts
@@ -14,6 +14,7 @@ import { getPatientInstructionQuickPicks } from 'src/api/api';
 import { QUERY_STALE_TIME } from 'src/constants';
 import { FEATURE_FLAGS } from 'src/constants/feature-flags';
 import { useGetErxConfigQuery } from 'src/features/visits/telemed/hooks/useGetErxConfig';
+import { isPermissionDeniedError } from 'src/helpers/apiErrors';
 import { useApiClients } from 'src/hooks/useAppClients';
 import useEvolveUser from 'src/hooks/useEvolveUser';
 import {
@@ -143,6 +144,12 @@ export const useGetMeetingData = (
 
 export type ExtractObjectType<T> = T extends (infer U)[] ? U : never;
 
+// The medication/allergen lookups are served by the eRx drug reference database, which not every role can
+// read. A 403 there is a role misconfiguration, not a transient failure, so say so rather than telling the
+// user to try again.
+export const MEDICATION_DATABASE_FORBIDDEN_MESSAGE =
+  'Your role does not have access to the medication database. Please contact an administrator.';
+
 export const useGetMedicationsSearch = (
   medicationSearchTerm: string
 ): UseQueryResult<ErxSearchMedicationsResponse, Error> => {
@@ -161,13 +168,20 @@ export const useGetMedicationsSearch = (
     enabled: Boolean(medicationSearchTerm),
     placeholderData: keepPreviousData,
     staleTime: QUERY_STALE_TIME,
+    // A role without eRx access will be denied every time — retrying just multiplies the 403s.
+    retry: (failureCount, error) => !isPermissionDeniedError(error) && failureCount < 3,
   });
 
   useEffect(() => {
     if (queryResult.error) {
-      enqueueSnackbar('An error occurred during the search. Please try again in a moment', {
-        variant: 'error',
-      });
+      enqueueSnackbar(
+        isPermissionDeniedError(queryResult.error)
+          ? MEDICATION_DATABASE_FORBIDDEN_MESSAGE
+          : 'An error occurred during the search. Please try again in a moment',
+        {
+          variant: 'error',
+        }
+      );
     }
   }, [queryResult.error]);
 
@@ -190,13 +204,20 @@ export const useGetMedicationDetails = (medicationId: number): UseQueryResult<Er
     enabled: Boolean(medicationId),
     placeholderData: keepPreviousData,
     staleTime: QUERY_STALE_TIME,
+    // A role without eRx access will be denied every time — retrying just multiplies the 403s.
+    retry: (failureCount, error) => !isPermissionDeniedError(error) && failureCount < 3,
   });
 
   useEffect(() => {
     if (queryResult.error) {
-      enqueueSnackbar(`An error occurred during looking up medication details: ${queryResult.error.message}`, {
-        variant: 'error',
-      });
+      enqueueSnackbar(
+        isPermissionDeniedError(queryResult.error)
+          ? MEDICATION_DATABASE_FORBIDDEN_MESSAGE
+          : `An error occurred during looking up medication details: ${queryResult.error.message}`,
+        {
+          variant: 'error',
+        }
+      );
     }
   }, [queryResult.error]);
 

--- a/apps/ehr/src/helpers/apiErrors.ts
+++ b/apps/ehr/src/helpers/apiErrors.ts
@@ -1,0 +1,13 @@
+/**
+ * The Oystehr SDK throws `OystehrSdkError`, which carries the HTTP status on `code`. A 403 means the
+ * signed-in user's role does not grant the action — permanent for that user, so retrying or polling can
+ * never succeed. Callers should stop and say what happened instead of spinning or reporting a generic
+ * "try again" failure.
+ */
+export const isPermissionDeniedError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const { code, status } = error as { code?: unknown; status?: unknown };
+  return code === 403 || status === 403;
+};

--- a/apps/ehr/src/hooks/useNavigationQuickPicks.ts
+++ b/apps/ehr/src/hooks/useNavigationQuickPicks.ts
@@ -39,6 +39,7 @@ const VISIT_CREATION_ROLES = [
   RoleType.CustomerSupport,
   RoleType.Staff,
   RoleType.Provider,
+  RoleType.Clinician,
 ];
 
 const NAVIGATION_DESTINATIONS: NavigationDestination[] = [

--- a/apps/ehr/src/pages/configuration/UpdateMedicationPage.tsx
+++ b/apps/ehr/src/pages/configuration/UpdateMedicationPage.tsx
@@ -1,5 +1,5 @@
 import { LoadingButton } from '@mui/lab';
-import { Autocomplete, debounce, Grid, Paper, TextField, Typography } from '@mui/material';
+import { Alert, Autocomplete, debounce, Grid, Paper, TextField, Typography } from '@mui/material';
 import { Medication } from 'fhir/r4b';
 import { enqueueSnackbar } from 'notistack';
 import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
@@ -7,10 +7,13 @@ import { useParams } from 'react-router-dom';
 import { getInHouseMedications, updateInHouseMedication } from 'src/api/api';
 import CustomBreadcrumbs from 'src/components/CustomBreadcrumbs';
 import Loading from 'src/components/Loading';
+import { dataTestIds } from 'src/constants/data-test-ids';
 import {
+  MEDICATION_DATABASE_FORBIDDEN_MESSAGE,
   useGetMedicationDetails,
   useGetMedicationsSearch,
 } from 'src/features/visits/shared/stores/appointment/appointment.queries';
+import { isPermissionDeniedError } from 'src/helpers/apiErrors';
 import { useApiClients } from 'src/hooks/useAppClients';
 import PageContainer from 'src/layout/PageContainer';
 import {
@@ -47,12 +50,17 @@ export default function UpdateMedicationPage(): ReactElement {
   const [debouncedSearchTermForPrecheck, setDebouncedSearchTermForPrecheck] = useState('');
 
   const medispanId = getMedispanId(medication);
-  const { isFetching: isSearching, data: medicationDetails } = useGetMedicationDetails(
-    medispanId ? parseInt(medispanId, 10) : 0
-  );
+  const {
+    isFetching: isSearching,
+    data: medicationDetails,
+    error: medicationDetailsError,
+  } = useGetMedicationDetails(medispanId ? parseInt(medispanId, 10) : 0);
   const medispanIdForInteractions = getMedispanIdForInteractions(medication);
-  const { isFetching: isFetchingDetailsForInteractions, data: medicationForInteractionsDetails } =
-    useGetMedicationDetails(medispanIdForInteractions ? parseInt(medispanIdForInteractions, 10) : 0);
+  const {
+    isFetching: isFetchingDetailsForInteractions,
+    data: medicationForInteractionsDetails,
+    error: interactionsDetailsError,
+  } = useGetMedicationDetails(medispanIdForInteractions ? parseInt(medispanIdForInteractions, 10) : 0);
   const { isFetching: isFetchingForPrecheck, data: dataForPrecheck } =
     useGetMedicationsSearch(debouncedSearchTermForPrecheck);
   const isSearchingForPrecheck = isFetchingDetailsForInteractions || isFetchingForPrecheck;
@@ -152,9 +160,21 @@ export default function UpdateMedicationPage(): ReactElement {
     setLoading(false);
   }
 
-  if (!medication || !medicationDetails) {
+  if (!medication || isSearching || isFetchingDetailsForInteractions) {
     return <Loading />;
   }
+
+  // The drug details come from the eRx reference database. When they can't be loaded the obsolete-medication
+  // remap field can't be shown, and submitting the form would clear the stored interactions Medispan ID — so
+  // explain why and block the update rather than rendering a spinner forever (the old behaviour).
+  const medicationDatabaseError = medicationDetailsError ?? interactionsDetailsError;
+  const blockingNotice = isPermissionDeniedError(medicationDatabaseError)
+    ? `${MEDICATION_DATABASE_FORBIDDEN_MESSAGE} Medication details cannot be loaded, so this medication cannot be updated.`
+    : medicationDatabaseError
+    ? 'The medication database could not be reached, so this medication cannot be updated right now. Please try again in a few moments.'
+    : !medicationDetails
+    ? 'Drug details for this medication could not be loaded, so it cannot be updated. Check that it has a Medispan ID.'
+    : null;
 
   return (
     <PageContainer>
@@ -172,6 +192,13 @@ export default function UpdateMedicationPage(): ReactElement {
               <Grid item xs={12}>
                 <Typography variant="h4">Update medication</Typography>
               </Grid>
+              {blockingNotice ? (
+                <Grid item xs={12}>
+                  <Alert severity="warning" data-testid={dataTestIds.updateMedicationPage.medicationDatabaseAlert}>
+                    {blockingNotice}
+                  </Alert>
+                </Grid>
+              ) : null}
               <Grid item xs={6}>
                 <Autocomplete
                   value={medication}
@@ -241,6 +268,7 @@ export default function UpdateMedicationPage(): ReactElement {
                   type="submit"
                   variant="contained"
                   loading={loading}
+                  disabled={Boolean(blockingNotice)}
                   sx={{ textTransform: 'none', borderRadius: 50, fontWeight: 'bold' }}
                 >
                   Update Medication

--- a/apps/ehr/tests/component/ExternalRxSuggestions.test.tsx
+++ b/apps/ehr/tests/component/ExternalRxSuggestions.test.tsx
@@ -61,6 +61,7 @@ describe('ExternalRxSuggestions', () => {
       isAvailable: false,
       externalMedications: [],
       error: null,
+      isPermissionDenied: false,
     });
 
     render(<ExternalRxSuggestions chartedMedications={[]} />, { wrapper });
@@ -73,10 +74,24 @@ describe('ExternalRxSuggestions', () => {
       isAvailable: false,
       externalMedications: [],
       error: null,
+      isPermissionDenied: false,
     });
 
     render(<ExternalRxSuggestions chartedMedications={[]} />, { wrapper });
     expect(screen.getByText(/not available/i)).toBeInTheDocument();
+  });
+
+  it('says why the history is unavailable when the role lacks access', () => {
+    vi.mocked(useExternalMedicationHistory).mockReturnValue({
+      isLoading: false,
+      isAvailable: false,
+      externalMedications: [],
+      error: Object.assign(new Error('Forbidden'), { code: 403 }),
+      isPermissionDenied: true,
+    });
+
+    render(<ExternalRxSuggestions chartedMedications={[]} />, { wrapper });
+    expect(screen.getByText(/your role does not have access to external medication history/i)).toBeInTheDocument();
   });
 
   it('shows empty state when all meds reconciled', () => {
@@ -85,6 +100,7 @@ describe('ExternalRxSuggestions', () => {
       isAvailable: true,
       externalMedications: [],
       error: null,
+      isPermissionDenied: false,
     });
 
     render(<ExternalRxSuggestions chartedMedications={[]} />, { wrapper });
@@ -97,6 +113,7 @@ describe('ExternalRxSuggestions', () => {
       isAvailable: true,
       externalMedications: [makeMatchedMed('Omeprazole', '20 mg')],
       error: null,
+      isPermissionDenied: false,
     });
 
     render(<ExternalRxSuggestions chartedMedications={[]} />, { wrapper });
@@ -109,6 +126,7 @@ describe('ExternalRxSuggestions', () => {
       isAvailable: true,
       externalMedications: [makeExternalMed({ name: 'UnknownDrug' })],
       error: null,
+      isPermissionDenied: false,
     });
 
     render(<ExternalRxSuggestions chartedMedications={[]} />, { wrapper });
@@ -135,6 +153,7 @@ describe('ExternalRxSuggestions', () => {
       isAvailable: true,
       externalMedications: [med],
       error: null,
+      isPermissionDenied: false,
     });
 
     render(<ExternalRxSuggestions chartedMedications={[]} />, { wrapper });
@@ -151,6 +170,7 @@ describe('ExternalRxSuggestions', () => {
       isAvailable: true,
       externalMedications: meds,
       error: null,
+      isPermissionDenied: false,
     });
 
     render(<ExternalRxSuggestions chartedMedications={[]} onSelectMedication={onSelect} />, { wrapper });
@@ -190,6 +210,7 @@ describe('ExternalRxSuggestions', () => {
       isAvailable: true,
       externalMedications: [med],
       error: null,
+      isPermissionDenied: false,
     });
 
     render(<ExternalRxSuggestions chartedMedications={[]} onSelectMedication={onSelect} />, { wrapper });
@@ -210,6 +231,7 @@ describe('ExternalRxSuggestions', () => {
       isAvailable: true,
       externalMedications: [makeExternalMed({ name: 'UnknownDrug' })],
       error: null,
+      isPermissionDenied: false,
     });
 
     render(<ExternalRxSuggestions chartedMedications={[]} onSelectMedication={onSelect} />, { wrapper });
@@ -227,6 +249,7 @@ describe('ExternalRxSuggestions', () => {
       isAvailable: true,
       externalMedications: [makeExternalMed({ name: 'TestMed', writtenDate: null, lastFillDate: null })],
       error: null,
+      isPermissionDenied: false,
     });
 
     render(<ExternalRxSuggestions chartedMedications={[]} />, { wrapper });
@@ -241,6 +264,7 @@ describe('ExternalRxSuggestions', () => {
       isAvailable: true,
       externalMedications: meds,
       error: null,
+      isPermissionDenied: false,
     });
 
     render(<ExternalRxSuggestions chartedMedications={[]} />, { wrapper });

--- a/apps/ehr/tests/component/UpdateMedicationPage.test.tsx
+++ b/apps/ehr/tests/component/UpdateMedicationPage.test.tsx
@@ -23,9 +23,14 @@ vi.mock('src/hooks/useAppClients', () => ({
   useApiClients: vi.fn(),
 }));
 
+const { FORBIDDEN_MESSAGE } = vi.hoisted(() => ({
+  FORBIDDEN_MESSAGE: 'Your role does not have access to the medication database. Please contact an administrator.',
+}));
+
 vi.mock('src/features/visits/shared/stores/appointment/appointment.queries', () => ({
   useGetMedicationsSearch: vi.fn(),
   useGetMedicationDetails: vi.fn(),
+  MEDICATION_DATABASE_FORBIDDEN_MESSAGE: FORBIDDEN_MESSAGE,
 }));
 
 import { useParams } from 'react-router-dom';
@@ -103,6 +108,39 @@ describe('UpdateMedicationPage', () => {
     vi.mocked(useParams).mockReturnValue({ 'medication-id': 'med-xyz' });
     render(<UpdateMedicationPage />, { wrapper: createWrapper() });
     await waitFor(() => expect(screen.getByRole('button', { name: /activate medication/i })).toBeInTheDocument());
+  });
+
+  // The drug details come from the eRx reference database, which not every role can read. Before, a failed
+  // lookup left the page on <Loading /> forever with only a raw-message snackbar to explain it.
+  it('explains a forbidden medication database lookup instead of loading forever', async () => {
+    vi.mocked(useGetMedicationDetails).mockReturnValue({
+      isFetching: false,
+      data: undefined,
+      error: Object.assign(new Error('Forbidden'), { code: 403 }),
+    } as any);
+
+    render(<UpdateMedicationPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => expect(screen.getByTestId('medication-database-alert')).toBeInTheDocument());
+    expect(screen.getByTestId('medication-database-alert')).toHaveTextContent(FORBIDDEN_MESSAGE);
+    expect(screen.queryByText(/refreshing/i)).not.toBeInTheDocument();
+    // Submitting with no details loaded would clear the stored interactions Medispan ID.
+    expect(screen.getByRole('button', { name: /^update medication$/i })).toBeDisabled();
+    // The status change doesn't depend on the drug database, so it stays available.
+    expect(screen.getByRole('button', { name: /remove medication/i })).toBeEnabled();
+  });
+
+  it('reports a non-permission medication database failure as transient', async () => {
+    vi.mocked(useGetMedicationDetails).mockReturnValue({
+      isFetching: false,
+      data: undefined,
+      error: Object.assign(new Error('Service Unavailable'), { code: 503 }),
+    } as any);
+
+    render(<UpdateMedicationPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => expect(screen.getByTestId('medication-database-alert')).toBeInTheDocument());
+    expect(screen.getByTestId('medication-database-alert')).toHaveTextContent(/could not be reached/i);
   });
 
   it('submits the original medication data when typed text does not match any option', async () => {

--- a/packages/utils/lib/types/api/action-logs.types.ts
+++ b/packages/utils/lib/types/api/action-logs.types.ts
@@ -11,7 +11,11 @@ export const GLOBAL_ACTION_LOG_VIEWER_ROLES = [
   RoleType.CustomerSupport,
   RoleType.Staff,
 ];
-export const PATIENT_ACTION_LOG_VIEWER_ROLES = [...GLOBAL_ACTION_LOG_VIEWER_ROLES, RoleType.Provider];
+export const PATIENT_ACTION_LOG_VIEWER_ROLES = [
+  ...GLOBAL_ACTION_LOG_VIEWER_ROLES,
+  RoleType.Provider,
+  RoleType.Clinician,
+];
 
 export const ActionLogChannelSchema = z.enum(['fax', 'email']);
 export type ActionLogChannel = z.infer<typeof ActionLogChannelSchema>;


### PR DESCRIPTION
Add RoleType.Clinician alongside Provider wherever the role gates general,
non-NPI access so Clinicians can log in and do the work they are allowed to
(in-house labs, procedures, documenting the progress note, administering meds):

- PRIMARY_EHR_STAFF_ROLES (App.tsx) — access to the EHR app at all
- Navbar provider nav items and the visit-creation quick picks
- PATIENT_ACTION_LOG_VIEWER_ROLES

Admin-tier navigation and the NPI-gated actions remain excluded (the latter are
gated on NPI presence in the UI and enforced in the zambdas).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>