### PR TITLE
fix(billing): restore claim-history records for working-copy field edits

### DIFF
--- a/apps/billing/src/pages/ClaimDetail.tsx
+++ b/apps/billing/src/pages/ClaimDetail.tsx
@@ -810,23 +810,21 @@ function RenderingProviderSection({
   ): Promise<string | null> => {
     if (!oystehrZambda) return null;
     try {
-      // By default, update existing provider below, taking into account that the payload
-      // may include the selected provider's ID at this point
+      // A selected reference provider is an attach/swap — even when the claim already has one:
+      // point the claim at a fresh working copy of the selection (recording the reference change,
+      // with its link, in the claim history), then apply the form's fields to that copy below.
+      // Without a selection, this is a field edit of the current working copy.
       let providerId =
-        'providerId' in payload && payload.providerId
-          ? selectedProvider
-            ? claim.renderingProviderId
-            : payload.providerId
-          : undefined;
+        'providerId' in payload && payload.providerId && !selectedProvider ? payload.providerId : undefined;
       if (!providerId) {
         if (selectedProvider?.id) {
-          // Selected from some base, add it to claim and update below
-          await updateResource('Claim', claim.id, {
+          const attachError = await updateResource('Claim', claim.id, {
             renderingProvider: {
               id: selectedProvider.id,
               type: selectedProvider.kind === 'organization' ? 'Organization' : 'Practitioner',
             },
           });
+          if (attachError) return attachError;
           const updatedClaim = await getBillingClaimDetail(oystehrZambda, { claimId: claim.id });
           providerId = updatedClaim.renderingProviderId;
         } else {
@@ -894,15 +892,17 @@ function FacilitySection({
   const handleSave = async (payload: SaveServiceFacilityInput): Promise<string | null> => {
     if (!oystehrZambda) return null;
     try {
-      // By default, update existing facility below, taking into account that the payload
-      // may include the selected facility's ID at this point
-      let facilityId = payload.facilityId ? (selected ? claim.serviceFacilityId : payload.facilityId) : undefined;
+      // A selected reference facility is an attach/swap — even when the claim already has one:
+      // point the claim at a fresh working copy of the selection (recording the reference change,
+      // with its link, in the claim history), then apply the form's fields to that copy below.
+      // Without a selection, this is a field edit of the current working copy.
+      let facilityId = payload.facilityId && !selected ? payload.facilityId : undefined;
       if (!facilityId) {
         if (selected?.id) {
-          // Selected from some base, add it to claim and update below
-          await updateResource('Claim', claim.id, {
+          const attachError = await updateResource('Claim', claim.id, {
             facilityId: selected.id,
           });
+          if (attachError) return attachError;
           const updatedClaim = await getBillingClaimDetail(oystehrZambda, { claimId: claim.id });
           facilityId = updatedClaim.serviceFacilityId;
         } else {
@@ -975,23 +975,21 @@ function BillingProviderSection({
   ): Promise<string | null> => {
     if (!oystehrZambda) return null;
     try {
-      // By default, update existing provider below, taking into account that the payload
-      // may include the selected provider's ID at this point
+      // A selected reference provider is an attach/swap — even when the claim already has one:
+      // point the claim at a fresh working copy of the selection (recording the reference change,
+      // with its link, in the claim history), then apply the form's fields to that copy below.
+      // Without a selection, this is a field edit of the current working copy.
       let providerId =
-        'providerId' in payload && payload.providerId
-          ? selectedProvider
-            ? claim.billingProviderFhirId
-            : payload.providerId
-          : undefined;
+        'providerId' in payload && payload.providerId && !selectedProvider ? payload.providerId : undefined;
       if (!providerId) {
         if (selectedProvider?.id) {
-          // Selected from some base, add it to claim and update below
-          await updateResource('Claim', claim.id, {
+          const attachError = await updateResource('Claim', claim.id, {
             billingProvider: {
               id: selectedProvider.id,
               type: selectedProvider.kind === 'organization' ? 'Organization' : 'Practitioner',
             },
           });
+          if (attachError) return attachError;
           const updatedClaim = await getBillingClaimDetail(oystehrZambda, { claimId: claim.id });
           providerId = updatedClaim.billingProviderFhirId;
         } else {

--- a/apps/billing/src/pages/ClaimDetail.tsx
+++ b/apps/billing/src/pages/ClaimDetail.tsx
@@ -570,7 +570,8 @@ function PatientSection({ claim }: { claim: ClaimDetailResponse }): ReactElement
 
   const handleSave = async (payload: UpdateBillingPatientInput): Promise<string | null> => {
     if (!oystehrZambda) return 'Client not ready';
-    await updateBillingPatient(oystehrZambda, payload);
+    // claimId scopes the edit to this claim so it lands in the claim's history.
+    await updateBillingPatient(oystehrZambda, { ...payload, claimId: claim.id });
     await refetchPatient();
     return null;
   };
@@ -659,7 +660,7 @@ export function InsuranceSection({
         const err = await updateResource('Claim', claim.id, claimFields);
         if (err) return err;
       }
-      await updateBillingCoverage(oystehrZambda, coverageToUpdateInput(data, coverageId));
+      await updateBillingCoverage(oystehrZambda, { ...coverageToUpdateInput(data, coverageId), claimId: claim.id });
       resetFields();
       return null;
     } catch (err) {
@@ -840,7 +841,7 @@ function RenderingProviderSection({
         }
       }
       // Update provider
-      await updateBillingProvider(oystehrZambda, { ...payload, providerId });
+      await updateBillingProvider(oystehrZambda, { ...payload, providerId, claimId: claim.id });
       resetFields();
       await refetchClaimProvider();
       return null;
@@ -913,7 +914,7 @@ function FacilitySection({
         }
       }
       // Update provider
-      await saveBillingServiceFacility(oystehrZambda, { ...payload, facilityId });
+      await saveBillingServiceFacility(oystehrZambda, { ...payload, facilityId, claimId: claim.id });
       resetFields();
       await refetchServiceFacility();
       return null;
@@ -1005,7 +1006,7 @@ function BillingProviderSection({
         }
       }
       // Update provider
-      await updateBillingProvider(oystehrZambda, { ...payload, providerId });
+      await updateBillingProvider(oystehrZambda, { ...payload, providerId, claimId: claim.id });
       resetFields();
       await refetchClaimProvider();
       return null;

--- a/packages/utils/lib/types/data/billing/billing.schemas.ts
+++ b/packages/utils/lib/types/data/billing/billing.schemas.ts
@@ -17,6 +17,11 @@ const nonEmptyString = z.string().trim().min(1);
 const nonNegativeInt = z.number().int().nonnegative();
 const gender = z.enum(['male', 'female', 'unknown']);
 
+// When a resource is edited in the context of a claim (the claim detail screen editing the claim's
+// working copies), the edit endpoints record the change in that claim's history. Edits from the
+// master screens carry no claim context and write no history record.
+const historyClaimId = z.string().uuid().optional();
+
 export const ALLOWED_BILLING_RESOURCE_TYPES = [
   'Patient',
   'Coverage',
@@ -213,6 +218,9 @@ export const SearchServiceFacilitiesInputSchema = z.object({
 
 export const SaveServiceFacilityInputSchema = z.object({
   facilityId: nonEmptyString.optional(),
+  // Only honored when updating an existing facility (a claim's working copy); creates are recorded
+  // by the subsequent claim attach.
+  claimId: historyClaimId,
   name: nonEmptyString,
   addressLine1: nonEmptyString,
   addressLine2: z.string().trim().optional(),
@@ -334,6 +342,7 @@ export const UpdateBillingProviderInputSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('individual'),
     providerId: nonEmptyString,
+    claimId: historyClaimId,
     firstName: nonEmptyString,
     lastName: nonEmptyString,
     roles: z.array(billingProviderRole).min(1),
@@ -346,6 +355,7 @@ export const UpdateBillingProviderInputSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('organization'),
     providerId: nonEmptyString,
+    claimId: historyClaimId,
     name: nonEmptyString,
     roles: z.array(billingProviderRole).min(1),
     npi: billingNpiSchema.optional(),
@@ -363,6 +373,7 @@ export const DeleteBillingProviderInputSchema = z.object({
 
 export const UpdateBillingPatientInputSchema = z.object({
   patientId: nonEmptyString,
+  claimId: historyClaimId,
   firstName: nonEmptyString,
   lastName: nonEmptyString,
   dob: nonEmptyString.optional(),
@@ -410,6 +421,7 @@ export const CreateBillingCoverageInputSchema = z
 export const UpdateBillingCoverageInputSchema = z
   .object({
     coverageId: nonEmptyString,
+    claimId: historyClaimId,
     payerId: nonEmptyString.optional(),
     memberId: nonEmptyString.optional(),
     insuranceType: insuranceTypeSchema.optional(),

--- a/packages/zambdas/src/billing/provenance.ts
+++ b/packages/zambdas/src/billing/provenance.ts
@@ -42,6 +42,7 @@ import {
   Secrets,
   userMe,
 } from 'utils';
+import { getCLIA, getPlaceOfServiceCode } from './service-facility.helpers';
 import {
   buildUpdatedClaimStatusTags,
   fhirName,
@@ -163,6 +164,8 @@ function projectPatient(p: Patient): FieldProjection[] {
     { field: 'dob', label: 'Date of Birth', value: p.birthDate ?? '' },
     { field: 'gender', label: 'Gender', value: p.gender ?? '' },
     { field: 'address', label: 'Address', value: formatAddress(p.address?.[0]) },
+    { field: 'phone', label: 'Phone', value: p.telecom?.find((t) => t.system === 'phone')?.value ?? '' },
+    { field: 'email', label: 'Email', value: p.telecom?.find((t) => t.system === 'email')?.value ?? '' },
   ];
 }
 
@@ -172,6 +175,7 @@ function projectPractitioner(p: Practitioner): FieldProjection[] {
     { field: 'npi', label: 'NPI', value: getNPI(p) ?? '' },
     { field: 'taxId', label: 'Tax ID', value: getTaxID(p) ?? '' },
     { field: 'taxonomy', label: 'Taxonomy', value: getTaxonomy(p) },
+    { field: 'address', label: 'Address', value: formatAddress(p.address?.[0]) },
   ];
 }
 
@@ -181,6 +185,7 @@ function projectOrganization(o: Organization): FieldProjection[] {
     { field: 'npi', label: 'NPI', value: getNPI(o) ?? '' },
     { field: 'taxId', label: 'Tax ID', value: getTaxID(o) ?? '' },
     { field: 'taxonomy', label: 'Taxonomy', value: getTaxonomy(o) },
+    { field: 'address', label: 'Address', value: formatAddress(o.address?.[0]) },
   ];
 }
 
@@ -188,6 +193,8 @@ function projectLocation(l: Location): FieldProjection[] {
   return [
     { field: 'name', label: 'Name', value: l.name ?? '' },
     { field: 'npi', label: 'NPI', value: getNPI(l) ?? '' },
+    { field: 'clia', label: 'CLIA', value: getCLIA(l) ?? '' },
+    { field: 'posCode', label: 'Place of Service', value: getPlaceOfServiceCode(l) ?? '' },
     { field: 'address', label: 'Address', value: formatAddress(l.address) },
   ];
 }

--- a/packages/zambdas/src/billing/save-billing-service-facility/index.ts
+++ b/packages/zambdas/src/billing/save-billing-service-facility/index.ts
@@ -1,8 +1,9 @@
 import Oystehr from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { Location } from 'fhir/r4b';
-import { FHIR_IDENTIFIER_NPI, INVALID_INPUT_ERROR } from 'utils';
+import { Location, ProvenanceAgent } from 'fhir/r4b';
+import { FHIR_IDENTIFIER_NPI, INVALID_INPUT_ERROR, makeOptimisticLockIfMatchHeader } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
+import { commitClaimResourceChange, resolveClaimActor } from '../provenance';
 import { applyServiceFacilityInput } from '../service-facility.helpers';
 import { createBillingClient, EXCLUDE_WORKING_COPIES_PARAMS, fetchById, isWorkingCopy } from '../shared';
 import { SaveServiceFacilityParams, validateRequestParameters } from './validateRequestParameters';
@@ -25,8 +26,15 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   console.groupEnd();
   console.debug('complexValidation success', existing);
 
+  // A claim-scoped edit (the claim screen editing the claim's facility working copy) is recorded in
+  // that claim's history, so it needs the acting user; master-screen edits carry no claim context
+  // and keep working without a resolvable caller.
+  const agent = params.claimId
+    ? await resolveClaimActor('caller', oystehr, input.headers?.Authorization, secrets)
+    : undefined;
+
   console.group('performEffect');
-  const response = await performEffect(oystehr, params, existing);
+  const response = await performEffect(oystehr, params, existing, agent);
   console.groupEnd();
   console.debug('performEffect success', response);
 
@@ -66,20 +74,35 @@ async function complexValidation(oystehr: Oystehr, params: SaveServiceFacilityPa
   return existing;
 }
 
-async function performEffect(
+export async function performEffect(
   oystehr: Oystehr,
   params: SaveServiceFacilityParams,
-  existing: Location | undefined
+  existing: Location | undefined,
+  agent?: ProvenanceAgent
 ): Promise<{ id: string | undefined }> {
   const location = applyServiceFacilityInput(params, existing);
 
   if (existing) {
+    if (params.claimId && agent) {
+      // Write the update and its claim-history Provenance in one transaction, keeping the same
+      // optimistic lock the plain update uses.
+      await commitClaimResourceChange(oystehr, {
+        resource: location,
+        before: existing,
+        agent,
+        claimReference: `Claim/${params.claimId}`,
+        ifMatch: makeOptimisticLockIfMatchHeader(existing),
+      });
+      return { id: location.id };
+    }
     const updated = await oystehr.fhir.update<Location>(location, {
       optimisticLockingVersionId: existing.meta?.versionId,
     });
     return { id: updated.id };
   }
 
+  // A create is never claim-scoped: the facility only enters a claim via the subsequent attach,
+  // which records the claim's facility change itself.
   const created = await oystehr.fhir.create<Location>(location);
   return { id: created.id };
 }

--- a/packages/zambdas/src/billing/save-billing-service-facility/index.ts
+++ b/packages/zambdas/src/billing/save-billing-service-facility/index.ts
@@ -22,16 +22,9 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   const oystehr = createBillingClient(m2mToken, secrets);
 
   console.group('complexValidation');
-  const existing = await complexValidation(oystehr, params);
+  const { existing, agent } = await complexValidation(oystehr, params, input.headers?.Authorization);
   console.groupEnd();
   console.debug('complexValidation success', existing);
-
-  // A claim-scoped edit (the claim screen editing the claim's facility working copy) is recorded in
-  // that claim's history, so it needs the acting user; master-screen edits carry no claim context
-  // and keep working without a resolvable caller.
-  const agent = params.claimId
-    ? await resolveClaimActor('caller', oystehr, input.headers?.Authorization, secrets)
-    : undefined;
 
   console.group('performEffect');
   const response = await performEffect(oystehr, params, existing, agent);
@@ -44,7 +37,11 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   };
 });
 
-async function complexValidation(oystehr: Oystehr, params: SaveServiceFacilityParams): Promise<Location | undefined> {
+async function complexValidation(
+  oystehr: Oystehr,
+  params: SaveServiceFacilityParams,
+  authorizationHeader: string | undefined
+): Promise<{ existing: Location | undefined; agent: ProvenanceAgent | undefined }> {
   const { facilityId, npi } = params;
 
   const existing = facilityId ? await fetchById<Location>(oystehr, 'Location', facilityId) : undefined;
@@ -71,7 +68,14 @@ async function complexValidation(oystehr: Oystehr, params: SaveServiceFacilityPa
     }
   }
 
-  return existing;
+  // A claim-scoped edit (the claim screen editing the claim's facility working copy) is recorded in
+  // that claim's history, so it needs the acting user; master-screen edits carry no claim context
+  // and keep working without a resolvable caller.
+  const agent = params.claimId
+    ? await resolveClaimActor('caller', oystehr, authorizationHeader, params.secrets)
+    : undefined;
+
+  return { existing, agent };
 }
 
 export async function performEffect(

--- a/packages/zambdas/src/billing/update-billing-coverage/index.ts
+++ b/packages/zambdas/src/billing/update-billing-coverage/index.ts
@@ -1,9 +1,10 @@
 import Oystehr, { BatchInputRequest } from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { randomUUID } from 'crypto';
-import { Coverage } from 'fhir/r4b';
+import { Coverage, ProvenanceAgent, RelatedPerson } from 'fhir/r4b';
 import { APIErrorCode, FHIR_RESOURCE_NOT_FOUND, setCoveragePlanType } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
+import { commitClaimResourceChange, diffResources, resolveClaimActor } from '../provenance';
 import {
   BillingFhirResource,
   buildSubscriberRelatedPerson,
@@ -33,7 +34,14 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
   const cvo = await complexValidation(params, oystehr);
 
-  const response = await performEffect(oystehr, params, cvo);
+  // A claim-scoped edit (the claim screen editing the claim's coverage working copy) is recorded in
+  // that claim's history, so it needs the acting user; master-screen edits carry no claim context
+  // and keep working without a resolvable caller.
+  const agent = params.claimId
+    ? await resolveClaimActor('caller', oystehr, input.headers?.Authorization, params.secrets)
+    : undefined;
+
+  const response = await performEffect(oystehr, params, cvo, agent);
   return { statusCode: 200, body: JSON.stringify(response) };
 });
 
@@ -61,10 +69,11 @@ async function complexValidation(
   return { patientId, coverage };
 }
 
-async function performEffect(
+export async function performEffect(
   oystehr: Oystehr,
   params: UpdateBillingCoverageParams,
-  cvo: ComplexValidationResult
+  cvo: ComplexValidationResult,
+  agent?: ProvenanceAgent
 ): Promise<{ id: string | undefined }> {
   const { patientId } = cvo;
   let coverage = structuredClone(cvo.coverage);
@@ -89,10 +98,12 @@ async function performEffect(
   const preCoverageRequests: BatchInputRequest<BillingFhirResource>[] = [];
   const postCoverageRequests: BatchInputRequest<BillingFhirResource>[] = [];
 
+  let newSubscriber: RelatedPerson | undefined;
+  let currentSubscriberId: string | undefined;
   if (params.relationship) {
     setCoverageRelationship(coverage, params.relationship);
     const currentRef = coverage.subscriber?.reference;
-    const currentSubscriberId = currentRef?.startsWith('RelatedPerson/') ? currentRef.split('/')[1] : undefined;
+    currentSubscriberId = currentRef?.startsWith('RelatedPerson/') ? currentRef.split('/')[1] : undefined;
 
     if (params.relationship === 'Self' || !params.policyHolder) {
       coverage.subscriber = { reference: `Patient/${patientId}` };
@@ -100,13 +111,13 @@ async function performEffect(
         postCoverageRequests.push({ method: 'DELETE', url: `RelatedPerson/${currentSubscriberId}` });
       }
     } else {
-      const subscriber = buildSubscriberRelatedPerson(patientId, params.relationship, params.policyHolder);
+      newSubscriber = buildSubscriberRelatedPerson(patientId, params.relationship, params.policyHolder);
       if (currentSubscriberId) {
-        subscriber.id = currentSubscriberId;
+        newSubscriber.id = currentSubscriberId;
         preCoverageRequests.push({
           method: 'PUT',
           url: `RelatedPerson/${currentSubscriberId}`,
-          resource: subscriber,
+          resource: newSubscriber,
         });
         coverage.subscriber = { reference: `RelatedPerson/${currentSubscriberId}` };
       } else {
@@ -114,7 +125,7 @@ async function performEffect(
         preCoverageRequests.push({
           method: 'POST',
           url: '/RelatedPerson',
-          resource: subscriber,
+          resource: newSubscriber,
           fullUrl: subscriberUrn,
         });
         coverage.subscriber = { reference: subscriberUrn };
@@ -126,13 +137,41 @@ async function performEffect(
     coverage = setCoveragePlanType(coverage, params.planType);
   }
 
+  // Moving insurance type re-homes the coverage to the right account (PBILLACCT vs WCOMPACCT).
+  const accountRequests =
+    params.insuranceType !== undefined
+      ? reconcileAccountsForCoverage(accounts, patientId, `Coverage/${params.coverageId}`, params.insuranceType)
+      : [];
+
+  if (params.claimId && agent) {
+    // Claim-scoped edit: write the coverage update and its claim-history Provenance in the same
+    // transaction. Policy-holder edits ride on the subscriber RelatedPerson, which the coverage
+    // projection can't see — fold them in as `policyHolder.*` changes, mirroring update-billing-claim.
+    const currentSubscriber =
+      params.relationship && currentSubscriberId
+        ? await fetchById<RelatedPerson>(oystehr, 'RelatedPerson', currentSubscriberId)
+        : undefined;
+    const policyHolderChanges = diffResources(currentSubscriber, newSubscriber).map((change) => ({
+      ...change,
+      field: `policyHolder.${change.field}`,
+      label: `Policy Holder ${change.label}`,
+    }));
+    await commitClaimResourceChange(oystehr, {
+      resource: coverage,
+      before: cvo.coverage,
+      agent,
+      claimReference: `Claim/${params.claimId}`,
+      extraChanges: policyHolderChanges,
+      preRequests: preCoverageRequests,
+      postRequests: [...accountRequests, ...postCoverageRequests],
+    });
+    return { id: params.coverageId };
+  }
+
   const requests: BatchInputRequest<BillingFhirResource>[] = [
     ...preCoverageRequests,
     { method: 'PUT', url: `Coverage/${params.coverageId}`, resource: coverage },
-    // Moving insurance type re-homes the coverage to the right account (PBILLACCT vs WCOMPACCT).
-    ...(params.insuranceType !== undefined
-      ? reconcileAccountsForCoverage(accounts, patientId, `Coverage/${params.coverageId}`, params.insuranceType)
-      : []),
+    ...accountRequests,
     ...postCoverageRequests,
   ];
 

--- a/packages/zambdas/src/billing/update-billing-coverage/index.ts
+++ b/packages/zambdas/src/billing/update-billing-coverage/index.ts
@@ -25,6 +25,7 @@ const ZAMBDA_NAME = 'update-billing-coverage';
 interface ComplexValidationResult {
   patientId: string;
   coverage: Coverage;
+  agent?: ProvenanceAgent;
 }
 
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
@@ -32,22 +33,16 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, params.secrets);
   const oystehr = createBillingClient(m2mToken, params.secrets);
 
-  const cvo = await complexValidation(params, oystehr);
+  const cvo = await complexValidation(params, oystehr, input.headers?.Authorization);
 
-  // A claim-scoped edit (the claim screen editing the claim's coverage working copy) is recorded in
-  // that claim's history, so it needs the acting user; master-screen edits carry no claim context
-  // and keep working without a resolvable caller.
-  const agent = params.claimId
-    ? await resolveClaimActor('caller', oystehr, input.headers?.Authorization, params.secrets)
-    : undefined;
-
-  const response = await performEffect(oystehr, params, cvo, agent);
+  const response = await performEffect(oystehr, params, cvo);
   return { statusCode: 200, body: JSON.stringify(response) };
 });
 
 async function complexValidation(
   params: UpdateBillingCoverageParams,
-  oystehr: Oystehr
+  oystehr: Oystehr,
+  authorizationHeader: string | undefined
 ): Promise<ComplexValidationResult> {
   const coverage = await fetchById<Coverage>(oystehr, 'Coverage', params.coverageId);
   const patientId = coverage.beneficiary?.reference?.split('/')[1];
@@ -66,16 +61,22 @@ async function complexValidation(
     }
   }
 
-  return { patientId, coverage };
+  // A claim-scoped edit (the claim screen editing the claim's coverage working copy) is recorded in
+  // that claim's history, so it needs the acting user; master-screen edits carry no claim context
+  // and keep working without a resolvable caller.
+  const agent = params.claimId
+    ? await resolveClaimActor('caller', oystehr, authorizationHeader, params.secrets)
+    : undefined;
+
+  return { patientId, coverage, agent };
 }
 
 export async function performEffect(
   oystehr: Oystehr,
   params: UpdateBillingCoverageParams,
-  cvo: ComplexValidationResult,
-  agent?: ProvenanceAgent
+  cvo: ComplexValidationResult
 ): Promise<{ id: string | undefined }> {
-  const { patientId } = cvo;
+  const { patientId, agent } = cvo;
   let coverage = structuredClone(cvo.coverage);
   const accounts = params.insuranceType !== undefined ? await getPatientAccounts(oystehr, patientId) : [];
 

--- a/packages/zambdas/src/billing/update-billing-patient/index.ts
+++ b/packages/zambdas/src/billing/update-billing-patient/index.ts
@@ -14,16 +14,23 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, params.secrets);
   const oystehr = createBillingClient(m2mToken, params.secrets);
 
-  // A claim-scoped edit (the claim screen editing the claim's patient working copy) is recorded in
-  // that claim's history, so it needs the acting user; master-screen edits carry no claim context
-  // and keep working without a resolvable caller.
-  const agent = params.claimId
-    ? await resolveClaimActor('caller', oystehr, input.headers?.Authorization, params.secrets)
-    : undefined;
+  const agent = await complexValidation(oystehr, params, input.headers?.Authorization);
 
   const response = await performEffect(oystehr, params, agent);
   return { statusCode: 200, body: JSON.stringify(response) };
 });
+
+// A claim-scoped edit (the claim screen editing the claim's patient working copy) is recorded in
+// that claim's history, so it needs the acting user; master-screen edits carry no claim context
+// and keep working without a resolvable caller.
+async function complexValidation(
+  oystehr: Oystehr,
+  params: UpdateBillingPatientParams,
+  authorizationHeader: string | undefined
+): Promise<ProvenanceAgent | undefined> {
+  if (!params.claimId) return undefined;
+  return resolveClaimActor('caller', oystehr, authorizationHeader, params.secrets);
+}
 
 export async function performEffect(
   oystehr: Oystehr,

--- a/packages/zambdas/src/billing/update-billing-patient/index.ts
+++ b/packages/zambdas/src/billing/update-billing-patient/index.ts
@@ -1,7 +1,8 @@
 import Oystehr from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { Patient } from 'fhir/r4b';
+import { Patient, ProvenanceAgent } from 'fhir/r4b';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
+import { commitClaimResourceChange, resolveClaimActor } from '../provenance';
 import { buildAddress, createBillingClient, fetchById } from '../shared';
 import { UpdateBillingPatientParams, validateRequestParameters } from './validateRequestParameters';
 
@@ -13,12 +14,24 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, params.secrets);
   const oystehr = createBillingClient(m2mToken, params.secrets);
 
-  const response = await performEffect(oystehr, params);
+  // A claim-scoped edit (the claim screen editing the claim's patient working copy) is recorded in
+  // that claim's history, so it needs the acting user; master-screen edits carry no claim context
+  // and keep working without a resolvable caller.
+  const agent = params.claimId
+    ? await resolveClaimActor('caller', oystehr, input.headers?.Authorization, params.secrets)
+    : undefined;
+
+  const response = await performEffect(oystehr, params, agent);
   return { statusCode: 200, body: JSON.stringify(response) };
 });
 
-async function performEffect(oystehr: Oystehr, params: UpdateBillingPatientParams): Promise<{ id: string }> {
+export async function performEffect(
+  oystehr: Oystehr,
+  params: UpdateBillingPatientParams,
+  agent?: ProvenanceAgent
+): Promise<{ id: string }> {
   const patient = await fetchById<Patient>(oystehr, 'Patient', params.patientId);
+  const before = structuredClone(patient);
 
   patient.name = [{ family: params.lastName, given: [params.firstName] }];
 
@@ -48,6 +61,17 @@ async function performEffect(oystehr: Oystehr, params: UpdateBillingPatientParam
 
   if (params.address) patient.address = [buildAddress(params.address)];
   else delete patient.address;
+
+  if (params.claimId && agent) {
+    // Write the update and its claim-history Provenance in one transaction.
+    await commitClaimResourceChange(oystehr, {
+      resource: patient,
+      before,
+      agent,
+      claimReference: `Claim/${params.claimId}`,
+    });
+    return { id: params.patientId };
+  }
 
   const updated = await oystehr.fhir.update<Patient>(patient);
   return { id: updated.id! };

--- a/packages/zambdas/src/billing/update-billing-provider/index.ts
+++ b/packages/zambdas/src/billing/update-billing-provider/index.ts
@@ -26,16 +26,23 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, params.secrets);
   const oystehr = createBillingClient(m2mToken, params.secrets);
 
-  // A claim-scoped edit (the claim screen editing a provider working copy) is recorded in that
-  // claim's history, so it needs the acting user; master-screen edits carry no claim context and
-  // keep working without a resolvable caller.
-  const agent = params.claimId
-    ? await resolveClaimActor('caller', oystehr, input.headers?.Authorization, params.secrets)
-    : undefined;
+  const agent = await complexValidation(oystehr, params, input.headers?.Authorization);
 
   const response = await performEffect(oystehr, params, agent);
   return { statusCode: 200, body: JSON.stringify(response) };
 });
+
+// A claim-scoped edit (the claim screen editing a provider working copy) is recorded in that
+// claim's history, so it needs the acting user; master-screen edits carry no claim context and
+// keep working without a resolvable caller.
+async function complexValidation(
+  oystehr: Oystehr,
+  params: UpdateBillingProviderParams,
+  authorizationHeader: string | undefined
+): Promise<ProvenanceAgent | undefined> {
+  if (!params.claimId) return undefined;
+  return resolveClaimActor('caller', oystehr, authorizationHeader, params.secrets);
+}
 
 export async function performEffect(
   oystehr: Oystehr,

--- a/packages/zambdas/src/billing/update-billing-provider/index.ts
+++ b/packages/zambdas/src/billing/update-billing-provider/index.ts
@@ -1,8 +1,9 @@
 import Oystehr from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { Organization, Practitioner } from 'fhir/r4b';
+import { Organization, Practitioner, ProvenanceAgent } from 'fhir/r4b';
 import { setNpi } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
+import { commitClaimResourceChange, resolveClaimActor } from '../provenance';
 import {
   buildAddress,
   createBillingClient,
@@ -25,24 +26,57 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, params.secrets);
   const oystehr = createBillingClient(m2mToken, params.secrets);
 
-  const response = await performEffect(oystehr, params);
+  // A claim-scoped edit (the claim screen editing a provider working copy) is recorded in that
+  // claim's history, so it needs the acting user; master-screen edits carry no claim context and
+  // keep working without a resolvable caller.
+  const agent = params.claimId
+    ? await resolveClaimActor('caller', oystehr, input.headers?.Authorization, params.secrets)
+    : undefined;
+
+  const response = await performEffect(oystehr, params, agent);
   return { statusCode: 200, body: JSON.stringify(response) };
 });
 
-async function performEffect(oystehr: Oystehr, params: UpdateBillingProviderParams): Promise<{ id: string }> {
+export async function performEffect(
+  oystehr: Oystehr,
+  params: UpdateBillingProviderParams,
+  agent?: ProvenanceAgent
+): Promise<{ id: string }> {
   if (params.kind === 'individual') {
     const provider = await fetchById<Practitioner>(oystehr, 'Practitioner', params.providerId);
+    const before = structuredClone(provider);
     provider.name = [{ family: params.lastName, given: [params.firstName] }];
     applyIdentifiersAndAddress(provider, params);
     applyTags(provider, params.roles, params.licenseType);
-    const updated = await oystehr.fhir.update(provider);
-    return { id: updated.id! };
+    return save(oystehr, params, provider, before, agent);
   }
 
   const provider = await fetchById<Organization>(oystehr, 'Organization', params.providerId);
+  const before = structuredClone(provider);
   provider.name = params.name;
   applyIdentifiersAndAddress(provider, params);
   applyTags(provider, params.roles, undefined);
+  return save(oystehr, params, provider, before, agent);
+}
+
+// Claim-scoped edits write the update and its claim-history Provenance in one transaction;
+// master-screen edits stay a plain update.
+async function save(
+  oystehr: Oystehr,
+  params: UpdateBillingProviderParams,
+  provider: Practitioner | Organization,
+  before: Practitioner | Organization,
+  agent: ProvenanceAgent | undefined
+): Promise<{ id: string }> {
+  if (params.claimId && agent) {
+    await commitClaimResourceChange(oystehr, {
+      resource: provider,
+      before,
+      agent,
+      claimReference: `Claim/${params.claimId}`,
+    });
+    return { id: params.providerId };
+  }
   const updated = await oystehr.fhir.update(provider);
   return { id: updated.id! };
 }

--- a/packages/zambdas/test/billing/service-facility.test.ts
+++ b/packages/zambdas/test/billing/service-facility.test.ts
@@ -522,7 +522,7 @@ describe('save-billing-service-facility handler', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
-    ({ index: saveHandler } = (await import('../../src/billing/save-billing-service-facility/index')) as {
+    ({ index: saveHandler } = (await import('../../src/billing/save-billing-service-facility/index')) as unknown as {
       index: ZambdaHandler;
     });
   });

--- a/packages/zambdas/test/unit/billing/save-billing-service-facility.test.ts
+++ b/packages/zambdas/test/unit/billing/save-billing-service-facility.test.ts
@@ -1,0 +1,101 @@
+import Oystehr from '@oystehr/sdk';
+import { Location, Provenance, ProvenanceAgent } from 'fhir/r4b';
+import { CLAIM_PROVENANCE_DIFF_EXTENSION_URL, ClaimFieldChange, SaveServiceFacilityInput } from 'utils';
+import { describe, expect, it, vi } from 'vitest';
+import { performEffect } from '../../../src/billing/save-billing-service-facility';
+
+const CLAIM_ID = '33333333-3333-4333-8333-333333333333';
+const agent: ProvenanceAgent = { who: { reference: 'Practitioner/test-user' } };
+
+const facility: Location = {
+  resourceType: 'Location',
+  id: 'fac-1',
+  status: 'active',
+  meta: { versionId: '4' },
+  name: 'Main Lab',
+  address: { line: ['1 Main St'], city: 'Springfield', state: 'CA', postalCode: '90210' },
+};
+
+const baseInput: SaveServiceFacilityInput = {
+  facilityId: 'fac-1',
+  name: 'Main Lab',
+  addressLine1: '1 Main St',
+  city: 'Springfield',
+  state: 'CA',
+  zip: '90210',
+};
+
+function makeOystehr(): {
+  oystehr: Oystehr;
+  update: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+  transaction: ReturnType<typeof vi.fn>;
+} {
+  const search = vi.fn().mockResolvedValue({ unbundle: () => [structuredClone(facility)] });
+  const update = vi.fn().mockImplementation((resource: Location) => Promise.resolve(resource));
+  const create = vi.fn().mockImplementation((resource: Location) => Promise.resolve({ ...resource, id: 'fac-new' }));
+  const transaction = vi.fn().mockResolvedValue({ entry: [] });
+  const oystehr = { fhir: { search, update, create, transaction } } as unknown as Oystehr;
+  return { oystehr, update, create, transaction };
+}
+
+const parseChanges = (provenance: Provenance): ClaimFieldChange[] =>
+  JSON.parse(provenance.extension!.find((e) => e.url === CLAIM_PROVENANCE_DIFF_EXTENSION_URL)!.valueString!);
+
+describe('save-billing-service-facility', () => {
+  it('writes the update and its claim-history Provenance in one transaction when claim-scoped', async () => {
+    const { oystehr, update, transaction } = makeOystehr();
+
+    const result = await performEffect(
+      oystehr,
+      { ...baseInput, claimId: CLAIM_ID, name: 'North Lab', clia: '05D1234567', secrets: null },
+      structuredClone(facility),
+      agent
+    );
+
+    expect(result).toEqual({ id: 'fac-1' });
+    expect(update).not.toHaveBeenCalled();
+    expect(transaction).toHaveBeenCalledTimes(1);
+    const requests = transaction.mock.calls[0][0].requests;
+    expect(requests.map((r: { method: string }) => r.method)).toEqual(['PUT', 'POST']);
+    expect(requests[0].url).toBe('Location/fac-1');
+    // The optimistic lock the plain update used is preserved.
+    expect(requests[0].ifMatch).toBe('W/"4"');
+    const provenance = requests[1].resource as Provenance;
+    expect(provenance.target).toEqual([{ reference: 'Location/fac-1' }, { reference: `Claim/${CLAIM_ID}` }]);
+    expect(provenance.agent?.[0]).toEqual(agent);
+    const changes = parseChanges(provenance);
+    expect(changes).toContainEqual({ field: 'name', label: 'Name', previousValue: 'Main Lab', newValue: 'North Lab' });
+    expect(changes).toContainEqual({ field: 'clia', label: 'CLIA', previousValue: null, newValue: '05D1234567' });
+  });
+
+  it('keeps the plain locked update (no Provenance) when no claimId is given', async () => {
+    const { oystehr, update, transaction } = makeOystehr();
+
+    const result = await performEffect(
+      oystehr,
+      { ...baseInput, name: 'North Lab', secrets: null },
+      structuredClone(facility)
+    );
+
+    expect(result).toEqual({ id: 'fac-1' });
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0][1]).toEqual({ optimisticLockingVersionId: '4' });
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  it('never claim-scopes a create — the subsequent claim attach records the change', async () => {
+    const { oystehr, create, transaction } = makeOystehr();
+
+    const result = await performEffect(
+      oystehr,
+      { ...baseInput, facilityId: undefined, claimId: CLAIM_ID, secrets: null },
+      undefined,
+      agent
+    );
+
+    expect(result).toEqual({ id: 'fac-new' });
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(transaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/zambdas/test/unit/billing/update-billing-coverage.test.ts
+++ b/packages/zambdas/test/unit/billing/update-billing-coverage.test.ts
@@ -1,0 +1,170 @@
+import Oystehr from '@oystehr/sdk';
+import { Coverage, Provenance, ProvenanceAgent, RelatedPerson } from 'fhir/r4b';
+import { CLAIM_PROVENANCE_DIFF_EXTENSION_URL, ClaimFieldChange } from 'utils';
+import { describe, expect, it, vi } from 'vitest';
+import { performEffect } from '../../../src/billing/update-billing-coverage';
+
+const CLAIM_ID = '44444444-4444-4444-8444-444444444444';
+const agent: ProvenanceAgent = { who: { reference: 'Practitioner/test-user' } };
+
+const coverage: Coverage = {
+  resourceType: 'Coverage',
+  id: 'cov-1',
+  status: 'active',
+  meta: { versionId: '5' },
+  subscriberId: 'OLD-123',
+  subscriber: { reference: 'Patient/pat-1' },
+  beneficiary: { reference: 'Patient/pat-1' },
+  payor: [{ reference: 'https://rcm-api.zapehr.com/v1/payer/9', display: 'Acme Health' }],
+};
+
+function makeOystehr(resourcesById: Record<string, unknown> = {}): {
+  oystehr: Oystehr;
+  transaction: ReturnType<typeof vi.fn>;
+} {
+  const search = vi.fn().mockImplementation(({ params }: { params: { name: string; value: string }[] }) => {
+    const id = params.find((p) => p.name === '_id')?.value ?? '';
+    const resource = resourcesById[id];
+    return Promise.resolve({ unbundle: () => (resource ? [resource] : []) });
+  });
+  const transaction = vi.fn().mockResolvedValue({ entry: [] });
+  const oystehr = { fhir: { search, transaction } } as unknown as Oystehr;
+  return { oystehr, transaction };
+}
+
+const parseChanges = (provenance: Provenance): ClaimFieldChange[] =>
+  JSON.parse(provenance.extension!.find((e) => e.url === CLAIM_PROVENANCE_DIFF_EXTENSION_URL)!.valueString!);
+
+describe('update-billing-coverage', () => {
+  it('writes the update and its claim-history Provenance in one transaction when claim-scoped', async () => {
+    const { oystehr, transaction } = makeOystehr();
+
+    const result = await performEffect(
+      oystehr,
+      { coverageId: 'cov-1', claimId: CLAIM_ID, memberId: 'NEW-456', secrets: null },
+      { patientId: 'pat-1', coverage: structuredClone(coverage) },
+      agent
+    );
+
+    expect(result).toEqual({ id: 'cov-1' });
+    expect(transaction).toHaveBeenCalledTimes(1);
+    const requests = transaction.mock.calls[0][0].requests;
+    expect(requests.map((r: { method: string }) => r.method)).toEqual(['PUT', 'POST']);
+    expect(requests[0].url).toBe('Coverage/cov-1');
+    const provenance = requests[1].resource as Provenance;
+    expect(provenance.target).toEqual([{ reference: 'Coverage/cov-1' }, { reference: `Claim/${CLAIM_ID}` }]);
+    expect(provenance.agent?.[0]).toEqual(agent);
+    expect(parseChanges(provenance)).toContainEqual({
+      field: 'memberId',
+      label: 'Member ID',
+      previousValue: 'OLD-123',
+      newValue: 'NEW-456',
+    });
+  });
+
+  it('folds policy-holder edits into the coverage record as policyHolder.* changes', async () => {
+    const { oystehr, transaction } = makeOystehr();
+
+    await performEffect(
+      oystehr,
+      {
+        coverageId: 'cov-1',
+        claimId: CLAIM_ID,
+        relationship: 'Spouse',
+        policyHolder: { firstName: 'Pat', lastName: 'Holder', dob: '1980-01-01', gender: 'female' },
+        secrets: null,
+      },
+      { patientId: 'pat-1', coverage: structuredClone(coverage) },
+      agent
+    );
+
+    const requests = transaction.mock.calls[0][0].requests;
+    // The new subscriber is created in the same transaction, before the coverage PUT.
+    expect(requests.map((r: { method: string; url: string }) => `${r.method} ${r.url}`)).toEqual([
+      'POST /RelatedPerson',
+      'PUT Coverage/cov-1',
+      'POST /Provenance',
+    ]);
+    const changes = parseChanges(requests[2].resource as Provenance);
+    expect(changes).toContainEqual(
+      expect.objectContaining({ field: 'relationship', label: 'Relationship', newValue: 'Spouse' })
+    );
+    expect(changes).toContainEqual({
+      field: 'policyHolder.name',
+      label: 'Policy Holder Name',
+      previousValue: null,
+      newValue: 'Holder, Pat',
+    });
+    expect(changes).toContainEqual({
+      field: 'policyHolder.dob',
+      label: 'Policy Holder Date of Birth',
+      previousValue: null,
+      newValue: '1980-01-01',
+    });
+  });
+
+  it('diffs the policy holder against the current subscriber when one exists', async () => {
+    const currentSubscriber: RelatedPerson = {
+      resourceType: 'RelatedPerson',
+      id: 'rp-1',
+      patient: { reference: 'Patient/pat-1' },
+      name: [{ given: ['Old'], family: 'Holder' }],
+      birthDate: '1975-05-05',
+    };
+    const withSubscriber: Coverage = {
+      ...structuredClone(coverage),
+      subscriber: { reference: 'RelatedPerson/rp-1' },
+    };
+    const { oystehr, transaction } = makeOystehr({ 'rp-1': currentSubscriber });
+
+    await performEffect(
+      oystehr,
+      {
+        coverageId: 'cov-1',
+        claimId: CLAIM_ID,
+        relationship: 'Spouse',
+        policyHolder: { firstName: 'Pat', lastName: 'Holder', dob: '1980-01-01', gender: 'female' },
+        secrets: null,
+      },
+      { patientId: 'pat-1', coverage: withSubscriber },
+      agent
+    );
+
+    const requests = transaction.mock.calls[0][0].requests;
+    expect(requests.map((r: { method: string; url: string }) => `${r.method} ${r.url}`)).toEqual([
+      'PUT RelatedPerson/rp-1',
+      'PUT Coverage/cov-1',
+      'POST /Provenance',
+    ]);
+    const changes = parseChanges(requests[2].resource as Provenance);
+    expect(changes).toContainEqual({
+      field: 'policyHolder.name',
+      label: 'Policy Holder Name',
+      previousValue: 'Holder, Old',
+      newValue: 'Holder, Pat',
+    });
+    expect(changes).toContainEqual({
+      field: 'policyHolder.dob',
+      label: 'Policy Holder Date of Birth',
+      previousValue: '1975-05-05',
+      newValue: '1980-01-01',
+    });
+  });
+
+  it('keeps the plain transaction (no Provenance) when no claimId is given', async () => {
+    const { oystehr, transaction } = makeOystehr();
+
+    await performEffect(
+      oystehr,
+      { coverageId: 'cov-1', memberId: 'NEW-456', secrets: null },
+      { patientId: 'pat-1', coverage: structuredClone(coverage) },
+      undefined
+    );
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+    const requests = transaction.mock.calls[0][0].requests;
+    expect(requests.map((r: { method: string; url: string }) => `${r.method} ${r.url}`)).toEqual([
+      'PUT Coverage/cov-1',
+    ]);
+  });
+});

--- a/packages/zambdas/test/unit/billing/update-billing-coverage.test.ts
+++ b/packages/zambdas/test/unit/billing/update-billing-coverage.test.ts
@@ -42,8 +42,7 @@ describe('update-billing-coverage', () => {
     const result = await performEffect(
       oystehr,
       { coverageId: 'cov-1', claimId: CLAIM_ID, memberId: 'NEW-456', secrets: null },
-      { patientId: 'pat-1', coverage: structuredClone(coverage) },
-      agent
+      { patientId: 'pat-1', coverage: structuredClone(coverage), agent }
     );
 
     expect(result).toEqual({ id: 'cov-1' });
@@ -74,8 +73,7 @@ describe('update-billing-coverage', () => {
         policyHolder: { firstName: 'Pat', lastName: 'Holder', dob: '1980-01-01', gender: 'female' },
         secrets: null,
       },
-      { patientId: 'pat-1', coverage: structuredClone(coverage) },
-      agent
+      { patientId: 'pat-1', coverage: structuredClone(coverage), agent }
     );
 
     const requests = transaction.mock.calls[0][0].requests;
@@ -126,8 +124,7 @@ describe('update-billing-coverage', () => {
         policyHolder: { firstName: 'Pat', lastName: 'Holder', dob: '1980-01-01', gender: 'female' },
         secrets: null,
       },
-      { patientId: 'pat-1', coverage: withSubscriber },
-      agent
+      { patientId: 'pat-1', coverage: withSubscriber, agent }
     );
 
     const requests = transaction.mock.calls[0][0].requests;
@@ -157,8 +154,7 @@ describe('update-billing-coverage', () => {
     await performEffect(
       oystehr,
       { coverageId: 'cov-1', memberId: 'NEW-456', secrets: null },
-      { patientId: 'pat-1', coverage: structuredClone(coverage) },
-      undefined
+      { patientId: 'pat-1', coverage: structuredClone(coverage) }
     );
 
     expect(transaction).toHaveBeenCalledTimes(1);

--- a/packages/zambdas/test/unit/billing/update-billing-patient.test.ts
+++ b/packages/zambdas/test/unit/billing/update-billing-patient.test.ts
@@ -1,0 +1,73 @@
+import Oystehr from '@oystehr/sdk';
+import { Patient, Provenance, ProvenanceAgent } from 'fhir/r4b';
+import { CLAIM_PROVENANCE_DIFF_EXTENSION_URL, ClaimFieldChange } from 'utils';
+import { describe, expect, it, vi } from 'vitest';
+import { performEffect } from '../../../src/billing/update-billing-patient';
+
+const CLAIM_ID = '11111111-1111-4111-8111-111111111111';
+const agent: ProvenanceAgent = { who: { reference: 'Practitioner/test-user' } };
+
+const patient: Patient = {
+  resourceType: 'Patient',
+  id: 'pat-1',
+  meta: { versionId: '2' },
+  name: [{ given: ['Jane'], family: 'Doe' }],
+  telecom: [{ system: 'phone', value: '555-0100' }],
+};
+
+function makeOystehr(): { oystehr: Oystehr; update: ReturnType<typeof vi.fn>; transaction: ReturnType<typeof vi.fn> } {
+  const search = vi.fn().mockResolvedValue({ unbundle: () => [structuredClone(patient)] });
+  const update = vi.fn().mockImplementation((resource: Patient) => Promise.resolve(resource));
+  const transaction = vi.fn().mockResolvedValue({ entry: [] });
+  const oystehr = { fhir: { search, update, transaction } } as unknown as Oystehr;
+  return { oystehr, update, transaction };
+}
+
+const parseChanges = (provenance: Provenance): ClaimFieldChange[] =>
+  JSON.parse(provenance.extension!.find((e) => e.url === CLAIM_PROVENANCE_DIFF_EXTENSION_URL)!.valueString!);
+
+describe('update-billing-patient', () => {
+  it('writes the update and its claim-history Provenance in one transaction when claim-scoped', async () => {
+    const { oystehr, update, transaction } = makeOystehr();
+
+    const result = await performEffect(
+      oystehr,
+      { patientId: 'pat-1', claimId: CLAIM_ID, firstName: 'Jane', lastName: 'Smith', phone: '555-0199', secrets: null },
+      agent
+    );
+
+    expect(result).toEqual({ id: 'pat-1' });
+    expect(update).not.toHaveBeenCalled();
+    expect(transaction).toHaveBeenCalledTimes(1);
+    const requests = transaction.mock.calls[0][0].requests;
+    expect(requests.map((r: { method: string }) => r.method)).toEqual(['PUT', 'POST']);
+    expect(requests[0].url).toBe('Patient/pat-1');
+    const provenance = requests[1].resource as Provenance;
+    expect(provenance.target).toEqual([{ reference: 'Patient/pat-1' }, { reference: `Claim/${CLAIM_ID}` }]);
+    expect(provenance.agent?.[0]).toEqual(agent);
+    // The prior version rides along for the history feature.
+    expect(provenance.entity?.[0]?.what?.reference).toBe('Patient/pat-1/_history/2');
+    const changes = parseChanges(provenance);
+    expect(changes).toContainEqual({
+      field: 'name',
+      label: 'Name',
+      previousValue: 'Doe, Jane',
+      newValue: 'Smith, Jane',
+    });
+    expect(changes).toContainEqual({ field: 'phone', label: 'Phone', previousValue: '555-0100', newValue: '555-0199' });
+  });
+
+  it('keeps the plain update (no Provenance) when no claimId is given', async () => {
+    const { oystehr, update, transaction } = makeOystehr();
+
+    const result = await performEffect(
+      oystehr,
+      { patientId: 'pat-1', firstName: 'Jane', lastName: 'Smith', secrets: null },
+      undefined
+    );
+
+    expect(result).toEqual({ id: 'pat-1' });
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(transaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/zambdas/test/unit/billing/update-billing-provider.test.ts
+++ b/packages/zambdas/test/unit/billing/update-billing-provider.test.ts
@@ -1,0 +1,86 @@
+import Oystehr from '@oystehr/sdk';
+import { Practitioner, Provenance, ProvenanceAgent } from 'fhir/r4b';
+import { CLAIM_PROVENANCE_DIFF_EXTENSION_URL, ClaimFieldChange } from 'utils';
+import { describe, expect, it, vi } from 'vitest';
+import { performEffect } from '../../../src/billing/update-billing-provider';
+
+const CLAIM_ID = '22222222-2222-4222-8222-222222222222';
+const agent: ProvenanceAgent = { who: { reference: 'Practitioner/test-user' } };
+
+const provider: Practitioner = {
+  resourceType: 'Practitioner',
+  id: 'prov-1',
+  meta: { versionId: '3' },
+  name: [{ given: ['John'], family: 'Smith' }],
+};
+
+function makeOystehr(): { oystehr: Oystehr; update: ReturnType<typeof vi.fn>; transaction: ReturnType<typeof vi.fn> } {
+  const search = vi.fn().mockResolvedValue({ unbundle: () => [structuredClone(provider)] });
+  const update = vi.fn().mockImplementation((resource: Practitioner) => Promise.resolve(resource));
+  const transaction = vi.fn().mockResolvedValue({ entry: [] });
+  const oystehr = { fhir: { search, update, transaction } } as unknown as Oystehr;
+  return { oystehr, update, transaction };
+}
+
+const parseChanges = (provenance: Provenance): ClaimFieldChange[] =>
+  JSON.parse(provenance.extension!.find((e) => e.url === CLAIM_PROVENANCE_DIFF_EXTENSION_URL)!.valueString!);
+
+describe('update-billing-provider', () => {
+  it('writes the update and its claim-history Provenance in one transaction when claim-scoped', async () => {
+    const { oystehr, update, transaction } = makeOystehr();
+
+    const result = await performEffect(
+      oystehr,
+      {
+        kind: 'individual',
+        providerId: 'prov-1',
+        claimId: CLAIM_ID,
+        firstName: 'John',
+        lastName: 'Jones',
+        roles: ['rendering'],
+        npi: '1234567893',
+        secrets: null,
+      },
+      agent
+    );
+
+    expect(result).toEqual({ id: 'prov-1' });
+    expect(update).not.toHaveBeenCalled();
+    expect(transaction).toHaveBeenCalledTimes(1);
+    const requests = transaction.mock.calls[0][0].requests;
+    expect(requests.map((r: { method: string }) => r.method)).toEqual(['PUT', 'POST']);
+    expect(requests[0].url).toBe('Practitioner/prov-1');
+    const provenance = requests[1].resource as Provenance;
+    expect(provenance.target).toEqual([{ reference: 'Practitioner/prov-1' }, { reference: `Claim/${CLAIM_ID}` }]);
+    expect(provenance.agent?.[0]).toEqual(agent);
+    const changes = parseChanges(provenance);
+    expect(changes).toContainEqual({
+      field: 'name',
+      label: 'Name',
+      previousValue: 'Smith, John',
+      newValue: 'Jones, John',
+    });
+    expect(changes).toContainEqual({ field: 'npi', label: 'NPI', previousValue: null, newValue: '1234567893' });
+  });
+
+  it('keeps the plain update (no Provenance) when no claimId is given', async () => {
+    const { oystehr, update, transaction } = makeOystehr();
+
+    const result = await performEffect(
+      oystehr,
+      {
+        kind: 'individual',
+        providerId: 'prov-1',
+        firstName: 'John',
+        lastName: 'Jones',
+        roles: ['rendering'],
+        secrets: null,
+      },
+      undefined
+    );
+
+    expect(result).toEqual({ id: 'prov-1' });
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(transaction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This fixes a bug where reference resource was not being updated when changing reference in claim edit by picking a new SF, BP, or RP. It also fixes a bug I had introduced where no provenance was being written for edits to working copies. 

🤖 generated code. and 🤖 generated description.

## Summary

Field edits to a claim's working-copy resources (patient, providers, service facility, coverage) from the claim detail screen have silently stopped appearing in the claim history. The RHF form conversion (#8692) rewired those cards from `update-billing-claim`'s provenance-aware resource branches to the master-screen CRUD endpoints — `update-billing-patient`, `update-billing-provider`, `save-billing-service-facility`, `update-billing-coverage` — which write bare FHIR updates with no Provenance. Claim-level edits (provider/facility swaps, diagnoses, service lines, payer, status, tags) were unaffected because they still go through `update-billing-claim`.

This PR makes the four CRUD endpoints provenance-aware behind an **optional `claimId`**, preserving the post-#8692 architecture (shared forms, one endpoint per resource kind) instead of re-wiring the UI back.

## How it works

- Each endpoint accepts an optional `claimId` (added to the zod input schemas). When present, the endpoint resolves the acting user in its `complexValidation` step, snapshots the resource, and commits the update **and** its claim-history Provenance in one transaction via `commitClaimResourceChange` — the same record every other history writer produces.
- When `claimId` is absent (master screens: Patients, Billing/Rendering Providers, Service Facilities), behavior is byte-for-byte unchanged — plain update, no actor resolution required, no history record.
- The claim detail screen passes `claim.id` in its patient, provider (both), facility-update, and coverage save calls.
- Details preserved per endpoint:
  - `save-billing-service-facility` keeps its optimistic lock (`ifMatch` from the fetched version); creates are never claim-scoped — a newly created facility only enters the claim via the subsequent attach, which records the claim's facility change itself.
  - `update-billing-coverage` folds subscriber `RelatedPerson` edits into the coverage's record as `policyHolder.*` changes (mirroring `update-billing-claim`), and carries its RelatedPerson create/update/delete and account-reconciliation requests in the same transaction, in the same order as before.

## Reference re-selection records as a swap (follow-up fix in this PR)

Re-picking a different reference resource for the billing provider, rendering provider, or service facility on a claim that already had one used to overwrite the existing working copy's fields in place: the claim never re-pointed, so the history showed inline field diffs instead of the linked reference change the initial association gets — and the copy's source-identifier extension kept naming the old reference resource, so its history links led to the wrong master. The claim screen now treats any selection as an attach/swap through `update-billing-claim` (fresh working copy, linked history row, correct source stamp) and then applies the form's fields to the new copy — a no-op unless the user tweaked values on top of the selection, in which case the tweaks get their own field-edit row.

## Projection additions

Some fields these forms edit were invisible to the history diff (an empty diff intentionally writes no record). Added projections so edits to them produce change entries:

- Patient: **phone**, **email**
- Service facility: **CLIA**, **place of service**
- Providers (Practitioner/Organization): **address**

## Tests

- New unit suites for all four endpoints: claim-scoped edits produce a single transaction of `PUT` + Provenance targeting `[resource, claim]` with the caller agent and the expected diff (including the new projections); un-scoped edits keep the plain update with no Provenance; coverage tests cover new-subscriber creation order, policy-holder diffs against an existing subscriber, and the un-scoped path.
- `cd packages/zambdas && npx vitest run --project unit test/unit/billing/` — 470 passed; `test/billing/service-facility.test.ts` (existing handler suite) — 22 passed.
- `apps/billing` component tests — 57 passed; `tsc --noEmit` clean in `utils`, `zambdas`, `apps/billing`; `npm run lint --workspace=billing-ui` clean.

## Notes for review

- This regression predates (and is independent of) #8921; the two PRs touch different parts of `provenance.ts` and can merge in either order.
- Not covered on purpose: provider roles/license/Stripe account and coverage insurance type are not projected into history (administrative master-data, not claim data) — say the word if you'd like them included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3UBqGqH6EtbDFud8AwcFE