### PR TITLE
Fixing timing for responsible party invalid email warning

### DIFF
--- a/apps/ehr/src/components/SelectCreditCard.tsx
+++ b/apps/ehr/src/components/SelectCreditCard.tsx
@@ -95,7 +95,7 @@ const CreditCardContent: FC<CreditCardContentProps> = (props) => {
     return hasNone || addingOne;
   })();
 
-  const initializing = isSetupDataFetching || isSetupDataLoading;
+  const initializing = isSetupDataLoading && !isSetupDataRefetching;
 
   const cardOptions: CardOption[] = [
     ...cards.map((card) => ({ id: card.id, label: labelForCard(card), brand: card.brand })),


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2419/rcm-ehr-when-taking-patient-payment-via-stripe-bad-email-address-fails