### PR TITLE
HOST-1032: Fix sub-refresh-invoice-task zambda patch error

### DIFF
--- a/packages/zambdas/src/subscriptions/task/sub-refresh-invoice-task/index.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-refresh-invoice-task/index.ts
@@ -74,6 +74,13 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     }
     console.log('Updating task input...', JSON.stringify(createInvoiceTaskInput(invoiceTaskInput), null, 2));
 
+    // The `task` we were handed is the subscription payload — a snapshot taken when the event was
+    // queued. It can be stale by the time we get here (duplicate deliveries, redelivery after a
+    // timeout, a concurrent update-invoice-task write), and every op below whose `op` depends on a
+    // path already existing (`replace`, `remove`) is rejected outright if that guess is wrong.
+    // Re-read the resource so those decisions are based on what is actually stored.
+    const currentTask = await oystehr.fhir.get<Task>({ resourceType: 'Task', id: taskId });
+
     const isZeroBalance = invoiceTaskInput.amountCents === 0;
     const updateOperations: Operation[] = [
       { op: 'replace', path: '/input', value: createInvoiceTaskInput(invoiceTaskInput) },
@@ -81,7 +88,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
     if (invoiceTaskInput.finalizationDate) {
       updateOperations.push({
-        op: task.authoredOn ? 'replace' : 'add',
+        op: currentTask.authoredOn ? 'replace' : 'add',
         path: '/authoredOn',
         value: invoiceTaskInput.finalizationDate,
       });
@@ -91,25 +98,28 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     // executionPeriod encodes the appointment date on both bounds so FHIR _sort=period
     // FHIR sorts Period by lower bound (asc) and upper bound (desc) — setting start == end makes
     // both directions sort by the appointment date correctly.
-    if (task.executionPeriod?.start && task.executionPeriod.end !== task.executionPeriod.start) {
+    if (currentTask.executionPeriod?.start && currentTask.executionPeriod.end !== currentTask.executionPeriod.start) {
       updateOperations.push({
-        op: task.executionPeriod.end ? 'replace' : 'add',
+        op: currentTask.executionPeriod.end ? 'replace' : 'add',
         path: '/executionPeriod/end',
-        value: task.executionPeriod.start,
+        value: currentTask.executionPeriod.start,
       });
     }
 
     if (isZeroBalance) {
       updateOperations.push({
-        op: task.businessStatus ? 'replace' : 'add',
+        op: currentTask.businessStatus ? 'replace' : 'add',
         path: '/businessStatus',
         value: ZERO_BALANCE_BUSINESS_STATUS,
       });
-    } else if (invoiceTaskInput.amountCents !== undefined && task.businessStatus) {
+    } else if (invoiceTaskInput.amountCents !== undefined && currentTask.businessStatus) {
       updateOperations.push({ op: 'remove', path: '/businessStatus' });
     }
 
-    const getLastTaskOutput = getLatestTaskOutput(task);
+    // Also read off the stored task: a send that finished after this event was queued has already
+    // written its output and status, and deriving the status from the stale payload would roll that
+    // back to "ready".
+    const getLastTaskOutput = getLatestTaskOutput(currentTask);
     if (getLastTaskOutput?.type === 'success') {
       updateOperations.push({ op: 'replace', path: '/status', value: mapDisplayToInvoiceTaskStatus('sent') });
     } else if (getLastTaskOutput?.type === 'error') {
@@ -118,15 +128,14 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
       updateOperations.push({ op: 'replace', path: '/status', value: mapDisplayToInvoiceTaskStatus('ready') });
     }
 
-    await oystehr.fhir.patch({
-      resourceType: 'Task',
-      id: taskId,
-      operations: updateOperations,
-    });
+    const droppedOperations = await patchTaskTolerantOfMissingPaths(oystehr, taskId, updateOperations);
     console.log(`Updated task input for task id: "${taskId}"`);
+    const droppedNote = droppedOperations.length
+      ? ` Operations that no longer applied were dropped: ${describeOperations(droppedOperations)}.`
+      : '';
     return {
       statusCode: 200,
-      body: JSON.stringify({ message: 'Task was successfully updated.' }),
+      body: JSON.stringify({ message: `Task was successfully updated.${droppedNote}` }),
     };
   }
 
@@ -144,6 +153,64 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     body: JSON.stringify({ message: notUpdatedMessage }),
   };
 });
