### PR TITLE
refactor date filter in tracking board

### DIFF
--- a/apps/ehr/src/components/input/DateRangeInput.tsx
+++ b/apps/ehr/src/components/input/DateRangeInput.tsx
@@ -81,7 +81,6 @@ export const DateRangeInput: React.FC<Props> = ({
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [rangeMode, setRangeMode] = useState(false);
-  const [session, setSession] = useState(0);
 
   const dateFrom = parseIsoDate(fromField.value);
   const dateTo = parseIsoDate(toField.value);
@@ -94,7 +93,6 @@ export const DateRangeInput: React.FC<Props> = ({
 
   const openPicker = (event: React.MouseEvent<HTMLElement>): void => {
     setRangeMode(isMultiDayRange);
-    setSession((current) => current + 1);
     setAnchorEl(event.currentTarget);
   };
 
@@ -149,7 +147,6 @@ export const DateRangeInput: React.FC<Props> = ({
         slotProps={{ paper: { 'data-testid': dataTestIds.dashboard.datePickerPopover } as Record<string, unknown> }}
       >
         <RangeCalendar
-          key={session}
           value={[dateFrom, dateTo]}
           rangeMode={rangeMode}
           maxRangeDays={maxRangeDays}

--- a/apps/ehr/src/components/input/DateRangeInput.tsx
+++ b/apps/ehr/src/components/input/DateRangeInput.tsx
@@ -1,45 +1,15 @@
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { Box, Button, Checkbox, Divider, FormControlLabel, Popover, TextField } from '@mui/material';
-import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
-import {
-  DateCalendar,
-  DateRange,
-  DateRangeCalendar,
-  LocalizationProvider,
-  RangePosition,
-} from '@mui/x-date-pickers-pro';
 import { DateTime } from 'luxon';
 import React, { useEffect, useState } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 import { dataTestIds } from 'src/constants/data-test-ids';
+import { RangeCalendar } from './RangeCalendar';
 
 const DISPLAY_FORMAT = 'MM/dd/yyyy';
 
 const INCOMPLETE_RANGE_MESSAGE = 'Both start and end dates are required.';
 const RANGE_ORDER_MESSAGE = 'Start date must be on or before end date.';
-
-// MUI's range calendar omits the standard month indicator and scales its day buttons to overlap
-// the range-preview border. Restore the shared visual treatment without changing range behavior,
-// colors, or the calendar's reserved six-week height.
-const RANGE_CALENDAR_SX = {
-  '& .MuiPickersCalendarHeader-labelContainer': {
-    cursor: 'default',
-    '&::after': {
-      borderLeft: '5px solid transparent',
-      borderRight: '5px solid transparent',
-      borderTop: '5px solid currentColor',
-      content: '""',
-      display: 'inline-block',
-      marginLeft: 0.5,
-    },
-  },
-  '& .MuiDateRangePickerDay-day': {
-    transform: 'none !important',
-    '& > *': {
-      transform: 'none !important',
-    },
-  },
-} as const;
 
 // Both sides parse in UTC so the day count is deterministic (24h/day) and matches how the
 // get-appointments zambda validates its cap server-side.
@@ -55,11 +25,6 @@ const parseIsoDate = (value: unknown): DateTime | null => {
   return parsed.isValid ? parsed : null;
 };
 
-// Puts a stable test id on every day cell so tests can click a specific date directly.
-const withDayTestId = (ownerState: { day: DateTime }): Record<string, string> => ({
-  'data-testid': dataTestIds.dashboard.datePickerDay(ownerState.day.toISODate() ?? ''),
-});
-
 type Props = {
   /** Form field names holding the range boundaries as ISO dates (yyyy-MM-dd). */
   dateFromName: string;
@@ -73,9 +38,9 @@ type Props = {
 
 /**
  * Date filter that defaults to single-date selection (the common case: one click picks a day and
- * writes it to both form fields). Checking "Date Range" switches the same popover to a one-month
- * range calendar where the user picks a start and an end date; only complete ranges are committed
- * to the form, so no intermediate (start, stale-end) pair ever triggers a fetch.
+ * writes it to both form fields). Checking "Date Range" keeps the same calendar but makes the next
+ * two clicks pick a start and an end date. Selection itself lives in `RangeCalendar`; this component
+ * owns the form fields, their validation, and the popover around it.
  */
 export const DateRangeInput: React.FC<Props> = ({
   dateFromName,
@@ -116,8 +81,7 @@ export const DateRangeInput: React.FC<Props> = ({
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [rangeMode, setRangeMode] = useState(false);
-  const [pendingRange, setPendingRange] = useState<DateRange<DateTime>>([null, null]);
-  const [rangePosition, setRangePosition] = useState<RangePosition>('start');
+  const [session, setSession] = useState(0);
 
   const dateFrom = parseIsoDate(fromField.value);
   const dateTo = parseIsoDate(toField.value);
@@ -130,8 +94,7 @@ export const DateRangeInput: React.FC<Props> = ({
 
   const openPicker = (event: React.MouseEvent<HTMLElement>): void => {
     setRangeMode(isMultiDayRange);
-    setPendingRange([dateFrom, dateTo]);
-    setRangePosition('start');
+    setSession((current) => current + 1);
     setAnchorEl(event.currentTarget);
   };
 
@@ -142,44 +105,23 @@ export const DateRangeInput: React.FC<Props> = ({
     toField.onChange(to.toISODate());
   };
 
+  const commitAndClose = (from: DateTime, to: DateTime): void => {
+    commitRange(from, to);
+    closePicker();
+  };
+
   const handleRangeModeToggle = (checked: boolean): void => {
     setRangeMode(checked);
-    setPendingRange([dateFrom, dateTo]);
-    setRangePosition('start');
     if (!checked && dateFrom && isMultiDayRange) {
       // Collapsing back to single-date keeps the start date selected.
       commitRange(dateFrom, dateFrom);
     }
   };
 
-  const handleRangeChange = (value: DateRange<DateTime>): void => {
-    // The first click always starts a fresh range: the calendar would otherwise merge the clicked
-    // day with the previous end date into a complete — but unintended — range and fetch it.
-    if (rangePosition === 'start') {
-      setPendingRange([value[0], null]);
-      setRangePosition('end');
-      return;
-    }
-    const [start, end] = value;
-    if (start && end) {
-      commitRange(start, end);
-      closePicker();
-    } else {
-      setPendingRange(value);
-    }
-  };
-
   const handleTodayClick = (): void => {
     const today = DateTime.now();
-    commitRange(today, today);
-    closePicker();
+    commitAndClose(today, today);
   };
-
-  // While the end date is being picked, cap it so the range cannot exceed the server-side limit.
-  const rangeEndLimit =
-    maxRangeDays != null && rangePosition === 'end' && pendingRange[0] && !pendingRange[1]
-      ? pendingRange[0].plus({ days: maxRangeDays })
-      : undefined;
 
   const fromText = dateFrom?.toFormat(DISPLAY_FORMAT) ?? '';
   const toText = dateTo?.toFormat(DISPLAY_FORMAT) ?? '';
@@ -204,32 +146,15 @@ export const DateRangeInput: React.FC<Props> = ({
         anchorEl={anchorEl}
         onClose={closePicker}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        slotProps={{ paper: { 'data-testid': dataTestIds.dashboard.datePickerPopover } as Record<string, unknown> }}
       >
-        <LocalizationProvider dateAdapter={AdapterLuxon}>
-          {rangeMode ? (
-            <DateRangeCalendar
-              calendars={1}
-              sx={RANGE_CALENDAR_SX}
-              value={pendingRange}
-              onChange={handleRangeChange}
-              rangePosition={rangePosition}
-              onRangePositionChange={setRangePosition}
-              maxDate={rangeEndLimit}
-              slotProps={{ day: withDayTestId }}
-            />
-          ) : (
-            <DateCalendar
-              value={dateFrom}
-              onChange={(day: DateTime | null) => {
-                if (day) {
-                  commitRange(day, day);
-                  closePicker();
-                }
-              }}
-              slotProps={{ day: withDayTestId }}
-            />
-          )}
-        </LocalizationProvider>
+        <RangeCalendar
+          key={session}
+          value={[dateFrom, dateTo]}
+          rangeMode={rangeMode}
+          maxRangeDays={maxRangeDays}
+          onComplete={commitAndClose}
+        />
         <Divider />
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 1, py: 0.5 }}>
           <FormControlLabel

--- a/apps/ehr/src/components/input/RangeCalendar.tsx
+++ b/apps/ehr/src/components/input/RangeCalendar.tsx
@@ -1,0 +1,154 @@
+import { alpha, Box } from '@mui/material';
+import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
+import { DateCalendar, LocalizationProvider, PickersDay, PickersDayProps } from '@mui/x-date-pickers-pro';
+import { DateTime } from 'luxon';
+import React, { useEffect, useState } from 'react';
+import { dataTestIds } from 'src/constants/data-test-ids';
+
+// MUI 6's `DateRangeCalendar` has no month view and sizes its days differently from `DateCalendar`,
+// so range selection is built on `DateCalendar` here instead. The switcher opens the first view.
+const CALENDAR_VIEWS = ['month', 'day'] as const;
+
+const BAND_START = { borderTopLeftRadius: '50%', borderBottomLeftRadius: '50%' } as const;
+const BAND_END = { borderTopRightRadius: '50%', borderBottomRightRadius: '50%' } as const;
+
+const IGNORE_HOVER = (): void => undefined;
+
+type DayState = {
+  /** Boundaries of the selection; `end` is null while it is still being picked. */
+  start: DateTime | null;
+  end: DateTime | null;
+  /** Day under the cursor, which previews where the range would end. */
+  hovered: DateTime | null;
+  onHover: (day: DateTime | null) => void;
+};
+
+// Given by context because `slotProps.day` only accepts props of the day component it replaces.
+const DayContext = React.createContext<DayState>({ start: null, end: null, hovered: null, onHover: IGNORE_HOVER });
+
+/** Day cell that owns its own selected state, so the band and `aria-selected` always agree. */
+const RangeDay: React.FC<PickersDayProps<DateTime>> = (dayProps) => {
+  const { start, end, hovered, onHover } = React.useContext(DayContext);
+  const { day, outsideCurrentMonth, isFirstVisibleCell, isLastVisibleCell } = dayProps;
+  const isStart = start != null && day.hasSame(start, 'day');
+  const isSelected = isStart || (end != null && day.hasSame(end, 'day'));
+  // Until the end date is picked, the hovered day stands in for it as a preview.
+  const bandEnd = end ?? hovered;
+  // A single day needs no band, only its selected circle.
+  const inBand =
+    !outsideCurrentMonth &&
+    start != null &&
+    bandEnd != null &&
+    !start.hasSame(bandEnd, 'day') &&
+    day >= start.startOf('day') &&
+    day <= bandEnd.startOf('day');
+  const isPreview = inBand && end == null;
+
+  return (
+    <Box
+      data-band={inBand ? (isPreview ? 'preview' : 'range') : undefined}
+      onMouseEnter={() => onHover(day)}
+      onMouseLeave={() => onHover(null)}
+      // The day keeps its margins, so this wrapper spans the whole cell and consecutive bands touch.
+      sx={(theme) => ({
+        display: 'flex',
+        ...(inBand && {
+          backgroundColor: alpha(
+            theme.palette.primary.main,
+            isPreview ? theme.palette.action.hoverOpacity : theme.palette.action.focusOpacity
+          ),
+          ...((isStart || isFirstVisibleCell) && BAND_START),
+          ...(((bandEnd != null && day.hasSame(bandEnd, 'day')) || isLastVisibleCell) && BAND_END),
+          // Rounded where the week ends too, as MUI's own range calendar does.
+          '&:first-of-type': BAND_START,
+          '&:last-of-type': BAND_END,
+        }),
+      })}
+    >
+      <PickersDay {...dayProps} selected={isSelected} aria-selected={isSelected} />
+    </Box>
+  );
+};
+
+const DAY_SLOTS = { day: RangeDay } as const;
+
+// Puts a stable test id on every day cell so tests can click a specific date directly.
+const withDayTestId = (ownerState: { day: DateTime }): Record<string, string> => ({
+  'data-testid': dataTestIds.dashboard.datePickerDay(ownerState.day.toISODate() ?? ''),
+});
+
+type Props = {
+  /** The committed selection, shown as the highlighted day or range. */
+  value: [DateTime | null, DateTime | null];
+  /** When true, a start and an end date are picked before the selection is reported. */
+  rangeMode: boolean;
+  /** When set, an end date further than this many days from the start cannot be selected. */
+  maxRangeDays?: number;
+  /** Called once a complete selection has been picked; a single date reports the same day twice. */
+  onComplete: (from: DateTime, to: DateTime) => void;
+};
+
+/**
+ * Calendar behind the tracking board date filter. One click picks a day; in range mode the first
+ * click stages a start and the second completes the range, so only complete ranges are reported.
+ */
+export const RangeCalendar: React.FC<Props> = ({ value: [dateFrom, dateTo], rangeMode, maxRangeDays, onComplete }) => {
+  // Set while the end date is being picked; until then the committed range stays highlighted.
+  const [pendingStart, setPendingStart] = useState<DateTime | null>(null);
+  // The date the calendar is built around: what its month view and navigation work from.
+  const [calendarDate, setCalendarDate] = useState<DateTime | null>(dateFrom);
+  const [hovered, setHovered] = useState<DateTime | null>(null);
+
+  // Leaving range mode drops a start that will never get its end.
+  useEffect(() => setPendingStart(null), [rangeMode]);
+
+  const handleDayPick = (day: DateTime | null): void => {
+    if (!day) {
+      return;
+    }
+    if (!rangeMode) {
+      onComplete(day, day);
+      return;
+    }
+    // A click without a staged start — or before it — starts a fresh range instead of completing a
+    // backwards one.
+    if (pendingStart == null || day < pendingStart) {
+      setPendingStart(day);
+      return;
+    }
+    onComplete(pendingStart, day);
+  };
+
+  // A staged start hides the committed end date: only the range being built is shown, previewed up
+  // to the hovered day until the second click lands.
+  const dayState: DayState =
+    pendingStart != null
+      ? { start: pendingStart, end: null, hovered, onHover: setHovered }
+      : // Nothing to preview without a staged start, so hovering is not tracked at all.
+        { start: dateFrom, end: dateTo, hovered: null, onHover: IGNORE_HOVER };
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterLuxon}>
+      <DayContext.Provider value={dayState}>
+        <DateCalendar
+          value={calendarDate}
+          views={CALENDAR_VIEWS}
+          openTo="day"
+          // Keeps the month view and its navigation on the month actually displayed, whether it was
+          // reached by the arrows or by picking a month.
+          onMonthChange={setCalendarDate}
+          onChange={(day, selectionState) => {
+            // The month view reports 'partial': it navigates, it does not pick a date.
+            if (selectionState === 'finish') {
+              handleDayPick(day);
+            }
+          }}
+          // While the end date is being picked, cap it so the range cannot exceed the server-side limit.
+          maxDate={maxRangeDays != null && pendingStart != null ? pendingStart.plus({ days: maxRangeDays }) : undefined}
+          slots={DAY_SLOTS}
+          slotProps={{ day: withDayTestId }}
+        />
+      </DayContext.Provider>
+    </LocalizationProvider>
+  );
+};

--- a/apps/ehr/src/components/input/RangeCalendar.tsx
+++ b/apps/ehr/src/components/input/RangeCalendar.tsx
@@ -12,19 +12,17 @@ const CALENDAR_VIEWS = ['month', 'day'] as const;
 const BAND_START = { borderTopLeftRadius: '50%', borderBottomLeftRadius: '50%' } as const;
 const BAND_END = { borderTopRightRadius: '50%', borderBottomRightRadius: '50%' } as const;
 
-const IGNORE_HOVER = (): void => undefined;
-
 type DayState = {
   /** Boundaries of the selection; `end` is null while it is still being picked. */
   start: DateTime | null;
   end: DateTime | null;
   /** Day under the cursor, which previews where the range would end. */
   hovered: DateTime | null;
-  onHover: (day: DateTime | null) => void;
+  onHover?: (day: DateTime | null) => void;
 };
 
 // Given by context because `slotProps.day` only accepts props of the day component it replaces.
-const DayContext = React.createContext<DayState>({ start: null, end: null, hovered: null, onHover: IGNORE_HOVER });
+const DayContext = React.createContext<DayState>({ start: null, end: null, hovered: null });
 
 /** Day cell that owns its own selected state, so the band and `aria-selected` always agree. */
 const RangeDay: React.FC<PickersDayProps<DateTime>> = (dayProps) => {
@@ -46,12 +44,18 @@ const RangeDay: React.FC<PickersDayProps<DateTime>> = (dayProps) => {
     day >= start.startOf('day') &&
     day <= bandEnd.startOf('day');
   const isPreview = inBand && end == null;
+  const hoverProps =
+    onHover == null
+      ? undefined
+      : {
+          onMouseEnter: (): void => onHover(canPreview ? day : null),
+          onMouseLeave: (): void => onHover(null),
+        };
 
   return (
     <Box
       data-band={inBand ? (isPreview ? 'preview' : 'range') : undefined}
-      onMouseEnter={() => onHover(canPreview ? day : null)}
-      onMouseLeave={() => onHover(null)}
+      {...hoverProps}
       // The day keeps its margins, so this wrapper spans the whole cell and consecutive bands touch.
       sx={(theme) => ({
         display: 'flex',
@@ -132,7 +136,7 @@ export const RangeCalendar: React.FC<Props> = ({ value: [dateFrom, dateTo], rang
     pendingStart != null
       ? { start: pendingStart, end: null, hovered, onHover: setHovered }
       : // Nothing to preview without a staged start, so hovering is not tracked at all.
-        { start: dateFrom, end: dateTo, hovered: null, onHover: IGNORE_HOVER };
+        { start: dateFrom, end: dateTo, hovered: null };
 
   return (
     <LocalizationProvider dateAdapter={AdapterLuxon}>

--- a/apps/ehr/src/components/input/RangeCalendar.tsx
+++ b/apps/ehr/src/components/input/RangeCalendar.tsx
@@ -29,7 +29,10 @@ const DayContext = React.createContext<DayState>({ start: null, end: null, hover
 /** Day cell that owns its own selected state, so the band and `aria-selected` always agree. */
 const RangeDay: React.FC<PickersDayProps<DateTime>> = (dayProps) => {
   const { start, end, hovered, onHover } = React.useContext(DayContext);
-  const { day, outsideCurrentMonth, isFirstVisibleCell, isLastVisibleCell } = dayProps;
+  const { day, disabled, outsideCurrentMonth, isFirstVisibleCell, isLastVisibleCell } = dayProps;
+  // Disabled days have `pointer-events: none`, so their hover lands on this wrapper instead: a day
+  // that cannot be picked must not preview a range, and neither must a blank outside-month cell.
+  const canPreview = !disabled && !outsideCurrentMonth;
   const isStart = start != null && day.hasSame(start, 'day');
   const isSelected = isStart || (end != null && day.hasSame(end, 'day'));
   // Until the end date is picked, the hovered day stands in for it as a preview.
@@ -47,7 +50,7 @@ const RangeDay: React.FC<PickersDayProps<DateTime>> = (dayProps) => {
   return (
     <Box
       data-band={inBand ? (isPreview ? 'preview' : 'range') : undefined}
-      onMouseEnter={() => onHover(day)}
+      onMouseEnter={() => onHover(canPreview ? day : null)}
       onMouseLeave={() => onHover(null)}
       // The day keeps its margins, so this wrapper spans the whole cell and consecutive bands touch.
       sx={(theme) => ({
@@ -99,8 +102,11 @@ export const RangeCalendar: React.FC<Props> = ({ value: [dateFrom, dateTo], rang
   const [calendarDate, setCalendarDate] = useState<DateTime | null>(dateFrom);
   const [hovered, setHovered] = useState<DateTime | null>(null);
 
-  // Leaving range mode drops a start that will never get its end.
-  useEffect(() => setPendingStart(null), [rangeMode]);
+  // Leaving range mode drops transient selection state that must not affect a later range.
+  useEffect(() => {
+    setPendingStart(null);
+    setHovered(null);
+  }, [rangeMode]);
 
   const handleDayPick = (day: DateTime | null): void => {
     if (!day) {
@@ -114,6 +120,7 @@ export const RangeCalendar: React.FC<Props> = ({ value: [dateFrom, dateTo], rang
     // backwards one.
     if (pendingStart == null || day < pendingStart) {
       setPendingStart(day);
+      setHovered(null);
       return;
     }
     onComplete(pendingStart, day);

--- a/apps/ehr/src/constants/data-test-ids.ts
+++ b/apps/ehr/src/constants/data-test-ids.ts
@@ -34,6 +34,7 @@ export const dataTestIds = {
     prebookedTab: 'prebooked-tab',
     locationSelect: 'location-select',
     dateFilter: 'tracking-board-date-filter',
+    datePickerPopover: 'date-picker-popover',
     dateRangeModeCheckbox: 'date-picker-range-mode-checkbox',
     datePickerTodayButton: 'date-picker-today-button',
     datePickerDay: (isoDate: string) => `date-picker-day-${isoDate}`,

--- a/apps/ehr/tests/component/DateRangeInput.test.tsx
+++ b/apps/ehr/tests/component/DateRangeInput.test.tsx
@@ -37,9 +37,29 @@ const openPicker = async (): Promise<void> => {
   await userEvent.click(screen.getByTestId(FIELD_TEST_ID));
 };
 
+const getDay = (isoDate: string): HTMLElement => screen.getByTestId(dataTestIds.dashboard.datePickerDay(isoDate));
+
 const clickDay = async (isoDate: string): Promise<void> => {
-  await userEvent.click(screen.getByTestId(dataTestIds.dashboard.datePickerDay(isoDate)));
+  await userEvent.click(getDay(isoDate));
 };
+
+const enableRangeMode = async (): Promise<void> => {
+  await userEvent.click(screen.getByTestId(dataTestIds.dashboard.dateRangeModeCheckbox));
+};
+const openMonthList = async (): Promise<void> => {
+  await userEvent.click(screen.getByRole('button', { name: /switch to/ }));
+};
+
+const clickMonth = async (name: string): Promise<void> => {
+  await userEvent.click(screen.getByRole('radio', { name }));
+};
+
+const goToNextMonth = async (): Promise<void> => {
+  await userEvent.click(screen.getByRole('button', { name: 'Next month' }));
+};
+
+const getMonthLabel = (): string => screen.getByText(/^[A-Z][a-z]+ \d{4}$/).textContent ?? '';
+const bandOf = (isoDate: string): string | undefined => getDay(isoDate).parentElement?.dataset.band;
 
 describe('DateRangeInput', () => {
   it('displays a single date when both boundaries are the same day and commits both on one day click', async () => {
@@ -57,38 +77,124 @@ describe('DateRangeInput', () => {
     render(<Harness dateFrom="2026-07-10" dateTo="2026-07-10" />);
 
     await openPicker();
-    await userEvent.click(screen.getByTestId(dataTestIds.dashboard.dateRangeModeCheckbox));
+    await enableRangeMode();
     await clickDay('2026-07-13');
-    // The first click only stages the start date; nothing is committed until the range is complete.
+    // The first click only stages the start date: nothing is committed until the range is complete,
+    // and the staged start is a selected day rather than a one-day band.
     expect(getValues()).toBe('2026-07-10|2026-07-10');
+    expect(getDay('2026-07-13')).toHaveAttribute('aria-selected', 'true');
+    expect(bandOf('2026-07-13')).toBeUndefined();
     await clickDay('2026-07-17');
 
     expect(getValues()).toBe('2026-07-13|2026-07-17');
   });
 
-  it('keeps the month label and day sizing consistent in Date Range mode', async () => {
+  it('previews the range that hovering would complete', async () => {
     render(<Harness dateFrom="2026-07-10" dateTo="2026-07-10" />);
 
     await openPicker();
-    await userEvent.click(screen.getByTestId(dataTestIds.dashboard.dateRangeModeCheckbox));
+    await enableRangeMode();
+    await clickDay('2026-07-13');
+    await userEvent.hover(getDay('2026-07-16'));
 
-    const rangeCalendar = document.querySelector('.MuiDateRangeCalendar-root');
-    expect(rangeCalendar).not.toBeNull();
+    expect(['2026-07-13', '2026-07-15', '2026-07-16'].map(bandOf)).toEqual(['preview', 'preview', 'preview']);
+    expect(bandOf('2026-07-17')).toBeUndefined();
+    // The preview follows the cursor and commits nothing.
+    await userEvent.unhover(getDay('2026-07-16'));
+    expect(bandOf('2026-07-15')).toBeUndefined();
+    expect(getValues()).toBe('2026-07-10|2026-07-10');
+  });
 
-    const monthLabel = rangeCalendar?.querySelector('.MuiPickersCalendarHeader-labelContainer');
-    expect(monthLabel).not.toBeNull();
-    expect(monthLabel).toHaveStyle({ cursor: 'default' });
+  it('starts a fresh range when the second click lands before the staged start date', async () => {
+    render(<Harness dateFrom="2026-07-10" dateTo="2026-07-10" />);
 
-    const rangeDay = screen.getByTestId(dataTestIds.dashboard.datePickerDay('2026-07-10'));
-    expect(rangeDay).toHaveClass('MuiDateRangePickerDay-day');
+    await openPicker();
+    await enableRangeMode();
+    await clickDay('2026-07-17');
+    await clickDay('2026-07-13');
+    expect(getValues()).toBe('2026-07-10|2026-07-10');
+    await clickDay('2026-07-15');
 
-    const injectedStyles = Array.from(document.querySelectorAll('style'))
-      .map((style) => style.textContent ?? '')
-      .filter((styles) => styles.includes('MuiDateRangeCalendar-root'))
-      .join('\n');
-    expect(injectedStyles).toContain('MuiPickersCalendarHeader-labelContainer::after');
-    expect(injectedStyles).toContain('MuiDateRangePickerDay-day');
-    expect(injectedStyles).toContain('transform:none!important');
+    expect(getValues()).toBe('2026-07-13|2026-07-15');
+  });
+
+  it('picks a month from the header and completes a range in it', async () => {
+    render(<Harness dateFrom="2026-07-10" dateTo="2026-07-10" />);
+
+    await openPicker();
+    await enableRangeMode();
+    await openMonthList();
+    await clickMonth('October');
+
+    // Choosing a month navigates back to the days without selecting anything.
+    expect(getMonthLabel()).toBe('October 2026');
+    expect(getValues()).toBe('2026-07-10|2026-07-10');
+
+    await clickDay('2026-10-05');
+    await clickDay('2026-10-09');
+
+    expect(getValues()).toBe('2026-10-05|2026-10-09');
+  });
+
+  it('keeps the year reached with the month arrows when a month is then picked', async () => {
+    render(<Harness dateFrom="2026-12-10" dateTo="2026-12-10" />);
+
+    await openPicker();
+    await goToNextMonth();
+    expect(getMonthLabel()).toBe('January 2027');
+
+    await openMonthList();
+    await clickMonth('March');
+
+    expect(getMonthLabel()).toBe('March 2027');
+    await clickDay('2027-03-04');
+    expect(getValues()).toBe('2027-03-04|2027-03-04');
+  });
+
+  it('forgets a staged start date and the month navigated to once the picker is dismissed', async () => {
+    // A committed multi-day range reopens in range mode, so the dismissal is what has to clear it.
+    render(<Harness dateFrom="2026-07-10" dateTo="2026-07-14" />);
+
+    await openPicker();
+    await goToNextMonth();
+    await clickDay('2026-08-20');
+    await userEvent.keyboard('{Escape}');
+
+    await openPicker();
+    expect(getMonthLabel()).toBe('July 2026');
+    // Without the staged start, this click starts a range instead of completing 08/20 - 07/25.
+    await clickDay('2026-07-25');
+    expect(getValues()).toBe('2026-07-10|2026-07-14');
+
+    await clickDay('2026-07-27');
+    expect(getValues()).toBe('2026-07-25|2026-07-27');
+  });
+
+  it('caps the end date at maxRangeDays days after the staged start date', async () => {
+    render(<Harness dateFrom="2026-07-10" dateTo="2026-07-10" />);
+
+    await openPicker();
+    await enableRangeMode();
+    await clickDay('2026-07-13');
+    await goToNextMonth();
+
+    // 45 days after 07/13 is 08/27, so the following day cannot close the range.
+    expect(getDay('2026-08-27')).toBeEnabled();
+    expect(getDay('2026-08-28')).toBeDisabled();
+  });
+
+  it('marks the committed range on its days and only its boundaries as selected', async () => {
+    render(<Harness dateFrom="2026-07-10" dateTo="2026-07-14" />);
+
+    await openPicker();
+
+    expect([10, 11, 12, 13, 14].map((day) => bandOf(`2026-07-${day}`))).toEqual(Array(5).fill('range'));
+    expect(bandOf('2026-07-09')).toBeUndefined();
+    expect(bandOf('2026-07-15')).toBeUndefined();
+
+    expect(getDay('2026-07-10')).toHaveAttribute('aria-selected', 'true');
+    expect(getDay('2026-07-14')).toHaveAttribute('aria-selected', 'true');
+    expect(getDay('2026-07-12')).toHaveAttribute('aria-selected', 'false');
   });
 
   it('collapses a multi-day range to its start date when the checkbox is unchecked', async () => {

--- a/apps/ehr/tests/component/DateRangeInput.test.tsx
+++ b/apps/ehr/tests/component/DateRangeInput.test.tsx
@@ -61,6 +61,11 @@ const goToNextMonth = async (): Promise<void> => {
 const getMonthLabel = (): string => screen.getByText(/^[A-Z][a-z]+ \d{4}$/).textContent ?? '';
 const bandOf = (isoDate: string): string | undefined => getDay(isoDate).parentElement?.dataset.band;
 
+// Disabled days do not take pointer events, so the cell around them is what gets hovered.
+const hoverCell = async (isoDate: string): Promise<void> => {
+  await userEvent.hover(getDay(isoDate).parentElement as HTMLElement);
+};
+
 describe('DateRangeInput', () => {
   it('displays a single date when both boundaries are the same day and commits both on one day click', async () => {
     render(<Harness dateFrom="2026-07-10" dateTo="2026-07-10" />);
@@ -101,6 +106,28 @@ describe('DateRangeInput', () => {
     expect(bandOf('2026-07-17')).toBeUndefined();
     // The preview follows the cursor and commits nothing.
     await userEvent.unhover(getDay('2026-07-16'));
+    expect(bandOf('2026-07-15')).toBeUndefined();
+    expect(getValues()).toBe('2026-07-10|2026-07-10');
+  });
+
+  it('does not reuse an old hover preview after Date Range mode is toggled with the keyboard', async () => {
+    render(<Harness dateFrom="2026-07-10" dateTo="2026-07-10" />);
+
+    await openPicker();
+    await enableRangeMode();
+    await clickDay('2026-07-13');
+    await userEvent.hover(getDay('2026-07-16'));
+    expect(bandOf('2026-07-15')).toBe('preview');
+
+    const checkbox = screen.getByTestId(dataTestIds.dashboard.dateRangeModeCheckbox);
+    checkbox.focus();
+    await userEvent.keyboard(' ');
+    await userEvent.keyboard(' ');
+
+    getDay('2026-07-14').focus();
+    await userEvent.keyboard('{Enter}');
+
+    expect(getDay('2026-07-14')).toHaveAttribute('aria-selected', 'true');
     expect(bandOf('2026-07-15')).toBeUndefined();
     expect(getValues()).toBe('2026-07-10|2026-07-10');
   });
@@ -181,6 +208,14 @@ describe('DateRangeInput', () => {
     // 45 days after 07/13 is 08/27, so the following day cannot close the range.
     expect(getDay('2026-08-27')).toBeEnabled();
     expect(getDay('2026-08-28')).toBeDisabled();
+
+    // Nor can it be previewed, even though its cell is what receives the hover.
+    await hoverCell('2026-08-28');
+    expect(bandOf('2026-08-27')).toBeUndefined();
+    expect(bandOf('2026-08-28')).toBeUndefined();
+
+    await hoverCell('2026-08-27');
+    expect(bandOf('2026-08-27')).toBe('preview');
   });
 
   it('marks the committed range on its days and only its boundaries as selected', async () => {
@@ -225,6 +260,34 @@ describe('DateRangeInput', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Start date must be on or before end date.')).toBeVisible();
+    });
+  });
+
+  it.each([
+    { dateFrom: '2026-07-10', dateTo: null },
+    { dateFrom: null, dateTo: '2026-07-10' },
+  ])('shows an inline error for an incomplete range seeded from outside the picker', async ({ dateFrom, dateTo }) => {
+    render(<Harness dateFrom={dateFrom} dateTo={dateTo} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Both start and end dates are required.')).toBeVisible();
+    });
+  });
+
+  it('accepts an empty externally seeded range', async () => {
+    render(<Harness dateFrom={null} dateTo={null} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId(FIELD_TEST_ID)).toHaveAttribute('aria-invalid', 'false');
+    });
+    expect(screen.queryByText('Both start and end dates are required.')).not.toBeInTheDocument();
+  });
+
+  it('shows an inline error for an over-limit range seeded from outside the picker', async () => {
+    render(<Harness dateFrom="2026-07-01" dateTo="2026-08-16" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Date range must not exceed 45 days.')).toBeVisible();
     });
   });
 });

--- a/apps/ehr/tests/component/DateRangeInput.test.tsx
+++ b/apps/ehr/tests/component/DateRangeInput.test.tsx
@@ -209,13 +209,12 @@ describe('DateRangeInput', () => {
     expect(getDay('2026-08-27')).toBeEnabled();
     expect(getDay('2026-08-28')).toBeDisabled();
 
-    // Nor can it be previewed, even though its cell is what receives the hover.
+    // A valid preview is cleared when the cursor moves onto an unselectable cell.
+    await hoverCell('2026-08-27');
+    expect(bandOf('2026-08-27')).toBe('preview');
     await hoverCell('2026-08-28');
     expect(bandOf('2026-08-27')).toBeUndefined();
     expect(bandOf('2026-08-28')).toBeUndefined();
-
-    await hoverCell('2026-08-27');
-    expect(bandOf('2026-08-27')).toBe('preview');
   });
 
   it('marks the committed range on its days and only its boundaries as selected', async () => {

--- a/apps/ehr/tests/e2e/specs/in-person/trackingBoardDateFilter.spec.ts
+++ b/apps/ehr/tests/e2e/specs/in-person/trackingBoardDateFilter.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+import { dataTestIds } from '../../../../src/constants/data-test-ids';
+import { openVisitsPage } from '../../page/VisitsPage';
+
+// Regression coverage for OTR-3134 (part of OTR-2985): ticking "Date Range" used to swap in MUI's
+// range calendar, which sizes its days differently and made the popover change dimensions. Component
+// tests cannot catch that — jsdom has no layout — so the geometry is asserted in a real browser here.
+
+test.describe('Tracking board date filter', () => {
+  test('keeps the calendar dimensions when Date Range is toggled', async ({ page }) => {
+    await openVisitsPage(page);
+
+    await page.getByTestId(dataTestIds.dashboard.dateFilter).click();
+    const popover = page.getByTestId(dataTestIds.dashboard.datePickerPopover);
+    await expect(popover).toBeVisible();
+    // Layout size, so the reading does not depend on where the popover sits or on the open animation.
+    const size = (): Promise<{ width: number; height: number }> =>
+      popover.evaluate((element: HTMLElement) => ({ width: element.offsetWidth, height: element.offsetHeight }));
+    const singleDateSize = await size();
+
+    const rangeCheckbox = page.getByTestId(dataTestIds.dashboard.dateRangeModeCheckbox);
+    await rangeCheckbox.click();
+    await expect(rangeCheckbox).toBeChecked();
+
+    expect(await size()).toEqual(singleDateSize);
+  });
+
+  test('opens the month list from the calendar header in Date Range mode', async ({ page }) => {
+    await openVisitsPage(page);
+
+    await page.getByTestId(dataTestIds.dashboard.dateFilter).click();
+    await page.getByTestId(dataTestIds.dashboard.dateRangeModeCheckbox).click();
+
+    await page.getByRole('button', { name: /switch to/ }).click();
+
+    await expect(page.getByRole('radio', { name: 'January' })).toBeVisible();
+    await expect(page.getByRole('radio', { name: 'December' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
Improved the tracking board date filter with a custom range calendar that supports month selection without changing the calendar layout. Added clear range highlighting, hover previews, cross-month selection, and maximum-range enforcement. Simplified the calendar state and hover logic to avoid unnecessary remounts and event handlers. Added component and E2E coverage for the updated behavior.