### PR TITLE
Billing app. Don't remove contained resources from ClaimResponse when matching ERA.

### DIFF
--- a/packages/zambdas/src/billing/match-claim-response/index.ts
+++ b/packages/zambdas/src/billing/match-claim-response/index.ts
@@ -64,10 +64,6 @@ async function performEffect(oystehr: Oystehr, params: Params): Promise<ClaimRes
             path: '/type',
             value: claim.type,
           },
-          {
-            op: 'remove',
-            path: '/contained',
-          },
         ],
       }),
     ],


### PR DESCRIPTION
`ClaimResponse.contained` stores original information about a claim which comes in ERA.