+
+/**
+ * Statuses the FHIR API may answer with when a patch targets a path that does not exist. Both are
+ * plausible for what is ultimately a client error, and the exact choice is a server detail — pinning
+ * this to a single code risks making the fallback below silently inert, which is the failure mode it
+ * exists to prevent. For the same reason the status is read structurally instead of through
+ * `instanceof Oystehr.OystehrSdkError`.
+ */
+const PATCH_PATH_REJECTION_STATUSES = new Set([400, 422]);
+
+const describeOperations = (operations: Operation[]): string =>
+  operations.map((operation) => `${operation.op} ${operation.path}`).join(', ');
+
+/**
+ * Applies `operations` to the Task, retrying once without the `remove` ops if the whole patch is
+ * rejected over a path that does not exist. Returns the ops that had to be dropped — empty when the
+ * first attempt succeeded.
+ *
+ * Re-reading the Task before building the patch narrows the window in which a concurrent write can
+ * invalidate a path we expect to exist, but it cannot close it. `remove` is the only op here that
+ * hard-fails on an already-absent path (RFC 6902), and since the patch is applied atomically that
+ * one lost race would otherwise discard the input/authoredOn/status updates too, leaving the task
+ * stuck in "updating". Dropping the removes and retrying converges on the same end state, because
+ * the field we wanted gone is already gone. The retry is a strict subset of the original ops, so a
+ * rejection with some other cause simply fails again and propagates.
+ *
+ * The caller is expected to surface the returned ops: a retry that succeeds still means we gave up
+ * on clearing a field, and that has to be visible rather than reported as an unqualified success.
+ */
+async function patchTaskTolerantOfMissingPaths(
+  oystehr: Oystehr,
+  taskId: string,
+  operations: Operation[]
+): Promise<Operation[]> {
+  try {
+    await oystehr.fhir.patch({ resourceType: 'Task', id: taskId, operations });
+    return [];
+  } catch (error) {
+    const status =
+      (error as { code?: number; statusCode?: number })?.code ?? (error as { statusCode?: number })?.statusCode;
+    const removals = operations.filter((operation) => operation.op === 'remove');
+    if (!PATCH_PATH_REJECTION_STATUSES.has(status as number) || removals.length === 0) {
+      throw error;
+    }
+    console.warn(
+      `Patch for task "${taskId}" was rejected with status ${status}; retrying without ${describeOperations(
+        removals
+      )}. Original error:`,
+      error
+    );
+    await oystehr.fhir.patch({
+      resourceType: 'Task',
+      id: taskId,
+      operations: operations.filter((operation) => operation.op !== 'remove'),
+    });
+    return removals;
+  }
+}
 
 async function getBillingRefreshData(oystehr: Oystehr, task: Task): Promise<RefreshedInvoiceData | undefined> {
   const claimId = getInvoiceTaskClaimId(task);

--- a/packages/zambdas/src/subscriptions/task/sub-refresh-invoice-task/index.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-refresh-invoice-task/index.ts
@@ -12,7 +12,9 @@ import {
   getLatestTaskOutput,
   getOrCreateCandidApiClient,
   getStartTimeFromEncounterStatusHistory,
+  InvoiceTaskInput,
   mapDisplayToInvoiceTaskStatus,
+  patchWithOptimisticLock,
   SearchBillingPatientARClaimsResponse,
   ZERO_BALANCE_BUSINESS_STATUS,
 } from 'utils';
@@ -76,66 +78,23 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
     // The `task` we were handed is the subscription payload — a snapshot taken when the event was
     // queued. It can be stale by the time we get here (duplicate deliveries, redelivery after a
-    // timeout, a concurrent update-invoice-task write), and every op below whose `op` depends on a
-    // path already existing (`replace`, `remove`) is rejected outright if that guess is wrong.
-    // Re-read the resource so those decisions are based on what is actually stored.
-    const currentTask = await oystehr.fhir.get<Task>({ resourceType: 'Task', id: taskId });
+    // timeout, a concurrent update-invoice-task write), and an op that assumes a path exists
+    // (`replace`, `remove`) is rejected outright if that guess is wrong. Re-read the resource so the
+    // patch is built against what is actually stored.
+    const currentTask = (await oystehr.fhir.get<Task>({ resourceType: 'Task', id: taskId })) as Task & { id: string };
 
-    const isZeroBalance = invoiceTaskInput.amountCents === 0;
-    const updateOperations: Operation[] = [
-      { op: 'replace', path: '/input', value: createInvoiceTaskInput(invoiceTaskInput) },
-    ];
+    // Re-reading narrows the window in which a concurrent write can invalidate a path we expect to
+    // exist, but it cannot close it. Patching under the version we read turns that lost race into a
+    // 412 rather than a patch built on a guess that no longer holds, and since every operation is a
+    // pure function of the stored Task, the retry recomputes them against what the winning write left.
+    await patchWithOptimisticLock(oystehr, currentTask, (freshTask) =>
+      buildUpdateOperations(freshTask, invoiceTaskInput)
+    );
 
-    if (invoiceTaskInput.finalizationDate) {
-      updateOperations.push({
-        op: currentTask.authoredOn ? 'replace' : 'add',
-        path: '/authoredOn',
-        value: invoiceTaskInput.finalizationDate,
-      });
-    }
-
-    // Ensure executionPeriod.end stays in sync with start (appointment date).
-    // executionPeriod encodes the appointment date on both bounds so FHIR _sort=period
-    // FHIR sorts Period by lower bound (asc) and upper bound (desc) — setting start == end makes
-    // both directions sort by the appointment date correctly.
-    if (currentTask.executionPeriod?.start && currentTask.executionPeriod.end !== currentTask.executionPeriod.start) {
-      updateOperations.push({
-        op: currentTask.executionPeriod.end ? 'replace' : 'add',
-        path: '/executionPeriod/end',
-        value: currentTask.executionPeriod.start,
-      });
-    }
-
-    if (isZeroBalance) {
-      updateOperations.push({
-        op: currentTask.businessStatus ? 'replace' : 'add',
-        path: '/businessStatus',
-        value: ZERO_BALANCE_BUSINESS_STATUS,
-      });
-    } else if (invoiceTaskInput.amountCents !== undefined && currentTask.businessStatus) {
-      updateOperations.push({ op: 'remove', path: '/businessStatus' });
-    }
-
-    // Also read off the stored task: a send that finished after this event was queued has already
-    // written its output and status, and deriving the status from the stale payload would roll that
-    // back to "ready".
-    const getLastTaskOutput = getLatestTaskOutput(currentTask);
-    if (getLastTaskOutput?.type === 'success') {
-      updateOperations.push({ op: 'replace', path: '/status', value: mapDisplayToInvoiceTaskStatus('sent') });
-    } else if (getLastTaskOutput?.type === 'error') {
-      updateOperations.push({ op: 'replace', path: '/status', value: mapDisplayToInvoiceTaskStatus('error') });
-    } else {
-      updateOperations.push({ op: 'replace', path: '/status', value: mapDisplayToInvoiceTaskStatus('ready') });
-    }
-
-    const droppedOperations = await patchTaskTolerantOfMissingPaths(oystehr, taskId, updateOperations);
     console.log(`Updated task input for task id: "${taskId}"`);
-    const droppedNote = droppedOperations.length
-      ? ` Operations that no longer applied were dropped: ${describeOperations(droppedOperations)}.`
-      : '';
     return {
       statusCode: 200,
-      body: JSON.stringify({ message: `Task was successfully updated.${droppedNote}` }),
+      body: JSON.stringify({ message: 'Task was successfully updated.' }),
     };
   }
 
