### PR TITLE
Issue 8769. EHR. Wrong external radiology details page is opened when it is opened from the Tracking board

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/OrdersIconsToolTip.tsx
+++ b/apps/ehr/src/features/visits/shared/components/OrdersIconsToolTip.tsx
@@ -22,6 +22,7 @@ import {
   getNursingOrdersUrl,
   getProcedureDetailsUrl,
   getProceduresUrl,
+  getRadiologyExternalOrderDetailsUrl,
   getRadiologyOrderEditUrl,
   getRadiologyUrl,
 } from 'src/features/visits/in-person/routing/helpers';
@@ -174,7 +175,11 @@ export const OrdersIconsToolTip: React.FC<OrdersIconsToolTipProps> = ({ appointm
       orders: radiologyOrders.map((order) => ({
         fhirResourceId: order.serviceRequestId,
         itemDescription: order.studyType,
-        detailPageUrl: withEncounter(getRadiologyOrderEditUrl(navAppointmentId, order.serviceRequestId)),
+        detailPageUrl: withEncounter(
+          order.external
+            ? getRadiologyExternalOrderDetailsUrl(navAppointmentId, order.serviceRequestId)
+            : getRadiologyOrderEditUrl(navAppointmentId, order.serviceRequestId)
+        ),
         statusChip: <RadiologyTableStatusChip status={order.status} />,
         unreadBadge: RADIOLOGY_ORDERS_PENDING_BADGE_STATUSES.includes(order.status),
       })),


### PR DESCRIPTION
#8769 