### PR TITLE
Add system-managed billing tags (Hold, auto-accident)

### DIFF
--- a/apps/billing/src/components/TagSelect.tsx
+++ b/apps/billing/src/components/TagSelect.tsx
@@ -1,13 +1,13 @@
 import { Autocomplete, AutocompleteRenderInputParams, Box, TextField, Typography } from '@mui/material';
 import { HTMLAttributes, ReactElement, ReactNode, Ref, useState } from 'react';
-import { HOLD_TAG_NAME } from 'utils';
+import { SYSTEM_MANAGED_TAGS } from 'utils';
 import { searchBillingTags } from '../api/api';
 import { useApiClients } from '../hooks/useAppClients';
 
 // Tag picker for the rules builder: only tags that exist in the tags feature can be chosen (no free
 // text), matching save-billing-rules' server-side check. The tag list is small and loads once on
-// first open (the Tags page precedent) with MUI's client-side filtering. The Hold tag is always
-// offered even before it has been seeded as a stored tag (it is built into the engine), and a
+// first open (the Tags page precedent) with MUI's client-side filtering. System-managed tags are
+// always offered even while the tag list is unavailable (they are built into the system), and a
 // stored-but-deleted tag stays visible so an existing rule renders faithfully — the server rejects
 // it with a clear message on the next save.
 
@@ -27,7 +27,10 @@ interface TagSelectProps {
   inputRef?: Ref<HTMLInputElement>;
 }
 