@@ -155,61 +114,59 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 });
 
 /**
- * Statuses the FHIR API may answer with when a patch targets a path that does not exist. Both are
- * plausible for what is ultimately a client error, and the exact choice is a server detail — pinning
- * this to a single code risks making the fallback below silently inert, which is the failure mode it
- * exists to prevent. For the same reason the status is read structurally instead of through
- * `instanceof Oystehr.OystehrSdkError`.
+ * Builds the patch for the refreshed invoice data against the Task as it is currently stored. Every
+ * decision here — `add` vs `replace`, whether to remove `businessStatus`, which status the send's
+ * output implies — is read off `currentTask` rather than the subscription payload, so re-running this
+ * with a re-fetched Task after an optimistic-locking conflict yields a patch valid for that version.
  */
-const PATCH_PATH_REJECTION_STATUSES = new Set([400, 422]);
+function buildUpdateOperations(currentTask: Task, invoiceTaskInput: InvoiceTaskInput): Operation[] {
+  const isZeroBalance = invoiceTaskInput.amountCents === 0;
+  const updateOperations: Operation[] = [
+    { op: 'replace', path: '/input', value: createInvoiceTaskInput(invoiceTaskInput) },
+  ];
 
-const describeOperations = (operations: Operation[]): string =>
-  operations.map((operation) => `${operation.op} ${operation.path}`).join(', ');
-
-/**
- * Applies `operations` to the Task, retrying once without the `remove` ops if the whole patch is
- * rejected over a path that does not exist. Returns the ops that had to be dropped — empty when the
- * first attempt succeeded.
- *
- * Re-reading the Task before building the patch narrows the window in which a concurrent write can
- * invalidate a path we expect to exist, but it cannot close it. `remove` is the only op here that
- * hard-fails on an already-absent path (RFC 6902), and since the patch is applied atomically that
- * one lost race would otherwise discard the input/authoredOn/status updates too, leaving the task
- * stuck in "updating". Dropping the removes and retrying converges on the same end state, because
- * the field we wanted gone is already gone. The retry is a strict subset of the original ops, so a
- * rejection with some other cause simply fails again and propagates.
- *
- * The caller is expected to surface the returned ops: a retry that succeeds still means we gave up
- * on clearing a field, and that has to be visible rather than reported as an unqualified success.
- */
-async function patchTaskTolerantOfMissingPaths(
-  oystehr: Oystehr,
-  taskId: string,
-  operations: Operation[]
-): Promise<Operation[]> {
-  try {
-    await oystehr.fhir.patch({ resourceType: 'Task', id: taskId, operations });
-    return [];
-  } catch (error) {
-    const status =
-      (error as { code?: number; statusCode?: number })?.code ?? (error as { statusCode?: number })?.statusCode;
-    const removals = operations.filter((operation) => operation.op === 'remove');
-    if (!PATCH_PATH_REJECTION_STATUSES.has(status as number) || removals.length === 0) {
-      throw error;
-    }
-    console.warn(
-      `Patch for task "${taskId}" was rejected with status ${status}; retrying without ${describeOperations(
-        removals
-      )}. Original error:`,
-      error
-    );
-    await oystehr.fhir.patch({
-      resourceType: 'Task',
-      id: taskId,
-      operations: operations.filter((operation) => operation.op !== 'remove'),
+  if (invoiceTaskInput.finalizationDate) {
+    updateOperations.push({
+      op: currentTask.authoredOn ? 'replace' : 'add',
+      path: '/authoredOn',
+      value: invoiceTaskInput.finalizationDate,
     });
-    return removals;
   }
+
+  // Ensure executionPeriod.end stays in sync with start (appointment date).
+  // executionPeriod encodes the appointment date on both bounds so FHIR _sort=period
+  // FHIR sorts Period by lower bound (asc) and upper bound (desc) — setting start == end makes
+  // both directions sort by the appointment date correctly.
+  if (currentTask.executionPeriod?.start && currentTask.executionPeriod.end !== currentTask.executionPeriod.start) {
+    updateOperations.push({
+      op: currentTask.executionPeriod.end ? 'replace' : 'add',
+      path: '/executionPeriod/end',
+      value: currentTask.executionPeriod.start,
+    });
+  }
+
+  if (isZeroBalance) {
+    updateOperations.push({
+      op: currentTask.businessStatus ? 'replace' : 'add',
+      path: '/businessStatus',
+      value: ZERO_BALANCE_BUSINESS_STATUS,
+    });
+  } else if (invoiceTaskInput.amountCents !== undefined && currentTask.businessStatus) {
+    updateOperations.push({ op: 'remove', path: '/businessStatus' });
+  }
+
+  // A send that finished after this event was queued has already written its output and status, and
+  // deriving the status from the stale payload would roll that back to "ready".
+  const getLastTaskOutput = getLatestTaskOutput(currentTask);
+  if (getLastTaskOutput?.type === 'success') {
+    updateOperations.push({ op: 'replace', path: '/status', value: mapDisplayToInvoiceTaskStatus('sent') });
+  } else if (getLastTaskOutput?.type === 'error') {
+    updateOperations.push({ op: 'replace', path: '/status', value: mapDisplayToInvoiceTaskStatus('error') });
+  } else {
+    updateOperations.push({ op: 'replace', path: '/status', value: mapDisplayToInvoiceTaskStatus('ready') });
+  }
+
+  return updateOperations;
 }
 
 async function getBillingRefreshData(oystehr: Oystehr, task: Task): Promise<RefreshedInvoiceData | undefined> {

--- a/packages/zambdas/test/unit/sub-refresh-invoice-task.test.ts
+++ b/packages/zambdas/test/unit/sub-refresh-invoice-task.test.ts
@@ -5,6 +5,7 @@ import {
   INVOICE_TASK_CLAIM_ID_IDENTIFIER_SYSTEM,
   invoiceTaskSourceTag,
   RcmTaskCodings,
+  ZERO_BALANCE_BUSINESS_STATUS,
   ZERO_BALANCE_BUSINESS_STATUS_CODE,
 } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -15,6 +16,7 @@ const mockClinicalClient = {
   fhir: {
     search: vi.fn(),
     patch: vi.fn(),
+    get: vi.fn(),
   },
   zambda: {
     execute: (...args: unknown[]) => mockZambdaExecute(...args),
@@ -86,20 +88,38 @@ const arItem = (overrides: Record<string, unknown> = {}): Record<string, unknown
   ...overrides,
 });
 
-const runHandler = (task: Task): Promise<APIGatewayProxyResult> =>
-  handler({
+/**
+ * `task` is the subscription payload; `storedTask` is what the handler will read back from FHIR
+ * right before patching. They differ when a concurrent write has moved the resource on.
+ */
+const runHandler = (task: Task, storedTask: Task = task): Promise<APIGatewayProxyResult> => {
+  mockClinicalClient.fhir.get.mockResolvedValue(storedTask);
+  return handler({
     headers: null,
     body: JSON.stringify(task),
     secrets: {
       PROJECT_ID: 'test-project',
     },
   });
+};
 
-const patchedOperations = (): Operation[] => mockClinicalClient.fhir.patch.mock.calls[0][0].operations as Operation[];
+const patchedOperations = (callIndex = 0): Operation[] =>
+  mockClinicalClient.fhir.patch.mock.calls[callIndex][0].operations as Operation[];
 
 const patchedInputEntry = (code: string): TaskInput | undefined => {
   const inputOp = patchedOperations().find((op) => op.path === '/input') as { value: TaskInput[] } | undefined;
   return inputOp?.value.find((entry) => entry.type.coding?.some((coding) => coding.code === code));
+};
+
+const nonZeroBalanceAr = (): void => {
+  mockZambdaExecute.mockResolvedValue({
+    output: {
+      claims: [arItem()],
+      total: 1,
+      offset: 0,
+      pageSize: 25,
+    },
+  });
 };
 
 describe('sub-refresh-invoice-task', () => {
@@ -199,6 +219,93 @@ describe('sub-refresh-invoice-task', () => {
         value: 'failed',
       },
     ]);
+  });
+
+  it('skips the businessStatus removal when the stored task no longer carries one', async () => {
+    nonZeroBalanceAr();
+
+    // A duplicate delivery: the payload still shows the zero-balance flag an earlier run removed.
+    await runHandler(billingTask({ businessStatus: ZERO_BALANCE_BUSINESS_STATUS }), billingTask());
+
+    expect(mockClinicalClient.fhir.patch).toHaveBeenCalledTimes(1);
+    expect(patchedOperations().find((op) => op.path === '/businessStatus')).toBeUndefined();
+  });
+
+  it('adds rather than replaces paths the stored task is missing', async () => {
+    nonZeroBalanceAr();
+
+    await runHandler(billingTask(), billingTask({ authoredOn: undefined }));
+
+    const authoredOnOp = patchedOperations().find((op) => op.path === '/authoredOn') as { op: string } | undefined;
+    expect(authoredOnOp?.op).toBe('add');
+  });
+
+  // The FHIR API's exact rejection for a patch against a missing path is a server detail, and it is
+  // reported on `code` or `statusCode` depending on how the SDK wrapped it — so all of these shapes
+  // have to reach the retry.
+  it.each([
+    { label: 'code 422', rejection: { code: 422 } },
+    { label: 'code 400', rejection: { code: 400 } },
+    { label: 'statusCode 422', rejection: { statusCode: 422 } },
+  ])('retries without the remove operation when the patch is rejected with $label', async ({ rejection }) => {
+    nonZeroBalanceAr();
+    mockClinicalClient.fhir.patch
+      .mockRejectedValueOnce(Object.assign(new Error('path that does not exist'), rejection))
+      .mockResolvedValueOnce({});
+
+    const taskWithZeroBalanceFlag = billingTask({ businessStatus: ZERO_BALANCE_BUSINESS_STATUS });
+    const result = await runHandler(taskWithZeroBalanceFlag);
+
+    expect(patchedOperations(0)).toContainEqual({ op: 'remove', path: '/businessStatus' });
+
+    const retriedOperations = patchedOperations(1);
+    expect(retriedOperations.some((op) => op.op === 'remove')).toBe(false);
+    expect(retriedOperations).toContainEqual({ op: 'replace', path: '/status', value: 'ready' });
+    expect(retriedOperations.some((op) => op.path === '/input')).toBe(true);
+
+    // A retry that succeeded still gave up on clearing businessStatus; the response has to say so.
+    const message = JSON.parse(result.body).message as string;
+    expect(message).toContain('successfully updated');
+    expect(message).toContain('remove /businessStatus');
+  });
+
+  it('reports an unqualified success when nothing had to be dropped', async () => {
+    nonZeroBalanceAr();
+
+    const result = await runHandler(billingTask({ businessStatus: ZERO_BALANCE_BUSINESS_STATUS }));
+
+    expect(mockClinicalClient.fhir.patch).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(result.body).message).toBe('Task was successfully updated.');
+  });
+
+  it('propagates patch failures that are not path rejections', async () => {
+    nonZeroBalanceAr();
+    mockClinicalClient.fhir.patch.mockRejectedValue(Object.assign(new Error('conflict'), { code: 409 }));
+
+    await expect(runHandler(billingTask({ businessStatus: ZERO_BALANCE_BUSINESS_STATUS }))).rejects.toThrow('conflict');
+    expect(mockClinicalClient.fhir.patch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a path rejection when the patch carries no remove operation', async () => {
+    nonZeroBalanceAr();
+    mockClinicalClient.fhir.patch.mockRejectedValue(Object.assign(new Error('bad path'), { code: 422 }));
+
+    // No stored businessStatus means no `remove` op, so there is nothing to drop and retry.
+    await expect(runHandler(billingTask())).rejects.toThrow('bad path');
+    expect(mockClinicalClient.fhir.patch).toHaveBeenCalledTimes(1);
+  });
+
+  it('derives the status from the stored task output, not the queued payload', async () => {
+    nonZeroBalanceAr();
+
+    // A send completed after this refresh event was queued: the payload predates its output.
+    const storedTask = billingTask({
+      output: [{ type: RcmTaskCodings.sendInvoiceOutputInvoiceId, valueString: 'invoice-1' }],
+    });
+    await runHandler(billingTask(), storedTask);
+
+    const statusOp = patchedOperations().find((op) => op.path === '/status') as { value: string } | undefined;
+    expect(statusOp?.value).toBe('completed');
   });
 
   it('routes candid and legacy untagged tasks through Candid, not patient AR', async () => {

--- a/packages/zambdas/test/unit/sub-refresh-invoice-task.test.ts
+++ b/packages/zambdas/test/unit/sub-refresh-invoice-task.test.ts
@@ -58,6 +58,8 @@ const billingTask = (overrides: Partial<Task> = {}): Task =>
     },
     authoredOn: '2026-07-01T00:00:00Z',
     meta: {
+      // The handler patches under this version, so it has to be present for the lock to be exercised.
+      versionId: '7',
       tag: [invoiceTaskSourceTag('ottehr-billing')],
     },
     identifier: [
@@ -89,11 +91,15 @@ const arItem = (overrides: Record<string, unknown> = {}): Record<string, unknown
 });
 
 /**
- * `task` is the subscription payload; `storedTask` is what the handler will read back from FHIR
- * right before patching. They differ when a concurrent write has moved the resource on.
+ * `task` is the subscription payload; `stored` is what the handler will read back from FHIR right
+ * before patching. They differ when a concurrent write has moved the resource on. Pass an array to
+ * make successive reads differ — the handler re-reads once per optimistic-locking retry, and the last
+ * entry answers every read after that.
  */
-const runHandler = (task: Task, storedTask: Task = task): Promise<APIGatewayProxyResult> => {
-  mockClinicalClient.fhir.get.mockResolvedValue(storedTask);
+const runHandler = (task: Task, stored: Task | Task[] = task): Promise<APIGatewayProxyResult> => {
+  const reads = Array.isArray(stored) ? stored : [stored];
+  reads.slice(0, -1).forEach((read) => mockClinicalClient.fhir.get.mockResolvedValueOnce(read));
+  mockClinicalClient.fhir.get.mockResolvedValue(reads[reads.length - 1]);
   return handler({
     headers: null,
     body: JSON.stringify(task),
@@ -240,36 +246,39 @@ describe('sub-refresh-invoice-task', () => {
     expect(authoredOnOp?.op).toBe('add');
   });
 
-  // The FHIR API's exact rejection for a patch against a missing path is a server detail, and it is
-  // reported on `code` or `statusCode` depending on how the SDK wrapped it — so all of these shapes
-  // have to reach the retry.
-  it.each([
-    { label: 'code 422', rejection: { code: 422 } },
-    { label: 'code 400', rejection: { code: 400 } },
-    { label: 'statusCode 422', rejection: { statusCode: 422 } },
-  ])('retries without the remove operation when the patch is rejected with $label', async ({ rejection }) => {
+  it('patches under the version it read', async () => {
     nonZeroBalanceAr();
-    mockClinicalClient.fhir.patch
-      .mockRejectedValueOnce(Object.assign(new Error('path that does not exist'), rejection))
-      .mockResolvedValueOnce({});
 
-    const taskWithZeroBalanceFlag = billingTask({ businessStatus: ZERO_BALANCE_BUSINESS_STATUS });
-    const result = await runHandler(taskWithZeroBalanceFlag);
+    await runHandler(billingTask(), billingTask({ meta: { versionId: '9' } }));
+
+    expect(mockClinicalClient.fhir.patch.mock.calls[0][1]).toEqual({ optimisticLockingVersionId: '9' });
+  });
+
+  it('recomputes the patch against the winning write when the optimistic lock rejects it', async () => {
+    nonZeroBalanceAr();
+    mockClinicalClient.fhir.patch.mockRejectedValueOnce(Object.assign(new Error('conflict'), { code: 412 }));
+
+    // The read that built the first patch still saw the zero-balance flag; the write that beat us to
+    // it had already cleared the flag and recorded a successful send.
+    await runHandler(billingTask(), [
+      billingTask({ businessStatus: ZERO_BALANCE_BUSINESS_STATUS }),
+      billingTask({
+        businessStatus: undefined,
+        output: [{ type: RcmTaskCodings.sendInvoiceOutputInvoiceId, valueString: 'invoice-1' }],
+      }),
+    ]);
 
     expect(patchedOperations(0)).toContainEqual({ op: 'remove', path: '/businessStatus' });
 
+    // The remove is gone because the field is, and the status follows the output the winner wrote
+    // rather than the "ready" the first attempt derived.
     const retriedOperations = patchedOperations(1);
-    expect(retriedOperations.some((op) => op.op === 'remove')).toBe(false);
-    expect(retriedOperations).toContainEqual({ op: 'replace', path: '/status', value: 'ready' });
+    expect(retriedOperations.find((op) => op.path === '/businessStatus')).toBeUndefined();
+    expect(retriedOperations).toContainEqual({ op: 'replace', path: '/status', value: 'completed' });
     expect(retriedOperations.some((op) => op.path === '/input')).toBe(true);
-
-    // A retry that succeeded still gave up on clearing businessStatus; the response has to say so.
-    const message = JSON.parse(result.body).message as string;
-    expect(message).toContain('successfully updated');
-    expect(message).toContain('remove /businessStatus');
   });
 
-  it('reports an unqualified success when nothing had to be dropped', async () => {
+  it('reports an unqualified success', async () => {
     nonZeroBalanceAr();
 
     const result = await runHandler(billingTask({ businessStatus: ZERO_BALANCE_BUSINESS_STATUS }));
@@ -278,21 +287,20 @@ describe('sub-refresh-invoice-task', () => {
     expect(JSON.parse(result.body).message).toBe('Task was successfully updated.');
   });
 
-  it('propagates patch failures that are not path rejections', async () => {
-    nonZeroBalanceAr();
-    mockClinicalClient.fhir.patch.mockRejectedValue(Object.assign(new Error('conflict'), { code: 409 }));
-
-    await expect(runHandler(billingTask({ businessStatus: ZERO_BALANCE_BUSINESS_STATUS }))).rejects.toThrow('conflict');
-    expect(mockClinicalClient.fhir.patch).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not retry a path rejection when the patch carries no remove operation', async () => {
+  it('propagates patch failures that are not version conflicts', async () => {
     nonZeroBalanceAr();
     mockClinicalClient.fhir.patch.mockRejectedValue(Object.assign(new Error('bad path'), { code: 422 }));
 
-    // No stored businessStatus means no `remove` op, so there is nothing to drop and retry.
-    await expect(runHandler(billingTask())).rejects.toThrow('bad path');
+    await expect(runHandler(billingTask({ businessStatus: ZERO_BALANCE_BUSINESS_STATUS }))).rejects.toThrow('bad path');
     expect(mockClinicalClient.fhir.patch).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up rather than retrying a conflict forever', async () => {
+    nonZeroBalanceAr();
+    mockClinicalClient.fhir.patch.mockRejectedValue(Object.assign(new Error('conflict'), { code: 412 }));
+
+    await expect(runHandler(billingTask())).rejects.toThrow('conflict');
+    expect(mockClinicalClient.fhir.patch).toHaveBeenCalledTimes(3);
   });
 
   it('derives the status from the stored task output, not the queued payload', async () => {


### PR DESCRIPTION
There was an error when trying to remove businessStatus field from Task resource while it was already gone.
Re-getting task resource inside zambda to have actual version and retrying patch using `patchWithOptimisticLock` if it fails.

> Cannot perform the operation at a path that does not exist for {"op":"remove","path":"/businessStatus"}