### PR TITLE
Fix. [Send fax] button should be disabled when visit in 'Intake' status

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/review-tab/SendFaxButton.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/SendFaxButton.tsx
@@ -58,7 +58,7 @@ export const SendFaxButton: FC<SendFaxButtonProps> = ({ appointment, encounter, 
     if (
       appointmentAccessibility.visitType === 'follow-up'
         ? encounter?.status === 'in-progress'
-        : inPersonStatus && !['intake', 'completed'].includes(inPersonStatus)
+        : inPersonStatus && !['completed'].includes(inPersonStatus)
     ) {
       return "Once the visit note has been signed, you will have the option to fax a copy to the patient's Primary Care Physician.";
     }


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2936/send-fax-button-should-be-disabled-when-visit-in-intake-status