-const HOLD_FALLBACK_OPTION: TagOption = { name: HOLD_TAG_NAME, description: 'Holds the claim and stops the engine.' };
+const SYSTEM_TAG_FALLBACK_OPTIONS: TagOption[] = SYSTEM_MANAGED_TAGS.map((tag) => ({
+  name: tag.name,
+  description: tag.description,
+}));
 
 export function TagSelect({
   value,
@@ -51,13 +54,13 @@ export function TagSelect({
     }
   };
 
-  // Fetched tags win the dedupe (a seeded Hold tag carries its real description); the stored value
-  // is appended last so it renders even when its definition has been deleted.
+  // Fetched tags win the dedupe (a stored system tag carries its stored description); the stored
+  // value is appended last so it renders even when its definition has been deleted.
   const stored = value?.trim();
   const seen = new Set<string>();
   const options = [
     ...(fetched ?? []),
-    HOLD_FALLBACK_OPTION,
+    ...SYSTEM_TAG_FALLBACK_OPTIONS,
     ...(stored ? [{ name: stored, description: '' }] : []),
   ].filter((option) => {
     if (seen.has(option.name)) return false;

--- a/apps/billing/src/pages/ClaimDetail.tsx
+++ b/apps/billing/src/pages/ClaimDetail.tsx
@@ -1550,7 +1550,7 @@ function TagAdder({
         <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', alignItems: 'center' }}>
           {available.map((t) => (
             <Chip
-              key={t.id}
+              key={t.id || t.name}
               label={t.name}
               size="small"
               color="primary"

--- a/apps/billing/src/pages/ClaimsList.tsx
+++ b/apps/billing/src/pages/ClaimsList.tsx
@@ -496,7 +496,7 @@ export default function ClaimsList(): ReactElement {
           >
             <MenuItem value="">All</MenuItem>
             {tagOptions.map((t) => (
-              <MenuItem key={t.id} value={t.name}>
+              <MenuItem key={t.id || t.name} value={t.name}>
                 {t.name}
               </MenuItem>
             ))}

--- a/apps/billing/src/pages/Tags.tsx
+++ b/apps/billing/src/pages/Tags.tsx
@@ -204,7 +204,7 @@ export default function Tags(): ReactElement {
             <tbody>
               {filtered.map((tag) => (
                 <tr
-                  key={tag.id}
+                  key={tag.id || tag.name}
                   style={{ cursor: 'pointer', transition: 'background 0.08s' }}
                   onMouseEnter={(e) => (e.currentTarget.style.background = otherColors.apptHover)}
                   onMouseLeave={(e) => (e.currentTarget.style.background = '')}
@@ -233,6 +233,23 @@ export default function Tags(): ReactElement {
                       />
                       {tag.name}
                     </span>
+                    {tag.isSystemTag && (
+                      <span
+                        title="System managed — applied automatically and cannot be edited or deleted"
+                        style={{
+                          marginLeft: 8,
+                          padding: '2px 8px',
+                          borderRadius: 999,
+                          fontSize: 11,
+                          fontWeight: 600,
+                          color: otherColors.tableRow,
+                          border: `1px solid ${otherColors.solidLine}`,
+                          background: '#FAFAFA',
+                        }}
+                      >
+                        System
+                      </span>
+                    )}
                   </td>
                   <td
                     style={{
@@ -270,38 +287,42 @@ export default function Tags(): ReactElement {
                       textAlign: 'right',
                     }}
                   >
-                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
-                      <IconButton
-                        size="small"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          openEdit(tag);
-                        }}
-                        sx={{
-                          width: 28,
-                          height: 28,
-                          color: 'action.disabled',
-                          '&:hover': { bgcolor: otherColors.apptHover, color: 'primary.dark' },
-                        }}
-                      >
-                        <EditIcon sx={{ fontSize: 15 }} />
-                      </IconButton>
-                      <IconButton
-                        size="small"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          void handleDelete(tag);
-                        }}
-                        sx={{
-                          width: 28,
-                          height: 28,
-                          color: 'action.disabled',
-                          '&:hover': { bgcolor: 'error.light', color: 'error.dark' },
-                        }}
-                      >
-                        <DeleteIcon sx={{ fontSize: 15 }} />
-                      </IconButton>
-                    </span>
+                    {!tag.isSystemTag && (
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
+                        <IconButton
+                          size="small"
+                          aria-label={`Edit tag ${tag.name}`}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            openEdit(tag);
+                          }}
+                          sx={{
+                            width: 28,
+                            height: 28,
+                            color: 'action.disabled',
+                            '&:hover': { bgcolor: otherColors.apptHover, color: 'primary.dark' },
+                          }}
+                        >
+                          <EditIcon sx={{ fontSize: 15 }} />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          aria-label={`Delete tag ${tag.name}`}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void handleDelete(tag);
+                          }}
+                          sx={{
+                            width: 28,
+                            height: 28,
+                            color: 'action.disabled',
+                            '&:hover': { bgcolor: 'error.light', color: 'error.dark' },
+                          }}
+                        >
+                          <DeleteIcon sx={{ fontSize: 15 }} />
+                        </IconButton>
+                      </span>
+                    )}
                   </td>
                 </tr>
               ))}

--- a/apps/billing/tests/component/Rules.test.tsx
+++ b/apps/billing/tests/component/Rules.test.tsx
@@ -231,7 +231,7 @@ describe('ConditionalEditor', () => {
 
     expect(await screen.findByRole('option', { name: /VIP/ })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /Hold/ })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: /auto-accident/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Auto Accident/ })).toBeInTheDocument();
     expect(searchBillingTagsMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/billing/tests/component/Rules.test.tsx
+++ b/apps/billing/tests/component/Rules.test.tsx
@@ -216,7 +216,7 @@ describe('ConditionalEditor', () => {
     expect(onValid).not.toHaveBeenCalled();
   });
 
-  it('offers only existing tags (plus the built-in Hold) in the apply-tag picker', async () => {
+  it('offers only existing tags (plus the built-in system-managed tags) in the apply-tag picker', async () => {
     searchBillingTagsMock.mockReset();
     searchBillingTagsMock.mockResolvedValue({ tags: [{ name: 'VIP', description: 'White-glove payers' }] });
     const conditional: RuleConditional = {
@@ -231,6 +231,7 @@ describe('ConditionalEditor', () => {
 
     expect(await screen.findByRole('option', { name: /VIP/ })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /Hold/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /auto-accident/ })).toBeInTheDocument();
     expect(searchBillingTagsMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/billing/tests/component/Tags.test.tsx
+++ b/apps/billing/tests/component/Tags.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { BillingTag } from 'utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Tags from '../../src/pages/Tags';
+
+const { searchBillingTagsMock, saveBillingTagMock, deleteBillingTagMock } = vi.hoisted(() => ({
+  searchBillingTagsMock: vi.fn(),
+  saveBillingTagMock: vi.fn(),
+  deleteBillingTagMock: vi.fn(),
+}));
+
+vi.mock('../../src/api/api', () => ({
+  searchBillingTags: searchBillingTagsMock,
+  saveBillingTag: saveBillingTagMock,
+  deleteBillingTag: deleteBillingTagMock,
+}));
+
+vi.mock('../../src/hooks/useAppClients', () => ({
+  useApiClients: () => ({
+    oystehrZambda: {},
+  }),
+}));
+
+const userTag: BillingTag = {
+  id: 'tag-1',
+  name: 'VIP',
+  description: 'White-glove payers',
+  usage: 4,
+  updatedAt: '2026-07-01T00:00:00Z',
+  isSystemTag: false,
+};
+
+// A system-managed tag that has never been stored: no id, no updatedAt (search-billing-tags always
+// reports these so they show up before first use).
+const systemTag: BillingTag = {
+  id: '',
+  name: 'Hold',
+  description: 'Holds the claim.',
+  usage: 0,
+  updatedAt: '',
+  isSystemTag: true,
+};
+
+describe('Tags page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchBillingTagsMock.mockResolvedValue({ tags: [userTag, systemTag] });
+  });
+
+  it('lists system-managed tags (even unstored ones) with a System badge', async () => {
+    render(<Tags />);
+
+    expect(await screen.findByText('Hold')).toBeInTheDocument();
+    expect(screen.getByText('VIP')).toBeInTheDocument();
+    expect(screen.getAllByText('System')).toHaveLength(1);
+  });
+
+  it('offers edit/delete for user tags but not for system-managed tags', async () => {
+    render(<Tags />);
+
+    await screen.findByText('Hold');
+    expect(screen.getByRole('button', { name: 'Edit tag VIP' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete tag VIP' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit tag Hold' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete tag Hold' })).not.toBeInTheDocument();
+  });
+});

--- a/packages/utils/lib/types/data/billing/billing.types.ts
+++ b/packages/utils/lib/types/data/billing/billing.types.ts
@@ -27,11 +27,15 @@ export const BILLING_INSURANCE_TYPE_LABELS: Record<BillingInsuranceType, string>
 };
 
 export interface BillingTag {
+  // Empty for a system-managed tag whose Basic definition hasn't been created yet.
   id: string;
   name: string;
   description: string;
   usage: number;
   updatedAt: string;
+  // System-managed tags (see ./system-tags.ts) are always returned by search-billing-tags and
+  // cannot be edited or deleted.
+  isSystemTag: boolean;
 }
 
 // Search/autocomplete option shapes — shared by the search-billing-* zambdas and the billing UI.

--- a/packages/utils/lib/types/data/billing/index.ts
+++ b/packages/utils/lib/types/data/billing/index.ts
@@ -7,3 +7,4 @@ export * from './rules-engine.constants';
 export * from './rules-engine.schemas';
 export * from './rules-engine.field-catalog';
 export * from './rules-engine.docs';
+export * from './system-tags';

--- a/packages/utils/lib/types/data/billing/rules-engine.constants.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.constants.ts
@@ -1,9 +1,3 @@
-// The well-known tag whose application by a rule terminates a rules-engine run and holds the claim.
-// It lives in utils because the rule schemas canonicalize free-text tag input against it and the
-// billing app's rule builder displays it; everything else about the engines (FHIR storage,
-// evaluation) is backend-only and lives in packages/zambdas/src/billing/rules-engine/.
-export const HOLD_TAG_NAME = 'Hold';
-
 // ---------------------------------------------------------------------------
 // Rules engines
 //

--- a/packages/utils/lib/types/data/billing/rules-engine.docs.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.docs.ts
@@ -1,4 +1,4 @@
-import { HOLD_TAG_NAME, RULES_ENGINE_TYPES, RULES_ENGINES } from './rules-engine.constants';
+import { RULES_ENGINE_TYPES, RULES_ENGINES } from './rules-engine.constants';
 import {
   ADD_SERVICE_LINE_FIELDS,
   RULE_FIELD_CATALOG,
@@ -17,6 +17,7 @@ import {
   RULE_OPERATOR_METADATA,
   RULE_OPERATORS,
 } from './rules-engine.schemas';
+import { HOLD_TAG_NAME } from './system-tags';
 
 // ---------------------------------------------------------------------------
 // Generated documentation for the pre-submission rules engine.

--- a/packages/utils/lib/types/data/billing/rules-engine.schemas.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { HOLD_TAG_NAME, RULES_ENGINE_TYPES, RulesEngineType } from './rules-engine.constants';
+import { RULES_ENGINE_TYPES, RulesEngineType } from './rules-engine.constants';
+import { HOLD_TAG_NAME } from './system-tags';
 
 // ---------------------------------------------------------------------------
 // Rule structure

--- a/packages/utils/lib/types/data/billing/rules-engine.test.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import { HOLD_TAG_NAME } from './rules-engine.constants';
 import {
   ADD_SERVICE_LINE_FIELDS,
   addServiceLineFieldProblem,
@@ -21,6 +20,7 @@ import {
   RuleActionSchema,
   SaveBillingRulesInputSchema,
 } from './rules-engine.schemas';
+import { HOLD_TAG_NAME } from './system-tags';
 
 // Schema-layer tests only: the engine's evaluator/serialization are backend code and are tested in
 // packages/zambdas/test/unit/billing/rules-engine.test.ts.

--- a/packages/utils/lib/types/data/billing/system-tags.ts
+++ b/packages/utils/lib/types/data/billing/system-tags.ts
@@ -4,7 +4,8 @@
 // SYSTEM_MANAGED_TAGS and everything downstream follows:
 // - search-billing-tags always returns them (so the Tags page shows them even before any claim
 //   has used them) and marks them isSystemTag,
-// - save-billing-tag / delete-billing-tag refuse to edit or delete them,
+// - save-billing-tag / delete-billing-tag refuse to edit or delete them, and refuse to create or
+//   rename another tag onto their names,
 // - tag validations (save-billing-rules, tag-billing-claim) always accept them,
 // - the zambdas seed their Basic definitions from these entries (see systemTagBasic in
 //   packages/zambdas/src/billing/shared.ts),
@@ -40,4 +41,13 @@ export const SYSTEM_MANAGED_TAGS: readonly SystemManagedTag[] = [HOLD_SYSTEM_TAG
 
 export function isSystemManagedTagName(name: string | undefined): boolean {
   return !!name && SYSTEM_MANAGED_TAGS.some((tag) => tag.name === name);
+}
+
+// The canonical system-managed name that `name` collides with, or undefined when there is none.
+// Case-insensitive, unlike isSystemManagedTagName: a user-created "hold" would only masquerade as
+// Hold, so the whole spelling family is reserved on the Tags page.
+export function collidingSystemManagedTagName(name: string | undefined): string | undefined {
+  const normalized = name?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  return SYSTEM_MANAGED_TAGS.find((tag) => tag.name.toLowerCase() === normalized)?.name;
 }

--- a/packages/utils/lib/types/data/billing/system-tags.ts
+++ b/packages/utils/lib/types/data/billing/system-tags.ts
@@ -1,0 +1,43 @@
+// System-managed tags: billing tags that are defined in code and applied by the system itself
+// (rules engine holds, claim-creation facts) rather than created by a biller on the Tags page.
+// This module is the single source of truth for them — add new system-managed tags to
+// SYSTEM_MANAGED_TAGS and everything downstream follows:
+// - search-billing-tags always returns them (so the Tags page shows them even before any claim
+//   has used them) and marks them isSystemTag,
+// - save-billing-tag / delete-billing-tag refuse to edit or delete them,
+// - tag validations (save-billing-rules, tag-billing-claim) always accept them,
+// - the zambdas seed their Basic definitions from these entries (see systemTagBasic in
+//   packages/zambdas/src/billing/shared.ts),
+// - the billing app's TagSelect offers them even while the tag list is unavailable.
+// It lives in utils because both the billing app and the zambdas consume it.
+
+export interface SystemManagedTag {
+  name: string;
+  description: string;
+}
+
+// The well-known tag whose application by a rule terminates a rules-engine run and holds the claim.
+// The rule schemas canonicalize free-text tag input against this name and the billing app's rule
+// builder displays it; everything else about the engines (FHIR storage, evaluation) is backend-only
+// and lives in packages/zambdas/src/billing/rules-engine/.
+export const HOLD_TAG_NAME = 'Hold';
+
+// Applied by create-billing-claim-from-encounter when the clinical visit was booked as an auto
+// accident.
+export const AUTO_ACCIDENT_TAG_NAME = 'auto-accident';
+
+export const HOLD_SYSTEM_TAG: SystemManagedTag = {
+  name: HOLD_TAG_NAME,
+  description: 'Claim was placed on hold either by a user or by a rule and requires review before it can proceed.',
+};
+
+export const AUTO_ACCIDENT_SYSTEM_TAG: SystemManagedTag = {
+  name: AUTO_ACCIDENT_TAG_NAME,
+  description: 'Claim is for a clinical encounter resulting from an auto accident',
+};
+
+export const SYSTEM_MANAGED_TAGS: readonly SystemManagedTag[] = [HOLD_SYSTEM_TAG, AUTO_ACCIDENT_SYSTEM_TAG];
+
+export function isSystemManagedTagName(name: string | undefined): boolean {
+  return !!name && SYSTEM_MANAGED_TAGS.some((tag) => tag.name === name);
+}

--- a/packages/utils/lib/types/data/billing/system-tags.ts
+++ b/packages/utils/lib/types/data/billing/system-tags.ts
@@ -24,7 +24,7 @@ export const HOLD_TAG_NAME = 'Hold';
 
 // Applied by create-billing-claim-from-encounter when the clinical visit was booked as an auto
 // accident.
-export const AUTO_ACCIDENT_TAG_NAME = 'auto-accident';
+export const AUTO_ACCIDENT_TAG_NAME = 'Auto Accident';
 
 export const HOLD_SYSTEM_TAG: SystemManagedTag = {
   name: HOLD_TAG_NAME,

--- a/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
+++ b/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
@@ -35,7 +35,6 @@ import { DateTime } from 'luxon';
 import {
   ACCOUNT_TYPE_CODE_SYSTEM,
   AR_STAGE,
-  AUTO_ACCIDENT_SYSTEM_TAG,
   AUTO_ACCIDENT_TAG_NAME,
   BILLING_RESOURCE_TAG,
   CLAIM_TAG_SYSTEM,
@@ -91,6 +90,7 @@ import {
   CURRENT_STATUS_TAG_SYSTEM,
   determineRulesEngineForClaim,
   ensureClaimInsurance,
+  ensureSystemManagedTags,
   findRef,
   getClaimTypeCoding,
   kickOffRulesEngine,
@@ -103,8 +103,6 @@ import {
   resourceDisplayName,
   SOURCE_FRIENDLY_PATIENT_ID_EXTENSION,
   SOURCE_IDENTIFIER_SYSTEM,
-  systemTagBasic,
-  TAG_CODE_SYSTEM,
 } from '../shared';
 import { CreateClaimFromEncounterParams, validateRequestParameters } from './validateRequestParameters';
 
@@ -139,7 +137,6 @@ interface BillingResources {
   renderingProvider?: Practitioner;
   serviceFacility?: Location;
   billingProvider?: Organization;
-  autoAccidentTag?: Basic;
   billingService?: Basic;
 }
 
@@ -440,13 +437,13 @@ export async function performEffect(
   const billingTags = [];
   if (clinicalResources.appointment.description?.toLowerCase() === 'auto accident') {
     billingTags.push(AUTO_ACCIDENT_TAG_NAME);
-    if (!billingResources.autoAccidentTag) {
-      requests.push({
-        method: 'POST',
-        url: '/Basic',
-        resource: systemTagBasic(AUTO_ACCIDENT_SYSTEM_TAG),
-      });
-      order.push('auto-accident-tag');
+    // Best-effort: make sure the system-managed tag definitions exist before the claim references
+    // one by name. Never fails claim creation — the definitions are cosmetic (search-billing-tags
+    // reports system-managed tags whether or not their Basics exist).
+    try {
+      await ensureSystemManagedTags(billingOystehr);
+    } catch (error) {
+      console.error('Failed to ensure system-managed tags exist:', error);
     }
   }
 
@@ -1077,15 +1074,6 @@ async function findExistingBillingResources(
   ).unbundle();
   const matchingBillingProvider = billingProviderSearch.length > 0 ? billingProviderSearch[0] : undefined;
 
-  // Look for the auto-accident tag
-  const tagSearch = (
-    await billingOystehr.fhir.search<Basic>({
-      resourceType: 'Basic',
-      params: [{ name: 'code', value: `${TAG_CODE_SYSTEM}|tag` }],
-    })
-  ).unbundle();
-  const autoAccidentTag = tagSearch.find((tag) => tag.code.text === AUTO_ACCIDENT_TAG_NAME);
-
   // Look for the "billing service" (urgent-care, workers-comp, etc) matching the appointment's serviceCategory
   let billingService: Basic | undefined;
   const appointmentService = getService(clinicalResources.appointment);
@@ -1111,7 +1099,6 @@ async function findExistingBillingResources(
     renderingProvider: renderingProvider,
     serviceFacility: matchingServiceFacility,
     billingProvider: matchingBillingProvider,
-    autoAccidentTag,
     billingService,
   };
 }

--- a/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
+++ b/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
@@ -437,9 +437,6 @@ export async function performEffect(
   const billingTags = [];
   if (clinicalResources.appointment.description?.toLowerCase() === 'auto accident') {
     billingTags.push(AUTO_ACCIDENT_TAG_NAME);
-    // Best-effort: make sure the system-managed tag definitions exist before the claim references
-    // one by name. Never fails claim creation — the definitions are cosmetic (search-billing-tags
-    // reports system-managed tags whether or not their Basics exist).
     try {
       await ensureSystemManagedTags(billingOystehr);
     } catch (error) {

--- a/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
+++ b/packages/zambdas/src/billing/create-billing-claim-from-encounter/handler.ts
@@ -35,6 +35,8 @@ import { DateTime } from 'luxon';
 import {
   ACCOUNT_TYPE_CODE_SYSTEM,
   AR_STAGE,
+  AUTO_ACCIDENT_SYSTEM_TAG,
+  AUTO_ACCIDENT_TAG_NAME,
   BILLING_RESOURCE_TAG,
   CLAIM_TAG_SYSTEM,
   claimStatusValuesToTags,
@@ -83,8 +85,6 @@ import {
 } from '../../shared';
 import { claimProvenanceRequest, recordedNow, resolveClaimActor } from '../provenance';
 import {
-  AUTO_ACCIDENT_TAG_DESCRIPTION,
-  AUTO_ACCIDENT_TAG_NAME,
   BILLING_WORKING_COPY_TAG,
   BillingFhirResource,
   createBillingClient,
@@ -103,9 +103,8 @@ import {
   resourceDisplayName,
   SOURCE_FRIENDLY_PATIENT_ID_EXTENSION,
   SOURCE_IDENTIFIER_SYSTEM,
+  systemTagBasic,
   TAG_CODE_SYSTEM,
-  TAG_DESCRIPTION_URL,
-  TAG_IS_SYSTEM_TAG_URL,
 } from '../shared';
 import { CreateClaimFromEncounterParams, validateRequestParameters } from './validateRequestParameters';
 
@@ -440,19 +439,12 @@ export async function performEffect(
 
   const billingTags = [];
   if (clinicalResources.appointment.description?.toLowerCase() === 'auto accident') {
-    billingTags.push('auto-accident');
+    billingTags.push(AUTO_ACCIDENT_TAG_NAME);
     if (!billingResources.autoAccidentTag) {
       requests.push({
         method: 'POST',
         url: '/Basic',
-        resource: {
-          resourceType: 'Basic',
-          code: { text: AUTO_ACCIDENT_TAG_NAME, coding: [{ system: TAG_CODE_SYSTEM, code: 'tag' }] },
-          extension: [
-            { url: TAG_DESCRIPTION_URL, valueString: AUTO_ACCIDENT_TAG_DESCRIPTION },
-            { url: TAG_IS_SYSTEM_TAG_URL, valueBoolean: true },
-          ],
-        },
+        resource: systemTagBasic(AUTO_ACCIDENT_SYSTEM_TAG),
       });
       order.push('auto-accident-tag');
     }

--- a/packages/zambdas/src/billing/delete-billing-tag/index.ts
+++ b/packages/zambdas/src/billing/delete-billing-tag/index.ts
@@ -18,7 +18,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   return { statusCode: 200, body: JSON.stringify(response) };
 });
 
-async function performEffect(oystehr: Oystehr, params: DeleteBillingTagParams): Promise<{ deleted: true }> {
+export async function performEffect(oystehr: Oystehr, params: DeleteBillingTagParams): Promise<{ deleted: true }> {
   const tagBundle = await oystehr.fhir.search<Basic>({
     resourceType: 'Basic',
     params: [

--- a/packages/zambdas/src/billing/rules-engine/constants.ts
+++ b/packages/zambdas/src/billing/rules-engine/constants.ts
@@ -58,8 +58,3 @@ export function rulesEngineForTaskCode(taskCode: string | undefined): RulesEngin
     (engine) => RULES_ENGINE_FHIR[engine].taskCode === taskCode
   );
 }
-
-// Description on the seeded Hold system-tag definition (the tag name itself, HOLD_TAG_NAME, lives in
-// utils because the rule schemas canonicalize against it and the rule-builder UI displays it).
-export const HOLD_TAG_DESCRIPTION =
-  'Claim was placed on hold either by a user or by a rule and requires review before it can proceed.';

--- a/packages/zambdas/src/billing/save-billing-rules/index.ts
+++ b/packages/zambdas/src/billing/save-billing-rules/index.ts
@@ -1,7 +1,7 @@
 import Oystehr from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { randomUUID } from 'crypto';
-import { Basic, List, Resource } from 'fhir/r4b';
+import { List, Resource } from 'fhir/r4b';
 import {
   BillingRule,
   BillingRulesResponse,
@@ -10,24 +10,21 @@ import {
   getResourcesFromBatchInlineRequests,
   getRuleFieldDef,
   getSecret,
-  HOLD_TAG_NAME,
   INVALID_INPUT_ERROR,
+  isSystemManagedTagName,
   SecretsKeys,
 } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
-import { HOLD_TAG_DESCRIPTION } from '../rules-engine/constants';
 import { rulesToList } from '../rules-engine/serialization';
 import {
   BILLING_WORKING_COPY_TAG,
   createBillingClient,
+  ensureSystemManagedTags,
   fetchDefinedTagNames,
   findRulesEngineList,
   hasTag,
   listToRulesReportingMalformed,
   PROVIDER_ROLE_TAG,
-  TAG_CODE_SYSTEM,
-  TAG_DESCRIPTION_URL,
-  TAG_IS_SYSTEM_TAG_URL,
 } from '../shared';
 import { SaveBillingRulesParams, validateRequestParameters } from './validateRequestParameters';
 
@@ -57,14 +54,15 @@ export async function complexValidation(oystehr: Oystehr, params: SaveBillingRul
 }
 
 // Every tag a rule applies must exist in the tags feature, so the rule builder's tag dropdown and
-// API-created rules obey the same contract. Hold is exempt: it is built into the engine and may not
-// be seeded as a stored tag yet (that only happens when an engine's first rules List is created).
-// Runs at most one Basic search, and none when no rule applies a non-Hold tag.
+// API-created rules obey the same contract. System-managed tags (Hold, auto-accident, …) are
+// exempt: they are built into the system and may not be seeded as stored tags yet (that only
+// happens when an engine's first rules List is created). Runs at most one Basic search, and none
+// when no rule applies a non-system tag.
 async function validateAppliedTagsExist(oystehr: Oystehr, rules: SaveBillingRulesParams['rules']): Promise<void> {
   const perRule = rules
     .map((rule) => ({
       name: rule.name,
-      tags: collectApplyTagNames(rule).filter((tag) => tag !== HOLD_TAG_NAME),
+      tags: collectApplyTagNames(rule).filter((tag) => !isSystemManagedTagName(tag)),
     }))
     .filter((entry) => entry.tags.length > 0);
   if (perRule.length === 0) return;
@@ -138,35 +136,15 @@ export async function performEffect(
     );
   } else {
     saved = await oystehr.fhir.create<List>(newList);
-    // Seed the Hold system tag definition the first time rules are configured.
-    await ensureHoldTag(oystehr);
+    // Best-effort: seed the system-managed tag definitions the first time rules are configured.
+    // Never fails the save — the Tags page reports system-managed tags whether or not their
+    // definitions exist.
+    try {
+      await ensureSystemManagedTags(oystehr);
+    } catch (error) {
+      console.error('Failed to ensure system-managed tags exist:', error);
+    }
   }
 
   return { rules: await listToRulesReportingMalformed(saved, env), versionId: saved.meta?.versionId };
-}
-
-// Best-effort: create the Hold system tag definition if it doesn't already exist. Never fails the save.
-async function ensureHoldTag(oystehr: Oystehr): Promise<void> {
-  try {
-    const result = await oystehr.fhir.search<Basic>({
-      resourceType: 'Basic',
-      params: [
-        { name: 'code', value: `${TAG_CODE_SYSTEM}|tag` },
-        { name: '_count', value: '200' },
-      ],
-    });
-    if (result.unbundle().some((b) => b.code?.text === HOLD_TAG_NAME)) return;
-
-    const tag: Basic = {
-      resourceType: 'Basic',
-      code: { text: HOLD_TAG_NAME, coding: [{ system: TAG_CODE_SYSTEM, code: 'tag' }] },
-      extension: [
-        { url: TAG_DESCRIPTION_URL, valueString: HOLD_TAG_DESCRIPTION },
-        { url: TAG_IS_SYSTEM_TAG_URL, valueBoolean: true },
-      ],
-    };
-    await oystehr.fhir.create<Basic>(tag);
-  } catch (error) {
-    console.error('Failed to ensure Hold system tag exists:', error);
-  }
 }

--- a/packages/zambdas/src/billing/save-billing-rules/index.ts
+++ b/packages/zambdas/src/billing/save-billing-rules/index.ts
@@ -54,7 +54,7 @@ export async function complexValidation(oystehr: Oystehr, params: SaveBillingRul
 }
 
 // Every tag a rule applies must exist in the tags feature, so the rule builder's tag dropdown and
-// API-created rules obey the same contract. System-managed tags (Hold, auto-accident, …) are
+// API-created rules obey the same contract. System-managed tags (Hold, Auto Accident, …) are
 // exempt: they are built into the system and may not be seeded as stored tags yet (that only
 // happens when an engine's first rules List is created). Runs at most one Basic search, and none
 // when no rule applies a non-system tag.

--- a/packages/zambdas/src/billing/save-billing-rules/index.ts
+++ b/packages/zambdas/src/billing/save-billing-rules/index.ts
@@ -136,9 +136,6 @@ export async function performEffect(
     );
   } else {
     saved = await oystehr.fhir.create<List>(newList);
-    // Best-effort: seed the system-managed tag definitions the first time rules are configured.
-    // Never fails the save — the Tags page reports system-managed tags whether or not their
-    // definitions exist.
     try {
       await ensureSystemManagedTags(oystehr);
     } catch (error) {

--- a/packages/zambdas/src/billing/save-billing-tag/index.ts
+++ b/packages/zambdas/src/billing/save-billing-tag/index.ts
@@ -1,7 +1,7 @@
 import Oystehr from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Basic, Claim } from 'fhir/r4b';
-import { CLAIM_TAG_SYSTEM, getPatchBinary, INVALID_INPUT_ERROR } from 'utils';
+import { CLAIM_TAG_SYSTEM, collidingSystemManagedTagName, getPatchBinary, INVALID_INPUT_ERROR } from 'utils';
 import { checkOrCreateM2MClientToken, fetchAllPages, wrapHandler, ZambdaInput } from '../../shared';
 import { createBillingClient, fetchById, isSystemTag, TAG_CODE_SYSTEM, TAG_DESCRIPTION_URL } from '../shared';
 import { SaveBillingTagParams, validateRequestParameters } from './validateRequestParameters';
@@ -19,8 +19,14 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   return { statusCode: 200, body: JSON.stringify(response) };
 });
 
-// When updating, load the tag being edited and confirm it exists. No-op for create.
-async function complexValidation(oystehr: Oystehr, params: SaveBillingTagParams): Promise<Basic | undefined> {
+// System-managed tag names are reserved (case-insensitively, so a "hold" can't masquerade as
+// Hold): a tag can neither be created with one nor renamed onto one. When updating, additionally
+// load the tag being edited and confirm it exists and isn't itself system-managed.
+export async function complexValidation(oystehr: Oystehr, params: SaveBillingTagParams): Promise<Basic | undefined> {
+  const collision = collidingSystemManagedTagName(params.name);
+  if (collision) {
+    throw INVALID_INPUT_ERROR(`"${collision}" is a system-managed tag name — pick a different name`);
+  }
   if (!params.tagId) return undefined;
   const tag = await fetchById<Basic>(oystehr, 'Basic', params.tagId);
   if (isSystemTag(tag)) {

--- a/packages/zambdas/src/billing/search-billing-tags/index.ts
+++ b/packages/zambdas/src/billing/search-billing-tags/index.ts
@@ -1,9 +1,9 @@
 import Oystehr, { BatchInputGetRequest } from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { Basic, Bundle } from 'fhir/r4b';
-import { BillingTag, CLAIM_TAG_SYSTEM } from 'utils';
+import { Bundle } from 'fhir/r4b';
+import { BillingTag, CLAIM_TAG_SYSTEM, SYSTEM_MANAGED_TAGS } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
-import { createBillingClient, searchTagBasics, TAG_DESCRIPTION_URL } from '../shared';
+import { createBillingClient, isSystemTag, searchTagBasics, TAG_DESCRIPTION_URL } from '../shared';
 
 let m2mToken: string;
 const ZAMBDA_NAME = 'search-billing-tags';
@@ -16,28 +16,50 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   return { statusCode: 200, body: JSON.stringify(response) };
 });
 
-async function performEffect(oystehr: Oystehr): Promise<{ tags: BillingTag[] }> {
+export async function performEffect(oystehr: Oystehr): Promise<{ tags: BillingTag[] }> {
   const basics = await searchTagBasics(oystehr);
-  const usageCounts = await getTagUsageCounts(oystehr, basics);
 
-  const tags: BillingTag[] = basics.map((b) => {
-    const name = b.code?.text ?? '';
-    return {
-      id: b.id ?? '',
-      name,
-      description: b.extension?.find((e) => e.url === TAG_DESCRIPTION_URL)?.valueString ?? '',
-      usage: usageCounts.get(name) ?? 0,
-      updatedAt: b.meta?.lastUpdated ?? '',
-    };
-  });
+  // System-managed tags are always reported, even before their Basic definitions exist (e.g. Hold
+  // before any rules List has been saved). They get synthetic entries with no id/updatedAt — but
+  // real usage counts, since claims can carry a system tag the moment the system applies it.
+  const storedNames = basics.map((b) => b.code?.text).filter((name): name is string => !!name);
+  const unstoredSystemTags = SYSTEM_MANAGED_TAGS.filter((def) => !storedNames.includes(def.name));
+
+  const usageCounts = await getTagUsageCounts(oystehr, [
+    ...new Set(storedNames),
+    ...unstoredSystemTags.map((def) => def.name),
+  ]);
+
+  const tags: BillingTag[] = [
+    ...basics.map((b) => {
+      const name = b.code?.text ?? '';
+      const systemDef = SYSTEM_MANAGED_TAGS.find((def) => def.name === name);
+      return {
+        id: b.id ?? '',
+        name,
+        description:
+          b.extension?.find((e) => e.url === TAG_DESCRIPTION_URL)?.valueString ?? systemDef?.description ?? '',
+        usage: usageCounts.get(name) ?? 0,
+        updatedAt: b.meta?.lastUpdated ?? '',
+        isSystemTag: isSystemTag(b),
+      };
+    }),
+    ...unstoredSystemTags.map((def) => ({
+      id: '',
+      name: def.name,
+      description: def.description,
+      usage: usageCounts.get(def.name) ?? 0,
+      updatedAt: '',
+      isSystemTag: true,
+    })),
+  ];
 
   return { tags };
 }
 
 // Count-only search per tag (_count=0 + _total=accurate) reads Bundle.total without fetching claims.
-async function getTagUsageCounts(oystehr: Oystehr, tags: Basic[]): Promise<Map<string, number>> {
+async function getTagUsageCounts(oystehr: Oystehr, tagNames: string[]): Promise<Map<string, number>> {
   const counts = new Map<string, number>();
-  const tagNames = tags.map((t) => t.code?.text).filter(Boolean) as string[];
   if (tagNames.length === 0) return counts;
 
   const requests: BatchInputGetRequest[] = tagNames.map((name) => ({

--- a/packages/zambdas/src/billing/shared.ts
+++ b/packages/zambdas/src/billing/shared.ts
@@ -251,14 +251,14 @@ export const TAG_CODE_SYSTEM = 'https://fhir.ottehr.com/billing/tag';
 export const TAG_DESCRIPTION_URL = 'https://fhir.ottehr.com/billing/tag-description';
 export const TAG_IS_SYSTEM_TAG_URL = 'https://fhir.ottehr.com/billing/is-system-tag';
 
-// The tag's name (code.text) is its identity everywhere tags are referenced (claim meta tags,
-// rules), so a definition whose name matches a system-managed tag is treated as system-managed
-// even if it was stored without the is-system-tag extension.
+// A tag definition is system-managed iff its name (code.text) is in SYSTEM_MANAGED_TAGS — the name
+// is the tag's identity everywhere tags are referenced (claim meta tags, rules), and the
+// code-defined list is the single source of truth. A definition whose name leaves the list (e.g.
+// after a system tag is renamed in code) degrades to an ordinary, editable/deletable tag. The
+// is-system-tag extension written by systemTagBasic records provenance only and deliberately does
+// not drive behavior.
 export function isSystemTag(tag: Basic): boolean {
-  return (
-    isSystemManagedTagName(tag.code?.text) ||
-    (tag.extension?.some((ext) => ext.url === TAG_IS_SYSTEM_TAG_URL && ext.valueBoolean === true) ?? false)
-  );
+  return isSystemManagedTagName(tag.code?.text);
 }
 
 // The one FHIR encoding of a system-managed tag definition (see utils' SYSTEM_MANAGED_TAGS).

--- a/packages/zambdas/src/billing/shared.ts
+++ b/packages/zambdas/src/billing/shared.ts
@@ -72,6 +72,7 @@ import {
   getTaxID,
   INVALID_INPUT_ERROR,
   isPayerUrl,
+  isSystemManagedTagName,
   isValidClaimStatusValue,
   isValidUUID,
   PATIENT_BILLING_ACCOUNT_TYPE,
@@ -79,6 +80,8 @@ import {
   Secrets,
   SecretsKeys,
   setCoveragePlanType,
+  SYSTEM_MANAGED_TAGS,
+  SystemManagedTag,
   withArStageInitialization,
   WORKERS_COMP_ACCOUNT_TYPE,
 } from 'utils';
@@ -248,8 +251,35 @@ export const TAG_CODE_SYSTEM = 'https://fhir.ottehr.com/billing/tag';
 export const TAG_DESCRIPTION_URL = 'https://fhir.ottehr.com/billing/tag-description';
 export const TAG_IS_SYSTEM_TAG_URL = 'https://fhir.ottehr.com/billing/is-system-tag';
 
+// The tag's name (code.text) is its identity everywhere tags are referenced (claim meta tags,
+// rules), so a definition whose name matches a system-managed tag is treated as system-managed
+// even if it was stored without the is-system-tag extension.
 export function isSystemTag(tag: Basic): boolean {
-  return tag.extension?.some((ext) => ext.url === TAG_IS_SYSTEM_TAG_URL && ext.valueBoolean === true) ?? false;
+  return (
+    isSystemManagedTagName(tag.code?.text) ||
+    (tag.extension?.some((ext) => ext.url === TAG_IS_SYSTEM_TAG_URL && ext.valueBoolean === true) ?? false)
+  );
+}
+
+// The one FHIR encoding of a system-managed tag definition (see utils' SYSTEM_MANAGED_TAGS).
+export function systemTagBasic(def: SystemManagedTag): Basic {
+  return {
+    resourceType: 'Basic',
+    code: { text: def.name, coding: [{ system: TAG_CODE_SYSTEM, code: 'tag' }] },
+    extension: [
+      { url: TAG_DESCRIPTION_URL, valueString: def.description },
+      { url: TAG_IS_SYSTEM_TAG_URL, valueBoolean: true },
+    ],
+  };
+}
+
+// Create the Basic definition of any system-managed tag that doesn't have one yet. Callers decide
+// whether a failure matters — seeding is cosmetic (search-billing-tags reports system-managed tags
+// whether or not their Basics exist).
+export async function ensureSystemManagedTags(oystehr: Oystehr): Promise<void> {
+  const defined = await fetchDefinedTagNames(oystehr);
+  const missing = SYSTEM_MANAGED_TAGS.filter((def) => !defined.has(def.name));
+  await Promise.all(missing.map((def) => oystehr.fhir.create<Basic>(systemTagBasic(def))));
 }
 
 // All tag definitions in the tags feature (Basic resources; the name lives in code.text), newest
@@ -291,9 +321,6 @@ export function setClaimRenderingProviderCareTeam(claim: Claim, provider: Refere
     careTeamSequence: Array.from(new Set([1, ...(item.careTeamSequence ?? [])])),
   }));
 }
-
-export const AUTO_ACCIDENT_TAG_NAME = 'auto-accident';
-export const AUTO_ACCIDENT_TAG_DESCRIPTION = 'Claim is for a clinical encounter resulting from an auto accident';
 
 const PROTECTED_OVERRIDE_KEYS = new Set(['id', 'meta', 'resourceType', 'extension']);
 

--- a/packages/zambdas/src/billing/tag-billing-claim/index.ts
+++ b/packages/zambdas/src/billing/tag-billing-claim/index.ts
@@ -1,7 +1,7 @@
 import Oystehr from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Claim, Coding, ProvenanceAgent } from 'fhir/r4b';
-import { CLAIM_TAG_SYSTEM, HOLD_TAG_NAME, INVALID_INPUT_ERROR } from 'utils';
+import { CLAIM_TAG_SYSTEM, INVALID_INPUT_ERROR, isSystemManagedTagName } from 'utils';
 import { checkOrCreateM2MClientToken, wrapHandler, ZambdaInput } from '../../shared';
 import { commitClaimMetaTagsWithProvenance, resolveClaimActor } from '../provenance';
 import { createBillingClient, fetchById, fetchDefinedTagNames } from '../shared';
@@ -23,10 +23,10 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
 // Adding a tag requires it to exist in the tags feature (the claim-detail UI only offers existing
 // tags; this closes the API path). Removal stays unrestricted so an orphaned tag — one whose
-// definition was deleted — can still be taken off a claim. Hold is built into the rules engine and
-// always allowed.
+// definition was deleted — can still be taken off a claim. System-managed tags are built into the
+// system and always allowed.
 export async function complexValidation(oystehr: Oystehr, params: TagBillingClaimParams): Promise<void> {
-  if (params.action !== 'add' || params.tagName === HOLD_TAG_NAME) return;
+  if (params.action !== 'add' || isSystemManagedTagName(params.tagName)) return;
   const defined = await fetchDefinedTagNames(oystehr);
   if (!defined.has(params.tagName)) {
     throw INVALID_INPUT_ERROR(`unknown tag "${params.tagName}" — create it on the Tags page first`);

--- a/packages/zambdas/test/unit/billing/create-billing-claim-from-encounter.test.ts
+++ b/packages/zambdas/test/unit/billing/create-billing-claim-from-encounter.test.ts
@@ -18,6 +18,8 @@ import {
   ACCOUNT_TYPE_CODE_SYSTEM,
   APIError,
   AR_STAGE,
+  AUTO_ACCIDENT_SYSTEM_TAG,
+  AUTO_ACCIDENT_TAG_NAME,
   BILLING_RESOURCE_TAG,
   CANDID_PLAN_TYPE_SYSTEM,
   CLAIM_STATUS_TAG_SYSTEMS,
@@ -59,16 +61,12 @@ import {
 } from '../../../src/billing/create-billing-claim-from-encounter/handler';
 import { validateRequestParameters } from '../../../src/billing/create-billing-claim-from-encounter/validateRequestParameters';
 import {
-  AUTO_ACCIDENT_TAG_DESCRIPTION,
-  AUTO_ACCIDENT_TAG_NAME,
   BILLING_WORKING_COPY_TAG,
   buildNoCoverageStub,
   CURRENT_STATUS_TAG_SYSTEM,
   SOURCE_FRIENDLY_PATIENT_ID_EXTENSION,
   SOURCE_IDENTIFIER_SYSTEM,
-  TAG_CODE_SYSTEM,
-  TAG_DESCRIPTION_URL,
-  TAG_IS_SYSTEM_TAG_URL,
+  systemTagBasic,
 } from '../../../src/billing/shared';
 
 // Local const so that DEPRECATED system doesn't get imported from utils
@@ -357,14 +355,7 @@ const billingResources: {
     resourceType: 'Organization',
     id: 'billing-organization-123',
   },
-  autoAccidentTag: {
-    resourceType: 'Basic',
-    code: { text: AUTO_ACCIDENT_TAG_NAME, coding: [{ system: TAG_CODE_SYSTEM, code: 'tag' }] },
-    extension: [
-      { url: TAG_DESCRIPTION_URL, valueString: AUTO_ACCIDENT_TAG_DESCRIPTION },
-      { url: TAG_IS_SYSTEM_TAG_URL, valueBoolean: true },
-    ],
-  },
+  autoAccidentTag: systemTagBasic(AUTO_ACCIDENT_SYSTEM_TAG),
   billingService: {
     resourceType: 'Basic',
     code: { text: 'urgent-care', coding: [{ system: CODE_SYSTEM_SERVICE_CATEGORY_TAG_SYSTEM, code: 'urgent-care' }] },

--- a/packages/zambdas/test/unit/billing/create-billing-claim-from-encounter.test.ts
+++ b/packages/zambdas/test/unit/billing/create-billing-claim-from-encounter.test.ts
@@ -3,6 +3,7 @@ import {
   Account,
   Appointment,
   Basic,
+  Claim,
   Condition,
   Coverage,
   Encounter,
@@ -281,7 +282,6 @@ const billingResources: {
   location: Location;
   practitioner: Practitioner;
   billingProvider: Organization;
-  autoAccidentTag: Basic;
   billingService: Basic;
 } = {
   person: {
@@ -355,7 +355,6 @@ const billingResources: {
     resourceType: 'Organization',
     id: 'billing-organization-123',
   },
-  autoAccidentTag: systemTagBasic(AUTO_ACCIDENT_SYSTEM_TAG),
   billingService: {
     resourceType: 'Basic',
     code: { text: 'urgent-care', coding: [{ system: CODE_SYSTEM_SERVICE_CATEGORY_TAG_SYSTEM, code: 'urgent-care' }] },
@@ -741,7 +740,6 @@ describe('create-billing-claim-from-encounter', () => {
             renderingProvider: undefined,
             serviceFacility: undefined,
             subscribers: [],
-            autoAccidentTag: undefined,
             billingService: undefined,
           },
         },
@@ -837,7 +835,6 @@ describe('create-billing-claim-from-encounter', () => {
             renderingProvider: undefined,
             serviceFacility: undefined,
             subscribers: [],
-            autoAccidentTag: undefined,
             billingService: undefined,
           },
         },
@@ -921,7 +918,6 @@ describe('create-billing-claim-from-encounter', () => {
             renderingProvider: undefined,
             serviceFacility: undefined,
             subscribers: [],
-            autoAccidentTag: undefined,
             billingService: undefined,
           },
         },
@@ -997,7 +993,6 @@ describe('create-billing-claim-from-encounter', () => {
             renderingProvider: undefined,
             serviceFacility: undefined,
             subscribers: [],
-            autoAccidentTag: undefined,
             billingService: undefined,
           },
         },
@@ -1047,10 +1042,6 @@ describe('create-billing-claim-from-encounter', () => {
             unbundle: () => [billingResources.billingProvider],
           })
           .mockResolvedValueOnce({
-            // Auto accident tag
-            unbundle: () => [billingResources.autoAccidentTag],
-          })
-          .mockResolvedValueOnce({
             // Billing service
             unbundle: () => [billingResources.billingService],
           }),
@@ -1080,7 +1071,6 @@ describe('create-billing-claim-from-encounter', () => {
             renderingProvider: billingResources.practitioner,
             serviceFacility: billingResources.location,
             subscribers: [billingResources.relatedPerson],
-            autoAccidentTag: billingResources.autoAccidentTag,
             billingService: billingResources.billingService,
           },
         },
@@ -2451,7 +2441,7 @@ describe('create-billing-claim-from-encounter', () => {
         ]),
       });
     });
-    it('creates claim with auto accident tag, creating the tag along the way', async () => {
+    it('creates claim with auto accident tag, seeding the tag definition along the way', async () => {
       const txFn = vi.fn().mockResolvedValue({
         entry: [
           { resource: { resourceType: 'Patient', id: 'billing-patient' } },
@@ -2462,14 +2452,16 @@ describe('create-billing-claim-from-encounter', () => {
           { resource: { resourceType: 'RelatedPerson', id: 'claim-subscriber' } },
           { resource: { resourceType: 'Coverage', id: 'claim-coverage' } },
           { resource: { resourceType: 'Person', id: 'billing-person' } },
-          { resource: { resourceType: 'Basic', id: 'auto-accident-tag' } },
           { resource: { resourceType: 'Basic', id: 'billing-service-basic' } },
           { resource: { resourceType: 'Claim', id: 'claim' } },
           { resource: { resourceType: 'Provenance', id: 'provenance' } },
         ],
       });
+      // ensureSystemManagedTags: no tag definitions exist yet, so the missing ones get created.
+      const searchFn = vi.fn().mockResolvedValue({ unbundle: () => [] });
+      const createFn = vi.fn().mockImplementation(async (resource: Basic) => resource);
       const billingOystehr = {
-        fhir: { transaction: txFn },
+        fhir: { transaction: txFn, search: searchFn, create: createFn },
         rcm: { constructPayerUrl: vi.fn().mockReturnValue('https://rcm-api.zapehr.com/v1/payer/payer-123') },
       } as unknown as Oystehr;
       const cvo: ComplexValidationOutput = {
@@ -2503,6 +2495,7 @@ describe('create-billing-claim-from-encounter', () => {
       };
       const result = await performEffect(billingOystehr, cvo, TEST_PROVENANCE_AGENT);
       expect(result.claimId).toEqual('claim');
+      expect(createFn).toHaveBeenCalledWith(systemTagBasic(AUTO_ACCIDENT_SYSTEM_TAG));
       expect(txFn).toHaveBeenCalledWith({
         requests: expect.arrayContaining([
           {
@@ -2586,6 +2579,69 @@ describe('create-billing-claim-from-encounter', () => {
             },
           },
         ]),
+      });
+    });
+    it('still creates the auto accident claim when seeding the tag definition fails', async () => {
+      const txFn = vi.fn().mockResolvedValue({
+        entry: [
+          { resource: { resourceType: 'Patient', id: 'billing-patient' } },
+          { resource: { resourceType: 'Patient', id: 'claim-patient' } },
+          { resource: { resourceType: 'RelatedPerson', id: 'billing-subscriber' } },
+          { resource: { resourceType: 'Coverage', id: 'billing-coverage' } },
+          { resource: { resourceType: 'Account', id: 'billing-account' } },
+          { resource: { resourceType: 'RelatedPerson', id: 'claim-subscriber' } },
+          { resource: { resourceType: 'Coverage', id: 'claim-coverage' } },
+          { resource: { resourceType: 'Person', id: 'billing-person' } },
+          { resource: { resourceType: 'Basic', id: 'billing-service-basic' } },
+          { resource: { resourceType: 'Claim', id: 'claim' } },
+          { resource: { resourceType: 'Provenance', id: 'provenance' } },
+        ],
+      });
+      const billingOystehr = {
+        fhir: {
+          transaction: txFn,
+          search: vi.fn().mockRejectedValue(new Error('FHIR is down')),
+          create: vi.fn(),
+        },
+        rcm: { constructPayerUrl: vi.fn().mockReturnValue('https://rcm-api.zapehr.com/v1/payer/payer-123') },
+      } as unknown as Oystehr;
+      const cvo: ComplexValidationOutput = {
+        clinicalResources: {
+          accounts: [clinicalResources.account],
+          appointment: {
+            ...clinicalResources.appointment,
+            description: 'Auto accident',
+          },
+          billingProvider: clinicalResources.billingProvider,
+          coverages: [clinicalResources.coverage],
+          diagnoses: [...clinicalResources.conditions],
+          encounter: clinicalResources.encounter,
+          location: clinicalResources.location,
+          patient: clinicalResources.patient,
+          payors: [oystehrResources.payor],
+          practitioners: [clinicalResources.practitioner],
+          procedures: [clinicalResources.procedure],
+        },
+        billingResources: {
+          accounts: [],
+          billingProvider: undefined,
+          coverages: [],
+          mainPatient: undefined,
+          person: undefined,
+          practitioners: [],
+          renderingProvider: undefined,
+          serviceFacility: undefined,
+          subscribers: [],
+        },
+      };
+      const result = await performEffect(billingOystehr, cvo, TEST_PROVENANCE_AGENT);
+      expect(result.claimId).toEqual('claim');
+      const claimRequest = txFn.mock.calls[0][0].requests.find(
+        (r: { url: string }) => r.url === '/Claim'
+      ) as BatchInputPostRequest<Claim>;
+      expect(claimRequest.resource.meta?.tag).toContainEqual({
+        system: CLAIM_TAG_SYSTEM,
+        code: AUTO_ACCIDENT_TAG_NAME,
       });
     });
     it('swaps Oystehr-invalid HCPCS system URL for HL7 system URL', async () => {

--- a/packages/zambdas/test/unit/billing/delete-billing-tag.test.ts
+++ b/packages/zambdas/test/unit/billing/delete-billing-tag.test.ts
@@ -1,0 +1,55 @@
+import Oystehr from '@oystehr/sdk';
+import { Basic } from 'fhir/r4b';
+import { HOLD_TAG_NAME } from 'utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { performEffect } from '../../../src/billing/delete-billing-tag';
+import { DeleteBillingTagParams } from '../../../src/billing/delete-billing-tag/validateRequestParameters';
+import { TAG_CODE_SYSTEM, TAG_IS_SYSTEM_TAG_URL } from '../../../src/billing/shared';
+
+const search = vi.fn();
+const deleteFn = vi.fn();
+const oystehr = { fhir: { search, delete: deleteFn } } as unknown as Oystehr;
+
+const params: DeleteBillingTagParams = { tagId: 'tag-1', secrets: null } as DeleteBillingTagParams;
+
+const tagBasic = (name: string, systemExtension?: boolean): Basic => ({
+  resourceType: 'Basic',
+  id: 'tag-1',
+  code: { text: name, coding: [{ system: TAG_CODE_SYSTEM, code: 'tag' }] },
+  extension: systemExtension ? [{ url: TAG_IS_SYSTEM_TAG_URL, valueBoolean: true }] : undefined,
+});
+
+// First search returns the tag definition; second is the count-only claim-usage search.
+const mockSearches = (tag: Basic, claimsUsingTag: number): void => {
+  search.mockImplementation(async ({ resourceType }: { resourceType: string }) =>
+    resourceType === 'Basic' ? { unbundle: () => [tag] } : { total: claimsUsingTag, unbundle: () => [] }
+  );
+};
+
+describe('delete-billing-tag performEffect', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes an unused user tag', async () => {
+    mockSearches(tagBasic('VIP'), 0);
+    await expect(performEffect(oystehr, params)).resolves.toEqual({ deleted: true });
+    expect(deleteFn).toHaveBeenCalledWith({ resourceType: 'Basic', id: 'tag-1' });
+  });
+
+  it('refuses to delete a system-managed tag, even one stored without the is-system-tag extension', async () => {
+    mockSearches(tagBasic(HOLD_TAG_NAME), 0);
+    await expect(performEffect(oystehr, params)).rejects.toThrow('Cannot delete system-level tags');
+    expect(deleteFn).not.toHaveBeenCalled();
+  });
+
+  it('deletes a stale extension-flagged definition that is no longer system-managed (e.g. the pre-rename auto-accident)', async () => {
+    mockSearches(tagBasic('auto-accident', true), 0);
+    await expect(performEffect(oystehr, params)).resolves.toEqual({ deleted: true });
+    expect(deleteFn).toHaveBeenCalledWith({ resourceType: 'Basic', id: 'tag-1' });
+  });
+
+  it('refuses to delete a tag that claims still use', async () => {
+    mockSearches(tagBasic('VIP'), 3);
+    await expect(performEffect(oystehr, params)).rejects.toThrow(/associated with one or more claims/);
+    expect(deleteFn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/zambdas/test/unit/billing/save-billing-rules.test.ts
+++ b/packages/zambdas/test/unit/billing/save-billing-rules.test.ts
@@ -1,11 +1,18 @@
 import Oystehr from '@oystehr/sdk';
 import { Basic, Bundle, List, Organization, Resource } from 'fhir/r4b';
-import { BillingRuleInput, DEFAULT_RULES_ENGINE, HOLD_TAG_NAME, RulesEngineType } from 'utils';
+import {
+  AUTO_ACCIDENT_TAG_NAME,
+  BillingRuleInput,
+  DEFAULT_RULES_ENGINE,
+  HOLD_TAG_NAME,
+  RulesEngineType,
+  SYSTEM_MANAGED_TAGS,
+} from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RULES_ENGINE_FHIR, RULES_ENGINE_TAG_SYSTEM } from '../../../src/billing/rules-engine/constants';
 import { complexValidation, performEffect } from '../../../src/billing/save-billing-rules';
 import { SaveBillingRulesParams } from '../../../src/billing/save-billing-rules/validateRequestParameters';
-import { BILLING_WORKING_COPY_TAG, PROVIDER_ROLE_TAG } from '../../../src/billing/shared';
+import { BILLING_WORKING_COPY_TAG, PROVIDER_ROLE_TAG, TAG_IS_SYSTEM_TAG_URL } from '../../../src/billing/shared';
 
 const search = vi.fn();
 const create = vi.fn();
@@ -33,7 +40,7 @@ describe('save-billing-rules performEffect', () => {
     // Echo the written List back (as the server would), stamping a versionId.
     create.mockImplementation(async (resource: List | Basic) => ({ ...resource, meta: { versionId: '1' } }));
     update.mockImplementation(async (resource: List) => ({ ...resource, meta: { versionId: '2' } }));
-    // ensureHoldTag's tag lookup: no tags exist yet.
+    // ensureSystemManagedTags' tag lookup: no tags exist yet.
     search.mockResolvedValue({ unbundle: () => [] });
   });
 
@@ -55,20 +62,33 @@ describe('save-billing-rules performEffect', () => {
     expect(savedList.entry?.map((e) => e.item?.reference)).toEqual([`#${created.id}`, '#rule-1']);
   });
 
-  it('creates the List and seeds the Hold system tag when no rules List exists yet', async () => {
+  it('creates the List and seeds every system-managed tag when no rules List exists yet', async () => {
     const response = await performEffect(oystehr, params([rule('First rule')]), undefined, 'test');
 
     expect(update).not.toHaveBeenCalled();
     const createdTypes = create.mock.calls.map(([r]) => r.resourceType);
     expect(createdTypes).toContain('List');
-    expect(createdTypes).toContain('Basic');
-    const holdTag = create.mock.calls.find(([r]) => r.resourceType === 'Basic')?.[0] as Basic;
-    expect(holdTag.code?.text).toBe(HOLD_TAG_NAME);
+    const seededTags = create.mock.calls.map(([r]) => r).filter((r): r is Basic => r.resourceType === 'Basic');
+    expect(seededTags.map((tag) => tag.code?.text)).toEqual(SYSTEM_MANAGED_TAGS.map((def) => def.name));
+    seededTags.forEach((tag) => {
+      expect(tag.extension).toContainEqual({ url: TAG_IS_SYSTEM_TAG_URL, valueBoolean: true });
+    });
     expect(response.versionId).toBe('1');
   });
 
-  it('does not re-seed the Hold tag when it already exists', async () => {
+  it('seeds only the system-managed tags that are missing', async () => {
     search.mockResolvedValue({ unbundle: () => [{ resourceType: 'Basic', code: { text: HOLD_TAG_NAME } }] });
+
+    await performEffect(oystehr, params([rule('First rule')]), undefined, 'test');
+
+    const seededTags = create.mock.calls.map(([r]) => r).filter((r): r is Basic => r.resourceType === 'Basic');
+    expect(seededTags.map((tag) => tag.code?.text)).toEqual([AUTO_ACCIDENT_TAG_NAME]);
+  });
+
+  it('does not re-seed system-managed tags that already exist', async () => {
+    search.mockResolvedValue({
+      unbundle: () => SYSTEM_MANAGED_TAGS.map((def) => ({ resourceType: 'Basic', code: { text: def.name } })),
+    });
 
     await performEffect(oystehr, params([rule('First rule')]), undefined, 'test');
 
@@ -141,9 +161,14 @@ describe('save-billing-rules complexValidation (applied tags must exist)', () =>
     );
   });
 
-  it('always allows the Hold tag, without even searching for tag definitions', async () => {
+  it('always allows system-managed tags, without even searching for tag definitions', async () => {
     mockSearches([]);
-    await expect(complexValidation(oystehr, params([tagRule('Hold it', HOLD_TAG_NAME)]))).resolves.toBeUndefined();
+    await expect(
+      complexValidation(
+        oystehr,
+        params([tagRule('Hold it', HOLD_TAG_NAME), tagRule('Mark accident', AUTO_ACCIDENT_TAG_NAME)])
+      )
+    ).resolves.toBeUndefined();
     expect(search.mock.calls.filter(([q]) => q.resourceType === 'Basic')).toHaveLength(0);
   });
 

--- a/packages/zambdas/test/unit/billing/save-billing-tag.test.ts
+++ b/packages/zambdas/test/unit/billing/save-billing-tag.test.ts
@@ -1,0 +1,67 @@
+import Oystehr from '@oystehr/sdk';
+import { Basic } from 'fhir/r4b';
+import { AUTO_ACCIDENT_TAG_NAME, HOLD_TAG_NAME } from 'utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { complexValidation } from '../../../src/billing/save-billing-tag';
+import { SaveBillingTagParams } from '../../../src/billing/save-billing-tag/validateRequestParameters';
+import { TAG_CODE_SYSTEM } from '../../../src/billing/shared';
+
+const search = vi.fn();
+const oystehr = { fhir: { search } } as unknown as Oystehr;
+
+const params = (name: string, tagId?: string): SaveBillingTagParams =>
+  ({ name, tagId, secrets: null }) as SaveBillingTagParams;
+
+const tagBasic = (id: string, name: string): Basic => ({
+  resourceType: 'Basic',
+  id,
+  code: { text: name, coding: [{ system: TAG_CODE_SYSTEM, code: 'tag' }] },
+});
+
+// Exact names plus case/spacing variants — the whole spelling family is reserved.
+const SYSTEM_TAG_NAME_VARIANTS = [
+  HOLD_TAG_NAME,
+  AUTO_ACCIDENT_TAG_NAME,
+  'hold',
+  'HOLD',
+  ' Hold ',
+  'auto accident',
+  'AUTO ACCIDENT',
+];
+
+describe('save-billing-tag complexValidation (system-managed tag names are reserved)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('allows creating a tag with an ordinary name', async () => {
+    await expect(complexValidation(oystehr, params('VIP'))).resolves.toBeUndefined();
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it.each(SYSTEM_TAG_NAME_VARIANTS)('rejects creating a tag named %s', async (name) => {
+    await expect(complexValidation(oystehr, params(name))).rejects.toThrow(/is a system-managed tag name/);
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it('rejects renaming an existing tag onto a system-managed name, without even fetching it', async () => {
+    await expect(complexValidation(oystehr, params(HOLD_TAG_NAME, 'tag-1'))).rejects.toThrow(
+      /is a system-managed tag name/
+    );
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it('rejects editing a tag that is itself system-managed by name', async () => {
+    search.mockResolvedValue({ unbundle: () => [tagBasic('tag-1', HOLD_TAG_NAME)] });
+    await expect(complexValidation(oystehr, params('Renamed', 'tag-1'))).rejects.toThrow(
+      'Cannot edit system-level tags'
+    );
+  });
+
+  it('allows editing a stale definition that is no longer system-managed (e.g. the pre-rename auto-accident)', async () => {
+    const stale: Basic = {
+      ...tagBasic('tag-2', 'auto-accident'),
+      extension: [{ url: 'https://fhir.ottehr.com/billing/is-system-tag', valueBoolean: true }],
+    };
+    search.mockResolvedValue({ unbundle: () => [stale] });
+    await expect(complexValidation(oystehr, params('Car crash', 'tag-2'))).resolves.toEqual(stale);
+  });
+});

--- a/packages/zambdas/test/unit/billing/search-billing-tags.test.ts
+++ b/packages/zambdas/test/unit/billing/search-billing-tags.test.ts
@@ -100,4 +100,16 @@ describe('search-billing-tags', () => {
     // The canonical description fills in when the stored definition has none.
     expect(hold?.description).toBe(HOLD_SYSTEM_TAG.description);
   });
+
+  it('does not flag a stale definition whose name has left the system-managed list, despite its extension', async () => {
+    // e.g. a pre-rename "auto-accident" definition seeded with the is-system-tag extension.
+    const stale: Basic = { ...systemTagBasic({ name: 'auto-accident', description: 'old seeded copy' }), id: 'aa-1' };
+    search.mockResolvedValue({ unbundle: () => [stale] });
+
+    const { tags } = await performEffect(oystehr);
+
+    expect(tags.find((tag) => tag.name === 'auto-accident')?.isSystemTag).toBe(false);
+    // The current system-managed tags still get their synthetic entries alongside it.
+    expect(tags.map((tag) => tag.name)).toEqual(['auto-accident', HOLD_TAG_NAME, AUTO_ACCIDENT_TAG_NAME]);
+  });
 });

--- a/packages/zambdas/test/unit/billing/search-billing-tags.test.ts
+++ b/packages/zambdas/test/unit/billing/search-billing-tags.test.ts
@@ -1,0 +1,103 @@
+import Oystehr from '@oystehr/sdk';
+import { Basic } from 'fhir/r4b';
+import { AUTO_ACCIDENT_SYSTEM_TAG, AUTO_ACCIDENT_TAG_NAME, HOLD_SYSTEM_TAG, HOLD_TAG_NAME } from 'utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { performEffect } from '../../../src/billing/search-billing-tags';
+import { systemTagBasic, TAG_CODE_SYSTEM, TAG_DESCRIPTION_URL } from '../../../src/billing/shared';
+
+const search = vi.fn();
+const batch = vi.fn();
+const oystehr = { fhir: { search, batch } } as unknown as Oystehr;
+
+const userTag = (id: string, name: string, description?: string): Basic => ({
+  resourceType: 'Basic',
+  id,
+  meta: { lastUpdated: '2026-07-01T00:00:00Z' },
+  code: { text: name, coding: [{ system: TAG_CODE_SYSTEM, code: 'tag' }] },
+  extension: description ? [{ url: TAG_DESCRIPTION_URL, valueString: description }] : undefined,
+});
+
+// Usage-count batch stub: answers each count-only claim search from usageByName, keyed by the tag
+// name encoded in the request URL.
+const mockUsage = (usageByName: Record<string, number>): void => {
+  batch.mockImplementation(async ({ requests }: { requests: { url: string }[] }) => ({
+    entry: requests.map((request) => {
+      const name = decodeURIComponent(request.url).match(/\|(.*)&_total/)?.[1] ?? '';
+      return { resource: { resourceType: 'Bundle', type: 'searchset', total: usageByName[name] ?? 0 } };
+    }),
+  }));
+};
+
+describe('search-billing-tags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUsage({});
+  });
+
+  it('appends system-managed tags that have no stored definition yet, after the stored tags', async () => {
+    search.mockResolvedValue({ unbundle: () => [userTag('tag-1', 'VIP', 'White-glove payers')] });
+    mockUsage({ VIP: 2 });
+
+    const { tags } = await performEffect(oystehr);
+
+    expect(tags.map((tag) => tag.name)).toEqual(['VIP', HOLD_TAG_NAME, AUTO_ACCIDENT_TAG_NAME]);
+    expect(tags[0]).toEqual({
+      id: 'tag-1',
+      name: 'VIP',
+      description: 'White-glove payers',
+      usage: 2,
+      updatedAt: '2026-07-01T00:00:00Z',
+      isSystemTag: false,
+    });
+    expect(tags[1]).toEqual({
+      id: '',
+      name: HOLD_TAG_NAME,
+      description: HOLD_SYSTEM_TAG.description,
+      usage: 0,
+      updatedAt: '',
+      isSystemTag: true,
+    });
+    expect(tags[2]).toEqual({
+      id: '',
+      name: AUTO_ACCIDENT_TAG_NAME,
+      description: AUTO_ACCIDENT_SYSTEM_TAG.description,
+      usage: 0,
+      updatedAt: '',
+      isSystemTag: true,
+    });
+  });
+
+  it('counts claims tagged with a system-managed tag even before its definition exists', async () => {
+    search.mockResolvedValue({ unbundle: () => [] });
+    mockUsage({ [HOLD_TAG_NAME]: 3 });
+
+    const { tags } = await performEffect(oystehr);
+
+    expect(tags.find((tag) => tag.name === HOLD_TAG_NAME)?.usage).toBe(3);
+    expect(tags.find((tag) => tag.name === AUTO_ACCIDENT_TAG_NAME)?.usage).toBe(0);
+  });
+
+  it('does not duplicate a system-managed tag whose definition has been seeded', async () => {
+    const seededHold: Basic = { ...systemTagBasic(HOLD_SYSTEM_TAG), id: 'hold-1' };
+    search.mockResolvedValue({ unbundle: () => [seededHold] });
+
+    const { tags } = await performEffect(oystehr);
+
+    const holdTags = tags.filter((tag) => tag.name === HOLD_TAG_NAME);
+    expect(holdTags).toHaveLength(1);
+    expect(holdTags[0].id).toBe('hold-1');
+    expect(holdTags[0].isSystemTag).toBe(true);
+    expect(holdTags[0].description).toBe(HOLD_SYSTEM_TAG.description);
+  });
+
+  it('flags a stored definition as a system tag by name even without the is-system-tag extension', async () => {
+    search.mockResolvedValue({ unbundle: () => [userTag('tag-2', HOLD_TAG_NAME)] });
+
+    const { tags } = await performEffect(oystehr);
+
+    const hold = tags.find((tag) => tag.name === HOLD_TAG_NAME);
+    expect(hold?.isSystemTag).toBe(true);
+    // The canonical description fills in when the stored definition has none.
+    expect(hold?.description).toBe(HOLD_SYSTEM_TAG.description);
+  });
+});

--- a/packages/zambdas/test/unit/billing/tag-billing-claim.test.ts
+++ b/packages/zambdas/test/unit/billing/tag-billing-claim.test.ts
@@ -1,6 +1,6 @@
 import Oystehr from '@oystehr/sdk';
 import { Basic } from 'fhir/r4b';
-import { HOLD_TAG_NAME } from 'utils';
+import { SYSTEM_MANAGED_TAGS } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { complexValidation } from '../../../src/billing/tag-billing-claim';
 import { TagBillingClaimParams } from '../../../src/billing/tag-billing-claim/validateRequestParameters';
@@ -30,10 +30,13 @@ describe('tag-billing-claim complexValidation (tag must exist to be added)', () 
     await expect(complexValidation(oystehr, params('add', 'Nope'))).rejects.toThrow(/unknown tag "Nope"/);
   });
 
-  it('always allows the Hold tag without a lookup', async () => {
-    await expect(complexValidation(oystehr, params('add', HOLD_TAG_NAME))).resolves.toBeUndefined();
-    expect(search).not.toHaveBeenCalled();
-  });
+  it.each(SYSTEM_MANAGED_TAGS.map((def) => def.name))(
+    'always allows the system-managed %s tag without a lookup',
+    async (tagName) => {
+      await expect(complexValidation(oystehr, params('add', tagName))).resolves.toBeUndefined();
+      expect(search).not.toHaveBeenCalled();
+    }
+  );
 
   it('allows removing an orphaned tag whose definition no longer exists', async () => {
     search.mockResolvedValue({ unbundle: () => [] });


### PR DESCRIPTION
Introduces 'system managed tags' concept. There used to be a number of places that referred to 'Hold' tag directly. Now Hold and 'Auto Accident' are defined in a shared 'system managed tags' pattern. Users can't delete system managed tags. When applying a system managed tag from code, there is a helper that will ensure it exists JIT as you need it.

🤖 generated code and description below.

## Summary

Introduces a system-managed tags feature for billing, allowing the system to define and apply tags (like "Hold" and "auto-accident") that cannot be edited or deleted by users. System-managed tags are always reported by the search endpoint, even before their FHIR definitions exist, and are clearly marked in the UI.

## Key Changes

- **New system-tags module** (`packages/utils/lib/types/data/billing/system-tags.ts`):
  - Defines `SYSTEM_MANAGED_TAGS` as the single source of truth for system-managed tag definitions
  - Exports `HOLD_TAG_NAME` and `AUTO_ACCIDENT_TAG_NAME` constants (moved from rules-engine.constants)
  - Provides `isSystemManagedTagName()` helper for validation

- **Search billing tags** (`search-billing-tags`):
  - Always returns system-managed tags, even before their Basic definitions are created
  - Marks system-managed tags with `isSystemTag: true` in the response
  - Counts usage for system-managed tags via batch requests
  - Appends unstoredSystemTags after user-defined tags in the response

- **Billing shared utilities** (`packages/zambdas/src/billing/shared.ts`):
  - Updated `isSystemTag()` to recognize tags by name (not just by extension)
  - Added `systemTagBasic()` to generate canonical FHIR encoding of system-managed tags
  - Added `ensureSystemManagedTags()` to seed missing system-managed tag definitions

- **Save billing rules** (`save-billing-rules`):
  - Calls `ensureSystemManagedTags()` when creating the first rules List (best-effort, non-blocking)
  - Allows system-managed tags in rules without requiring them to be pre-seeded
  - Uses `isSystemManagedTagName()` instead of checking only for Hold

- **Tag billing claim** (`tag-billing-claim`):
  - Accepts system-managed tags without lookup validation
  - Uses `isSystemManagedTagName()` for the check

- **Create billing claim from encounter**:
  - Uses `AUTO_ACCIDENT_SYSTEM_TAG` from utils instead of local constants
  - Calls `systemTagBasic()` to generate the auto-accident tag definition

- **Tags UI** (`apps/billing/src/pages/Tags.tsx`):
  - Displays "System" badge for system-managed tags
  - Disables edit/delete buttons for system-managed tags
  - Uses `tag.id || tag.name` as React key to handle unstoredSystemTags (which have empty id)

- **TagSelect component** (`apps/billing/src/components/TagSelect.tsx`):
  - Offers all system-managed tags even while the tag list is unavailable
  - Uses fallback options from `SYSTEM_MANAGED_TAGS` instead of just Hold

- **BillingTag type** (`packages/utils/lib/types/data/billing/billing.types.ts`):
  - Added `isSystemTag: boolean` field
  - Clarified that `id` and `updatedAt` are empty for unstoredSystemTags

- **Tests**:
  - Added comprehensive unit tests for `search-billing-tags` covering unstoredSystemTags, usage counting, and deduplication
  - Added component tests for Tags page showing System badge and disabled edit/delete
  - Updated existing tests to use `SYSTEM_MANAGED_TAGS` and `isSystemManagedTagName()`

## Notable Implementation Details

- System-managed tags are identified by name (code.text), not just by extension, so a stored definition without the is-system-tag extension is still treated as system-managed if its name matches
- `search-billing-tags` reports system-managed tags with synthetic entries (empty id/updatedAt) before their Basic definitions exist, enabling the UI to show them immediately
- Seeding of system-managed tag definitions is best-effort and non-blocking—the system works correctly whether or not the Basics are created
- The Tags page uses `tag.id || tag.name` as the React key to handle both stored tags (with id) and uns

https://claude.ai/code/session_01UCszr9nkHtSfXi7obxkAjx