### PR TITLE
Run zambda unit tests without worker isolation (10x faster) via canonical suite-wide mocks

### DIFF
--- a/packages/zambdas/package.json
+++ b/packages/zambdas/package.json
@@ -54,7 +54,7 @@
     "probe-outreach-action-ids": "NODE_OPTIONS='--preserve-symlinks' tsx src/scripts/probe-outreach-action-ids.ts",
     "probe-outreach-retries": "NODE_OPTIONS='--preserve-symlinks' tsx src/scripts/probe-outreach-retries.ts",
     "test": "ENV=${ENV:-local} vitest run",
-    "test:unit:ci": "ENV=${ENV:-local} vitest run --project unit --maxWorkers=6 --coverage --coverage.reportsDirectory=./coverage/unit --passWithNoTests --reporter=dot --reporter=github-actions",
+    "test:unit:ci": "ENV=${ENV:-local} vitest run --project unit --no-isolate --minWorkers=6 --maxWorkers=6 --coverage --coverage.reportsDirectory=./coverage/unit --passWithNoTests --reporter=dot --reporter=github-actions",
     "test:integration:ci": "ENV=${ENV:-local} vitest run --project integration --minWorkers=12 --maxWorkers=12 --no-isolate --coverage --passWithNoTests --reporter=dot --reporter=github-actions",
     "test:watch": "ENV=${ENV:-local} vitest watch",
     "test:coverage": "c8 npm run test",

--- a/packages/zambdas/src/ehr/extract-insurance-card/test/extract-insurance-card.test.ts
+++ b/packages/zambdas/src/ehr/extract-insurance-card/test/extract-insurance-card.test.ts
@@ -15,27 +15,8 @@ import { index } from '../index';
 import { validateRequestParameters } from '../validateRequestParameters';
 import { makePlainJpeg } from './image-fixtures';
 
-vi.mock('../../../shared/ai', () => ({
-  invokeChatbotVertexAI: vi.fn(),
-  VERTEX_AI_MODEL: 'gemini-3.1-flash-lite',
-}));
-
-vi.mock('../../../shared', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../shared')>();
-  return {
-    ...actual,
-    getAuth0Token: vi.fn(),
-  };
-});
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('utils')>();
-  return {
-    ...actual,
-    createOystehrClient: vi.fn(),
-    getPresignedURL: vi.fn(),
-  };
-});
+// invokeChatbotVertexAI, getAuth0Token, createOystehrClient, and getPresignedURL are canonical
+// suite-wide mocks (vitest.unit-mocks.setup.ts); per-test behavior is installed in beforeEach/tests.
 
 const Z3_URL = 'https://project-api.zapehr.com/v1/z3/insurance-cards-bucket/patient-1/insurance-card-front.jpg';
 const PRESIGNED_URL = 'https://signed.example.com/insurance-card-front.jpg';
@@ -112,7 +93,7 @@ const mockOystehr = { fhir: { search: mockSearch, patch: mockPatch } };
 const fetchMock = vi.fn();
 
 async function invokeHandler(input: ZambdaInput): Promise<APIGatewayProxyResult> {
-  // vitest.setup.ts mocks sentry's wrapHandler as a pass-through, so the handler is directly callable
+  // the real wrapHandler applies suite-wide (Sentry itself is mocked), so errors surface as response envelopes
   return (await (index as unknown as (input: ZambdaInput) => Promise<APIGatewayProxyResult>)(input))!;
 }
 

--- a/packages/zambdas/src/ehr/extract-photo-id/test/extract-photo-id.test.ts
+++ b/packages/zambdas/src/ehr/extract-photo-id/test/extract-photo-id.test.ts
@@ -9,27 +9,8 @@ import { EXTRACTION_PROMPT, parseModelResponse, photoIdResponseSchema } from '..
 import { index } from '../index';
 import { validateRequestParameters } from '../validateRequestParameters';
 
-vi.mock('../../../shared/ai', () => ({
-  invokeChatbotVertexAI: vi.fn(),
-  VERTEX_AI_MODEL: 'gemini-3.1-flash-lite',
-}));
-
-vi.mock('../../../shared', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../shared')>();
-  return {
-    ...actual,
-    getAuth0Token: vi.fn(),
-  };
-});
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('utils')>();
-  return {
-    ...actual,
-    createOystehrClient: vi.fn(),
-    getPresignedURL: vi.fn(),
-  };
-});
+// invokeChatbotVertexAI, getAuth0Token, createOystehrClient, and getPresignedURL are canonical
+// suite-wide mocks (vitest.unit-mocks.setup.ts); per-test behavior is installed in beforeEach/tests.
 
 const Z3_URL = 'https://project-api.zapehr.com/v1/z3/photo-id-cards-bucket/patient-1/photo-id-front.jpg';
 const PRESIGNED_URL = 'https://signed.example.com/photo-id-front.jpg';
@@ -111,7 +92,7 @@ const mockOystehr = { fhir: { search: mockSearch, patch: mockPatch } };
 const fetchMock = vi.fn();
 
 async function invokeHandler(input: ZambdaInput): Promise<APIGatewayProxyResult> {
-  // vitest.setup.ts mocks sentry's wrapHandler as a pass-through, so the handler is directly callable
+  // the real wrapHandler applies suite-wide (Sentry itself is mocked), so errors surface as response envelopes
   return (await (index as unknown as (input: ZambdaInput) => Promise<APIGatewayProxyResult>)(input))!;
 }
 

--- a/packages/zambdas/src/ehr/rotate-insurance-card-image/test/rotate-insurance-card-image.test.ts
+++ b/packages/zambdas/src/ehr/rotate-insurance-card-image/test/rotate-insurance-card-image.test.ts
@@ -15,24 +15,9 @@ import { isRedAt, makeOrientedSceneJpeg } from '../../extract-insurance-card/tes
 import { index } from '../index';
 import { validateRequestParameters } from '../validateRequestParameters';
 
-vi.mock('../../../shared', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../../shared')>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn(),
-    createClinicalOystehrClient: vi.fn(),
-    createPresignedUrl: vi.fn(),
-    uploadObjectToZ3: vi.fn(),
-  };
-});
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('utils')>();
-  return {
-    ...actual,
-    getPresignedURL: vi.fn(),
-  };
-});
+// checkOrCreateM2MClientToken, createClinicalOystehrClient, createPresignedUrl, uploadObjectToZ3,
+// and getPresignedURL are canonical suite-wide mocks (vitest.unit-mocks.setup.ts); behavior is
+// installed per-test via vi.mocked(...) below.
 
 const DOC_REF_ID = '0a4f6f4e-2e1f-4a3b-9d5c-8e7f6a5b4c3d';
 const Z3_URL = 'https://project-api.zapehr.com/v1/z3/insurance-cards-bucket/patient-1/insurance-card-front.jpg';

--- a/packages/zambdas/test/billing/export-billing-claim-x12.test.ts
+++ b/packages/zambdas/test/billing/export-billing-claim-x12.test.ts
@@ -4,6 +4,8 @@ import type { APIGatewayProxyResult } from 'aws-lambda';
 import { APIErrorCode, MISSING_REQUEST_BODY, MISSING_REQUEST_SECRETS } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateRequestParameters } from '../../src/billing/export-billing-claim-x12/validateRequestParameters';
+import { createBillingClient } from '../../src/billing/shared';
+import { checkOrCreateM2MClientToken } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 const PROJECT_API = 'https://project-api.zapehr.com/v1';
@@ -74,26 +76,10 @@ describe('export-billing-claim-x12 validateRequestParameters', () => {
   });
 });
 
-const { claimToX12Mock } = vi.hoisted(() => ({ claimToX12Mock: vi.fn() }));
-
-vi.mock('../../src/shared', async () => {
-  const { safeValidate } = await import('../../src/shared/validation');
-  const { validateJsonBody } = await import('../../src/shared/helpers');
-  return {
-    safeValidate,
-    validateJsonBody,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-vi.mock('../../src/billing/shared', () => ({
-  createBillingClient: () => ({
-    rcm: {
-      claimToX12: claimToX12Mock,
-    },
-  }),
-}));
+// checkOrCreateM2MClientToken and createBillingClient are canonical suite-wide mocks
+// (vitest.unit-mocks.setup.ts); the real wrapHandler applies, so thrown errors surface as
+// the topLevelCatch envelope rather than rejections.
+const claimToX12Mock = vi.fn();
 
 const { index: handler } = (await import('../../src/billing/export-billing-claim-x12/index')) as unknown as {
   index: (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
@@ -102,6 +88,12 @@ const { index: handler } = (await import('../../src/billing/export-billing-claim
 describe('export-billing-claim-x12 handler', () => {
   beforeEach(() => {
     claimToX12Mock.mockReset();
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createBillingClient).mockReturnValue({
+      rcm: {
+        claimToX12: claimToX12Mock,
+      },
+    } as unknown as ReturnType<typeof createBillingClient>);
   });
 
   it('calls rcm.claimToX12 with the claim id and returns the x12 payload', async () => {
@@ -114,6 +106,7 @@ describe('export-billing-claim-x12 handler', () => {
       }),
       secrets: {
         PROJECT_API,
+        ENVIRONMENT: 'local',
       },
     });
 
@@ -132,56 +125,67 @@ describe('export-billing-claim-x12 handler', () => {
       })
     );
 
-    await expect(
-      handler({
-        headers: null,
-        body: JSON.stringify({
-          claimId: CLAIM_ID,
-        }),
-        secrets: {
-          PROJECT_API,
-        },
-      })
-    ).rejects.toMatchObject({
+    const result = await handler({
+      headers: null,
+      body: JSON.stringify({
+        claimId: CLAIM_ID,
+      }),
+      secrets: {
+        PROJECT_API,
+        ENVIRONMENT: 'local',
+      },
+    });
+
+    // The real wrapHandler converts the thrown APIError into the topLevelCatch envelope.
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toEqual({
       code: APIErrorCode.RESOURCE_INCOMPLETE_FOR_OPERATION,
       message: reason,
     });
   });
 
-  it('rethrows an unsupported-project (4022) SDK error unchanged', async () => {
+  it('surfaces an unsupported-project (4022) SDK error message in the error envelope', async () => {
     const original = new Oystehr.OystehrSdkError({
       message: 'This endpoint is only for FHIR R4 projects',
       code: 4022,
     });
     claimToX12Mock.mockRejectedValue(original);
 
-    await expect(
-      handler({
-        headers: null,
-        body: JSON.stringify({
-          claimId: CLAIM_ID,
-        }),
-        secrets: {
-          PROJECT_API,
-        },
-      })
-    ).rejects.toBe(original);
+    const result = await handler({
+      headers: null,
+      body: JSON.stringify({
+        claimId: CLAIM_ID,
+      }),
+      secrets: {
+        PROJECT_API,
+        ENVIRONMENT: 'local',
+      },
+    });
+
+    // The handler rethrows the SDK error unchanged; 4022 is a valid APIErrorCode, so the
+    // wrapper's envelope carries the original message and code through to the client.
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toEqual({
+      code: 4022,
+      message: 'This endpoint is only for FHIR R4 projects',
+    });
   });
 
-  it('rethrows an unexpected (non-SDK) error unchanged', async () => {
-    const original = new Error('Unexpected error');
-    claimToX12Mock.mockRejectedValue(original);
+  it('masks an unexpected (non-SDK) error as an internal error', async () => {
+    claimToX12Mock.mockRejectedValue(new Error('Unexpected error'));
 
-    await expect(
-      handler({
-        headers: null,
-        body: JSON.stringify({
-          claimId: CLAIM_ID,
-        }),
-        secrets: {
-          PROJECT_API,
-        },
-      })
-    ).rejects.toBe(original);
+    const result = await handler({
+      headers: null,
+      body: JSON.stringify({
+        claimId: CLAIM_ID,
+      }),
+      secrets: {
+        PROJECT_API,
+        ENVIRONMENT: 'local',
+      },
+    });
+
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body)).toEqual({ error: 'Internal error' });
   });
 });

--- a/packages/zambdas/test/billing/service-facility.test.ts
+++ b/packages/zambdas/test/billing/service-facility.test.ts
@@ -9,15 +9,21 @@ import {
   SaveServiceFacilityInput,
 } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { index as deleteIndex } from '../../src/billing/delete-billing-service-facility/index';
+import { index as saveIndex } from '../../src/billing/save-billing-service-facility/index';
 import { validateRequestParameters } from '../../src/billing/save-billing-service-facility/validateRequestParameters';
 import { applyServiceFacilityInput, mapServiceFacility } from '../../src/billing/service-facility.helpers';
+import { createBillingClient } from '../../src/billing/shared';
+import { checkOrCreateM2MClientToken } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
+
+// src/shared and src/billing/shared are mocked suite-wide in vitest.unit-mocks.setup.ts.
 
 function makeInput(body: Record<string, unknown> | null): ZambdaInput {
   return {
     headers: null,
     body: body ? JSON.stringify(body) : (null as unknown as string),
-    secrets: {} as ZambdaInput['secrets'],
+    secrets: { ENVIRONMENT: 'local' } as ZambdaInput['secrets'],
   };
 }
 
@@ -30,21 +36,10 @@ const mockOystehrClient = {
   },
 };
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-vi.mock('../../src/billing/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    createBillingClient: vi.fn(() => mockOystehrClient),
-  };
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+  vi.mocked(createBillingClient).mockReturnValue(mockOystehrClient as never);
 });
 
 const validPayload: SaveServiceFacilityInput = {
@@ -517,15 +512,7 @@ describe('mapServiceFacility', () => {
 
 describe('save-billing-service-facility handler', () => {
   type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
-  let saveHandler!: ZambdaHandler;
-
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    vi.resetModules();
-    ({ index: saveHandler } = (await import('../../src/billing/save-billing-service-facility/index')) as unknown as {
-      index: ZambdaHandler;
-    });
-  });
+  const saveHandler = saveIndex as unknown as ZambdaHandler;
 
   it('updates an existing facility with the optimistic-lock version id', async () => {
     const existing: Location = {
@@ -574,15 +561,7 @@ describe('save-billing-service-facility handler', () => {
 
 describe('delete-billing-service-facility handler', () => {
   type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
-  let deleteHandler!: ZambdaHandler;
-
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    vi.resetModules();
-    ({ index: deleteHandler } = (await import('../../src/billing/delete-billing-service-facility/index')) as {
-      index: ZambdaHandler;
-    });
-  });
+  const deleteHandler = deleteIndex as unknown as ZambdaHandler;
 
   it('deactivates the facility with the optimistic-lock version id', async () => {
     const existing: Location = {

--- a/packages/zambdas/test/get-my-practitioner-id.test.ts
+++ b/packages/zambdas/test/get-my-practitioner-id.test.ts
@@ -3,13 +3,7 @@ import { Secrets, SecretsKeys, userMe } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getMyPractitionerId } from '../src/shared';
 
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('utils')>();
-  return {
-    ...actual,
-    userMe: vi.fn(),
-  };
-});
+// userMe is a canonical suite-wide mock (vitest.unit-mocks.setup.ts); each test installs its behavior.
 
 const secrets: Secrets = {
   [SecretsKeys.FHIR_API]: 'http://fhir',

--- a/packages/zambdas/test/process-telemed-recording.test.ts
+++ b/packages/zambdas/test/process-telemed-recording.test.ts
@@ -1,39 +1,14 @@
 import { DocumentReference, Encounter } from 'fhir/r4b';
+import { createOystehrClient, getAttendingPractitionerId } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-// vi.mock factories are hoisted above other top-level statements, so shared mock fns must be created via vi.hoisted.
-const { transcribeAndCreateResourcesFromZ3Audio, fhirGet, getAttendingPractitionerId } = vi.hoisted(() => ({
-  transcribeAndCreateResourcesFromZ3Audio: vi.fn(async () => 'DocumentReference/new,Observation/new'),
-  fhirGet: vi.fn(),
-  getAttendingPractitionerId: vi.fn(),
-}));
-
-// Mock the shared AI pipeline so no real transcription / FHIR writes happen.
-vi.mock('../src/shared/ai', () => ({
-  transcribeAndCreateResourcesFromZ3Audio,
-}));
-
-// Mock auth so the handler runs offline.
-vi.mock('../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../src/shared')>();
-  return {
-    ...actual,
-    getAuth0Token: vi.fn(async () => 'mock-token'),
-  };
-});
-
-// createOystehrClient/getAttendingPractitionerId are imported from 'utils' by the handler, so mock the encounter
-// lookup and provider attribution here instead of '../src/shared'.
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('utils')>();
-  return {
-    ...actual,
-    createOystehrClient: vi.fn(() => ({ fhir: { get: fhirGet } })),
-    getAttendingPractitionerId,
-  };
-});
-
+import { getAuth0Token } from '../src/shared';
+import { transcribeAndCreateResourcesFromZ3Audio } from '../src/shared/ai';
 import { index } from '../src/subscriptions/document-reference/process-telemed-recording/index';
+
+// transcribeAndCreateResourcesFromZ3Audio, getAuth0Token, createOystehrClient, and
+// getAttendingPractitionerId are canonical suite-wide mocks (vitest.unit-mocks.setup.ts);
+// this file's defaults are installed in beforeEach below.
+const fhirGet = vi.fn();
 
 const RECORDING_URL = 'https://project-api.zapehr.com/v1/z3/myproject-TelemedRecordings/meeting-uuid/audio.mp4';
 const secrets = {
@@ -61,8 +36,13 @@ const encounter: Encounter = { resourceType: 'Encounter', id: 'enc-1', status: '
 describe('process-telemed-recording subscription', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(transcribeAndCreateResourcesFromZ3Audio).mockResolvedValue(
+      'DocumentReference/new,Observation/new' as never
+    );
+    vi.mocked(getAuth0Token).mockResolvedValue('mock-token');
+    vi.mocked(createOystehrClient).mockReturnValue({ fhir: { get: fhirGet } } as never);
     fhirGet.mockResolvedValue(encounter);
-    getAttendingPractitionerId.mockReturnValue('prac-1');
+    vi.mocked(getAttendingPractitionerId).mockReturnValue('prac-1');
   });
 
   it('processes a telemed recording: resolves the encounter, attributes the provider, and runs the AI pipeline', async () => {

--- a/packages/zambdas/test/process-telemed-recording.test.ts
+++ b/packages/zambdas/test/process-telemed-recording.test.ts
@@ -86,7 +86,7 @@ describe('process-telemed-recording subscription', () => {
   });
 
   it('skips when the encounter has no attending practitioner', async () => {
-    getAttendingPractitionerId.mockReturnValue(undefined);
+    vi.mocked(getAttendingPractitionerId).mockReturnValue(undefined);
 
     const result = await invoke(telemedRecordingDocRef());
 

--- a/packages/zambdas/test/rcm/add-procedure-code.test.ts
+++ b/packages/zambdas/test/rcm/add-procedure-code.test.ts
@@ -1,8 +1,9 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { ChargeItemDefinition } from 'fhir/r4b';
 import { CPT_CODE_SYSTEM, CPT_MODIFIER_EXTENSION_URL } from 'utils';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateRequestParameters } from '../../src/rcm/fee-schedules/add-procedure-code/validateRequestParameters';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 // ---------------------------------------------------------------------------
@@ -10,7 +11,8 @@ import type { ZambdaInput } from '../../src/shared/types/common';
 // ---------------------------------------------------------------------------
 
 function makeInput(body: Record<string, unknown>): ZambdaInput {
-  return { headers: null, body: JSON.stringify(body), secrets: null };
+  // ENVIRONMENT is required by the real wrapHandler (configSentry) that now wraps the handler.
+  return { headers: null, body: JSON.stringify(body), secrets: { ENVIRONMENT: 'local' } };
 }
 
 const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
@@ -90,17 +92,6 @@ const fakeExisting = (propertyGroup: ChargeItemDefinition['propertyGroup']): Cha
     propertyGroup: propertyGroup || [],
   }) as ChargeItemDefinition;
 
-// We test the handler logic by mocking the shared helpers and oystehr client
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
 const mockOystehrClient = {
   fhir: {
     get: vi.fn(),
@@ -108,7 +99,15 @@ const mockOystehrClient = {
   },
 };
 
-// Import handler AFTER mocks are set up — cast away Lambda wrapper types since wrapHandler mock unwraps them
+// checkOrCreateM2MClientToken and createClinicalOystehrClient are canonical suite-wide
+// mocks (vitest.unit-mocks.setup.ts); this file's defaults are installed here.
+beforeEach(() => {
+  vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+  vi.mocked(createClinicalOystehrClient).mockReturnValue(
+    mockOystehrClient as unknown as ReturnType<typeof createClinicalOystehrClient>
+  );
+});
+
 const { index: handler } = (await import('../../src/rcm/fee-schedules/add-procedure-code/index')) as unknown as {
   index: (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 };

--- a/packages/zambdas/test/rcm/bulk-add-procedure-codes.test.ts
+++ b/packages/zambdas/test/rcm/bulk-add-procedure-codes.test.ts
@@ -1,8 +1,9 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { ChargeItemDefinition } from 'fhir/r4b';
 import { CPT_CODE_SYSTEM, CPT_MODIFIER_EXTENSION_URL } from 'utils';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateRequestParameters } from '../../src/rcm/fee-schedules/bulk-add-procedure-codes/validateRequestParameters';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 function beforeEachClearMocks(): void {
@@ -17,7 +18,8 @@ function beforeEachClearMocks(): void {
 const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
 
 function makeInput(body: Record<string, unknown>): ZambdaInput {
-  return { headers: null, body: JSON.stringify(body), secrets: null };
+  // ENVIRONMENT is required by the real wrapHandler (configSentry) that now wraps the handler.
+  return { headers: null, body: JSON.stringify(body), secrets: { ENVIRONMENT: 'local' } };
 }
 
 describe('bulk-add-procedure-codes validateRequestParameters', () => {
@@ -112,22 +114,21 @@ const fakeExisting = (propertyGroup: ChargeItemDefinition['propertyGroup']): Cha
     propertyGroup: propertyGroup || [],
   }) as ChargeItemDefinition;
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
 const mockOystehrClient = {
   fhir: {
     get: vi.fn(),
     update: vi.fn(),
   },
 };
+
+// checkOrCreateM2MClientToken and createClinicalOystehrClient are canonical suite-wide
+// mocks (vitest.unit-mocks.setup.ts); this file's defaults are installed here.
+beforeEach(() => {
+  vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+  vi.mocked(createClinicalOystehrClient).mockReturnValue(
+    mockOystehrClient as unknown as ReturnType<typeof createClinicalOystehrClient>
+  );
+});
 
 const { index: handler } = (await import('../../src/rcm/fee-schedules/bulk-add-procedure-codes/index')) as unknown as {
   index: (input: ZambdaInput) => Promise<APIGatewayProxyResult>;

--- a/packages/zambdas/test/rcm/cm-add-procedure-code.test.ts
+++ b/packages/zambdas/test/rcm/cm-add-procedure-code.test.ts
@@ -1,8 +1,9 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { ChargeItemDefinition } from 'fhir/r4b';
 import { CPT_CODE_SYSTEM, CPT_MODIFIER_EXTENSION_URL } from 'utils';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateRequestParameters } from '../../src/rcm/charge-masters/cm-add-procedure-code/validateRequestParameters';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 // ---------------------------------------------------------------------------
@@ -12,7 +13,8 @@ import type { ZambdaInput } from '../../src/shared/types/common';
 const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
 
 function makeInput(body: Record<string, unknown>): ZambdaInput {
-  return { headers: null, body: JSON.stringify(body), secrets: null };
+  // ENVIRONMENT is required by the real wrapHandler (configSentry) that now wraps the handler.
+  return { headers: null, body: JSON.stringify(body), secrets: { ENVIRONMENT: 'local' } };
 }
 
 describe('cm-add-procedure-code validateRequestParameters', () => {
@@ -80,22 +82,21 @@ const fakeExisting = (propertyGroup: ChargeItemDefinition['propertyGroup']): Cha
     propertyGroup: propertyGroup || [],
   }) as ChargeItemDefinition;
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
 const mockOystehrClient = {
   fhir: {
     get: vi.fn(),
     update: vi.fn(),
   },
 };
+
+// checkOrCreateM2MClientToken and createClinicalOystehrClient are canonical suite-wide
+// mocks (vitest.unit-mocks.setup.ts); this file's defaults are installed here.
+beforeEach(() => {
+  vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+  vi.mocked(createClinicalOystehrClient).mockReturnValue(
+    mockOystehrClient as unknown as ReturnType<typeof createClinicalOystehrClient>
+  );
+});
 
 const { index: handler } = (await import('../../src/rcm/charge-masters/cm-add-procedure-code/index')) as unknown as {
   index: (input: ZambdaInput) => Promise<APIGatewayProxyResult>;

--- a/packages/zambdas/test/rcm/cm-bulk-add-procedure-codes.test.ts
+++ b/packages/zambdas/test/rcm/cm-bulk-add-procedure-codes.test.ts
@@ -1,8 +1,9 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { ChargeItemDefinition } from 'fhir/r4b';
 import { CPT_CODE_SYSTEM, CPT_MODIFIER_EXTENSION_URL } from 'utils';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateRequestParameters } from '../../src/rcm/charge-masters/cm-bulk-add-procedure-codes/validateRequestParameters';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 function beforeEachClearMocks(): void {
@@ -17,7 +18,8 @@ function beforeEachClearMocks(): void {
 const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
 
 function makeInput(body: Record<string, unknown>): ZambdaInput {
-  return { headers: null, body: JSON.stringify(body), secrets: null };
+  // ENVIRONMENT is required by the real wrapHandler (configSentry) that now wraps the handler.
+  return { headers: null, body: JSON.stringify(body), secrets: { ENVIRONMENT: 'local' } };
 }
 
 describe('cm-bulk-add-procedure-codes validateRequestParameters', () => {
@@ -84,22 +86,21 @@ const fakeExisting = (propertyGroup: ChargeItemDefinition['propertyGroup']): Cha
     propertyGroup: propertyGroup || [],
   }) as ChargeItemDefinition;
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
 const mockOystehrClient = {
   fhir: {
     get: vi.fn(),
     update: vi.fn(),
   },
 };
+
+// checkOrCreateM2MClientToken and createClinicalOystehrClient are canonical suite-wide
+// mocks (vitest.unit-mocks.setup.ts); this file's defaults are installed here.
+beforeEach(() => {
+  vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+  vi.mocked(createClinicalOystehrClient).mockReturnValue(
+    mockOystehrClient as unknown as ReturnType<typeof createClinicalOystehrClient>
+  );
+});
 
 const { index: handler } = (await import(
   '../../src/rcm/charge-masters/cm-bulk-add-procedure-codes/index'

--- a/packages/zambdas/test/rcm/employers-helpers-and-candid-sync.test.ts
+++ b/packages/zambdas/test/rcm/employers-helpers-and-candid-sync.test.ts
@@ -1,30 +1,18 @@
 import { Address, Organization } from 'fhir/r4b';
-import { MISSING_REQUEST_SECRETS } from 'utils';
+import { getOrCreateCandidApiClient, MISSING_REQUEST_SECRETS } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-// hoisted to avoid dependency issues
-const { mockGetOrCreateCandidApiClient } = vi.hoisted(() => ({
-  mockGetOrCreateCandidApiClient: vi.fn(),
-}));
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    getOrCreateCandidApiClient: mockGetOrCreateCandidApiClient,
-  };
-});
-
-const {
+// This file tests the REAL candid-sync implementations: the canonical suite-wide mocks
+// (vitest.unit-mocks.setup.ts) wrap them with delegate-to-real defaults, so calling them
+// exercises the real code while getOrCreateCandidApiClient (also canonical) is stubbed below.
+import {
   createCandidClientIfConfigured,
   createCandidEmployerPayer,
-  updateCandidEmployerPayer,
   toggleCandidEmployerPayer,
-} = await import('../../src/rcm/employers/candid-sync');
-
-const {
-  EMPLOYER_NOTES_EXTENSION_URL,
+  updateCandidEmployerPayer,
+} from '../../src/rcm/employers/candid-sync';
+import {
   buildEmployerType,
+  EMPLOYER_NOTES_EXTENSION_URL,
   getCandidPayerIdFromOrganization,
   isEmployerOrganization,
   normalizeAddress,
@@ -32,7 +20,9 @@ const {
   normalizeIdentifier,
   normalizeTelecom,
   setOrUpdateCandidIdentifier,
-} = await import('../../src/rcm/employers/helpers');
+} from '../../src/rcm/employers/helpers';
+
+const mockGetOrCreateCandidApiClient = vi.mocked(getOrCreateCandidApiClient);
 
 describe('RCM employer helpers', () => {
   it('detects employer organizations by type code', () => {

--- a/packages/zambdas/test/rcm/employers-zambdas.test.ts
+++ b/packages/zambdas/test/rcm/employers-zambdas.test.ts
@@ -1,10 +1,18 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { Organization } from 'fhir/r4b';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createCandidClientIfConfigured,
+  createCandidEmployerPayer,
+  toggleCandidEmployerPayer,
+  updateCandidEmployerPayer,
+} from '../../src/rcm/employers/candid-sync';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 function makeInput(body: Record<string, unknown>): ZambdaInput {
-  return { headers: null, body: JSON.stringify(body), secrets: null };
+  // ENVIRONMENT is required by the real wrapHandler (configSentry) that now wraps the handlers.
+  return { headers: null, body: JSON.stringify(body), secrets: { ENVIRONMENT: 'local' } };
 }
 
 const mockOystehrClient = {
@@ -16,27 +24,12 @@ const mockOystehrClient = {
   },
 };
 
-const mockCreateCandidClientIfConfigured = vi.fn();
-const mockCreateCandidEmployerPayer = vi.fn();
-const mockUpdateCandidEmployerPayer = vi.fn();
-const mockToggleCandidEmployerPayer = vi.fn();
-
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-vi.mock('../../src/rcm/employers/candid-sync', () => ({
-  createCandidClientIfConfigured: mockCreateCandidClientIfConfigured,
-  createCandidEmployerPayer: mockCreateCandidEmployerPayer,
-  updateCandidEmployerPayer: mockUpdateCandidEmployerPayer,
-  toggleCandidEmployerPayer: mockToggleCandidEmployerPayer,
-}));
+// The candid-sync module and the shared auth/client helpers are canonical suite-wide
+// mocks (vitest.unit-mocks.setup.ts); this file's defaults are installed in beforeEach.
+const mockCreateCandidClientIfConfigured = vi.mocked(createCandidClientIfConfigured);
+const mockCreateCandidEmployerPayer = vi.mocked(createCandidEmployerPayer);
+const mockUpdateCandidEmployerPayer = vi.mocked(updateCandidEmployerPayer);
+const mockToggleCandidEmployerPayer = vi.mocked(toggleCandidEmployerPayer);
 
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
@@ -89,7 +82,15 @@ describe('RCM employer zambdas', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreateCandidClientIfConfigured.mockReturnValue(null);
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(
+      mockOystehrClient as unknown as ReturnType<typeof createClinicalOystehrClient>
+    );
+    mockCreateCandidClientIfConfigured.mockResolvedValue(null);
+    // Inert defaults: the real implementations must never run in these tests.
+    mockCreateCandidEmployerPayer.mockResolvedValue(undefined);
+    mockUpdateCandidEmployerPayer.mockResolvedValue(undefined);
+    mockToggleCandidEmployerPayer.mockResolvedValue(undefined);
   });
 
   it('create-employer creates org and persists Candid payer id when Candid sync succeeds', async () => {
@@ -105,7 +106,9 @@ describe('RCM employer zambdas', () => {
 
     mockOystehrClient.fhir.create.mockResolvedValue(created);
     mockOystehrClient.fhir.update.mockResolvedValue(updated);
-    mockCreateCandidClientIfConfigured.mockReturnValue({});
+    mockCreateCandidClientIfConfigured.mockResolvedValue(
+      {} as unknown as Awaited<ReturnType<typeof createCandidClientIfConfigured>>
+    );
     mockCreateCandidEmployerPayer.mockResolvedValue('candid-payer-1');
 
     const result = await createEmployerHandler(makeInput({ name: 'Wayne Enterprises' }));
@@ -151,7 +154,9 @@ describe('RCM employer zambdas', () => {
 
     mockOystehrClient.fhir.get.mockResolvedValue(existing);
     mockOystehrClient.fhir.update.mockResolvedValue(updated);
-    mockCreateCandidClientIfConfigured.mockReturnValue({});
+    mockCreateCandidClientIfConfigured.mockResolvedValue(
+      {} as unknown as Awaited<ReturnType<typeof createCandidClientIfConfigured>>
+    );
 
     const result = await updateEmployerHandler(
       makeInput({ employerId: EMPLOYER_ID, name: 'Wayne Ent', category: 'Occupational Medicine' })
@@ -186,7 +191,9 @@ describe('RCM employer zambdas', () => {
 
     mockOystehrClient.fhir.get.mockResolvedValue(existing);
     mockOystehrClient.fhir.update.mockResolvedValue(updated);
-    mockCreateCandidClientIfConfigured.mockReturnValue({});
+    mockCreateCandidClientIfConfigured.mockResolvedValue(
+      {} as unknown as Awaited<ReturnType<typeof createCandidClientIfConfigured>>
+    );
 
     const result = await updateEmployerHandler(makeInput({ employerId: EMPLOYER_ID, active: true }));
 
@@ -216,7 +223,9 @@ describe('RCM employer zambdas', () => {
 
     mockOystehrClient.fhir.get.mockResolvedValue(existing);
     mockOystehrClient.fhir.update.mockResolvedValue(updated);
-    mockCreateCandidClientIfConfigured.mockReturnValue({});
+    mockCreateCandidClientIfConfigured.mockResolvedValue(
+      {} as unknown as Awaited<ReturnType<typeof createCandidClientIfConfigured>>
+    );
 
     const result = await updateEmployerHandler(makeInput({ employerId: EMPLOYER_ID, active: false }));
 
@@ -233,7 +242,7 @@ describe('RCM employer zambdas', () => {
       unbundle: () => [makeEmployer()],
     });
 
-    const result = await listEmployersHandler({ headers: null, body: JSON.stringify({}), secrets: null });
+    const result = await listEmployersHandler(makeInput({}));
     expect(result.statusCode).toBe(200);
 
     const body = JSON.parse(result.body);

--- a/packages/zambdas/test/rcm/get-payment-locations.test.ts
+++ b/packages/zambdas/test/rcm/get-payment-locations.test.ts
@@ -1,7 +1,8 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { Location } from 'fhir/r4b';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateRequestParameters } from '../../src/rcm/payments/get-payment-locations/validateRequestParameters';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 // ---------------------------------------------------------------------------
@@ -9,12 +10,13 @@ import type { ZambdaInput } from '../../src/shared/types/common';
 // ---------------------------------------------------------------------------
 
 function makeInput(): ZambdaInput {
-  return { headers: null, body: JSON.stringify({}), secrets: null };
+  // ENVIRONMENT is required by the real wrapHandler (configSentry) that now wraps the handler.
+  return { headers: null, body: JSON.stringify({}), secrets: { ENVIRONMENT: 'local' } };
 }
 
 describe('get-payment-locations validateRequestParameters', () => {
   it('returns secrets from input', () => {
-    const result = validateRequestParameters(makeInput());
+    const result = validateRequestParameters({ headers: null, body: JSON.stringify({}), secrets: null });
     expect(result).toMatchObject({ secrets: null });
   });
 });
@@ -29,14 +31,13 @@ const mockOystehrClient = {
   },
 };
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
+// checkOrCreateM2MClientToken and createClinicalOystehrClient are canonical suite-wide
+// mocks (vitest.unit-mocks.setup.ts); this file's defaults are installed here.
+beforeEach(() => {
+  vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+  vi.mocked(createClinicalOystehrClient).mockReturnValue(
+    mockOystehrClient as unknown as ReturnType<typeof createClinicalOystehrClient>
+  );
 });
 
 const { index: handler } = (await import('../../src/rcm/payments/get-payment-locations/index')) as unknown as {

--- a/packages/zambdas/test/rcm/get-stripe-account-info.test.ts
+++ b/packages/zambdas/test/rcm/get-stripe-account-info.test.ts
@@ -1,6 +1,7 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateRequestParameters } from '../../src/rcm/payments/get-stripe-account-info/validateRequestParameters';
+import { getStripeClient } from '../../src/shared/stripeIntegration';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 // ---------------------------------------------------------------------------
@@ -8,14 +9,19 @@ import type { ZambdaInput } from '../../src/shared/types/common';
 // ---------------------------------------------------------------------------
 
 function makeInput(body: Record<string, unknown> | null): ZambdaInput {
-  return { headers: null, body: body ? JSON.stringify(body) : (null as unknown as string), secrets: null };
+  // ENVIRONMENT is required by the real wrapHandler (configSentry) that now wraps the handler.
+  return {
+    headers: null,
+    body: body ? JSON.stringify(body) : (null as unknown as string),
+    secrets: { ENVIRONMENT: 'local' },
+  };
 }
 
 describe('get-stripe-account-info validateRequestParameters', () => {
   it('returns validated params for valid input', () => {
     const result = validateRequestParameters(makeInput({ stripeAccountId: 'acct_123abc' }));
     expect(result).toMatchObject({ stripeAccountId: 'acct_123abc' });
-    expect(result.secrets).toBeNull();
+    expect(result.secrets).toEqual({ ENVIRONMENT: 'local' });
   });
 
   it('throws when stripeAccountId is missing', () => {
@@ -60,19 +66,11 @@ const mockStripeClient = {
   },
 };
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
+// getStripeClient is a canonical suite-wide mock (vitest.unit-mocks.setup.ts); this
+// file's default is installed here.
+beforeEach(() => {
+  vi.mocked(getStripeClient).mockReturnValue(mockStripeClient as unknown as ReturnType<typeof getStripeClient>);
 });
-
-vi.mock('../../src/shared/stripeIntegration', () => ({
-  getStripeClient: vi.fn(() => mockStripeClient),
-}));
 
 const { index: handler } = (await import('../../src/rcm/payments/get-stripe-account-info/index')) as unknown as {
   index: (input: ZambdaInput) => Promise<APIGatewayProxyResult>;

--- a/packages/zambdas/test/rcm/get-terminal-readers.test.ts
+++ b/packages/zambdas/test/rcm/get-terminal-readers.test.ts
@@ -1,6 +1,7 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateRequestParameters } from '../../src/rcm/payments/get-terminal-readers/validateRequestParameters';
+import { getStripeClient } from '../../src/shared/stripeIntegration';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 // ---------------------------------------------------------------------------
@@ -8,7 +9,12 @@ import type { ZambdaInput } from '../../src/shared/types/common';
 // ---------------------------------------------------------------------------
 
 function makeInput(body: Record<string, unknown> | null): ZambdaInput {
-  return { headers: null, body: body ? JSON.stringify(body) : (null as unknown as string), secrets: null };
+  // ENVIRONMENT is required by the real wrapHandler (configSentry) that now wraps the handler.
+  return {
+    headers: null,
+    body: body ? JSON.stringify(body) : (null as unknown as string),
+    secrets: { ENVIRONMENT: 'local' },
+  };
 }
 
 describe('get-terminal-readers validateRequestParameters', () => {
@@ -20,7 +26,7 @@ describe('get-terminal-readers validateRequestParameters', () => {
       stripeAccountId: 'acct_123abc',
       terminalLocationId: 'tml_456def',
     });
-    expect(result.secrets).toBeNull();
+    expect(result.secrets).toEqual({ ENVIRONMENT: 'local' });
   });
 
   it('throws when stripeAccountId is missing', () => {
@@ -83,19 +89,11 @@ const mockStripeClient = {
   },
 };
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
+// getStripeClient is a canonical suite-wide mock (vitest.unit-mocks.setup.ts); this
+// file's default is installed here.
+beforeEach(() => {
+  vi.mocked(getStripeClient).mockReturnValue(mockStripeClient as unknown as ReturnType<typeof getStripeClient>);
 });
-
-vi.mock('../../src/shared/stripeIntegration', () => ({
-  getStripeClient: vi.fn(() => mockStripeClient),
-}));
 
 const { index: handler } = (await import('../../src/rcm/payments/get-terminal-readers/index')) as unknown as {
   index: (input: ZambdaInput) => Promise<APIGatewayProxyResult>;

--- a/packages/zambdas/test/rcm/get-version-history.test.ts
+++ b/packages/zambdas/test/rcm/get-version-history.test.ts
@@ -1,8 +1,9 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { Bundle, ChargeItemDefinition } from 'fhir/r4b';
 import { CPT_CODE_SYSTEM } from 'utils';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateRequestParameters } from '../../src/rcm/fee-schedules/get-version-history/validateRequestParameters';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 // ---------------------------------------------------------------------------
@@ -12,7 +13,8 @@ import type { ZambdaInput } from '../../src/shared/types/common';
 const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
 
 function makeInput(body: Record<string, unknown>): ZambdaInput {
-  return { headers: null, body: JSON.stringify(body), secrets: null };
+  // ENVIRONMENT is required by the real wrapHandler (configSentry) that now wraps the handler.
+  return { headers: null, body: JSON.stringify(body), secrets: { ENVIRONMENT: 'local' } };
 }
 
 describe('get-version-history validateRequestParameters', () => {
@@ -30,21 +32,20 @@ describe('get-version-history validateRequestParameters', () => {
 // index handler
 // ---------------------------------------------------------------------------
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
 const mockOystehrClient = {
   fhir: {
     history: vi.fn(),
   },
 };
+
+// checkOrCreateM2MClientToken and createClinicalOystehrClient are canonical suite-wide
+// mocks (vitest.unit-mocks.setup.ts); this file's defaults are installed here.
+beforeEach(() => {
+  vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+  vi.mocked(createClinicalOystehrClient).mockReturnValue(
+    mockOystehrClient as unknown as ReturnType<typeof createClinicalOystehrClient>
+  );
+});
 
 const { index: handler } = (await import('../../src/rcm/fee-schedules/get-version-history/index')) as unknown as {
   index: (input: ZambdaInput) => Promise<APIGatewayProxyResult>;

--- a/packages/zambdas/test/rcm/save-terminal-location.test.ts
+++ b/packages/zambdas/test/rcm/save-terminal-location.test.ts
@@ -1,12 +1,14 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { Device } from 'fhir/r4b';
 import {
+  findTerminalDeviceForLocation,
   STRIPE_TERMINAL_LOCATION_DEVICE_TYPE_CODE,
   STRIPE_TERMINAL_LOCATION_DEVICE_TYPE_SYSTEM,
   STRIPE_TERMINAL_LOCATION_IDENTIFIER_SYSTEM,
 } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateRequestParameters } from '../../src/rcm/payments/save-terminal-location/validateRequestParameters';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 // ---------------------------------------------------------------------------
@@ -16,7 +18,12 @@ import type { ZambdaInput } from '../../src/shared/types/common';
 const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
 
 function makeInput(body: Record<string, unknown> | null): ZambdaInput {
-  return { headers: null, body: body ? JSON.stringify(body) : (null as unknown as string), secrets: null };
+  // ENVIRONMENT is required by the real wrapHandler (configSentry) that now wraps the handler.
+  return {
+    headers: null,
+    body: body ? JSON.stringify(body) : (null as unknown as string),
+    secrets: { ENVIRONMENT: 'local' },
+  };
 }
 
 describe('save-terminal-location validateRequestParameters', () => {
@@ -82,28 +89,9 @@ const mockOystehrClient = {
   },
 };
 
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    findTerminalDeviceForLocation: vi.fn(async () => {
-      const searchResult = await mockOystehrClient.fhir.search();
-      return searchResult;
-    }),
-  };
-});
-
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-const { findTerminalDeviceForLocation } = await import('utils');
+// findTerminalDeviceForLocation, checkOrCreateM2MClientToken, and createClinicalOystehrClient
+// are canonical suite-wide mocks (vitest.unit-mocks.setup.ts); defaults are installed in
+// the beforeEach below.
 const mockedFindDevice = vi.mocked(findTerminalDeviceForLocation);
 
 const { index: handler } = (await import('../../src/rcm/payments/save-terminal-location/index')) as unknown as {
@@ -139,6 +127,14 @@ function makeDevice(terminalLocationId: string): Device {
 describe('save-terminal-location handler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(
+      mockOystehrClient as unknown as ReturnType<typeof createClinicalOystehrClient>
+    );
+    mockedFindDevice.mockImplementation(async () => {
+      const searchResult = await mockOystehrClient.fhir.search();
+      return searchResult;
+    });
   });
 
   it('creates a new Device when no existing device and terminalLocationId is provided', async () => {

--- a/packages/zambdas/test/rcm/scheduled-outreach/cron-task-promoter.test.ts
+++ b/packages/zambdas/test/rcm/scheduled-outreach/cron-task-promoter.test.ts
@@ -1,12 +1,22 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { PlanDefinition, Task } from 'fhir/r4b';
 import { DateTime } from 'luxon';
-import { PRIVATE_EXTENSION_BASE_URL } from 'utils';
+import { FEATURE_FLAGS_CONFIG, PRIVATE_EXTENSION_BASE_URL } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { dedupeOutreachTasks } from '../../../src/cron/rcm/outreach-task-promoter/dedupe-outreach-tasks';
 import { index } from '../../../src/cron/rcm/outreach-task-promoter/index';
-import { parseNotificationsTimeRestriction } from '../../../src/rcm/scheduled-outreach-config/helpers';
+import {
+  getOrCreateOutreachConfig,
+  parseNotificationsTimeRestriction,
+} from '../../../src/rcm/scheduled-outreach-config/helpers';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../../src/shared';
 import type { ZambdaInput } from '../../../src/shared/types/common';
+
+// FEATURE_FLAGS_CONFIG, checkOrCreateM2MClientToken, createClinicalOystehrClient,
+// getOrCreateOutreachConfig, and parseNotificationsTimeRestriction are canonical suite-wide
+// mocks (vitest.unit-mocks.setup.ts); per-file defaults are installed in beforeEach below.
+// The REAL wrapHandler now wraps the handler, so thrown errors surface as an error envelope
+// (statusCode + JSON body) unless they occur before the top-level catch (e.g. missing secrets).
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -24,49 +34,30 @@ const mockOystehrClient = {
   },
 };
 
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    FEATURE_FLAGS_CONFIG: {
-      automatedPatientOutreachEnabled: true,
-      mailingPaperStatementsEnabled: true,
-    },
-  };
-});
-
-vi.mock('../../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-// Mock the config helpers to return a plan with no time restriction
-vi.mock('../../../src/rcm/scheduled-outreach-config/helpers', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    getOrCreateOutreachConfig: vi.fn().mockResolvedValue({
-      resourceType: 'PlanDefinition',
-      id: 'plan-1',
-      status: 'active',
-    } as PlanDefinition),
-    parseNotificationsTimeRestriction: vi.fn().mockReturnValue({
-      enabled: false,
-      windowStart: '09:00',
-      windowEnd: '21:00',
-      timezone: 'America/New_York',
-    }),
-  };
-});
-
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
-const testSecrets = { test: 'secret' };
+const testSecrets = { test: 'secret', ENVIRONMENT: 'local' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.assign(FEATURE_FLAGS_CONFIG, {
+    automatedPatientOutreachEnabled: true,
+    mailingPaperStatementsEnabled: true,
+  });
+  vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+  vi.mocked(createClinicalOystehrClient).mockReturnValue(mockOystehrClient as any);
+  vi.mocked(getOrCreateOutreachConfig).mockResolvedValue({
+    resourceType: 'PlanDefinition',
+    id: 'plan-1',
+    status: 'active',
+  } as PlanDefinition);
+  vi.mocked(parseNotificationsTimeRestriction).mockReturnValue({
+    enabled: false,
+    windowStart: '09:00',
+    windowEnd: '21:00',
+    timezone: 'America/New_York',
+  });
+});
 
 function mockBundle(resources: any[]): { unbundle: () => any[] } {
   return { unbundle: () => resources };
@@ -85,10 +76,6 @@ function makeDraftTask(id: string, overrides?: Partial<Task>): Task {
 
 describe('cron-outreach-task-promoter', () => {
   const handler = index as ZambdaHandler;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
 
   it('promotes draft tasks to requested status', async () => {
     const draftTask = makeDraftTask('task-1');
@@ -179,43 +166,46 @@ describe('cron-outreach-task-promoter', () => {
   });
 
   it('throws when secrets are not defined', async () => {
-    await expect(handler({ headers: null, body: null, secrets: null })).rejects.toThrow('Secrets are not defined');
+    // With the real wrapHandler, configSentry reads the ENVIRONMENT secret before the
+    // top-level catch, so a null-secrets invocation still rejects (with the missing-secret error).
+    await expect(handler({ headers: null, body: null, secrets: null })).rejects.toThrow();
   });
 });
 
 describe('cron-outreach-task-promoter with SMS time restriction', () => {
   const handler = index as ZambdaHandler;
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('blocks SMS tasks when outside notification window', async () => {
     // Mock DateTime.now() to a fixed time outside the narrow window to avoid flakiness
     const realNow = DateTime.now;
-    vi.spyOn(DateTime, 'now').mockImplementation(() =>
-      realNow.call(DateTime).set({ hour: 12, minute: 0, second: 0, millisecond: 0 })
-    );
+    const nowSpy = vi
+      .spyOn(DateTime, 'now')
+      .mockImplementation(() => realNow.call(DateTime).set({ hour: 12, minute: 0, second: 0, millisecond: 0 }));
 
-    // Enable restriction with a very narrow window that won't match the mocked time (12:00 UTC)
-    (parseNotificationsTimeRestriction as any).mockReturnValue({
-      enabled: true,
-      windowStart: '03:00',
-      windowEnd: '03:01',
-      timezone: 'UTC',
-    });
+    try {
+      // Enable restriction with a very narrow window that won't match the mocked time (12:00 UTC)
+      vi.mocked(parseNotificationsTimeRestriction).mockReturnValue({
+        enabled: true,
+        windowStart: '03:00',
+        windowEnd: '03:01',
+        timezone: 'UTC',
+      });
 
-    const smsTask = makeDraftTask('task-sms', {
-      input: [{ type: { text: 'mediums' }, valueString: 'sms' }],
-    });
-    mockSearch.mockResolvedValueOnce(mockBundle([smsTask]));
+      const smsTask = makeDraftTask('task-sms', {
+        input: [{ type: { text: 'mediums' }, valueString: 'sms' }],
+      });
+      mockSearch.mockResolvedValueOnce(mockBundle([smsTask]));
 
-    const result = await handler({ headers: null, body: null, secrets: testSecrets });
+      const result = await handler({ headers: null, body: null, secrets: testSecrets });
 
-    const body = JSON.parse(result.body);
-    expect(body.blocked).toBe(1);
-    expect(body.promoted).toBe(0);
-    expect(mockPatch).not.toHaveBeenCalled();
+      const body = JSON.parse(result.body);
+      expect(body.blocked).toBe(1);
+      expect(body.promoted).toBe(0);
+      expect(mockPatch).not.toHaveBeenCalled();
+    } finally {
+      // Restore DateTime.now so the spy cannot leak into other files under --no-isolate
+      nowSpy.mockRestore();
+    }
   });
 });
 
@@ -223,10 +213,6 @@ describe('cron-outreach-task-promoter with SMS time restriction', () => {
 
 describe('dedupeOutreachTasks', () => {
   const TAG_SYSTEM = `${PRIVATE_EXTENSION_BASE_URL}/outreach-task`;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
 
   function makeKeyedTask(
     id: string,

--- a/packages/zambdas/test/rcm/scheduled-outreach/executors.test.ts
+++ b/packages/zambdas/test/rcm/scheduled-outreach/executors.test.ts
@@ -1,7 +1,23 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { Task } from 'fhir/r4b';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  checkOrCreateM2MClientToken,
+  createClinicalOystehrClient,
+  fillOutreachTemplate,
+  getEmailClient,
+  getStripeClient,
+  resolveTemplatePlaceholders,
+  sendSmsForPatient,
+} from '../../../src/shared';
 import type { ZambdaInput } from '../../../src/shared/types/common';
+import { index as subOutreachLogIndex } from '../../../src/subscriptions/task/sub-outreach-log/index';
+import { index as subOutreachReferToCollectionsIndex } from '../../../src/subscriptions/task/sub-outreach-refer-to-collections/index';
+
+// All the src/shared exports stubbed here are canonical suite-wide mocks
+// (vitest.unit-mocks.setup.ts); per-file defaults are installed in beforeEach below.
+// The REAL wrapHandler now wraps the handlers, so plain thrown errors surface as a
+// 500 error envelope instead of a rejected promise.
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -21,24 +37,20 @@ const mockOystehrClient = {
   },
 };
 
-vi.mock('../../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-    fillOutreachTemplate: vi.fn((_t: string, _p: any) => 'resolved message'),
-    resolveTemplatePlaceholders: vi.fn().mockResolvedValue({}),
-    sendSmsForPatient: vi.fn(),
-    getEmailClient: vi.fn().mockReturnValue({ send: vi.fn() }),
-    getStripeClient: vi.fn(),
-  };
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+  vi.mocked(createClinicalOystehrClient).mockReturnValue(mockOystehrClient as any);
+  vi.mocked(fillOutreachTemplate).mockReturnValue('resolved message');
+  vi.mocked(resolveTemplatePlaceholders).mockResolvedValue({} as any);
+  vi.mocked(sendSmsForPatient).mockImplementation(() => undefined as never);
+  vi.mocked(getEmailClient).mockReturnValue({ send: vi.fn() } as any);
+  vi.mocked(getStripeClient).mockImplementation(() => undefined as never);
 });
 
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
-const testSecrets = { test: 'secret' };
+const testSecrets = { test: 'secret', ENVIRONMENT: 'local' };
 
 function makeTaskInput(overrides?: Partial<Task>): Task {
   return {
@@ -70,13 +82,7 @@ function makeZambdaInput(task: Task): ZambdaInput {
 // ── Executor: sub-outreach-log ─────────────────────────────────────────────
 
 describe('sub-outreach-log', () => {
-  let handler: ZambdaHandler;
-
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    const mod = await import('../../../src/subscriptions/task/sub-outreach-log/index');
-    handler = mod.index as ZambdaHandler;
-  });
+  const handler = subOutreachLogIndex as unknown as ZambdaHandler;
 
   it('marks task as in-progress then completed', async () => {
     const task = makeTaskInput({ input: [{ type: { text: 'action-type' }, valueString: 'log' }] });
@@ -118,37 +124,33 @@ describe('sub-outreach-log', () => {
     expect(result.statusCode).toBe(500);
   });
 
-  it('throws when body is missing', async () => {
-    await expect(handler({ headers: null, body: null, secrets: testSecrets })).rejects.toThrow(
-      'No request body provided'
-    );
+  it('returns a 500 error envelope when body is missing', async () => {
+    // The real wrapHandler converts the thrown 'No request body provided' into an error envelope
+    const result = await handler({ headers: null, body: null, secrets: testSecrets });
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body)).toEqual({ error: 'Internal error' });
   });
 
   it('throws when secrets are missing', async () => {
+    // configSentry reads the ENVIRONMENT secret before the top-level catch,
+    // so a null-secrets invocation still rejects.
     const task = makeTaskInput();
-    await expect(handler({ headers: null, body: JSON.stringify(task), secrets: null })).rejects.toThrow(
-      'Secrets are not defined'
-    );
+    await expect(handler({ headers: null, body: JSON.stringify(task), secrets: null })).rejects.toThrow();
   });
 
-  it('throws when resource type is not Task', async () => {
+  it('returns a 500 error envelope when resource type is not Task', async () => {
     const notATask = { resourceType: 'Patient', id: 'pat-1' };
-    await expect(handler({ headers: null, body: JSON.stringify(notATask), secrets: testSecrets })).rejects.toThrow(
-      'Expected Task resource'
-    );
+    const result = await handler({ headers: null, body: JSON.stringify(notATask), secrets: testSecrets });
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body)).toEqual({ error: 'Internal error' });
+    expect(mockPatch).not.toHaveBeenCalled();
   });
 });
 
 // ── Executor: sub-outreach-refer-to-collections ─────────────────────────────
 
 describe('sub-outreach-refer-to-collections', () => {
-  let handler: ZambdaHandler;
-
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    const mod = await import('../../../src/subscriptions/task/sub-outreach-refer-to-collections/index');
-    handler = mod.index as ZambdaHandler;
-  });
+  const handler = subOutreachReferToCollectionsIndex as unknown as ZambdaHandler;
 
   it('marks task as in-progress then rejected (not yet implemented)', async () => {
     const task = makeTaskInput({

--- a/packages/zambdas/test/rcm/scheduled-outreach/produce-outreach-tasks-filtering.test.ts
+++ b/packages/zambdas/test/rcm/scheduled-outreach/produce-outreach-tasks-filtering.test.ts
@@ -1,5 +1,14 @@
+import { FEATURE_FLAGS_CONFIG } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { OutreachAction } from '../../../src/rcm/scheduled-outreach-config/helpers';
+import { produceOutreachTasks } from '../../../src/rcm/scheduled-outreach/producers/shared/produce-outreach-tasks';
+import {
+  getOrCreateOutreachConfig,
+  type OutreachAction,
+  parsePlanDefinitionToActions,
+} from '../../../src/rcm/scheduled-outreach-config/helpers';
+
+// FEATURE_FLAGS_CONFIG, getOrCreateOutreachConfig, and parsePlanDefinitionToActions are canonical
+// suite-wide mocks (vitest.unit-mocks.setup.ts); behavior is installed per-test via vi.mocked(...).
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -16,50 +25,6 @@ const mockOystehrClient = {
     transaction: vi.fn(),
   },
 };
-
-const mockFeatureFlags = {
-  automatedPatientOutreachEnabled: true,
-  mailingPaperStatementsEnabled: true,
-};
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    FEATURE_FLAGS_CONFIG: mockFeatureFlags,
-  };
-});
-
-vi.mock('../../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-vi.mock('../../../src/shared/helpers', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    getPatchBinary: vi.fn(),
-  };
-});
-
-// Mock the config helpers to return our test PlanDefinition
-const mockGetOrCreateOutreachConfig = vi.fn();
-const mockParsePlanDefinitionToActions = vi.fn();
-
-vi.mock('../../../src/rcm/scheduled-outreach-config/helpers', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    getOrCreateOutreachConfig: (...args: unknown[]) => mockGetOrCreateOutreachConfig(...args),
-    parsePlanDefinitionToActions: (...args: unknown[]) => mockParsePlanDefinitionToActions(...args),
-  };
-});
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -84,23 +49,20 @@ function makeAction(overrides?: Partial<OutreachAction>): OutreachAction {
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe('produceOutreachTasks — producer-level filtering', () => {
-  let produceOutreachTasks: typeof import('../../../src/rcm/scheduled-outreach/producers/shared/produce-outreach-tasks').produceOutreachTasks;
-
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    mockFeatureFlags.automatedPatientOutreachEnabled = true;
-    mockFeatureFlags.mailingPaperStatementsEnabled = true;
+    Object.assign(FEATURE_FLAGS_CONFIG, {
+      automatedPatientOutreachEnabled: true,
+      mailingPaperStatementsEnabled: true,
+    });
 
-    mockGetOrCreateOutreachConfig.mockResolvedValue({
+    vi.mocked(getOrCreateOutreachConfig).mockResolvedValue({
       resourceType: 'PlanDefinition',
       id: 'plan-1',
       status: 'active',
     });
     mockSearch.mockResolvedValue(mockBundle([])); // no existing tasks
     mockCreate.mockImplementation((task: any) => Promise.resolve({ ...task, id: 'task-new' }));
-
-    const mod = await import('../../../src/rcm/scheduled-outreach/producers/shared/produce-outreach-tasks');
-    produceOutreachTasks = mod.produceOutreachTasks;
   });
 
   it('skips refer-to-collections actions (not yet implemented)', async () => {
@@ -112,7 +74,7 @@ describe('produceOutreachTasks — producer-level filtering', () => {
       }),
       makeAction({ id: 'sms-1', actionType: 'send-notification' }),
     ];
-    mockParsePlanDefinitionToActions.mockReturnValue(actions);
+    vi.mocked(parsePlanDefinitionToActions).mockReturnValue(actions);
 
     const result = await produceOutreachTasks({
       triggerEvent: 'invoice-due',
@@ -132,7 +94,7 @@ describe('produceOutreachTasks — producer-level filtering', () => {
   });
 
   it('skips paper-mail-only notification when mailingPaperStatementsEnabled is false', async () => {
-    mockFeatureFlags.mailingPaperStatementsEnabled = false;
+    Object.assign(FEATURE_FLAGS_CONFIG, { mailingPaperStatementsEnabled: false });
 
     const actions: OutreachAction[] = [
       makeAction({
@@ -142,7 +104,7 @@ describe('produceOutreachTasks — producer-level filtering', () => {
       }),
       makeAction({ id: 'sms-1', actionType: 'send-notification' }),
     ];
-    mockParsePlanDefinitionToActions.mockReturnValue(actions);
+    vi.mocked(parsePlanDefinitionToActions).mockReturnValue(actions);
 
     const result = await produceOutreachTasks({
       triggerEvent: 'invoice-due',
@@ -160,7 +122,7 @@ describe('produceOutreachTasks — producer-level filtering', () => {
   });
 
   it('does NOT skip paper-mail notification when feature is enabled', async () => {
-    mockFeatureFlags.mailingPaperStatementsEnabled = true;
+    Object.assign(FEATURE_FLAGS_CONFIG, { mailingPaperStatementsEnabled: true });
 
     const actions: OutreachAction[] = [
       makeAction({
@@ -169,7 +131,7 @@ describe('produceOutreachTasks — producer-level filtering', () => {
         sendNotificationConfig: { mediums: ['paper-mail'], smsTemplate: '', emailTemplate: '' },
       }),
     ];
-    mockParsePlanDefinitionToActions.mockReturnValue(actions);
+    vi.mocked(parsePlanDefinitionToActions).mockReturnValue(actions);
 
     const result = await produceOutreachTasks({
       triggerEvent: 'invoice-due',
@@ -184,7 +146,7 @@ describe('produceOutreachTasks — producer-level filtering', () => {
   });
 
   it('does NOT skip multi-medium notification that includes paper-mail when feature is disabled', async () => {
-    mockFeatureFlags.mailingPaperStatementsEnabled = false;
+    Object.assign(FEATURE_FLAGS_CONFIG, { mailingPaperStatementsEnabled: false });
 
     const actions: OutreachAction[] = [
       makeAction({
@@ -193,7 +155,7 @@ describe('produceOutreachTasks — producer-level filtering', () => {
         sendNotificationConfig: { mediums: ['sms', 'paper-mail'], smsTemplate: 'hi', emailTemplate: '' },
       }),
     ];
-    mockParsePlanDefinitionToActions.mockReturnValue(actions);
+    vi.mocked(parsePlanDefinitionToActions).mockReturnValue(actions);
 
     const result = await produceOutreachTasks({
       triggerEvent: 'invoice-due',

--- a/packages/zambdas/test/rcm/scheduled-outreach/produce-outreach-tasks.test.ts
+++ b/packages/zambdas/test/rcm/scheduled-outreach/produce-outreach-tasks.test.ts
@@ -1,6 +1,7 @@
 import { PlanDefinition } from 'fhir/r4b';
 import { DateTime } from 'luxon';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FEATURE_FLAGS_CONFIG } from 'utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildOutreachTaskIdentityQuery,
   buildTaskInput,
@@ -8,6 +9,10 @@ import {
   produceOutreachTasks,
 } from '../../../src/rcm/scheduled-outreach/producers/shared/produce-outreach-tasks';
 import type { OutreachAction } from '../../../src/rcm/scheduled-outreach-config/helpers';
+import { getPatchBinary } from '../../../src/shared/helpers';
+
+// FEATURE_FLAGS_CONFIG and getPatchBinary are canonical suite-wide mocks
+// (vitest.unit-mocks.setup.ts); per-file defaults are installed in beforeEach below.
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -34,39 +39,6 @@ const mockPatientWithValidContacts = {
     { system: 'email', value: 'test@example.com' },
   ],
 };
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    FEATURE_FLAGS_CONFIG: {
-      automatedPatientOutreachEnabled: true,
-      mailingPaperStatementsEnabled: true,
-    },
-  };
-});
-
-vi.mock('../../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-vi.mock('../../../src/shared/helpers', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    getPatchBinary: vi.fn(({ resourceId, resourceType, patchOperations }) => ({
-      method: 'PATCH',
-      url: `/${resourceType}/${resourceId}`,
-      resource: { resourceType: 'Binary', data: JSON.stringify(patchOperations) },
-    })),
-  };
-});
 
 function makePlanDefinition(actions: OutreachAction[]): PlanDefinition {
   return {
@@ -168,7 +140,24 @@ describe('produce-outreach-tasks', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+    Object.assign(FEATURE_FLAGS_CONFIG, {
+      automatedPatientOutreachEnabled: true,
+      mailingPaperStatementsEnabled: true,
+    });
+    vi.mocked(getPatchBinary).mockImplementation(
+      ({ resourceId, resourceType, patchOperations }) =>
+        ({
+          method: 'PATCH',
+          url: `/${resourceType}/${resourceId}`,
+          resource: { resourceType: 'Binary', data: JSON.stringify(patchOperations) },
+        }) as any
+    );
     mockGet.mockResolvedValue(mockPatientWithValidContacts);
+  });
+
+  afterEach(() => {
+    // Do not let a stubbed global fetch leak into other files under --no-isolate
+    vi.unstubAllGlobals();
   });
 
   describe('buildTaskInput', () => {

--- a/packages/zambdas/test/rcm/scheduled-outreach/producers.test.ts
+++ b/packages/zambdas/test/rcm/scheduled-outreach/producers.test.ts
@@ -1,14 +1,19 @@
 import { Encounter, Invoice } from 'fhir/r4b';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { produceDischargeOutreach } from '../../../src/rcm/scheduled-outreach/producers/shared/produce-discharge-outreach';
+import { produceInvoiceIssuedOutreach } from '../../../src/rcm/scheduled-outreach/producers/shared/produce-invoice-issued-outreach';
+import { produceOutreachTasks } from '../../../src/rcm/scheduled-outreach/producers/shared/produce-outreach-tasks';
+import {
+  getOrCreateOutreachConfig,
+  parsePlanDefinitionToActions,
+} from '../../../src/rcm/scheduled-outreach-config/helpers';
+
+// produceOutreachTasks, getOrCreateOutreachConfig, and parsePlanDefinitionToActions are canonical
+// suite-wide mocks (vitest.unit-mocks.setup.ts); per-file defaults are installed in beforeEach below.
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
-const mockProduceOutreachTasks = vi.fn();
-
-vi.mock('../../../src/rcm/scheduled-outreach/producers/shared/produce-outreach-tasks', () => ({
-  produceOutreachTasks: mockProduceOutreachTasks,
-  OUTREACH_TASK_TAG_SYSTEM: 'https://fhir.ottehr.com/r4/outreach-task',
-}));
+const mockProduceOutreachTasks = vi.mocked(produceOutreachTasks);
 
 const mockOystehr = {
   fhir: {
@@ -18,33 +23,25 @@ const mockOystehr = {
   },
 };
 
-vi.mock('../../../src/rcm/scheduled-outreach-config/helpers', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    getOrCreateOutreachConfig: vi
-      .fn()
-      .mockResolvedValue({ resourceType: 'PlanDefinition', id: 'plan-1', status: 'active', action: [] }),
-    parsePlanDefinitionToActions: vi.fn().mockReturnValue([]),
-  };
-});
-
 function defaultOutreachResult(): { created: never[]; skipped: never[] } {
   return { created: [], skipped: [] };
 }
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockProduceOutreachTasks.mockResolvedValue(defaultOutreachResult());
+  vi.mocked(getOrCreateOutreachConfig).mockResolvedValue({
+    resourceType: 'PlanDefinition',
+    id: 'plan-1',
+    status: 'active',
+    action: [],
+  });
+  vi.mocked(parsePlanDefinitionToActions).mockReturnValue([]);
+});
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe('produceDischargeOutreach', () => {
-  let produceDischargeOutreach: typeof import('../../../src/rcm/scheduled-outreach/producers/shared/produce-discharge-outreach').produceDischargeOutreach;
-
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    mockProduceOutreachTasks.mockResolvedValue(defaultOutreachResult());
-    const mod = await import('../../../src/rcm/scheduled-outreach/producers/shared/produce-discharge-outreach');
-    produceDischargeOutreach = mod.produceDischargeOutreach;
-  });
-
   it('fetches the encounter and produces tasks for both discharge-time and date-of-visit triggers', async () => {
     const encounter: Encounter = {
       resourceType: 'Encounter',
@@ -124,15 +121,6 @@ describe('produceDischargeOutreach', () => {
 });
 
 describe('produceInvoiceIssuedOutreach', () => {
-  let produceInvoiceIssuedOutreach: typeof import('../../../src/rcm/scheduled-outreach/producers/shared/produce-invoice-issued-outreach').produceInvoiceIssuedOutreach;
-
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    mockProduceOutreachTasks.mockResolvedValue(defaultOutreachResult());
-    const mod = await import('../../../src/rcm/scheduled-outreach/producers/shared/produce-invoice-issued-outreach');
-    produceInvoiceIssuedOutreach = mod.produceInvoiceIssuedOutreach;
-  });
-
   it('produces tasks for invoice-issued trigger', async () => {
     const invoice: Invoice = {
       resourceType: 'Invoice',

--- a/packages/zambdas/test/rcm/scheduled-outreach/task-management.test.ts
+++ b/packages/zambdas/test/rcm/scheduled-outreach/task-management.test.ts
@@ -1,7 +1,16 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { Task } from 'fhir/r4b';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { index as cancelOutreachTaskIndex } from '../../../src/rcm/scheduled-outreach/cancel-outreach-task/index';
+import { index as listOutreachTasksIndex } from '../../../src/rcm/scheduled-outreach/list-outreach-tasks/index';
+import { index as retryOutreachTaskIndex } from '../../../src/rcm/scheduled-outreach/retry-outreach-task/index';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../../src/shared';
 import type { ZambdaInput } from '../../../src/shared/types/common';
+
+// checkOrCreateM2MClientToken and createClinicalOystehrClient are canonical suite-wide mocks
+// (vitest.unit-mocks.setup.ts); per-file defaults are installed in beforeEach below.
+// The REAL wrapHandler now wraps the handlers, so thrown API errors surface as an
+// error envelope (statusCode + JSON body) instead of a rejected promise.
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -20,19 +29,15 @@ const mockOystehrClient = {
   },
 };
 
-vi.mock('../../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+  vi.mocked(createClinicalOystehrClient).mockReturnValue(mockOystehrClient as any);
 });
 
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
-const testSecrets = { test: 'secret' };
+const testSecrets = { test: 'secret', ENVIRONMENT: 'local' };
 
 function makeInput(body: Record<string, unknown>): ZambdaInput {
   return { headers: null, body: JSON.stringify(body), secrets: testSecrets };
@@ -41,13 +46,7 @@ function makeInput(body: Record<string, unknown>): ZambdaInput {
 // ── cancel-outreach-task ──────────────────────────────────────────────────
 
 describe('cancel-outreach-task', () => {
-  let handler: ZambdaHandler;
-
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    const mod = await import('../../../src/rcm/scheduled-outreach/cancel-outreach-task/index');
-    handler = mod.index as ZambdaHandler;
-  });
+  const handler = cancelOutreachTaskIndex as unknown as ZambdaHandler;
 
   it('cancels a draft task', async () => {
     const task: Task = {
@@ -129,11 +128,16 @@ describe('cancel-outreach-task', () => {
     expect(result.statusCode).toBe(400);
   });
 
-  it('throws when taskId is missing', async () => {
-    await expect(handler(makeInput({}))).rejects.toThrow();
+  it('returns a 400 error envelope when taskId is missing', async () => {
+    // MISSING_REQUIRED_PARAMETERS is an API error; the real wrapHandler turns it into a 400 response
+    const result = await handler(makeInput({}));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).message).toContain('taskId');
   });
 
   it('throws when secrets are missing', async () => {
+    // configSentry reads the ENVIRONMENT secret before the top-level catch,
+    // so a null-secrets invocation still rejects.
     await expect(handler({ headers: null, body: JSON.stringify({ taskId: 'x' }), secrets: null })).rejects.toThrow();
   });
 });
@@ -141,13 +145,7 @@ describe('cancel-outreach-task', () => {
 // ── retry-outreach-task ──────────────────────────────────────────────────
 
 describe('retry-outreach-task', () => {
-  let handler: ZambdaHandler;
-
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    const mod = await import('../../../src/rcm/scheduled-outreach/retry-outreach-task/index');
-    handler = mod.index as ZambdaHandler;
-  });
+  const handler = retryOutreachTaskIndex as unknown as ZambdaHandler;
 
   const outreachTag = { system: 'https://fhir.zapehr.com/r4/StructureDefinitions/outreach-task', code: 'invoice-due' };
 
@@ -258,21 +256,20 @@ describe('retry-outreach-task', () => {
     expect(result.statusCode).toBe(400);
   });
 
-  it('throws when taskId is missing', async () => {
-    await expect(handler(makeInput({}))).rejects.toThrow();
+  it('returns a 400 error envelope when taskId is missing', async () => {
+    const result = await handler(makeInput({}));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).message).toContain('taskId');
   });
 });
 
 // ── list-outreach-tasks ──────────────────────────────────────────────────
 
 describe('list-outreach-tasks', () => {
-  let handler: ZambdaHandler;
+  const handler = listOutreachTasksIndex as unknown as ZambdaHandler;
 
-  beforeEach(async () => {
-    vi.clearAllMocks();
+  beforeEach(() => {
     mockSearch.mockReset();
-    const mod = await import('../../../src/rcm/scheduled-outreach/list-outreach-tasks/index');
-    handler = mod.index as ZambdaHandler;
   });
 
   function mockBundle(resources: any[], total?: number): { unbundle: () => any[]; total: number; link: never[] } {

--- a/packages/zambdas/test/sub-harvest-paperwork-page.test.ts
+++ b/packages/zambdas/test/sub-harvest-paperwork-page.test.ts
@@ -1,6 +1,18 @@
 import { Task } from 'fhir/r4b';
-import { pageHarvestStrategy, TASK_INPUT_TYPE_CODES, TASK_INPUT_TYPE_SYSTEM } from 'utils';
-import { describe, expect, it, vi } from 'vitest';
+import { getRelatedPersonForPatient, pageHarvestStrategy, TASK_INPUT_TYPE_CODES, TASK_INPUT_TYPE_SYSTEM } from 'utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createConsentResources,
+  createDocumentResources,
+  createErxContactOperation,
+  createMasterRecordPatchOperations,
+  createUpdatePharmacyPatchOps,
+  getAccountAndCoverageResourcesForPatient,
+  makeEncounterAccountPatchOp,
+  mergeEncounterAccounts,
+  updatePatientAccountFromQuestionnaire,
+} from '../src/ehr/shared/harvest';
+import { getAuth0Token } from '../src/shared';
 import { extractPatchIndex, extractQrId } from '../src/subscriptions/task/sub-harvest-paperwork/index';
 import {
   executePageHarvest,
@@ -8,35 +20,25 @@ import {
   strategyHandlers,
 } from '../src/subscriptions/task/sub-harvest-paperwork/page-handlers';
 
-// Mock the harvest module so strategy handlers don't make real FHIR calls
-vi.mock('../src/ehr/shared/harvest', () => ({
-  createMasterRecordPatchOperations: vi.fn(() => ({
+// The harvest module, getRelatedPersonForPatient, and getAuth0Token are canonical suite-wide
+// mocks (vitest.unit-mocks.setup.ts); stub them so strategy handlers make no real FHIR calls.
+beforeEach(() => {
+  vi.mocked(createMasterRecordPatchOperations).mockReturnValue({
     patient: { patchOpsForDirectUpdate: [] },
-  })),
-  createUpdatePharmacyPatchOps: vi.fn(() => []),
-  updatePatientAccountFromQuestionnaire: vi.fn(async () => {}),
-  getAccountAndCoverageResourcesForPatient: vi.fn(async () => ({ account: undefined, workersCompAccount: undefined })),
-  createDocumentResources: vi.fn(async () => {}),
-  createConsentResources: vi.fn(async () => {}),
-  createErxContactOperation: vi.fn(() => null),
-  mergeEncounterAccounts: vi.fn(() => ({ accounts: undefined, changed: false })),
-  makeEncounterAccountPatchOp: vi.fn(() => []),
-}));
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('utils')>();
-  return {
-    ...actual,
-    getRelatedPersonForPatient: vi.fn(async () => null),
-  };
-});
-
-vi.mock('../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../src/shared')>();
-  return {
-    ...actual,
-    getAuth0Token: vi.fn(async () => 'mock-token'),
-  };
+  } as never);
+  vi.mocked(createUpdatePharmacyPatchOps).mockReturnValue([] as never);
+  vi.mocked(updatePatientAccountFromQuestionnaire).mockResolvedValue(undefined as never);
+  vi.mocked(getAccountAndCoverageResourcesForPatient).mockResolvedValue({
+    account: undefined,
+    workersCompAccount: undefined,
+  } as never);
+  vi.mocked(createDocumentResources).mockResolvedValue(undefined as never);
+  vi.mocked(createConsentResources).mockResolvedValue(undefined as never);
+  vi.mocked(createErxContactOperation).mockReturnValue(null as never);
+  vi.mocked(mergeEncounterAccounts).mockReturnValue({ accounts: undefined, changed: false } as never);
+  vi.mocked(makeEncounterAccountPatchOp).mockReturnValue([] as never);
+  vi.mocked(getRelatedPersonForPatient).mockResolvedValue(null as never);
+  vi.mocked(getAuth0Token).mockResolvedValue('mock-token');
 });
 
 // ── Helper: build a well-formed Task ──────────────────────────────────────

--- a/packages/zambdas/test/unit/billing/billing-stripe-webhook.test.ts
+++ b/packages/zambdas/test/unit/billing/billing-stripe-webhook.test.ts
@@ -4,20 +4,8 @@ import { Claim, Organization, PaymentNotice } from 'fhir/r4b';
 import Stripe from 'stripe';
 import { BILLING_RESOURCE_TAG, Secrets } from 'utils';
 import { ottehrIdentifierSystem } from 'utils/lib/fhir/systemUrls';
-import { afterEach, describe, expect, it, Mock, vi } from 'vitest';
-
-vi.mock('../../../src/shared', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  wrapHandler: (_name: string, handler: unknown) => handler,
-  checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('m2m-token'),
-  getStripeClient: vi.fn(),
-}));
-
-vi.mock('../../../src/billing/shared', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  createBillingClient: vi.fn(),
-}));
-
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+// src/shared and src/billing/shared are mocked suite-wide in vitest.unit-mocks.setup.ts.
 import { index, performEffect } from '../../../src/billing/billing-stripe-webhook';
 import { validateRequestParameters } from '../../../src/billing/billing-stripe-webhook/validateRequestParameters';
 import { createBillingClient } from '../../../src/billing/shared';
@@ -33,6 +21,7 @@ const CLAIM_ENC_SYSTEM = ottehrIdentifierSystem('claim-encounter-id');
 const stripe = new Stripe('sk_test_123');
 
 const secrets: Secrets = {
+  ENVIRONMENT: 'local',
   BILLING_INTEGRATION: 'all',
   STRIPE_SECRET_KEY: 'sk_test_123',
   STRIPE_PUBLIC_KEY: 'pk_test_123',
@@ -93,6 +82,10 @@ const signedInput = (event: Stripe.Event): ZambdaInput => {
   const signature = stripe.webhooks.generateTestHeaderString({ payload, secret: WEBHOOK_SECRET });
   return { body: payload, headers: { 'Stripe-Signature': signature }, secrets };
 };
+
+beforeEach(() => {
+  (checkOrCreateM2MClientToken as Mock).mockResolvedValue('m2m-token');
+});
 
 afterEach(() => {
   vi.clearAllMocks();

--- a/packages/zambdas/test/unit/billing/get-billing-claim-detail.test.ts
+++ b/packages/zambdas/test/unit/billing/get-billing-claim-detail.test.ts
@@ -7,17 +7,8 @@ import { fetchClaimEraLinks, fetchClaimResponsesByClaimIds } from '../../../src/
 import { performEffect } from '../../../src/billing/get-billing-claim-detail';
 import { fetchClaimGraph, resolvePayersByRef } from '../../../src/billing/shared';
 
-vi.mock('../../../src/billing/shared', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  fetchClaimGraph: vi.fn(),
-  resolvePayersByRef: vi.fn(),
-}));
-
-vi.mock('../../../src/billing/claim-amounts', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  fetchClaimResponsesByClaimIds: vi.fn(),
-  fetchClaimEraLinks: vi.fn(),
-}));
+// src/billing/shared and src/billing/claim-amounts are mocked suite-wide in
+// vitest.unit-mocks.setup.ts; behaviors are installed in beforeEach below.
 
 const CLAIM_ENC_SYSTEM = ottehrIdentifierSystem('claim-encounter-id');
 

--- a/packages/zambdas/test/unit/billing/get-billing-claim-history.test.ts
+++ b/packages/zambdas/test/unit/billing/get-billing-claim-history.test.ts
@@ -14,10 +14,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { performEffect } from '../../../src/billing/get-billing-claim-history';
 import { SOURCE_IDENTIFIER_SYSTEM } from '../../../src/billing/shared';
 
-vi.mock('@sentry/aws-serverless', async (importActual) => ({
-  ...(await importActual<typeof import('@sentry/aws-serverless')>()),
-  captureException: vi.fn(),
-}));
+// @sentry/aws-serverless is a canonical suite-wide mock (vitest.unit-mocks.setup.ts).
 const captureExceptionMock = vi.mocked(captureException);
 
 beforeEach(() => captureExceptionMock.mockClear());

--- a/packages/zambdas/test/unit/billing/get-billing-patient-balance.test.ts
+++ b/packages/zambdas/test/unit/billing/get-billing-patient-balance.test.ts
@@ -6,9 +6,8 @@ import { validateRequestParameters } from '../../../src/billing/get-billing-pati
 import { fetchAllActivePatientArClaims } from '../../../src/billing/search-billing-patient-ar-claims/handler';
 import { createMockSecrets, createMockZambdaInput } from '../validate-request-parameters/helpers';
 
-vi.mock('../../../src/billing/search-billing-patient-ar-claims/handler', () => ({
-  fetchAllActivePatientArClaims: vi.fn(),
-}));
+// src/billing/search-billing-patient-ar-claims/handler is mocked suite-wide in
+// vitest.unit-mocks.setup.ts.
 
 const oystehr = {} as unknown as Oystehr;
 

--- a/packages/zambdas/test/unit/billing/record-billing-manual-payment.test.ts
+++ b/packages/zambdas/test/unit/billing/record-billing-manual-payment.test.ts
@@ -5,24 +5,11 @@ import { Claim, Encounter, PaymentNotice, PaymentReconciliation } from 'fhir/r4b
 import { APIErrorCode, BILLING_RESOURCE_TAG, PAYMENT_METHOD_EXTENSION_URL, Secrets } from 'utils';
 import { ottehrIdentifierSystem } from 'utils/lib/fhir/systemUrls';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
-
-vi.mock('../../../src/shared', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  wrapHandler: (_name: string, handler: unknown) => handler,
-  checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('m2m-token'),
-  createClinicalOystehrClient: vi.fn(),
-  getUser: vi.fn(),
-}));
-
-vi.mock('../../../src/billing/shared', async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  createBillingClient: vi.fn(),
-}));
-
+// src/shared and src/billing/shared are mocked suite-wide in vitest.unit-mocks.setup.ts.
 import { CHECK_NUMBER_IDENTIFIER_SYSTEM, MANUAL_PAYMENT_IDEMPOTENCY_KEY_SYSTEM } from '../../../src/billing/payments';
 import { index as _index } from '../../../src/billing/record-billing-manual-payment';
 import { createBillingClient } from '../../../src/billing/shared';
-import { createClinicalOystehrClient, getUser, ZambdaInput } from '../../../src/shared';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient, getUser, ZambdaInput } from '../../../src/shared';
 
 const index = _index as unknown as (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
@@ -32,6 +19,7 @@ const OTHER_ENCOUNTER_ID = randomUUID();
 
 const secrets: Secrets = {
   DEFAULT_BILLING_RESOURCE: 'Organization/default-bp',
+  ENVIRONMENT: 'local',
 };
 
 const baseParams = {
@@ -130,6 +118,7 @@ describe('record-billing-manual-payment', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-22T12:00:00Z'));
     vi.clearAllMocks();
+    (checkOrCreateM2MClientToken as Mock).mockResolvedValue('m2m-token');
     (createClinicalOystehrClient as Mock).mockReturnValue(makeClinicalOystehr([encounter]));
     (getUser as Mock).mockResolvedValue({ profile: 'Practitioner/prac-1' });
   });
@@ -148,9 +137,10 @@ describe('record-billing-manual-payment', () => {
     const { oystehr, create } = makeBillingOystehr([]);
     (createBillingClient as Mock).mockReturnValue(oystehr);
 
-    await expect(index(makeInput({ ...baseParams, ...override }))).rejects.toMatchObject({
-      code: APIErrorCode.INVALID_INPUT,
-    });
+    // The real wrapHandler converts the thrown APIError into an error envelope.
+    const result = await index(makeInput({ ...baseParams, ...override }));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toMatchObject({ code: APIErrorCode.INVALID_INPUT });
     expect(create).not.toHaveBeenCalled();
   });
 
@@ -159,9 +149,9 @@ describe('record-billing-manual-payment', () => {
     const { oystehr, create } = makeBillingOystehr([]);
     (createBillingClient as Mock).mockReturnValue(oystehr);
 
-    await expect(index(makeInput(baseParams))).rejects.toMatchObject({
-      code: APIErrorCode.FHIR_RESOURCE_NOT_FOUND,
-    });
+    const result = await index(makeInput(baseParams));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toMatchObject({ code: APIErrorCode.FHIR_RESOURCE_NOT_FOUND });
     expect(create).not.toHaveBeenCalled();
   });
 
@@ -289,10 +279,9 @@ describe('record-billing-manual-payment', () => {
       create.mockResolvedValue(existing);
       (createBillingClient as Mock).mockReturnValue(oystehr);
 
-      await expect(index(makeInput(baseParams))).rejects.toMatchObject({
-        code: APIErrorCode.MANUAL_PAYMENT_CONFLICT,
-        statusCode: 409,
-      });
+      const result = await index(makeInput(baseParams));
+      expect(result.statusCode).toBe(409);
+      expect(JSON.parse(result.body)).toMatchObject({ code: APIErrorCode.MANUAL_PAYMENT_CONFLICT });
       expect(update).not.toHaveBeenCalled();
     }
   );

--- a/packages/zambdas/test/unit/billing/sub-patient-payment-billing-record.test.ts
+++ b/packages/zambdas/test/unit/billing/sub-patient-payment-billing-record.test.ts
@@ -1,62 +1,33 @@
 import { Encounter, PaymentNotice, Task } from 'fhir/r4b';
-import { PAYMENT_METHOD_EXTENSION_URL, Secrets } from 'utils';
+import {
+  getOrCreateCandidApiClient,
+  getStripeAccountForAppointmentOrEncounter,
+  PAYMENT_METHOD_EXTENSION_URL,
+  Secrets,
+} from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CLINICAL_PAYMENT_NOTICE_ID_SYSTEM, recordBillingPatientPayment } from '../../../src/billing/payments';
+import { createBillingClient } from '../../../src/billing/shared';
+import {
+  createClinicalOystehrClient,
+  createPatientPaymentReceiptPdf,
+  getAuth0Token,
+  getStripeClient,
+  performCandidPreEncounterSync,
+} from '../../../src/shared';
+import { patchTaskStatus } from '../../../src/subscriptions/helpers';
+import { index as _index } from '../../../src/subscriptions/task/sub-patient-payment-candid-sync-and-receipt/index';
+import { validateRequestParameters } from '../../../src/subscriptions/task/validateRequestParameters';
 
-const mockPerformCandidPreEncounterSync = vi.fn();
-const mockCreatePatientPaymentReceiptPdf = vi.fn();
-const mockRecordBillingPatientPayment = vi.fn();
-const mockPatchTaskStatus = vi.fn();
-const mockCreateClinicalOystehrClient = vi.fn();
-const mockGetStripeClient = vi.fn();
+// All shared-module mocks (src/shared, src/billing/*, src/subscriptions/*, utils, @sentry) are
+// registered suite-wide in vitest.unit-mocks.setup.ts; per-test behavior is installed below
+// via vi.mocked(...).
+
+const index = _index as unknown as (input: unknown) => Promise<{ statusCode: number; body: string }>;
 
 const mockFhirSearch = vi.fn();
 const mockOystehrClient = { fhir: { search: mockFhirSearch } };
 const mockStripeClient = { paymentIntents: { retrieve: vi.fn() } };
-
-vi.mock('../../../src/shared', async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  performCandidPreEncounterSync: mockPerformCandidPreEncounterSync,
-  createPatientPaymentReceiptPdf: mockCreatePatientPaymentReceiptPdf,
-  getAuth0Token: vi.fn().mockResolvedValue('test-token'),
-  createClinicalOystehrClient: mockCreateClinicalOystehrClient,
-  getStripeClient: mockGetStripeClient,
-  wrapHandler: (_name: string, handler: unknown) => handler,
-}));
-
-vi.mock('../../../src/billing/payments', async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  recordBillingPatientPayment: mockRecordBillingPatientPayment,
-}));
-
-vi.mock('../../../src/billing/shared', async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  createBillingClient: vi.fn().mockReturnValue({}),
-}));
-
-vi.mock('utils', async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  getStripeAccountForAppointmentOrEncounter: vi.fn().mockResolvedValue('acct_test'),
-  getOrCreateCandidApiClient: vi.fn().mockResolvedValue({}),
-}));
-
-vi.mock('../../../src/subscriptions/helpers', () => ({
-  patchTaskStatus: (...args: unknown[]) => mockPatchTaskStatus(...args),
-}));
-
-vi.mock('../../../src/subscriptions/task/validateRequestParameters', () => ({
-  validateRequestParameters: vi.fn(),
-}));
-
-vi.mock('@sentry/aws-serverless', () => ({
-  captureException: vi.fn(),
-}));
-
-const { validateRequestParameters } = await import('../../../src/subscriptions/task/validateRequestParameters');
-const { CLINICAL_PAYMENT_NOTICE_ID_SYSTEM } = await import('../../../src/billing/payments');
-const { index: _index } = await import(
-  '../../../src/subscriptions/task/sub-patient-payment-candid-sync-and-receipt/index'
-);
-const index = _index as unknown as (input: unknown) => Promise<{ statusCode: number; body: string }>;
 
 const STRIPE_PAYMENT_ID_SYSTEM = 'https://fhir.oystehr.com/PaymentIdSystem/stripe';
 
@@ -131,15 +102,23 @@ function setupFhirSearches(paymentNotice: PaymentNotice, encounter: Encounter): 
   });
 }
 
+// The real wrapHandler applies suite-wide; it reads the ENVIRONMENT secret from the
+// invocation input ('local' keeps error reporting inert).
+const zambdaInput = { headers: {}, body: '{}', secrets: { ENVIRONMENT: 'local' } };
+
 describe('sub-patient-payment-candid-sync-and-receipt: Ottehr billing record', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreateClinicalOystehrClient.mockReturnValue(mockOystehrClient);
-    mockGetStripeClient.mockReturnValue(mockStripeClient);
-    mockPerformCandidPreEncounterSync.mockResolvedValue(undefined);
-    mockCreatePatientPaymentReceiptPdf.mockResolvedValue({ url: 'https://example.com/receipt.pdf' });
-    mockRecordBillingPatientPayment.mockResolvedValue({ notice: { id: 'billing-pn-1' } });
-    mockPatchTaskStatus.mockResolvedValue({ status: 'completed', statusReason: { text: 'success' } });
+    vi.mocked(getAuth0Token).mockResolvedValue('test-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(mockOystehrClient as never);
+    vi.mocked(getStripeClient).mockReturnValue(mockStripeClient as never);
+    vi.mocked(performCandidPreEncounterSync).mockResolvedValue(undefined);
+    vi.mocked(createPatientPaymentReceiptPdf).mockResolvedValue({ url: 'https://example.com/receipt.pdf' } as never);
+    vi.mocked(recordBillingPatientPayment).mockResolvedValue({ notice: { id: 'billing-pn-1' } } as never);
+    vi.mocked(patchTaskStatus).mockResolvedValue({ status: 'completed', statusReason: { text: 'success' } } as never);
+    vi.mocked(createBillingClient).mockReturnValue({} as never);
+    vi.mocked(getStripeAccountForAppointmentOrEncounter).mockResolvedValue('acct_test');
+    vi.mocked(getOrCreateCandidApiClient).mockResolvedValue({} as never);
   });
 
   function setup(notice: PaymentNotice, encounterId: string, billingIntegration?: string): void {
@@ -153,11 +132,11 @@ describe('sub-patient-payment-candid-sync-and-receipt: Ottehr billing record', (
     const notice = makePaymentNotice({ id: 'pn-1', amountDollars: 25, encounterId: 'enc-1' });
     setup(notice, 'enc-1', 'ottehr');
 
-    const result = await index({ headers: {}, body: '{}', secrets: {} });
+    const result = await index(zambdaInput);
 
     expect(result.statusCode).toBe(200);
-    expect(mockRecordBillingPatientPayment).toHaveBeenCalledTimes(1);
-    expect(mockRecordBillingPatientPayment.mock.calls[0][1]).toMatchObject({
+    expect(recordBillingPatientPayment).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(recordBillingPatientPayment).mock.calls[0][1]).toMatchObject({
       encounterId: 'enc-1',
       amountInCents: 2500,
       paymentMethod: 'cash',
@@ -167,8 +146,8 @@ describe('sub-patient-payment-candid-sync-and-receipt: Ottehr billing record', (
       description: 'cash collected from patient',
       submitterRef: { reference: 'Practitioner/front-desk' },
     });
-    expect(mockPerformCandidPreEncounterSync).not.toHaveBeenCalled();
-    expect(mockPatchTaskStatus).toHaveBeenCalledWith(
+    expect(performCandidPreEncounterSync).not.toHaveBeenCalled();
+    expect(patchTaskStatus).toHaveBeenCalledWith(
       expect.objectContaining({ taskStatusToUpdate: 'completed' }),
       expect.anything()
     );
@@ -178,12 +157,12 @@ describe('sub-patient-payment-candid-sync-and-receipt: Ottehr billing record', (
     const notice = makePaymentNotice({ id: 'pn-2', amountDollars: 10, encounterId: 'enc-2' });
     setup(notice, 'enc-2', 'all');
 
-    await index({ headers: {}, body: '{}', secrets: {} });
+    await index(zambdaInput);
 
-    expect(mockRecordBillingPatientPayment).toHaveBeenCalledTimes(1);
-    expect(mockPerformCandidPreEncounterSync).toHaveBeenCalledTimes(1);
-    expect(mockRecordBillingPatientPayment.mock.invocationCallOrder[0]).toBeLessThan(
-      mockPerformCandidPreEncounterSync.mock.invocationCallOrder[0]
+    expect(recordBillingPatientPayment).toHaveBeenCalledTimes(1);
+    expect(performCandidPreEncounterSync).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(recordBillingPatientPayment).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(performCandidPreEncounterSync).mock.invocationCallOrder[0]
     );
   });
 
@@ -191,10 +170,10 @@ describe('sub-patient-payment-candid-sync-and-receipt: Ottehr billing record', (
     const notice = makePaymentNotice({ id: 'pn-3', amountDollars: 10, encounterId: 'enc-3' });
     setup(notice, 'enc-3', 'candid');
 
-    await index({ headers: {}, body: '{}', secrets: {} });
+    await index(zambdaInput);
 
-    expect(mockRecordBillingPatientPayment).not.toHaveBeenCalled();
-    expect(mockPerformCandidPreEncounterSync).toHaveBeenCalledTimes(1);
+    expect(recordBillingPatientPayment).not.toHaveBeenCalled();
+    expect(performCandidPreEncounterSync).toHaveBeenCalledTimes(1);
   });
 
   it('skips billing for Stripe-identified notices', async () => {
@@ -208,23 +187,23 @@ describe('sub-patient-payment-candid-sync-and-receipt: Ottehr billing record', (
     setup(notice, 'enc-4', 'all');
     mockStripeClient.paymentIntents.retrieve.mockResolvedValue({ id: 'pi_123', status: 'succeeded' });
 
-    await index({ headers: {}, body: '{}', secrets: {} });
+    await index(zambdaInput);
 
-    expect(mockRecordBillingPatientPayment).not.toHaveBeenCalled();
-    expect(mockPerformCandidPreEncounterSync).toHaveBeenCalledWith(expect.objectContaining({ amountCents: undefined }));
+    expect(recordBillingPatientPayment).not.toHaveBeenCalled();
+    expect(performCandidPreEncounterSync).toHaveBeenCalledWith(expect.objectContaining({ amountCents: undefined }));
   });
 
   it('skips candid and fails the task when the billing record fails, receipt still runs', async () => {
     const notice = makePaymentNotice({ id: 'pn-5', amountDollars: 20, encounterId: 'enc-5' });
     setup(notice, 'enc-5', 'all');
-    mockRecordBillingPatientPayment.mockRejectedValue(new Error('billing store down'));
+    vi.mocked(recordBillingPatientPayment).mockRejectedValue(new Error('billing store down'));
 
-    const result = await index({ headers: {}, body: '{}', secrets: {} });
+    const result = await index(zambdaInput);
 
     expect(result.statusCode).toBe(200);
-    expect(mockPerformCandidPreEncounterSync).not.toHaveBeenCalled();
-    expect(mockCreatePatientPaymentReceiptPdf).toHaveBeenCalledTimes(1);
-    const patch = mockPatchTaskStatus.mock.calls[0][0];
+    expect(performCandidPreEncounterSync).not.toHaveBeenCalled();
+    expect(createPatientPaymentReceiptPdf).toHaveBeenCalledTimes(1);
+    const patch = vi.mocked(patchTaskStatus).mock.calls[0][0];
     expect(patch.taskStatusToUpdate).toBe('failed');
     expect(patch.statusReasonToUpdate).toContain('Ottehr billing payment record failed');
     expect(patch.statusReasonToUpdate).toContain('Candid sync skipped');
@@ -234,9 +213,14 @@ describe('sub-patient-payment-candid-sync-and-receipt: Ottehr billing record', (
     const notice = makePaymentNotice({ id: 'pn-7', amountDollars: 10, encounterId: 'enc-other' });
     setup(notice, 'enc-7', 'ottehr');
 
-    await expect(index({ headers: {}, body: '{}', secrets: {} })).rejects.toThrow('expected Encounter/enc-7');
-    expect(mockRecordBillingPatientPayment).not.toHaveBeenCalled();
-    expect(mockPatchTaskStatus).toHaveBeenCalledWith(
+    // The real wrapHandler turns the thrown "references ..., expected Encounter/enc-7" error into
+    // a structured 500 response instead of rejecting.
+    const result = await index(zambdaInput);
+
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body)).toEqual({ error: 'Internal error' });
+    expect(recordBillingPatientPayment).not.toHaveBeenCalled();
+    expect(patchTaskStatus).toHaveBeenCalledWith(
       expect.objectContaining({ taskStatusToUpdate: 'failed' }),
       expect.anything()
     );
@@ -252,11 +236,11 @@ describe('sub-patient-payment-candid-sync-and-receipt: Ottehr billing record', (
     const notice = makePaymentNotice({ id: 'pn-8', amountDollars: 10, encounterId: 'enc-8', ...override });
     setup(notice, 'enc-8', 'ottehr');
 
-    const result = await index({ headers: {}, body: '{}', secrets: {} });
+    const result = await index(zambdaInput);
 
     expect(result.statusCode).toBe(200);
-    expect(mockRecordBillingPatientPayment).not.toHaveBeenCalled();
-    const patch = mockPatchTaskStatus.mock.calls[0][0];
+    expect(recordBillingPatientPayment).not.toHaveBeenCalled();
+    const patch = vi.mocked(patchTaskStatus).mock.calls[0][0];
     expect(patch.taskStatusToUpdate).toBe('failed');
     expect(patch.statusReasonToUpdate).toContain(reason);
   });
@@ -270,9 +254,9 @@ describe('sub-patient-payment-candid-sync-and-receipt: Ottehr billing record', (
     });
     setup(notice, 'enc-9', 'ottehr');
 
-    await index({ headers: {}, body: '{}', secrets: {} });
+    await index(zambdaInput);
 
-    expect(mockRecordBillingPatientPayment.mock.calls[0][1]).toMatchObject({
+    expect(vi.mocked(recordBillingPatientPayment).mock.calls[0][1]).toMatchObject({
       paymentDate: '2026-04-22',
       description: undefined,
       submitterRef: undefined,

--- a/packages/zambdas/test/unit/candid-pre-encounter-sync.test.ts
+++ b/packages/zambdas/test/unit/candid-pre-encounter-sync.test.ts
@@ -1,21 +1,17 @@
 import { ENCOUNTER_PAYMENT_VARIANT_EXTENSION_URL, PaymentVariant, SERVICE_CATEGORY_SYSTEM } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-// ── Mocks (hoisted before imports) ─────────────────────────────────────────────
-
-const mockGetAccountAndCoverageResourcesForPatient = vi.fn();
-
-vi.mock('../../src/ehr/shared/harvest', () => ({
-  getAccountAndCoverageResourcesForPatient: (...args: any[]) => mockGetAccountAndCoverageResourcesForPatient(...args),
-}));
-
-vi.mock('../../src/shared/chart-data', () => ({
-  chartDataResourceHasMetaTagByCode: vi.fn(),
-}));
-
 // ── Imports ────────────────────────────────────────────────────────────────────
-
+// src/ehr/shared/harvest (and src/shared/chart-data) are mocked suite-wide in
+// vitest.unit-mocks.setup.ts; performCandidPreEncounterSync delegates to the real
+// implementation, which is what this file tests.
 import { performCandidPreEncounterSync } from '../../src/shared/candid';
+
+// IMPORTANT: harvest must be imported AFTER candid. The real harvest module imports the
+// src/shared barrel (which re-exports candid), so if the harvest mock factory executes
+// first, vitest's mock-cycle guard hands the real candid module the RAW harvest module and
+// the vi.mocked(getAccountAndCoverageResourcesForPatient) overrides below go dead. A
+// dynamic import keeps this ordering safe from lint import sorting.
+const { getAccountAndCoverageResourcesForPatient } = await import('../../src/ehr/shared/harvest');
 
 // ── Mock helpers ───────────────────────────────────────────────────────────────
 
@@ -142,11 +138,11 @@ describe('performCandidPreEncounterSync – amountCents guard (real implementati
     mockOystehr = makeMockOystehr();
     mockCandidApiClient = makeMockCandidApiClient();
 
-    mockGetAccountAndCoverageResourcesForPatient.mockResolvedValue({
+    vi.mocked(getAccountAndCoverageResourcesForPatient).mockResolvedValue({
       coverages: {},
       insuranceOrgs: [],
       occupationalMedicineAccount: undefined,
-    });
+    } as any);
   });
 
   it('calls patientPayments.v4.create when amountCents > 0', async () => {
@@ -227,7 +223,7 @@ describe('performCandidPreEncounterSync – amountCents guard (real implementati
 
   it('creates only one Cash Pay coverage for self-pay encounters even when insurance coverages are present', async () => {
     mockOystehr = makeMockOystehr({ paymentVariant: PaymentVariant.selfPay });
-    mockGetAccountAndCoverageResourcesForPatient.mockResolvedValue({
+    vi.mocked(getAccountAndCoverageResourcesForPatient).mockResolvedValue({
       coverages: {
         primary: {
           payor: [{ reference: 'Organization/org-1' }],
@@ -251,7 +247,7 @@ describe('performCandidPreEncounterSync – amountCents guard (real implementati
         },
       ],
       occupationalMedicineAccount: undefined,
-    });
+    } as any);
 
     await performCandidPreEncounterSync({
       encounterId: ENCOUNTER_ID,
@@ -272,7 +268,7 @@ describe('performCandidPreEncounterSync – amountCents guard (real implementati
 
   it('syncs WC insurance (not Cash Pay) for workers-comp visit even when payment variant is selfPay', async () => {
     mockOystehr = makeMockOystehr({ paymentVariant: PaymentVariant.selfPay, serviceCategory: 'workers-comp' });
-    mockGetAccountAndCoverageResourcesForPatient.mockResolvedValue({
+    vi.mocked(getAccountAndCoverageResourcesForPatient).mockResolvedValue({
       coverages: {
         workersComp: {
           payor: [{ reference: 'Organization/wc-org-1' }],
@@ -295,7 +291,7 @@ describe('performCandidPreEncounterSync – amountCents guard (real implementati
         },
       ],
       occupationalMedicineAccount: undefined,
-    });
+    } as any);
 
     await performCandidPreEncounterSync({
       encounterId: ENCOUNTER_ID,

--- a/packages/zambdas/test/unit/candid-send-claim.test.ts
+++ b/packages/zambdas/test/unit/candid-send-claim.test.ts
@@ -1,15 +1,24 @@
-import { MISSING_REQUEST_SECRETS, RESOURCE_INCOMPLETE_FOR_OPERATION_ERROR } from 'utils';
+import { captureException, captureMessage } from '@sentry/aws-serverless';
+import { DiagnosisTypeCode } from 'candidhealth/api';
+import {
+  ACCIDENT_STATE_EXTENSION,
+  ACCIDENT_TYPE_SYSTEM,
+  getOrCreateCandidApiClient,
+  MISSING_REQUEST_SECRETS,
+  RESOURCE_INCOMPLETE_FOR_OPERATION_ERROR,
+} from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createClinicalOystehrClient, createEncounterFromAppointment, getAuth0Token } from '../../src/shared';
+import { buildRelatedCausesInformation, createCandidDiagnoses } from '../../src/shared/candid';
+import { getAppointmentAndRelatedResources } from '../../src/shared/pdf/visit-details-pdf/get-video-resources';
+import { index as _index } from '../../src/subscriptions/task/sub-send-claim/index';
+import { validateRequestParameters } from '../../src/subscriptions/task/validateRequestParameters';
 
-// ── Mocks ──────────────────────────────────────────────────────────────────────
+// All shared-module mocks (src/shared, utils, @sentry/aws-serverless, validateRequestParameters,
+// get-video-resources) are registered suite-wide in vitest.unit-mocks.setup.ts; per-test behavior
+// is installed below via vi.mocked(...).
 
-const mockCreateEncounterFromAppointment = vi.fn();
-const mockGetAuth0Token = vi.fn().mockResolvedValue('test-token');
-const mockCreateOystehrClient = vi.fn();
-// hoisted to avoid dependency issues
-const { mockGetOrCreateCandidApiClient } = vi.hoisted(() => ({
-  mockGetOrCreateCandidApiClient: vi.fn(),
-}));
+const index = _index as unknown as (input: any) => Promise<{ statusCode: number; body: string }>;
 
 const mockFhirPatch = vi.fn();
 const mockFhirSearch = vi.fn();
@@ -22,57 +31,6 @@ const mockOystehrClient = {
     create: vi.fn(),
   },
 };
-
-const mockGetAppointmentAndRelatedResources = vi.fn();
-
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    createEncounterFromAppointment: mockCreateEncounterFromAppointment,
-    getAuth0Token: mockGetAuth0Token,
-    createClinicalOystehrClient: mockCreateOystehrClient,
-    wrapHandler: (_name: string, handler: any) => handler,
-    CANDID_ENCOUNTER_ID_IDENTIFIER_SYSTEM: 'https://api.joincandidhealth.com/api/encounters/v4/response/encounter_id',
-  };
-});
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    getOrCreateCandidApiClient: mockGetOrCreateCandidApiClient,
-  };
-});
-
-vi.mock('../../src/subscriptions/task/validateRequestParameters', () => ({
-  validateRequestParameters: vi.fn(),
-}));
-
-vi.mock('../../src/shared/pdf/visit-details-pdf/get-video-resources', () => ({
-  getAppointmentAndRelatedResources: (...args: any[]) => mockGetAppointmentAndRelatedResources(...args),
-}));
-
-const { mockCaptureException, mockCaptureMessage } = vi.hoisted(() => ({
-  mockCaptureException: vi.fn(),
-  mockCaptureMessage: vi.fn(),
-}));
-
-vi.mock('@sentry/aws-serverless', () => ({
-  captureException: mockCaptureException,
-  captureMessage: mockCaptureMessage,
-}));
-
-// ── Imports (after mocks) ──────────────────────────────────────────────────────
-
-const { validateRequestParameters } = await import('../../src/subscriptions/task/validateRequestParameters');
-
-const { index: _index } = await import('../../src/subscriptions/task/sub-send-claim/index');
-const index = _index as unknown as (input: any) => Promise<{ statusCode: number; body: string }>;
-
-const { createCandidDiagnoses, buildRelatedCausesInformation } = await import('../../src/shared/candid');
-const { DiagnosisTypeCode } = await import('candidhealth/api');
-const { ACCIDENT_TYPE_SYSTEM, ACCIDENT_STATE_EXTENSION } = await import('utils');
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -131,22 +89,27 @@ function makeVisitResources(opts: {
   };
 }
 
+// The real wrapHandler applies suite-wide: it reads the ENVIRONMENT secret from the invocation
+// input. 'testing' (not 'local') so sendWarning still reaches captureMessage.
+const zambdaInput = { headers: {}, body: '{}', secrets: { ENVIRONMENT: 'testing' } };
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 describe('sub-send-claim', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreateOystehrClient.mockReturnValue(mockOystehrClient);
+    vi.mocked(getAuth0Token).mockResolvedValue('test-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(mockOystehrClient as any);
     mockFhirPatch.mockResolvedValue({ resourceType: 'Task', id: 'task-1', status: 'completed' });
     // candid is configured by default, tests override to skip when needed
-    mockGetOrCreateCandidApiClient.mockResolvedValue({} as any);
+    vi.mocked(getOrCreateCandidApiClient).mockResolvedValue({} as any);
   });
 
   it('creates a Candid encounter and patches FHIR Encounter with the Candid ID', async () => {
     setupValidatedParams('task-1', 'appt-1');
     const visitResources = makeVisitResources({ encounterId: 'enc-1' });
-    mockGetAppointmentAndRelatedResources.mockResolvedValue(visitResources);
-    mockCreateEncounterFromAppointment.mockResolvedValue('candid-enc-abc');
+    vi.mocked(getAppointmentAndRelatedResources).mockResolvedValue(visitResources);
+    vi.mocked(createEncounterFromAppointment).mockResolvedValue('candid-enc-abc');
     mockFhirPatch.mockResolvedValue({
       resourceType: 'Task',
       id: 'task-1',
@@ -154,10 +117,10 @@ describe('sub-send-claim', () => {
       statusReason: { coding: [{ code: 'claim sent successfully' }] },
     });
 
-    const result = await index({ headers: {}, body: '{}', secrets: {} });
+    const result = await index(zambdaInput);
 
     expect(result.statusCode).toBe(200);
-    expect(mockCreateEncounterFromAppointment).toHaveBeenCalledTimes(1);
+    expect(createEncounterFromAppointment).toHaveBeenCalledTimes(1);
 
     // Verify FHIR patch was called to add Candid encounter ID to the Encounter
     expect(mockFhirPatch).toHaveBeenCalledWith(
@@ -183,7 +146,7 @@ describe('sub-send-claim', () => {
       encounterId: 'enc-2',
       existingCandidEncounterId: 'candid-enc-already-exists',
     });
-    mockGetAppointmentAndRelatedResources.mockResolvedValue(visitResources);
+    vi.mocked(getAppointmentAndRelatedResources).mockResolvedValue(visitResources);
     mockFhirPatch.mockResolvedValue({
       resourceType: 'Task',
       id: 'task-2',
@@ -191,19 +154,19 @@ describe('sub-send-claim', () => {
       statusReason: { coding: [{ code: 'claim sent successfully' }] },
     });
 
-    const result = await index({ headers: {}, body: '{}', secrets: {} });
+    const result = await index(zambdaInput);
 
     expect(result.statusCode).toBe(200);
     // createEncounterFromAppointment should NOT be called
-    expect(mockCreateEncounterFromAppointment).not.toHaveBeenCalled();
+    expect(createEncounterFromAppointment).not.toHaveBeenCalled();
   });
 
   it('skips Candid when getOrCreateCandidApiClient rejects with MISSING_REQUEST_SECRETS', async () => {
-    mockGetOrCreateCandidApiClient.mockRejectedValueOnce(MISSING_REQUEST_SECRETS);
+    vi.mocked(getOrCreateCandidApiClient).mockRejectedValueOnce(MISSING_REQUEST_SECRETS);
 
     setupValidatedParams('task-3', 'appt-3');
     const visitResources = makeVisitResources({ encounterId: 'enc-3' });
-    mockGetAppointmentAndRelatedResources.mockResolvedValue(visitResources);
+    vi.mocked(getAppointmentAndRelatedResources).mockResolvedValue(visitResources);
     mockFhirPatch.mockResolvedValue({
       resourceType: 'Task',
       id: 'task-3',
@@ -211,17 +174,17 @@ describe('sub-send-claim', () => {
       statusReason: { coding: [{ code: 'claim sent successfully' }] },
     });
 
-    const result = await index({ headers: {}, body: '{}', secrets: {} });
+    const result = await index(zambdaInput);
 
     expect(result.statusCode).toBe(200);
-    expect(mockCreateEncounterFromAppointment).not.toHaveBeenCalled();
+    expect(createEncounterFromAppointment).not.toHaveBeenCalled();
   });
 
   it('uses /identifier (array) when encounter has no existing identifiers', async () => {
     setupValidatedParams('task-4', 'appt-4');
     const visitResources = makeVisitResources({ encounterId: 'enc-4', hasIdentifiers: false });
-    mockGetAppointmentAndRelatedResources.mockResolvedValue(visitResources);
-    mockCreateEncounterFromAppointment.mockResolvedValue('candid-enc-new');
+    vi.mocked(getAppointmentAndRelatedResources).mockResolvedValue(visitResources);
+    vi.mocked(createEncounterFromAppointment).mockResolvedValue('candid-enc-new');
     mockFhirPatch.mockResolvedValue({
       resourceType: 'Task',
       id: 'task-4',
@@ -229,7 +192,7 @@ describe('sub-send-claim', () => {
       statusReason: { coding: [{ code: 'claim sent successfully' }] },
     });
 
-    await index({ headers: {}, body: '{}', secrets: {} });
+    await index(zambdaInput);
 
     // When encounter.identifier is undefined, patch uses /identifier with array value
     expect(mockFhirPatch).toHaveBeenCalledWith(
@@ -256,8 +219,8 @@ describe('sub-send-claim', () => {
     setupValidatedParams('task-5', 'appt-5');
     const visitResources = makeVisitResources({ encounterId: 'enc-5' });
     // encounter.identifier = [] (defined but empty)
-    mockGetAppointmentAndRelatedResources.mockResolvedValue(visitResources);
-    mockCreateEncounterFromAppointment.mockResolvedValue('candid-enc-append');
+    vi.mocked(getAppointmentAndRelatedResources).mockResolvedValue(visitResources);
+    vi.mocked(createEncounterFromAppointment).mockResolvedValue('candid-enc-append');
     mockFhirPatch.mockResolvedValue({
       resourceType: 'Task',
       id: 'task-5',
@@ -265,7 +228,7 @@ describe('sub-send-claim', () => {
       statusReason: { coding: [{ code: 'claim sent successfully' }] },
     });
 
-    await index({ headers: {}, body: '{}', secrets: {} });
+    await index(zambdaInput);
 
     // When encounter.identifier exists (even empty array), patch uses /identifier/-
     expect(mockFhirPatch).toHaveBeenCalledWith(
@@ -288,7 +251,7 @@ describe('sub-send-claim', () => {
       encounterId: 'enc-6',
       existingCandidEncounterId: 'already-done',
     });
-    mockGetAppointmentAndRelatedResources.mockResolvedValue(visitResources);
+    vi.mocked(getAppointmentAndRelatedResources).mockResolvedValue(visitResources);
     mockFhirPatch.mockResolvedValue({
       resourceType: 'Task',
       id: 'task-6',
@@ -296,7 +259,7 @@ describe('sub-send-claim', () => {
       statusReason: { coding: [{ system: 'status-reason', code: 'claim sent successfully' }] },
     });
 
-    const result = await index({ headers: {}, body: '{}', secrets: {} });
+    const result = await index(zambdaInput);
 
     expect(result.statusCode).toBe(200);
     // Task patch for status update to 'completed'
@@ -315,7 +278,7 @@ describe('sub-send-claim', () => {
     );
   });
 
-  it('throws when no appointment ID is found on task focus', async () => {
+  it('returns the error envelope when no appointment ID is found on task focus', async () => {
     vi.mocked(validateRequestParameters).mockReturnValue({
       task: {
         id: 'task-7',
@@ -330,35 +293,41 @@ describe('sub-send-claim', () => {
       secrets: {} as any,
     } as any);
 
-    await expect(index({ headers: {}, body: '{}', secrets: {} })).rejects.toThrow(
-      'no appointment ID found on task focus'
-    );
+    // The real wrapHandler turns the thrown "no appointment ID found on task focus" error into a
+    // structured 500 response instead of rejecting.
+    const result = await index(zambdaInput);
+
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body)).toEqual({ error: 'Internal error' });
   });
 
-  it('throws when visit resources are not found', async () => {
+  it('returns the error envelope when visit resources are not found', async () => {
     setupValidatedParams('task-8', 'appt-8');
-    mockGetAppointmentAndRelatedResources.mockResolvedValue(undefined);
+    vi.mocked(getAppointmentAndRelatedResources).mockResolvedValue(undefined);
 
-    await expect(index({ headers: {}, body: '{}', secrets: {} })).rejects.toThrow(
-      'Visit resources are not properly defined'
-    );
+    // The real wrapHandler turns the thrown "Visit resources are not properly defined" error into a
+    // structured 500 response instead of rejecting.
+    const result = await index(zambdaInput);
+
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body)).toEqual({ error: 'Internal error' });
   });
 
   it('fails the task without throwing when the claim can not be created (e.g. provider has no NPI)', async () => {
     // Missing data is not a bug, so the handler must not throw: throwing reports it to Sentry as an
     // exception. It goes out as a warning instead.
     setupValidatedParams('task-10', 'appt-10');
-    mockGetAppointmentAndRelatedResources.mockResolvedValue(makeVisitResources({ encounterId: 'enc-10' }));
-    mockCreateEncounterFromAppointment.mockRejectedValue(
+    vi.mocked(getAppointmentAndRelatedResources).mockResolvedValue(makeVisitResources({ encounterId: 'enc-10' }));
+    vi.mocked(createEncounterFromAppointment).mockRejectedValue(
       RESOURCE_INCOMPLETE_FOR_OPERATION_ERROR("Practitioner pract-1 has no NPI identifier, so a claim can't be created")
     );
 
-    const result = await index({ headers: {}, body: '{}', secrets: {} });
+    const result = await index(zambdaInput);
 
     expect(result.statusCode).toBe(400);
     expect(JSON.parse(result.body).message).toContain('has no NPI identifier');
-    expect(mockCaptureException).not.toHaveBeenCalled();
-    expect(mockCaptureMessage).toHaveBeenCalledWith(
+    expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).toHaveBeenCalledWith(
       'Claim could not be created because required data is missing',
       expect.objectContaining({
         level: 'warning',
@@ -383,8 +352,8 @@ describe('sub-send-claim', () => {
   it('handles null candidEncounterId from createEncounterFromAppointment (no patch ops)', async () => {
     setupValidatedParams('task-9', 'appt-9');
     const visitResources = makeVisitResources({ encounterId: 'enc-9' });
-    mockGetAppointmentAndRelatedResources.mockResolvedValue(visitResources);
-    mockCreateEncounterFromAppointment.mockResolvedValue(null);
+    vi.mocked(getAppointmentAndRelatedResources).mockResolvedValue(visitResources);
+    vi.mocked(createEncounterFromAppointment).mockResolvedValue(null);
     mockFhirPatch.mockResolvedValue({
       resourceType: 'Task',
       id: 'task-9',
@@ -392,7 +361,7 @@ describe('sub-send-claim', () => {
       statusReason: { coding: [{ code: 'claim sent successfully' }] },
     });
 
-    const result = await index({ headers: {}, body: '{}', secrets: {} });
+    const result = await index(zambdaInput);
 
     expect(result.statusCode).toBe(200);
     // The Encounter patch should still happen but with empty operations array

--- a/packages/zambdas/test/unit/candid-send-claim.test.ts
+++ b/packages/zambdas/test/unit/candid-send-claim.test.ts
@@ -349,11 +349,11 @@ describe('sub-send-claim', () => {
     );
   });
 
-  it('handles null candidEncounterId from createEncounterFromAppointment (no patch ops)', async () => {
+  it('handles a nullish candidEncounterId from createEncounterFromAppointment (no patch ops)', async () => {
     setupValidatedParams('task-9', 'appt-9');
     const visitResources = makeVisitResources({ encounterId: 'enc-9' });
     vi.mocked(getAppointmentAndRelatedResources).mockResolvedValue(visitResources);
-    vi.mocked(createEncounterFromAppointment).mockResolvedValue(null);
+    vi.mocked(createEncounterFromAppointment).mockResolvedValue(undefined);
     mockFhirPatch.mockResolvedValue({
       resourceType: 'Task',
       id: 'task-9',

--- a/packages/zambdas/test/unit/candid-sync.test.ts
+++ b/packages/zambdas/test/unit/candid-sync.test.ts
@@ -1,14 +1,27 @@
 import { Encounter, PaymentNotice } from 'fhir/r4b';
+import {
+  getOptionalSecret,
+  getOrCreateCandidApiClient,
+  getSecret,
+  getStripeAccountForAppointmentOrEncounter,
+} from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createClinicalOystehrClient,
+  createPatientPaymentReceiptPdf,
+  getAuth0Token,
+  getStripeClient,
+  performCandidPreEncounterSync,
+} from '../../src/shared';
+import { patchTaskStatus } from '../../src/subscriptions/helpers';
+import { index as _index } from '../../src/subscriptions/task/sub-patient-payment-candid-sync-and-receipt/index';
+import { validateRequestParameters } from '../../src/subscriptions/task/validateRequestParameters';
 
-// ── Mocks ──────────────────────────────────────────────────────────────────────
+// All shared-module mocks (src/shared, utils, subscriptions helpers/validateRequestParameters,
+// @sentry/aws-serverless) are registered suite-wide in vitest.unit-mocks.setup.ts; per-test
+// behavior is installed below via vi.mocked(...).
 
-const mockPerformCandidPreEncounterSync = vi.fn();
-const mockCreatePatientPaymentReceiptPdf = vi.fn();
-const mockGetAuth0Token = vi.fn().mockResolvedValue('test-token');
-const mockCreateOystehrClient = vi.fn();
-const mockGetStripeClient = vi.fn();
-const mockPatchTaskStatus = vi.fn();
+const index = _index as unknown as (input: any) => Promise<{ statusCode: number; body: string }>;
 
 const mockFhirSearch = vi.fn();
 const mockFhirGet = vi.fn();
@@ -29,56 +42,6 @@ const mockStripeClient = {
     retrieve: vi.fn(),
   },
 };
-
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    performCandidPreEncounterSync: mockPerformCandidPreEncounterSync,
-    createPatientPaymentReceiptPdf: mockCreatePatientPaymentReceiptPdf,
-    getAuth0Token: mockGetAuth0Token,
-    createClinicalOystehrClient: mockCreateOystehrClient,
-    getStripeClient: mockGetStripeClient,
-    wrapHandler: (_name: string, handler: any) => handler,
-    STRIPE_PAYMENT_ID_SYSTEM: 'https://fhir.oystehr.com/PaymentIdSystem/stripe',
-  };
-});
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    getStripeAccountForAppointmentOrEncounter: vi.fn().mockResolvedValue('acct_test'),
-    getOptionalSecret: vi.fn().mockReturnValue('candid-client-id-value'),
-    // tests don't drive real candid traffic, so any non-empty string is fine
-    getSecret: vi.fn().mockReturnValue('test-value'),
-    // stub to avoid reading the unmocked secret, skipping performCandidPreEncounterSync
-    getOrCreateCandidApiClient: vi.fn().mockResolvedValue({}),
-  };
-});
-
-vi.mock('../../src/subscriptions/helpers', () => ({
-  patchTaskStatus: (...args: any[]) => mockPatchTaskStatus(...args),
-}));
-
-vi.mock('../../src/subscriptions/task/validateRequestParameters', () => ({
-  validateRequestParameters: vi.fn(),
-}));
-
-vi.mock('@sentry/aws-serverless', () => ({
-  captureException: vi.fn(),
-}));
-
-// ── Imports (after mocks) ──────────────────────────────────────────────────────
-
-const { validateRequestParameters } = await import('../../src/subscriptions/task/validateRequestParameters');
-
-// The mock for wrapHandler makes `index` a plain async function (input) => result
-// so we cast to the simplified signature for test ergonomics.
-const { index: _index } = await import(
-  '../../src/subscriptions/task/sub-patient-payment-candid-sync-and-receipt/index'
-);
-const index = _index as unknown as (input: any) => Promise<{ statusCode: number; body: string }>;
 
 // ── Fixtures ───────────────────────────────────────────────────────────────────
 
@@ -116,11 +79,18 @@ const makeEncounter = (id: string, patientId: string): Encounter => ({
 describe('sub-patient-payment-candid-sync-and-receipt: Stripe payment skip logic', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreateOystehrClient.mockReturnValue(mockOystehrClient);
-    mockGetStripeClient.mockReturnValue(mockStripeClient);
-    mockPerformCandidPreEncounterSync.mockResolvedValue(undefined);
-    mockCreatePatientPaymentReceiptPdf.mockResolvedValue({ url: 'https://example.com/receipt.pdf' });
-    mockPatchTaskStatus.mockResolvedValue({ status: 'completed', statusReason: { text: 'success' } });
+    vi.mocked(getAuth0Token).mockResolvedValue('test-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(mockOystehrClient as any);
+    vi.mocked(getStripeClient).mockReturnValue(mockStripeClient as any);
+    vi.mocked(performCandidPreEncounterSync).mockResolvedValue(undefined);
+    vi.mocked(createPatientPaymentReceiptPdf).mockResolvedValue({ url: 'https://example.com/receipt.pdf' } as any);
+    vi.mocked(patchTaskStatus).mockResolvedValue({ status: 'completed', statusReason: { text: 'success' } } as any);
+    vi.mocked(getStripeAccountForAppointmentOrEncounter).mockResolvedValue('acct_test');
+    vi.mocked(getOptionalSecret).mockReturnValue('candid-client-id-value');
+    // tests don't drive real candid traffic, so any non-empty string is fine
+    vi.mocked(getSecret).mockReturnValue('test-value');
+    // stub to avoid reading the unmocked secret, skipping performCandidPreEncounterSync
+    vi.mocked(getOrCreateCandidApiClient).mockResolvedValue({} as any);
   });
 
   function setupValidatedParams(taskId: string, paymentNoticeId: string, encounterId: string): void {
@@ -168,7 +138,7 @@ describe('sub-patient-payment-candid-sync-and-receipt: Stripe payment skip logic
     const result = await index({ headers: {}, body: '{}', secrets: {} });
 
     expect(result.statusCode).toBe(200);
-    expect(mockPerformCandidPreEncounterSync).toHaveBeenCalledWith(
+    expect(performCandidPreEncounterSync).toHaveBeenCalledWith(
       expect.objectContaining({
         encounterId: 'enc-100',
         amountCents: 2500, // $25.00 = 2500 cents
@@ -192,7 +162,7 @@ describe('sub-patient-payment-candid-sync-and-receipt: Stripe payment skip logic
     const result = await index({ headers: {}, body: '{}', secrets: {} });
 
     expect(result.statusCode).toBe(200);
-    expect(mockPerformCandidPreEncounterSync).toHaveBeenCalledWith(
+    expect(performCandidPreEncounterSync).toHaveBeenCalledWith(
       expect.objectContaining({
         encounterId: 'enc-200',
         amountCents: undefined, // Stripe payment → do NOT record in Candid
@@ -216,8 +186,8 @@ describe('sub-patient-payment-candid-sync-and-receipt: Stripe payment skip logic
     await index({ headers: {}, body: '{}', secrets: {} });
 
     // Sync is always called, even for Stripe — only the payment amount is skipped
-    expect(mockPerformCandidPreEncounterSync).toHaveBeenCalledTimes(1);
-    expect(mockPerformCandidPreEncounterSync).toHaveBeenCalledWith(
+    expect(performCandidPreEncounterSync).toHaveBeenCalledTimes(1);
+    expect(performCandidPreEncounterSync).toHaveBeenCalledWith(
       expect.objectContaining({
         encounterId: 'enc-300',
         candidApiClient: expect.anything(),
@@ -239,7 +209,7 @@ describe('sub-patient-payment-candid-sync-and-receipt: Stripe payment skip logic
     const result = await index({ headers: {}, body: '{}', secrets: {} });
 
     expect(result.statusCode).toBe(200);
-    expect(mockPerformCandidPreEncounterSync).toHaveBeenCalledWith(
+    expect(performCandidPreEncounterSync).toHaveBeenCalledWith(
       expect.objectContaining({
         amountCents: 1500, // $15.00 = 1500 cents
       })
@@ -262,7 +232,7 @@ describe('sub-patient-payment-candid-sync-and-receipt: Stripe payment skip logic
     const result = await index({ headers: {}, body: '{}', secrets: {} });
 
     expect(result.statusCode).toBe(200);
-    expect(mockPerformCandidPreEncounterSync).toHaveBeenCalledWith(
+    expect(performCandidPreEncounterSync).toHaveBeenCalledWith(
       expect.objectContaining({
         amountCents: undefined, // Terminal/card-reader payment → skip Candid
       })
@@ -279,13 +249,16 @@ describe('sub-patient-payment-candid-sync-and-receipt: Stripe payment skip logic
 
     setupValidatedParams('task-6', 'pn-fail-1', 'enc-600');
     setupFhirSearches(paymentNotice, encounter);
-    mockPerformCandidPreEncounterSync.mockRejectedValue(new Error('Candid API down'));
-    mockPatchTaskStatus.mockResolvedValue({ status: 'failed', statusReason: { text: 'Candid sync failed' } });
+    vi.mocked(performCandidPreEncounterSync).mockRejectedValue(new Error('Candid API down'));
+    vi.mocked(patchTaskStatus).mockResolvedValue({
+      status: 'failed',
+      statusReason: { text: 'Candid sync failed' },
+    } as any);
 
     const result = await index({ headers: {}, body: '{}', secrets: {} });
 
     expect(result.statusCode).toBe(200);
-    expect(mockPatchTaskStatus).toHaveBeenCalledWith(
+    expect(patchTaskStatus).toHaveBeenCalledWith(
       expect.objectContaining({
         taskStatusToUpdate: 'failed',
       }),
@@ -306,7 +279,7 @@ describe('sub-patient-payment-candid-sync-and-receipt: Stripe payment skip logic
 
     await index({ headers: {}, body: '{}', secrets: {} });
 
-    expect(mockPerformCandidPreEncounterSync).toHaveBeenCalledWith(
+    expect(performCandidPreEncounterSync).toHaveBeenCalledWith(
       expect.objectContaining({
         amountCents: 1299,
       })
@@ -327,7 +300,7 @@ describe('sub-patient-payment-candid-sync-and-receipt: Stripe payment skip logic
     await index({ headers: {}, body: '{}', secrets: {} });
 
     // $0 cash payment → amountCents = 0, still passed (performCandidPreEncounterSync handles falsy check)
-    expect(mockPerformCandidPreEncounterSync).toHaveBeenCalledWith(
+    expect(performCandidPreEncounterSync).toHaveBeenCalledWith(
       expect.objectContaining({
         amountCents: 0,
       })

--- a/packages/zambdas/test/unit/cleanup-invoice-exports.test.ts
+++ b/packages/zambdas/test/unit/cleanup-invoice-exports.test.ts
@@ -3,12 +3,15 @@ import { Task as FhirTask } from 'fhir/r4b';
 import { DateTime } from 'luxon';
 import { EXPORT_CSV_OUTPUT_URL_CODE, EXPORT_INVOICES_CSV_TASK_SYSTEM } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { index } from '../../src/cron/cleanup-invoice-exports/index';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 function makeInput(): ZambdaInput {
-  return { headers: null, body: null, secrets: { PROJECT_ID: 'test-project' } };
+  return { headers: null, body: null, secrets: { PROJECT_ID: 'test-project', ENVIRONMENT: 'local' } };
 }
 
+// src/shared is mocked suite-wide in vitest.unit-mocks.setup.ts.
 const mockOystehrClient = {
   fhir: {
     search: vi.fn(),
@@ -19,19 +22,9 @@ const mockOystehrClient = {
   },
 };
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
-let handler!: ZambdaHandler;
+const handler = index as unknown as ZambdaHandler;
 
 const BUCKET_NAME = 'test-project-invoiceable-patients-reports';
 const Z3_BASE_URL = `https://api.example.com/z3/${BUCKET_NAME}`;
@@ -60,12 +53,10 @@ function makeCompletedTask(id: string, lastUpdated: string, objectPath?: string)
 }
 
 describe('cleanup-invoice-exports', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
-    ({ index: handler } = (await import('../../src/cron/cleanup-invoice-exports/index')) as {
-      index: ZambdaHandler;
-    });
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(mockOystehrClient as never);
   });
 
   it('deletes Z3 files and Tasks older than 10 minutes', async () => {

--- a/packages/zambdas/test/unit/create-billing-invoices-tasks.test.ts
+++ b/packages/zambdas/test/unit/create-billing-invoices-tasks.test.ts
@@ -1,7 +1,13 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { PatientArClaimItem } from 'utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchAllActivePatientArClaims } from '../../src/billing/search-billing-patient-ar-claims/handler';
+import { createBillingClient } from '../../src/billing/shared';
+import { index } from '../../src/cron/create-billing-invoices-tasks/index';
+import { checkOrCreateM2MClientToken } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
+
+// Shared modules (src/shared, src/billing/*) are mocked suite-wide in vitest.unit-mocks.setup.ts.
 
 const mockZambdaExecute = vi.fn();
 const mockBillingClient = {
@@ -9,28 +15,11 @@ const mockBillingClient = {
     execute: (...args: unknown[]) => mockZambdaExecute(...args),
   },
 };
-const mockFetchAllActivePatientArClaims = vi.fn();
-
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-vi.mock('../../src/billing/shared', () => ({
-  createBillingClient: () => mockBillingClient,
-}));
-
-vi.mock('../../src/billing/search-billing-patient-ar-claims/handler', () => ({
-  fetchAllActivePatientArClaims: (...args: unknown[]) => mockFetchAllActivePatientArClaims(...args),
-}));
 
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
-let handler!: ZambdaHandler;
+const handler = index as unknown as ZambdaHandler;
+
 let warnSpy!: ReturnType<typeof vi.spyOn>;
 
 const arItem = (overrides: Partial<PatientArClaimItem> = {}): PatientArClaimItem => ({
@@ -52,7 +41,7 @@ const arItem = (overrides: Partial<PatientArClaimItem> = {}): PatientArClaimItem
   ...overrides,
 });
 
-const secrets = { BILLING_INTEGRATION: 'ottehr' };
+const secrets = { BILLING_INTEGRATION: 'ottehr', ENVIRONMENT: 'local' };
 
 const runHandler = (): Promise<APIGatewayProxyResult> =>
   handler({
@@ -62,13 +51,11 @@ const runHandler = (): Promise<APIGatewayProxyResult> =>
   });
 
 describe('create-billing-invoices-tasks', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    ({ index: handler } = (await import('../../src/cron/create-billing-invoices-tasks/index')) as unknown as {
-      index: ZambdaHandler;
-    });
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createBillingClient).mockReturnValue(mockBillingClient as never);
   });
 
   afterEach(() => {
@@ -81,17 +68,18 @@ describe('create-billing-invoices-tasks', () => {
       body: null,
       secrets: {
         BILLING_INTEGRATION: 'candid',
+        ENVIRONMENT: 'local',
       },
     });
 
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body).message).toContain('disabled');
-    expect(mockFetchAllActivePatientArClaims).not.toHaveBeenCalled();
+    expect(fetchAllActivePatientArClaims).not.toHaveBeenCalled();
     expect(mockZambdaExecute).not.toHaveBeenCalled();
   });
 
   it('forwards linked active AR claims to the clinical endpoint', async () => {
-    mockFetchAllActivePatientArClaims.mockResolvedValue([arItem()]);
+    vi.mocked(fetchAllActivePatientArClaims).mockResolvedValue([arItem()]);
     mockZambdaExecute.mockResolvedValue({
       output: {
         created: 1,
@@ -102,7 +90,7 @@ describe('create-billing-invoices-tasks', () => {
     const result = await runHandler();
     expect(result.statusCode).toBe(200);
 
-    expect(mockFetchAllActivePatientArClaims).toHaveBeenCalledWith(mockBillingClient);
+    expect(fetchAllActivePatientArClaims).toHaveBeenCalledWith(mockBillingClient);
     expect(mockZambdaExecute).toHaveBeenCalledWith({
       id: 'create-invoice-tasks-for-billing-claims',
       claims: [
@@ -121,7 +109,7 @@ describe('create-billing-invoices-tasks', () => {
   });
 
   it('drops claims without encounter linkage and does not call the endpoint when none remain', async () => {
-    mockFetchAllActivePatientArClaims.mockResolvedValue([
+    vi.mocked(fetchAllActivePatientArClaims).mockResolvedValue([
       arItem({
         claimId: 'claim-unlinked',
         encounterId: null,
@@ -136,7 +124,7 @@ describe('create-billing-invoices-tasks', () => {
   });
 
   it('forwards every linked claim from a single fetch', async () => {
-    mockFetchAllActivePatientArClaims.mockResolvedValue([
+    vi.mocked(fetchAllActivePatientArClaims).mockResolvedValue([
       arItem({
         claimId: 'claim-1',
         encounterId: 'enc-1',
@@ -155,7 +143,7 @@ describe('create-billing-invoices-tasks', () => {
 
     await runHandler();
 
-    expect(mockFetchAllActivePatientArClaims).toHaveBeenCalledTimes(1);
+    expect(fetchAllActivePatientArClaims).toHaveBeenCalledTimes(1);
     expect(mockZambdaExecute).toHaveBeenCalledTimes(1);
     const call = mockZambdaExecute.mock.calls[0][0] as { claims: { claimId: string }[] };
     expect(call.claims.map((c) => c.claimId)).toEqual(['claim-1', 'claim-2']);

--- a/packages/zambdas/test/unit/create-invoice-tasks-for-billing-claims.test.ts
+++ b/packages/zambdas/test/unit/create-invoice-tasks-for-billing-claims.test.ts
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/aws-serverless';
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { Bundle, Encounter, Task } from 'fhir/r4b';
 import {
@@ -8,7 +9,13 @@ import {
   RcmTaskCodings,
 } from 'utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { index } from '../../src/ehr/create-invoice-tasks-for-billing-claims/index';
+import { getOrCreateInvoicingConfig, parseInvoicingConfig } from '../../src/rcm/invoice-config/helpers';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
+
+// Shared modules (src/shared, invoice-config helpers, @sentry/aws-serverless) are mocked
+// suite-wide in vitest.unit-mocks.setup.ts; defaults are re-established in beforeEach below.
 
 const CLAIM_1 = '11111111-1111-4111-8111-111111111111';
 const CLAIM_2 = '22222222-2222-4222-8222-222222222222';
@@ -24,34 +31,11 @@ const mockClinicalClient = {
     create: vi.fn(),
   },
 };
-const mockCaptureException = vi.fn();
-
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: () => mockClinicalClient,
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-vi.mock('../../src/rcm/invoice-config/helpers', () => ({
-  getOrCreateInvoicingConfig: vi.fn().mockResolvedValue({ questionnaireResponse: {} }),
-  parseInvoicingConfig: () => ({
-    dueDaysFromGeneration: 30,
-    defaultSmsTemplate: 'sms template',
-    defaultInvoiceMemo: 'memo template',
-  }),
-}));
-
-vi.mock('@sentry/aws-serverless', () => ({
-  captureException: (...args: unknown[]) => mockCaptureException(...args),
-}));
 
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
-let handler!: ZambdaHandler;
+const handler = index as unknown as ZambdaHandler;
+
 let warnSpy!: ReturnType<typeof vi.spyOn>;
 
 const claimInput = (overrides: Partial<BillingInvoiceTaskClaim> = {}): BillingInvoiceTaskClaim => ({
@@ -117,23 +101,27 @@ const runHandler = (claims: BillingInvoiceTaskClaim[]): Promise<APIGatewayProxyR
   handler({
     headers: null,
     body: JSON.stringify({ claims }),
-    secrets: {},
+    secrets: { ENVIRONMENT: 'local' },
   });
 
 describe('create-invoice-tasks-for-billing-claims', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(mockClinicalClient as never);
+    vi.mocked(getOrCreateInvoicingConfig).mockResolvedValue({ questionnaireResponse: {} } as never);
+    vi.mocked(parseInvoicingConfig).mockReturnValue({
+      dueDaysFromGeneration: 30,
+      defaultSmsTemplate: 'sms template',
+      defaultInvoiceMemo: 'memo template',
+    });
     mockClinicalClient.fhir.create.mockImplementation((task: Task) =>
       Promise.resolve({
         ...task,
         id: 'created-1',
       })
     );
-    ({ index: handler } = (await import('../../src/ehr/create-invoice-tasks-for-billing-claims/index')) as unknown as {
-      index: ZambdaHandler;
-    });
   });
 
   afterEach(() => {
@@ -211,7 +199,7 @@ describe('create-invoice-tasks-for-billing-claims', () => {
 
     expect(JSON.parse(result.body)).toEqual({ created: 0, skipped: 1 });
     expect(mockClinicalClient.fhir.create).not.toHaveBeenCalled();
-    expect(mockCaptureException).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
   });
 
   it('warns naming the candid source when a legacy candid task blocks the encounter', async () => {

--- a/packages/zambdas/test/unit/create-invoices-tasks-gating.test.ts
+++ b/packages/zambdas/test/unit/create-invoices-tasks-gating.test.ts
@@ -1,30 +1,20 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { index } from '../../src/cron/create-invoices-tasks/index';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
-const mockCreateClinicalOystehrClient = vi.fn();
-
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: (...args: unknown[]) => mockCreateClinicalOystehrClient(...args),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
+// src/shared is mocked suite-wide in vitest.unit-mocks.setup.ts.
 
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
-let handler!: ZambdaHandler;
+const handler = index as unknown as ZambdaHandler;
 
 describe('create-invoices-tasks gating', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
-    ({ index: handler } = (await import('../../src/cron/create-invoices-tasks/index')) as unknown as {
-      index: ZambdaHandler;
-    });
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockImplementation(() => undefined as never);
   });
 
   it('skips without touching FHIR or Candid when the env is ottehr-only', async () => {
@@ -33,11 +23,12 @@ describe('create-invoices-tasks gating', () => {
       body: null,
       secrets: {
         BILLING_INTEGRATION: 'ottehr',
+        ENVIRONMENT: 'local',
       },
     });
 
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body).message).toContain('disabled');
-    expect(mockCreateClinicalOystehrClient).not.toHaveBeenCalled();
+    expect(createClinicalOystehrClient).not.toHaveBeenCalled();
   });
 });

--- a/packages/zambdas/test/unit/create-invoices-tasks.test.ts
+++ b/packages/zambdas/test/unit/create-invoices-tasks.test.ts
@@ -6,13 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createTaskForEncounter } from '../../src/cron/create-invoices-tasks/index';
 import type { ParsedInvoicingConfig } from '../../src/rcm/invoice-config/helpers';
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
+// src/shared (incl. wrapHandler) is mocked suite-wide in vitest.unit-mocks.setup.ts.
 
 const config: ParsedInvoicingConfig = {
   dueDaysFromGeneration: 30,

--- a/packages/zambdas/test/unit/export-invoices.test.ts
+++ b/packages/zambdas/test/unit/export-invoices.test.ts
@@ -2,10 +2,15 @@ import type { APIGatewayProxyResult } from 'aws-lambda';
 import { Task as FhirTask } from 'fhir/r4b';
 import { EXPORT_CSV_OUTPUT_URL_CODE, EXPORT_INVOICES_CSV_TASK_CODE, EXPORT_INVOICES_CSV_TASK_SYSTEM } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { index } from '../../src/ehr/export-invoices/index';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
+import { createPresignedUrl } from '../../src/shared/z3Utils';
+
+// src/shared and src/shared/z3Utils are mocked suite-wide in vitest.unit-mocks.setup.ts.
 
 function makeInput(body: Record<string, unknown>): ZambdaInput {
-  return { headers: null, body: JSON.stringify(body), secrets: { PROJECT_ID: 'test-project' } };
+  return { headers: null, body: JSON.stringify(body), secrets: { PROJECT_ID: 'test-project', ENVIRONMENT: 'local' } };
 }
 
 const mockOystehrClient = {
@@ -15,30 +20,15 @@ const mockOystehrClient = {
   },
 };
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-const mockCreatePresignedUrl = vi.fn();
-vi.mock('../../src/shared/z3Utils', () => ({
-  createPresignedUrl: (...args: unknown[]) => mockCreatePresignedUrl(...args),
-}));
-
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
-let handler!: ZambdaHandler;
+const handler = index as unknown as ZambdaHandler;
 
 describe('export-invoices', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
-    ({ index: handler } = (await import('../../src/ehr/export-invoices/index')) as { index: ZambdaHandler });
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(mockOystehrClient as never);
   });
 
   describe('kick-off mode', () => {
@@ -148,7 +138,7 @@ describe('export-invoices', () => {
           },
         ],
       } as FhirTask);
-      mockCreatePresignedUrl.mockResolvedValue('https://presigned-download-url.com');
+      vi.mocked(createPresignedUrl).mockResolvedValue('https://presigned-download-url.com');
 
       const result = await handler(makeInput({ taskId: 'task-123' }));
 
@@ -156,7 +146,7 @@ describe('export-invoices', () => {
       const body = JSON.parse(result.body);
       expect(body.status).toBe('completed');
       expect(body.downloadUrl).toBe('https://presigned-download-url.com');
-      expect(mockCreatePresignedUrl).toHaveBeenCalledWith('mock-token', z3Url, 'download');
+      expect(createPresignedUrl).toHaveBeenCalledWith('mock-token', z3Url, 'download');
     });
 
     it('returns in-progress status', async () => {

--- a/packages/zambdas/test/unit/find-applicable-charge-master.test.ts
+++ b/packages/zambdas/test/unit/find-applicable-charge-master.test.ts
@@ -1,27 +1,13 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { ChargeItemDefinition } from 'fhir/r4b';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-// Stub shared module so the handler can be imported without real secrets/auth
-// Note: vi.mock is hoisted, so we must inline the constant rather than referencing a variable.
-vi.mock('../../src/shared', () => ({
-  checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-  createClinicalOystehrClient: vi.fn(),
-  RCM_TAG_SYSTEM: 'https://fhir.zapehr.com/r4/StructureDefinitions/rcm',
-  wrapHandler: (_name: string, handler: any) => handler,
-  ZambdaInput: {},
-  safeValidate: (schema: any, input: unknown) => schema.parse(input),
-  safeJsonParse: (body: string) => JSON.parse(body),
-}));
-
-const RCM_TAG_SYSTEM = 'https://fhir.zapehr.com/r4/StructureDefinitions/rcm';
-
 import { getPayerUrl } from 'utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { index as _handler } from '../../src/rcm/charge-masters/find-applicable-charge-master/index';
-import { createClinicalOystehrClient } from '../../src/shared';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient, RCM_TAG_SYSTEM } from '../../src/shared';
 import { ZambdaInput } from '../../src/shared/types';
 
-// Our mock replaces wrapHandler so it returns the raw single-arg function, not the 3-arg Lambda handler.
+// checkOrCreateM2MClientToken and createClinicalOystehrClient are canonical suite-wide mocks
+// (vitest.unit-mocks.setup.ts); the real wrapHandler applies, so results are response envelopes.
 const handler = _handler as unknown as (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
 // ---------------------------------------------------------------------------
@@ -108,7 +94,11 @@ function stubSearch(chargeMasters: ChargeItemDefinition[]): void {
 }
 
 function makeInput(body: Record<string, any>): any {
-  return { body: JSON.stringify(body), headers: null, secrets: { FHIR_API: 'x', PROJECT_API: 'x' } } as any;
+  return {
+    body: JSON.stringify(body),
+    headers: null,
+    secrets: { FHIR_API: 'x', PROJECT_API: 'x', ENVIRONMENT: 'local' },
+  } as any;
 }
 
 function parseBody(result: any): any {
@@ -121,6 +111,8 @@ function parseBody(result: any): any {
 describe('find-applicable-charge-master', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockImplementation(() => undefined as never);
   });
 
   // -----------------------------------------------------------------------

--- a/packages/zambdas/test/unit/find-applicable-fee-schedule.test.ts
+++ b/packages/zambdas/test/unit/find-applicable-fee-schedule.test.ts
@@ -1,25 +1,13 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { ChargeItemDefinition } from 'fhir/r4b';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-// Stub shared module
-// Note: vi.mock is hoisted, so we must inline the constant rather than referencing a variable.
-vi.mock('../../src/shared', () => ({
-  checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-  createClinicalOystehrClient: vi.fn(),
-  RCM_TAG_SYSTEM: 'https://fhir.zapehr.com/r4/StructureDefinitions/rcm',
-  wrapHandler: (_name: string, handler: any) => handler,
-  ZambdaInput: {},
-  safeValidate: (schema: any, input: unknown) => schema.parse(input),
-  safeJsonParse: (body: string) => JSON.parse(body),
-}));
-
 import { getPayerUrl } from 'utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { index as _handler } from '../../src/rcm/fee-schedules/find-applicable-fee-schedule/index';
-import { createClinicalOystehrClient } from '../../src/shared';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import { ZambdaInput } from '../../src/shared/types';
 
-// Our mock replaces wrapHandler so it returns the raw single-arg function, not the 3-arg Lambda handler.
+// checkOrCreateM2MClientToken and createClinicalOystehrClient are canonical suite-wide mocks
+// (vitest.unit-mocks.setup.ts); the real wrapHandler applies, so results are response envelopes.
 const handler = _handler as unknown as (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
 // ---------------------------------------------------------------------------
@@ -81,7 +69,11 @@ function stubSearch(feeSchedules: ChargeItemDefinition[]): void {
 }
 
 function makeInput(body: Record<string, any>): any {
-  return { body: JSON.stringify(body), headers: null, secrets: { FHIR_API: 'x', PROJECT_API: 'x' } } as any;
+  return {
+    body: JSON.stringify(body),
+    headers: null,
+    secrets: { FHIR_API: 'x', PROJECT_API: 'x', ENVIRONMENT: 'local' },
+  } as any;
 }
 
 function parseBody(result: any): any {
@@ -94,6 +86,8 @@ function parseBody(result: any): any {
 describe('find-applicable-fee-schedule', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockImplementation(() => undefined as never);
   });
 
   // -----------------------------------------------------------------------

--- a/packages/zambdas/test/unit/in-house-medication-templates.test.ts
+++ b/packages/zambdas/test/unit/in-house-medication-templates.test.ts
@@ -29,13 +29,11 @@ import {
   getAssociatedDxFromMaAndRequests,
 } from '../../src/ehr/apply-template/apply-in-house-medications';
 import { TemplateEncounterResource } from '../../src/ehr/shared/template-helpers';
+import { getMyPractitionerId } from '../../src/shared';
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../src/shared')>();
-  return {
-    ...actual,
-    getMyPractitionerId: vi.fn().mockResolvedValue('pract-1'),
-  };
+// getMyPractitionerId is a canonical suite-wide mock (vitest.unit-mocks.setup.ts).
+beforeEach(() => {
+  vi.mocked(getMyPractitionerId).mockResolvedValue('pract-1');
 });
 
 // ─── Factories ────────────────────────────────────────────────────────────────

--- a/packages/zambdas/test/unit/inbound-fax-handlers.test.ts
+++ b/packages/zambdas/test/unit/inbound-fax-handlers.test.ts
@@ -1,69 +1,36 @@
+import { captureException } from '@sentry/aws-serverless';
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Communication, List, Task } from 'fhir/r4b';
+import {
+  APIErrorCode,
+  createOystehrClient,
+  FAX_TASK,
+  getUiTaskCategoryForCode,
+  OYSTEHR_OUTBOUND_FAX_STATUS_EXTENSION_URL,
+} from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ZambdaInput } from '../../src/shared';
-
-// The exported `index` is typed as an AWS 3-arg Handler, but `wrapHandler` is mocked to
-// return the single-arg inner function; cast the imports to reflect the runtime shape.
-type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-const { mockOystehr, mockDeleteZ3Object, mockCaptureException } = vi.hoisted(() => ({
-  mockOystehr: {
-    fhir: {
-      get: vi.fn(),
-      search: vi.fn(),
-      create: vi.fn(),
-      patch: vi.fn(),
-      transaction: vi.fn(),
-    },
-  },
-  mockDeleteZ3Object: vi.fn(),
-  mockCaptureException: vi.fn(),
-}));
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    createOystehrClient: vi.fn(() => mockOystehr),
-  };
-});
-
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    getAuth0Token: vi.fn().mockResolvedValue('mock-token'),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-vi.mock('../../src/shared/z3Utils', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    deleteZ3Object: mockDeleteZ3Object,
-  };
-});
-
-vi.mock('@sentry/aws-serverless', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    captureException: mockCaptureException,
-  };
-});
-
-import { APIErrorCode, FAX_TASK, getUiTaskCategoryForCode, OYSTEHR_OUTBOUND_FAX_STATUS_EXTENSION_URL } from 'utils';
 import { index as deleteInboundFaxRaw } from '../../src/ehr/delete-inbound-fax/index';
 import { index as fileInboundFaxRaw } from '../../src/ehr/file-inbound-fax/index';
-import { Z3Error } from '../../src/shared/z3Utils';
+import { checkOrCreateM2MClientToken, getAuth0Token, type ZambdaInput } from '../../src/shared';
+import { deleteZ3Object, Z3Error } from '../../src/shared/z3Utils';
 import { index as handleInboundFaxRaw } from '../../src/subscriptions/communication/handle-inbound-fax/index';
+
+// utils, src/shared, src/shared/z3Utils, and @sentry/aws-serverless are mocked suite-wide in
+// vitest.unit-mocks.setup.ts; per-test behavior is installed in beforeEach via vi.mocked(...).
+
+// The exported `index` is typed as an AWS 3-arg Handler, but the (mocked) Sentry wrapper
+// returns the single-arg inner function; cast the imports to reflect the runtime shape.
+type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
+
+const mockOystehr = {
+  fhir: {
+    get: vi.fn(),
+    search: vi.fn(),
+    create: vi.fn(),
+    patch: vi.fn(),
+    transaction: vi.fn(),
+  },
+};
 
 const fileInboundFax = fileInboundFaxRaw as unknown as ZambdaHandler;
 const deleteInboundFax = deleteInboundFaxRaw as unknown as ZambdaHandler;
@@ -146,6 +113,9 @@ const deleteBody = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(createOystehrClient).mockReturnValue(mockOystehr as never);
+  vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+  vi.mocked(getAuth0Token).mockResolvedValue('mock-token');
 });
 
 // ---------------------------------------------------------------------------
@@ -361,14 +331,14 @@ describe('delete-inbound-fax handler', () => {
 
   it('SECURITY: ignores a client-supplied pdfUrl and deletes the Z3 object stored on the verified Task', async () => {
     mockTaskRead();
-    mockDeleteZ3Object.mockResolvedValue(undefined);
+    vi.mocked(deleteZ3Object).mockResolvedValue(undefined);
 
     const result = await deleteInboundFax(makeInput(deleteBody));
 
     expect(result.statusCode).toBe(200);
-    expect(mockDeleteZ3Object).toHaveBeenCalledTimes(1);
-    expect(mockDeleteZ3Object).toHaveBeenCalledWith(TASK_PDF_URL, 'mock-token');
-    expect(mockDeleteZ3Object).not.toHaveBeenCalledWith(CLIENT_SUPPLIED_PDF_URL, expect.anything());
+    expect(deleteZ3Object).toHaveBeenCalledTimes(1);
+    expect(deleteZ3Object).toHaveBeenCalledWith(TASK_PDF_URL, 'mock-token');
+    expect(deleteZ3Object).not.toHaveBeenCalledWith(CLIENT_SUPPLIED_PDF_URL, expect.anything());
 
     // Communication delete + Task cancel are one transaction
     const { requests } = mockOystehr.fhir.transaction.mock.calls[0][0];
@@ -383,7 +353,7 @@ describe('delete-inbound-fax handler', () => {
 
     expect(result.statusCode).toBe(400);
     expect(JSON.parse(result.body).message).toContain('is not an inbound-fax task');
-    expect(mockDeleteZ3Object).not.toHaveBeenCalled();
+    expect(deleteZ3Object).not.toHaveBeenCalled();
     expect(mockOystehr.fhir.transaction).not.toHaveBeenCalled();
   });
 
@@ -393,7 +363,7 @@ describe('delete-inbound-fax handler', () => {
     const result = await deleteInboundFax(makeInput(deleteBody));
 
     expect(result.statusCode).toBe(400);
-    expect(mockDeleteZ3Object).not.toHaveBeenCalled();
+    expect(deleteZ3Object).not.toHaveBeenCalled();
     expect(mockOystehr.fhir.transaction).not.toHaveBeenCalled();
   });
 
@@ -404,25 +374,25 @@ describe('delete-inbound-fax handler', () => {
 
     expect(result.statusCode).toBe(400);
     expect(JSON.parse(result.body).code).toBe(APIErrorCode.PRECONDITION_FAILED);
-    expect(mockDeleteZ3Object).not.toHaveBeenCalled();
+    expect(deleteZ3Object).not.toHaveBeenCalled();
     expect(mockOystehr.fhir.transaction).not.toHaveBeenCalled();
   });
 
   it('fails the operation (without touching FHIR) when the Z3 delete fails, and reports it', async () => {
     mockTaskRead();
-    mockDeleteZ3Object.mockRejectedValue(new Z3Error('delete failed', 500));
+    vi.mocked(deleteZ3Object).mockRejectedValue(new Z3Error('delete failed', 500));
 
     const result = await deleteInboundFax(makeInput(deleteBody));
 
     expect(result.statusCode).toBe(500);
-    expect(mockCaptureException).toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalled();
     // Nothing else deleted: the operation stays retryable and the PDF is never orphaned
     expect(mockOystehr.fhir.transaction).not.toHaveBeenCalled();
   });
 
   it('continues when the Z3 object is already gone (404)', async () => {
     mockTaskRead();
-    mockDeleteZ3Object.mockRejectedValue(new Z3Error('not found', 404));
+    vi.mocked(deleteZ3Object).mockRejectedValue(new Z3Error('not found', 404));
 
     const result = await deleteInboundFax(makeInput(deleteBody));
 
@@ -608,7 +578,7 @@ describe('handle-inbound-fax handler', () => {
       // 200 keeps the subscription from retrying forever; Sentry carries the signal instead.
       expect(result.statusCode).toBe(200);
       expect(JSON.parse(result.body)).toEqual({ alreadyProcessed: true });
-      expect(mockCaptureException).toHaveBeenCalled();
+      expect(captureException).toHaveBeenCalled();
       expect(mockOystehr.fhir.transaction).not.toHaveBeenCalled();
     });
   });

--- a/packages/zambdas/test/unit/mailed-statements-report.test.ts
+++ b/packages/zambdas/test/unit/mailed-statements-report.test.ts
@@ -1,9 +1,11 @@
 import { Appointment, Communication, Encounter, Patient } from 'fhir/r4b';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { index } from '../../src/ehr/mailed-statements-report/index';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 // ---------------------------------------------------------------------------
-// Mocks
+// Mocks — src/shared is mocked suite-wide in vitest.unit-mocks.setup.ts
 // ---------------------------------------------------------------------------
 
 const mockOystehrClient = {
@@ -11,18 +13,6 @@ const mockOystehrClient = {
     search: vi.fn(),
   },
 };
-
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-import { index } from '../../src/ehr/mailed-statements-report/index';
 
 const MAIL_VENDOR_EXTENSION_URL = 'https://extensions.fhir.ottehr.com/mail-vendor';
 
@@ -34,7 +24,7 @@ function makeInput(body: Record<string, unknown>): ZambdaInput {
   return {
     headers: null,
     body: JSON.stringify(body),
-    secrets: { POSTGRID_API_KEY: 'test' },
+    secrets: { POSTGRID_API_KEY: 'test', ENVIRONMENT: 'local' },
   };
 }
 
@@ -117,6 +107,8 @@ function makeAppointment(id: string): Appointment {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+  vi.mocked(createClinicalOystehrClient).mockReturnValue(mockOystehrClient as never);
   // Default fallback so the trailing sync-state Basic search (getMailedStatementSyncState)
   // and any otherwise-unmatched search resolve to an empty bundle.
   mockOystehrClient.fhir.search.mockResolvedValue(makeSearchBundle([]));

--- a/packages/zambdas/test/unit/postgrid-get-letter.test.ts
+++ b/packages/zambdas/test/unit/postgrid-get-letter.test.ts
@@ -1,3 +1,4 @@
+import { getSecret } from 'utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getPostGridLetter } from '../../src/shared/postgrid';
 
@@ -7,23 +8,14 @@ import { getPostGridLetter } from '../../src/shared/postgrid';
 
 const mockFetch = vi.fn<typeof fetch>();
 
-// ---------------------------------------------------------------------------
-// Mock getSecret — returns a fixed API key
-// ---------------------------------------------------------------------------
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    getSecret: () => 'test-postgrid-api-key',
-  };
-});
-
 const secrets = { POSTGRID_API_KEY: 'test-postgrid-api-key' } as any;
 
+// getSecret is a canonical suite-wide mock (vitest.unit-mocks.setup.ts) — stub it to return
+// a fixed API key.
 beforeEach(() => {
   vi.clearAllMocks();
   vi.stubGlobal('fetch', mockFetch);
+  vi.mocked(getSecret).mockReturnValue('test-postgrid-api-key');
 });
 
 afterEach(() => {

--- a/packages/zambdas/test/unit/require-admin-user.test.ts
+++ b/packages/zambdas/test/unit/require-admin-user.test.ts
@@ -3,13 +3,7 @@ import { NOT_AUTHORIZED, RoleType, Secrets, SecretsKeys, userMe } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getUser, requireAdminUser, requireUserWithRole } from '../../src/shared';
 
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('utils')>();
-  return {
-    ...actual,
-    userMe: vi.fn(),
-  };
-});
+// userMe is a canonical suite-wide mock (vitest.unit-mocks.setup.ts); each test installs its behavior.
 
 const secrets: Secrets = {
   [SecretsKeys.FHIR_API]: 'http://fhir',

--- a/packages/zambdas/test/unit/retry-action-log.test.ts
+++ b/packages/zambdas/test/unit/retry-action-log.test.ts
@@ -7,30 +7,32 @@ import {
   OYSTEHR_OUTBOUND_FAX_STATUS_EXTENSION_URL,
   VISIT_NOTE_SUMMARY_CODE,
 } from 'utils';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { hasRetryChild, isRetryable, performEffect, resolveDocumentReference } from '../../src/ehr/retry-action-log';
+import { getEmailClient, makeAddressUrl } from '../../src/shared/communication';
+import { createOutboundDeliveryAttemptIdempotently } from '../../src/shared/outbound-delivery';
+import { getAppointmentAndRelatedResources } from '../../src/shared/pdf/visit-details-pdf/get-video-resources';
+import { createMockSecrets } from './validate-request-parameters/helpers';
 
+// getEmailClient, makeAddressUrl, and getAppointmentAndRelatedResources are canonical
+// suite-wide mocks (vitest.unit-mocks.setup.ts); this file's defaults are installed here.
 const mockSendEmail = vi.fn();
-vi.mock('../../src/shared/communication', () => ({
-  getEmailClient: () => ({
+beforeEach(() => {
+  vi.mocked(getEmailClient).mockReturnValue({
     getFeatureFlag: () => true,
     sendVirtualCompletionEmail: mockSendEmail,
     sendInPersonCompletionEmail: mockSendEmail,
-  }),
-  makeAddressUrl: (address: string) => `https://maps.example.test/?q=${encodeURIComponent(address)}`,
-}));
-
-vi.mock('../../src/shared/pdf/visit-details-pdf/get-video-resources', () => ({
-  getAppointmentAndRelatedResources: vi.fn().mockResolvedValue({
+  } as unknown as ReturnType<typeof getEmailClient>);
+  vi.mocked(makeAddressUrl).mockImplementation(
+    (address: string) => `https://maps.example.test/?q=${encodeURIComponent(address)}`
+  );
+  vi.mocked(getAppointmentAndRelatedResources).mockResolvedValue({
     appointment: { resourceType: 'Appointment', id: 'appointment-1', status: 'fulfilled' },
     patient: { resourceType: 'Patient', id: 'patient-1' },
     location: { resourceType: 'Location', id: 'location-1', name: 'Virtual' },
     timezone: 'America/New_York',
-  }),
-}));
-
-import { hasRetryChild, isRetryable, performEffect, resolveDocumentReference } from '../../src/ehr/retry-action-log';
-import { createOutboundDeliveryAttemptIdempotently } from '../../src/shared/outbound-delivery';
-import { createMockSecrets } from './validate-request-parameters/helpers';
+  } as unknown as Awaited<ReturnType<typeof getAppointmentAndRelatedResources>>);
+});
 
 const emailTask: Task = {
   ...makeOutboundDeliveryAttempt({

--- a/packages/zambdas/test/unit/send-fax-attempt.test.ts
+++ b/packages/zambdas/test/unit/send-fax-attempt.test.ts
@@ -1,7 +1,13 @@
 import { Appointment, Bundle, DocumentReference, Patient, Task } from 'fhir/r4b';
 import { getOutboundDeliveryInput, OUTBOUND_DELIVERY_INPUT_CODES, VISIT_NOTE_SUMMARY_CODE } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { index } from '../../src/ehr/send-fax';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient, getUser } from '../../src/shared';
 import { createMockSecrets, createMockZambdaInput } from './validate-request-parameters/helpers';
+
+// src/shared is mocked suite-wide in vitest.unit-mocks.setup.ts; per-test behavior is
+// installed in beforeEach via vi.mocked(...). The real wrapHandler applies, so handler
+// errors resolve to a structured error envelope instead of rejecting.
 
 const mockFhirSearch = vi.fn();
 const mockFhirGet = vi.fn();
@@ -12,16 +18,6 @@ const mockOystehrClient = {
   fhir: { search: mockFhirSearch, get: mockFhirGet, create: mockFhirCreate, patch: mockFhirPatch },
   fax: { send: mockFaxSend },
 };
-
-vi.mock('../../src/shared', async (importOriginal) => ({
-  ...((await importOriginal()) as Record<string, unknown>),
-  checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-  createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-  getUser: vi.fn().mockResolvedValue({ id: 'user-1', profile: 'Practitioner/prac-1' }),
-  wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-}));
-
-import { index } from '../../src/ehr/send-fax';
 
 const APPOINTMENT_ID = '650e8400-e29b-41d4-a716-446655440000';
 
@@ -57,6 +53,9 @@ function makeSearchBundle(pcpFax: string, system: 'fax' | 'phone' = 'fax'): unkn
 describe('send-fax outbound attempt', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(mockOystehrClient as never);
+    vi.mocked(getUser).mockResolvedValue({ id: 'user-1', profile: 'Practitioner/prac-1' } as never);
     mockFhirSearch.mockResolvedValue(makeSearchBundle('(212) 555-1234'));
     mockFhirGet.mockResolvedValue({ resourceType: 'Practitioner', id: 'prac-1', name: [{ family: 'Sender' }] });
     mockFhirCreate.mockImplementation((task: Task) => Promise.resolve({ ...task, id: 'attempt-1' }));
@@ -90,14 +89,15 @@ describe('send-fax outbound attempt', () => {
 
   it('retains and marks the attempt failed when the provider rejects the send', async () => {
     mockFaxSend.mockRejectedValue(new Error('provider unavailable'));
-    await expect(
-      (index as any)(
-        createMockZambdaInput(
-          { appointmentId: APPOINTMENT_ID, faxNumber: '2125551234' },
-          { secrets: createMockSecrets() }
-        )
+    // The real wrapHandler turns the rethrown provider error into a structured 500 response.
+    const response = await (index as any)(
+      createMockZambdaInput(
+        { appointmentId: APPOINTMENT_ID, faxNumber: '2125551234' },
+        { secrets: createMockSecrets() }
       )
-    ).rejects.toThrow('provider unavailable');
+    );
+    expect(response.statusCode).toBe(500);
+    expect(JSON.parse(response.body)).toEqual({ error: 'Internal error' });
     expect(mockFhirCreate).toHaveBeenCalledTimes(1);
     expect(mockFhirPatch).toHaveBeenCalledWith(
       expect.objectContaining({ operations: expect.arrayContaining([expect.objectContaining({ value: 'failed' })]) })
@@ -121,14 +121,16 @@ describe('send-fax outbound attempt', () => {
   it('keeps a visible pending attempt when completion persistence exhausts its retries', async () => {
     mockFhirPatch.mockRejectedValue(new Error('FHIR unavailable'));
 
-    await expect(
-      (index as any)(
-        createMockZambdaInput(
-          { appointmentId: APPOINTMENT_ID, faxNumber: '2125551234' },
-          { secrets: createMockSecrets() }
-        )
+    // The real wrapHandler turns the thrown "outbound attempt could not be completed" error into a
+    // structured 500 response.
+    const response = await (index as any)(
+      createMockZambdaInput(
+        { appointmentId: APPOINTMENT_ID, faxNumber: '2125551234' },
+        { secrets: createMockSecrets() }
       )
-    ).rejects.toThrow('outbound attempt could not be completed');
+    );
+    expect(response.statusCode).toBe(500);
+    expect(JSON.parse(response.body)).toEqual({ error: 'Internal error' });
     expect(mockFaxSend).toHaveBeenCalledTimes(1);
     expect(mockFhirCreate).toHaveBeenCalledTimes(1);
     expect(mockFhirPatch).toHaveBeenCalledTimes(3);

--- a/packages/zambdas/test/unit/sub-export-invoices-csv.test.ts
+++ b/packages/zambdas/test/unit/sub-export-invoices-csv.test.ts
@@ -18,25 +18,13 @@ const mockOystehrClient = {
   },
 };
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
+// checkOrCreateM2MClientToken, createClinicalOystehrClient, and wrapTaskHandler are canonical
+// suite-wide mocks (vitest.unit-mocks.setup.ts); behavior is installed per-test in beforeEach.
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
+import { wrapTaskHandler } from '../../src/subscriptions/task/helpers';
 
-// The subscription uses wrapTaskHandler; mock it to extract the inner handler
+// The subscription uses wrapTaskHandler at import time; capture the inner handler.
 let capturedHandler: (input: { task: FhirTask; secrets: Record<string, string> }, oystehr: unknown) => Promise<unknown>;
-
-vi.mock('../../src/subscriptions/task/helpers', () => ({
-  wrapTaskHandler: (_name: string, fn: typeof capturedHandler) => {
-    capturedHandler = fn;
-    return fn;
-  },
-}));
 
 // Helper to build a FHIR search result bundle
 function makeFhirBundle(
@@ -158,8 +146,15 @@ describe('sub-export-invoices-csv', () => {
     vi.clearAllMocks();
     vi.resetModules();
     mockOystehrClient.z3.uploadFile.mockResolvedValue(undefined);
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(mockOystehrClient as never);
+    vi.mocked(wrapTaskHandler).mockImplementation(((_name: string, fn: typeof capturedHandler) => {
+      capturedHandler = fn;
+      return fn;
+    }) as never);
 
-    // Import to trigger wrapTaskHandler and capture the handler
+    // Import to trigger wrapTaskHandler and capture the handler (vi.resetModules above
+    // makes the module re-execute for every test)
     await import('../../src/subscriptions/sub-export-invoices-csv/index');
   });
 

--- a/packages/zambdas/test/unit/sub-refresh-invoice-task.test.ts
+++ b/packages/zambdas/test/unit/sub-refresh-invoice-task.test.ts
@@ -2,6 +2,7 @@ import type { APIGatewayProxyResult } from 'aws-lambda';
 import type { Operation } from 'fast-json-patch';
 import { Task, TaskInput } from 'fhir/r4b';
 import {
+  getOrCreateCandidApiClient,
   INVOICE_TASK_CLAIM_ID_IDENTIFIER_SYSTEM,
   invoiceTaskSourceTag,
   RcmTaskCodings,
@@ -9,7 +10,11 @@ import {
   ZERO_BALANCE_BUSINESS_STATUS_CODE,
 } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
+import { index } from '../../src/subscriptions/task/sub-refresh-invoice-task/index';
+
+// src/shared and utils are mocked suite-wide in vitest.unit-mocks.setup.ts.
 
 const mockZambdaExecute = vi.fn();
 const mockClinicalClient = {
@@ -22,29 +27,10 @@ const mockClinicalClient = {
     execute: (...args: unknown[]) => mockZambdaExecute(...args),
   },
 };
-const mockGetOrCreateCandidApiClient = vi.fn();
-
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockClinicalClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    getOrCreateCandidApiClient: (...args: unknown[]) => mockGetOrCreateCandidApiClient(...args),
-  };
-});
 
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
-let handler!: ZambdaHandler;
+const handler = index as unknown as ZambdaHandler;
 
 const billingTask = (overrides: Partial<Task> = {}): Task =>
   ({
@@ -105,6 +91,7 @@ const runHandler = (task: Task, stored: Task | Task[] = task): Promise<APIGatewa
     body: JSON.stringify(task),
     secrets: {
       PROJECT_ID: 'test-project',
+      ENVIRONMENT: 'local',
     },
   });
 };
@@ -129,13 +116,11 @@ const nonZeroBalanceAr = (): void => {
 };
 
 describe('sub-refresh-invoice-task', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(mockClinicalClient as never);
     mockClinicalClient.fhir.patch.mockResolvedValue({});
-    ({ index: handler } = (await import('../../src/subscriptions/task/sub-refresh-invoice-task/index')) as unknown as {
-      index: ZambdaHandler;
-    });
   });
 
   it('refreshes a billing-sourced task from patient AR without touching Candid', async () => {
@@ -151,7 +136,7 @@ describe('sub-refresh-invoice-task', () => {
     const result = await runHandler(billingTask());
 
     expect(JSON.parse(result.body).message).toContain('successfully updated');
-    expect(mockGetOrCreateCandidApiClient).not.toHaveBeenCalled();
+    expect(getOrCreateCandidApiClient).not.toHaveBeenCalled();
     expect(mockZambdaExecute).toHaveBeenCalledWith({
       id: 'search-billing-patient-ar-claims',
       claimIds: ['claim-1'],
@@ -291,7 +276,10 @@ describe('sub-refresh-invoice-task', () => {
     nonZeroBalanceAr();
     mockClinicalClient.fhir.patch.mockRejectedValue(Object.assign(new Error('bad path'), { code: 422 }));
 
-    await expect(runHandler(billingTask({ businessStatus: ZERO_BALANCE_BUSINESS_STATUS }))).rejects.toThrow('bad path');
+    // The real wrapHandler converts the propagated error into an internal-error envelope.
+    const result = await runHandler(billingTask({ businessStatus: ZERO_BALANCE_BUSINESS_STATUS }));
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body)).toEqual({ error: 'Internal error' });
     expect(mockClinicalClient.fhir.patch).toHaveBeenCalledTimes(1);
   });
 
@@ -299,7 +287,10 @@ describe('sub-refresh-invoice-task', () => {
     nonZeroBalanceAr();
     mockClinicalClient.fhir.patch.mockRejectedValue(Object.assign(new Error('conflict'), { code: 412 }));
 
-    await expect(runHandler(billingTask())).rejects.toThrow('conflict');
+    // The real wrapHandler converts the propagated conflict into an internal-error envelope.
+    const result = await runHandler(billingTask());
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body)).toEqual({ error: 'Internal error' });
     expect(mockClinicalClient.fhir.patch).toHaveBeenCalledTimes(3);
   });
 
@@ -317,13 +308,13 @@ describe('sub-refresh-invoice-task', () => {
   });
 
   it('routes candid and legacy untagged tasks through Candid, not patient AR', async () => {
-    mockGetOrCreateCandidApiClient.mockResolvedValue({
+    vi.mocked(getOrCreateCandidApiClient).mockResolvedValue({
       patientAr: {
         v1: {
           itemize: vi.fn(),
         },
       },
-    });
+    } as never);
     mockClinicalClient.fhir.search.mockResolvedValue({
       unbundle: () => [],
     });
@@ -334,7 +325,7 @@ describe('sub-refresh-invoice-task', () => {
     });
     const result = await runHandler(untaggedTask);
 
-    expect(mockGetOrCreateCandidApiClient).toHaveBeenCalled();
+    expect(getOrCreateCandidApiClient).toHaveBeenCalled();
     expect(mockZambdaExecute).not.toHaveBeenCalled();
     expect(JSON.parse(result.body).message).toContain('no Candid inventory record');
   });

--- a/packages/zambdas/test/unit/sub-send-invoice-to-patient.test.ts
+++ b/packages/zambdas/test/unit/sub-send-invoice-to-patient.test.ts
@@ -1,9 +1,28 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { Account, Appointment, Encounter, Patient, Task, TaskInput } from 'fhir/r4b';
-import { invoiceTaskSourceTag, PATIENT_BILLING_ACCOUNT_TYPE, RcmTaskCodings } from 'utils';
+import {
+  getStripeAccountForAppointmentOrEncounter,
+  getStripeCustomerIdFromAccount,
+  invoiceTaskSourceTag,
+  PATIENT_BILLING_ACCOUNT_TYPE,
+  RcmTaskCodings,
+} from 'utils';
 import { ottehrCodeSystemUrl } from 'utils/lib/fhir/systemUrls';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { produceOutreachTasks } from '../../src/rcm/scheduled-outreach/producers/shared/produce-outreach-tasks';
+import {
+  checkOrCreateM2MClientToken,
+  createClinicalOystehrClient,
+  getStripeClient,
+  resolveTemplatePlaceholders,
+  resolveTimezone,
+  sendSmsForPatient,
+} from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
+import { index } from '../../src/subscriptions/task/sub-send-invoice-to-patient/index';
+
+// Shared modules (src/shared, utils, produce-outreach-tasks) are mocked suite-wide in
+// vitest.unit-mocks.setup.ts; non-delegating defaults are re-established in beforeEach below.
 
 const mockClinicalClient = {
   fhir: {
@@ -24,38 +43,10 @@ const mockStripe = {
     create: vi.fn(),
   },
 };
-const mockSendSmsForPatient = vi.fn();
-
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockClinicalClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-    getStripeClient: () => mockStripe,
-    sendSmsForPatient: (...args: unknown[]) => mockSendSmsForPatient(...args),
-    resolveTemplatePlaceholders: vi.fn().mockResolvedValue({}),
-    resolveTimezone: () => 'America/New_York',
-  };
-});
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    getStripeCustomerIdFromAccount: () => 'cus_1',
-    getStripeAccountForAppointmentOrEncounter: vi.fn().mockResolvedValue(undefined),
-  };
-});
-
-vi.mock('../../src/rcm/scheduled-outreach/producers/shared', () => ({
-  produceOutreachTasks: vi.fn().mockResolvedValue(undefined),
-}));
 
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
-let handler!: ZambdaHandler;
+const handler = index as unknown as ZambdaHandler;
 
 const invoiceInput = (): TaskInput[] =>
   ['dueDate', 'smsTextMessage', 'amountCents'].map((code) => ({
@@ -143,9 +134,17 @@ const runHandler = (invoiceTask: Task): Promise<APIGatewayProxyResult> =>
   });
 
 describe('sub-send-invoice-to-patient source guard', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(mockClinicalClient as never);
+    vi.mocked(getStripeClient).mockReturnValue(mockStripe as never);
+    vi.mocked(sendSmsForPatient).mockResolvedValue(undefined as never);
+    vi.mocked(resolveTemplatePlaceholders).mockResolvedValue({} as never);
+    vi.mocked(resolveTimezone).mockReturnValue('America/New_York');
+    vi.mocked(getStripeCustomerIdFromAccount).mockReturnValue('cus_1');
+    vi.mocked(getStripeAccountForAppointmentOrEncounter).mockResolvedValue(undefined as never);
+    vi.mocked(produceOutreachTasks).mockResolvedValue(undefined as never);
     mockClinicalClient.fhir.search.mockResolvedValue({
       unbundle: () => [encounter, patient, account, appointment],
     });
@@ -169,11 +168,6 @@ describe('sub-send-invoice-to-patient source guard', () => {
       status: 'open',
       hosted_invoice_url: 'https://invoice.example.com',
     });
-    ({ index: handler } = (await import(
-      '../../src/subscriptions/task/sub-send-invoice-to-patient/index'
-    )) as unknown as {
-      index: ZambdaHandler;
-    });
   });
 
   it('sends a billing-sourced task through Stripe without a Candid encounter id', async () => {
@@ -186,11 +180,15 @@ describe('sub-send-invoice-to-patient source guard', () => {
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body).message).toContain('sent successfully');
     expect(mockStripe.invoices.sendInvoice).toHaveBeenCalledWith('inv_1', { stripeAccount: undefined });
-    expect(mockSendSmsForPatient).toHaveBeenCalled();
+    expect(sendSmsForPatient).toHaveBeenCalled();
   });
 
   it('still rejects candid and legacy untagged tasks without a Candid encounter id', async () => {
-    await expect(runHandler(task())).rejects.toThrow('CandidEncounterId is not found');
+    // The real wrapHandler turns the thrown "CandidEncounterId is not found" error into an
+    // internal-error envelope rather than rejecting.
+    const result = await runHandler(task());
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body)).toEqual({ error: 'Internal error' });
 
     expect(mockStripe.invoices.create).not.toHaveBeenCalled();
     const patchCall = mockClinicalClient.fhir.patch.mock.calls[0][0] as {

--- a/packages/zambdas/test/unit/sync-mailed-statement-statuses.test.ts
+++ b/packages/zambdas/test/unit/sync-mailed-statement-statuses.test.ts
@@ -1,37 +1,19 @@
 import { Communication, Extension } from 'fhir/r4b';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { PostGridLetter, PostGridLetterStatus } from '../../src/shared/postgrid';
+import {
+  getPostGridLetter,
+  MAIL_VENDOR_EXTENSION_URL,
+  type PostGridLetter,
+  type PostGridLetterStatus,
+} from '../../src/shared/postgrid';
+import { syncMailedStatementStatuses } from '../../src/shared/sync-mailed-statement-statuses';
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
-const mockGetPostGridLetter = vi.fn<(id: string, secrets: unknown) => Promise<PostGridLetter>>();
-
-vi.mock('../../src/shared/postgrid', () => ({
-  getPostGridLetter: (...args: unknown[]) => mockGetPostGridLetter(args[0] as string, args[1]),
-  MAIL_VENDOR_EXTENSION_URL: 'https://extensions.fhir.ottehr.com/mail-vendor',
-}));
-
-// We also need to mock luxon DateTime.now() for deterministic timestamps
-vi.mock('luxon', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    DateTime: {
-      ...(actual.DateTime as Record<string, unknown>),
-      now: () => ({
-        toUTC: () => ({
-          toISO: () => '2025-06-01T00:00:00.000Z',
-        }),
-      }),
-    },
-  };
-});
-
-import { syncMailedStatementStatuses } from '../../src/shared/sync-mailed-statement-statuses';
-
-const MAIL_VENDOR_EXTENSION_URL = 'https://extensions.fhir.ottehr.com/mail-vendor';
+// getPostGridLetter is a canonical suite-wide mock (vitest.unit-mocks.setup.ts).
+const mockGetPostGridLetter = vi.mocked(getPostGridLetter);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -90,10 +72,16 @@ const secrets = { POSTGRID_API_KEY: 'test-key' } as any;
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Deterministic DateTime.now() timestamps. Only Date is faked so the real setTimeout
+  // stays in place for the spy below (replacing the old whole-module luxon mock, which
+  // is unsafe under --no-isolate).
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(new Date('2025-06-01T00:00:00.000Z'));
   // Speed up tests by eliminating the rate-limit delay
   vi.spyOn(globalThis, 'setTimeout').mockImplementation((fn: TimerHandler) => {
     if (typeof fn === 'function') fn();

--- a/packages/zambdas/test/unit/user-activation-erx-unenroll.test.ts
+++ b/packages/zambdas/test/unit/user-activation-erx-unenroll.test.ts
@@ -1,12 +1,17 @@
 import { captureException } from '@sentry/aws-serverless';
 import type { APIGatewayProxyResult } from 'aws-lambda';
-import { UserActivationZambdaOutput } from 'utils';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFetchClientWithOystehrAuth, UserActivationZambdaOutput } from 'utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { index as userActivationIndex } from '../../src/ehr/user-activation/index';
+import { checkOrCreateM2MClientToken, createClinicalOystehrClient } from '../../src/shared';
 import type { ZambdaInput } from '../../src/shared/types/common';
 
 // Deactivating an Oystehr user doesn't touch their enrollment with the upstream eRx provider, so
 // user-activation unenrolls the linked Practitioner as part of deactivation. These tests cover that
 // side effect: when it runs, when it's skipped, and that it can never fail the deactivation itself.
+//
+// src/shared, utils, and @sentry/aws-serverless are mocked suite-wide in
+// vitest.unit-mocks.setup.ts; per-test behavior is installed in beforeEach via vi.mocked(...).
 
 const USER_ID = '550e8400-e29b-41d4-a716-446655440000';
 const PRACTITIONER_ID = 'practitioner-abc';
@@ -28,27 +33,9 @@ const mockOystehrClient = {
   },
 };
 
-vi.mock('../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
-  };
-});
-
-vi.mock('utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('utils')>();
-  return {
-    ...actual,
-    createFetchClientWithOystehrAuth: vi.fn(() => ({ oystehrFetch: mockOystehrFetch })),
-  };
-});
-
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
-let handler!: ZambdaHandler;
+const handler = userActivationIndex as unknown as ZambdaHandler;
 
 const makeInput = (mode: 'activate' | 'deactivate'): ZambdaInput => ({
   headers: { Authorization: 'Bearer test-token' },
@@ -74,12 +61,11 @@ const givenUser = (overrides?: { roles?: (typeof PROVIDER_ROLE)[]; profile?: str
 const parseBody = (result: APIGatewayProxyResult): UserActivationZambdaOutput => JSON.parse(result.body);
 
 describe('user-activation eRx unenrollment', () => {
-  beforeAll(async () => {
-    ({ index: handler } = (await import('../../src/ehr/user-activation/index')) as { index: ZambdaHandler });
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(checkOrCreateM2MClientToken).mockResolvedValue('mock-token');
+    vi.mocked(createClinicalOystehrClient).mockReturnValue(mockOystehrClient as never);
+    vi.mocked(createFetchClientWithOystehrAuth).mockReturnValue({ oystehrFetch: mockOystehrFetch } as never);
     // The role lookup (`GET /iam/role`) is the only oystehrFetch call whose response is read.
     mockOystehrFetch.mockResolvedValue([PROVIDER_ROLE, INACTIVE_ROLE]);
     mockFhirPatch.mockResolvedValue({});

--- a/packages/zambdas/test/unit/visit-note-email-attempt.test.ts
+++ b/packages/zambdas/test/unit/visit-note-email-attempt.test.ts
@@ -1,26 +1,13 @@
 import { Task } from 'fhir/r4b';
 import { getOutboundDeliveryInput, OUTBOUND_DELIVERY_INPUT_CODES } from 'utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-const { mockSendEmail, mockGetFeatureFlag, mockGetEmailClient } = vi.hoisted(() => {
-  const sendEmail = vi.fn();
-  const getFeatureFlag = vi.fn(() => true);
-  return {
-    mockSendEmail: sendEmail,
-    mockGetFeatureFlag: getFeatureFlag,
-    mockGetEmailClient: vi.fn(() => ({
-      getFeatureFlag,
-      sendVirtualCompletionEmail: sendEmail,
-      sendInPersonCompletionEmail: sendEmail,
-    })),
-  };
-});
-vi.mock('../../src/shared/communication', () => ({
-  makeAddressUrl: (address: string) => `https://maps.example.test/?q=${encodeURIComponent(address)}`,
-  getEmailClient: mockGetEmailClient,
-}));
-
+import { getEmailClient, makeAddressUrl } from '../../src/shared/communication';
 import { buildVisitNoteEmailTemplate, sendVisitNoteEmailAttempt } from '../../src/shared/visit-note-email';
+
+// getEmailClient and makeAddressUrl are canonical suite-wide mocks (vitest.unit-mocks.setup.ts);
+// this file's defaults are installed in beforeEach below.
+const mockSendEmail = vi.fn();
+const mockGetFeatureFlag = vi.fn(() => true);
 
 describe('visit-note email attempt', () => {
   const create = vi.fn();
@@ -29,6 +16,14 @@ describe('visit-note email attempt', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getEmailClient).mockReturnValue({
+      getFeatureFlag: mockGetFeatureFlag,
+      sendVirtualCompletionEmail: mockSendEmail,
+      sendInPersonCompletionEmail: mockSendEmail,
+    } as unknown as ReturnType<typeof getEmailClient>);
+    vi.mocked(makeAddressUrl).mockImplementation(
+      (address: string) => `https://maps.example.test/?q=${encodeURIComponent(address)}`
+    );
     create.mockImplementation((task: Task) => Promise.resolve({ ...task, id: 'attempt-1' }));
     patch.mockImplementation(({ operations }: any) =>
       Promise.resolve({ resourceType: 'Task', id: 'attempt-1', status: operations[0].value, intent: 'order' })
@@ -124,7 +119,7 @@ describe('visit-note email attempt', () => {
       existingEmailClient
     );
 
-    expect(mockGetEmailClient).not.toHaveBeenCalled();
+    expect(getEmailClient).not.toHaveBeenCalled();
     expect(mockSendEmail).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/zambdas/vitest.config.ts
+++ b/packages/zambdas/vitest.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     silent: true,
+    // Restore vi.stubGlobal stubs after every test. Several unit tests stub global fetch
+    // per-test without unstubbing; under --no-isolate a leaked stub would replace the
+    // no-network guard's fetch for every later file in the worker.
+    unstubGlobals: true,
     // Root-only in vitest 3 (not a ProjectConfig option). Generous so the integration globalSetup
     // teardown — two 5s settle waits + the leak-gate sweep across many resource types + deletes —
     // never times out.
@@ -29,6 +33,11 @@ export default defineConfig({
     // flight are the only concurrency axis), so CI raises its cap — but that only pays off when the
     // CPU-bound co-suites are worker-capped too; uncapped, the extra forks just thrash the runner
     // (measured: 10 workers ≈ 6 workers under oversubscription, plus co-suite timeouts).
+    //
+    // NOTE for --no-isolate runs (the unit CI script): pin --minWorkers equal to --maxWorkers.
+    // With minWorkers below maxWorkers, tinypool's idle-worker recycling races pool destruction
+    // at the end of the run and surfaces as an unhandled "Terminating worker thread" rejection
+    // (exit 1 with every test green). Reproduced reliably with minWorkers=1; pinning fixes it.
     maxWorkers: 6,
     minWorkers: 1,
     // Root-only, applies to every forked test worker (unit and integration). The CI job's
@@ -72,7 +81,9 @@ export default defineConfig({
           // hook default under heavy transform load across the ~450 test files.
           hookTimeout: 30000,
           // no globalSetup and no retry: unit tests must be deterministic and run offline.
-          setupFiles: ['../test-utils/lib/no-network.setup.ts', './vitest.setup.ts'],
+          // vitest.unit-mocks.setup.ts registers the canonical suite-wide mocks — required
+          // for --no-isolate (shared module registry), see the header comment in that file.
+          setupFiles: ['../test-utils/lib/no-network.setup.ts', './vitest.setup.ts', './vitest.unit-mocks.setup.ts'],
         },
       },
       {

--- a/packages/zambdas/vitest.unit-mocks.setup.ts
+++ b/packages/zambdas/vitest.unit-mocks.setup.ts
@@ -1,0 +1,324 @@
+import { afterEach, vi } from 'vitest';
+
+// Canonical, suite-wide mocks for every module that any unit test file needs to stub.
+//
+// WHY THIS FILE EXISTS — the unit suite runs with `--no-isolate` in CI (12x faster: the
+// module graph is transformed and executed once per worker instead of once per file).
+// Under a shared worker the module registry persists across test files, which breaks the
+// old pattern of each test file registering its own `vi.mock('utils', factory)`:
+//
+//   1. A module like `src/shared/auth.ts` is executed once per worker. Whatever instance
+//      of `utils` was active at that moment is captured in its imports forever. A later
+//      file's own factory produces a NEW mock instance that the cached module never sees,
+//      so the file's `vi.mocked(...)` handles are silently dead (observed: 30 tests
+//      failing against real implementations, e.g. real `userMe` throwing "Invalid JWT").
+//   2. Conversely, a file's factory that replaced a whole module leaked into every later
+//      file in the worker, so tests could silently exercise a neighbor's mock.
+//
+// THE CONTRACT — exactly ONE mock registration per shared module, made here so it is in
+// force before the first file in every worker imports anything:
+//
+//   - Every wrapped export is a `vi.fn` that DELEGATES TO THE REAL IMPLEMENTATION by
+//     default, so files that never stub it keep today's behavior.
+//   - A test that needs different behavior sets it in `beforeEach`/the test body via
+//     `vi.mocked(fn).mockResolvedValue(...)` on the imported symbol — never with its own
+//     `vi.mock(...)` factory for these modules (that reintroduces bug #1).
+//   - The `afterEach` below resets every wrapper (call history AND implementation) so
+//     nothing leaks between tests or files.
+//   - Setup files re-execute for every test file even under --no-isolate, but the module
+//     registry persists — so the mock namespaces are memoized on `globalThis` to keep the
+//     `vi.fn` instances stable across re-executions. Cached importers and fresh importers
+//     must see the SAME objects or per-file overrides stop working.
+//
+// Adding a new stub: add the export name to the module's list below (or a new vi.mock
+// block following the same pattern). The `missing export` guard throws loudly if a wrapped
+// name disappears from the real module, so this file cannot silently drift.
+
+type AnyFn = (...args: any[]) => any;
+
+interface ManagedMock {
+  fn: ReturnType<typeof vi.fn>;
+  impl: AnyFn | undefined;
+}
+
+const G = globalThis as {
+  __zambdaCanonicalMockRegistry?: Map<string, Record<string, unknown>>;
+  __zambdaManagedMocks?: ManagedMock[];
+  __zambdaManagedResetters?: Array<() => void>;
+};
+
+const moduleRegistry = (G.__zambdaCanonicalMockRegistry ??= new Map());
+const managedMocks = (G.__zambdaManagedMocks ??= []);
+const managedResetters = (G.__zambdaManagedResetters ??= []);
+
+/**
+ * Build (once per worker) a mock namespace for `spec`: the real module with each named
+ * export replaced by a resettable vi.fn. Entries are either an export name (delegates to
+ * the real implementation) or `[name, impl]` (a canonical replacement implementation,
+ * restored on reset — used where the real implementation must never run in unit tests).
+ */
+const wrapModule = (
+  spec: string,
+  actual: Record<string, unknown>,
+  wrapped: Array<string | [string, AnyFn]>
+): Record<string, unknown> => {
+  const existing = moduleRegistry.get(spec);
+  if (existing) return existing;
+
+  const namespace: Record<string, unknown> = { ...actual };
+  for (const entry of wrapped) {
+    const [name, replacement] = typeof entry === 'string' ? [entry, undefined] : entry;
+    if (!(name in actual) && replacement === undefined) {
+      throw new Error(`Canonical unit mock: export "${name}" is missing from module "${spec}" — update this file.`);
+    }
+    const impl = replacement ?? (actual[name] as AnyFn | undefined);
+    const fn = vi.fn(impl);
+    managedMocks.push({ fn, impl });
+    namespace[name] = fn;
+  }
+  moduleRegistry.set(spec, namespace);
+  return namespace;
+};
+
+// Setup files re-run per test file, so this hook re-registers for each file's suite.
+afterEach(() => {
+  for (const { fn, impl } of managedMocks) {
+    fn.mockReset();
+    if (impl) fn.mockImplementation(impl);
+  }
+  for (const reset of managedResetters) reset();
+});
+
+// ---------------------------------------------------------------------------------------
+// The `utils` package
+// ---------------------------------------------------------------------------------------
+vi.mock('utils', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const namespace = wrapModule('utils', actual, [
+    'userMe',
+    'createOystehrClient',
+    'getPresignedURL',
+    'createFetchClientWithOystehrAuth',
+    'getSecret',
+    'getOptionalSecret',
+    'getStripeCustomerIdFromAccount',
+    'getStripeAccountForAppointmentOrEncounter',
+    'getOrCreateCandidApiClient',
+    'findTerminalDeviceForLocation',
+    'getRelatedPersonForPatient',
+    'getAttendingPractitionerId',
+  ]);
+  // FEATURE_FLAGS_CONFIG is a frozen data object, not a function: expose a stable mutable
+  // copy that tests may adjust (e.g. `Object.assign(FEATURE_FLAGS_CONFIG, {...})` in
+  // beforeEach) and restore it to the real values after every test.
+  if (!managedResetters.some((r) => (r as { flagsReset?: boolean }).flagsReset)) {
+    const pristine = JSON.parse(JSON.stringify(actual.FEATURE_FLAGS_CONFIG));
+    const mutableFlags = namespace.FEATURE_FLAGS_CONFIG as Record<string, unknown>;
+    if (Object.isFrozen(mutableFlags)) {
+      namespace.FEATURE_FLAGS_CONFIG = { ...pristine };
+    }
+    const flags = namespace.FEATURE_FLAGS_CONFIG as Record<string, unknown>;
+    const reset = Object.assign(
+      () => {
+        for (const key of Object.keys(flags)) delete flags[key];
+        Object.assign(flags, JSON.parse(JSON.stringify(pristine)));
+      },
+      { flagsReset: true }
+    );
+    managedResetters.push(reset);
+  }
+  return namespace;
+});
+
+// ---------------------------------------------------------------------------------------
+// @sentry/aws-serverless — never load the real SDK in tests (SSR import issues). Same
+// shape as the legacy mock in vitest.setup.ts, but with worker-stable instances; this
+// registration is later in setupFiles order, so it wins for the unit project.
+// ---------------------------------------------------------------------------------------
+vi.mock('@sentry/aws-serverless', () =>
+  wrapModule('@sentry/aws-serverless', {}, [
+    ['init', () => undefined],
+    ['isInitialized', () => false],
+    ['setTag', () => undefined],
+    ['setTags', () => undefined],
+    ['captureException', () => undefined],
+    ['captureMessage', () => undefined],
+    ['withScope', (cb: (scope: { setTag: (k: string, v: unknown) => void }) => void) => cb({ setTag: vi.fn() })],
+    // Pass the handler through unchanged.
+    ['wrapHandler', (handler: AnyFn) => handler],
+  ])
+);
+
+// ---------------------------------------------------------------------------------------
+// src/shared submodules. The src/shared barrel does `export *` from these, so wrapping at
+// the defining module covers imports through the barrel and direct submodule imports alike.
+// ---------------------------------------------------------------------------------------
+vi.mock('./src/shared/auth', async (importOriginal) =>
+  wrapModule('src/shared/auth', await importOriginal(), ['checkOrCreateM2MClientToken', 'getUser'])
+);
+
+vi.mock('./src/shared/helpers', async (importOriginal) =>
+  wrapModule('src/shared/helpers', await importOriginal(), [
+    'createClinicalOystehrClient',
+    'getPatchBinary',
+    'resolveTimezone',
+  ])
+);
+
+vi.mock('./src/shared/getAuth0Token', async (importOriginal) =>
+  wrapModule('src/shared/getAuth0Token', await importOriginal(), ['getAuth0Token'])
+);
+
+// The lambda wrapper is applied AT IMPORT TIME (`export const index = wrapHandler(...)`),
+// so under a shared registry there is exactly one chance to choose its behavior for the
+// whole worker: the REAL wrapHandler, suite-wide. With @sentry/aws-serverless mocked above,
+// the real wrapHandler reduces to the top-level-catch envelope (configSentry is inert), so
+// tests observe production error semantics. Per-file passthrough stubs cannot work here —
+// handlers bake the wrapper at import — and tests must assert the error envelope instead
+// of a raw throw. Requires input.secrets to include ENVIRONMENT (configSentry reads it).
+vi.mock('./src/shared/sentry', async (importOriginal) =>
+  wrapModule('src/shared/sentry', await importOriginal(), ['wrapHandler'])
+);
+
+vi.mock('./src/shared/practitioners', async (importOriginal) =>
+  wrapModule('src/shared/practitioners', await importOriginal(), ['getMyPractitionerId'])
+);
+
+vi.mock('./src/shared/candid', async (importOriginal) =>
+  wrapModule('src/shared/candid', await importOriginal(), [
+    'createEncounterFromAppointment',
+    'performCandidPreEncounterSync',
+  ])
+);
+
+vi.mock('./src/shared/communication', async (importOriginal) =>
+  wrapModule('src/shared/communication', await importOriginal(), [
+    'getEmailClient',
+    'makeAddressUrl',
+    'sendSmsForPatient',
+  ])
+);
+
+vi.mock('./src/shared/z3Utils', async (importOriginal) =>
+  wrapModule('src/shared/z3Utils', await importOriginal(), ['createPresignedUrl', 'uploadObjectToZ3', 'deleteZ3Object'])
+);
+
+vi.mock('./src/shared/stripeIntegration', async (importOriginal) =>
+  wrapModule('src/shared/stripeIntegration', await importOriginal(), ['getStripeClient'])
+);
+
+vi.mock('./src/shared/postgrid', async (importOriginal) =>
+  wrapModule('src/shared/postgrid', await importOriginal(), ['getPostGridLetter'])
+);
+
+vi.mock('./src/shared/chart-data', async (importOriginal) =>
+  wrapModule('src/shared/chart-data', await importOriginal(), ['chartDataResourceHasMetaTagByCode'])
+);
+
+vi.mock('./src/shared/pdf/patient-payment-receipt-pdf', async (importOriginal) =>
+  wrapModule('src/shared/pdf/patient-payment-receipt-pdf', await importOriginal(), ['createPatientPaymentReceiptPdf'])
+);
+
+vi.mock('./src/shared/pdf/visit-details-pdf/get-video-resources', async (importOriginal) =>
+  wrapModule('src/shared/pdf/visit-details-pdf/get-video-resources', await importOriginal(), [
+    'getAppointmentAndRelatedResources',
+  ])
+);
+
+vi.mock('./src/shared/template-placeholders', async (importOriginal) =>
+  wrapModule('src/shared/template-placeholders', await importOriginal(), [
+    'resolveTemplatePlaceholders',
+    'fillOutreachTemplate',
+  ])
+);
+
+vi.mock('./src/shared/ai', async (importOriginal) =>
+  wrapModule('src/shared/ai', await importOriginal(), [
+    'invokeChatbotVertexAI',
+    'transcribeAndCreateResourcesFromZ3Audio',
+  ])
+);
+
+// ---------------------------------------------------------------------------------------
+// Feature-area shared modules
+// ---------------------------------------------------------------------------------------
+vi.mock('./src/ehr/shared/harvest', async (importOriginal) =>
+  wrapModule('src/ehr/shared/harvest', await importOriginal(), [
+    'createMasterRecordPatchOperations',
+    'createUpdatePharmacyPatchOps',
+    'updatePatientAccountFromQuestionnaire',
+    'getAccountAndCoverageResourcesForPatient',
+    'createDocumentResources',
+    'createConsentResources',
+    'createErxContactOperation',
+    'mergeEncounterAccounts',
+    'makeEncounterAccountPatchOp',
+  ])
+);
+
+vi.mock('./src/billing/shared', async (importOriginal) =>
+  wrapModule('src/billing/shared', await importOriginal(), [
+    'createBillingClient',
+    'fetchClaimGraph',
+    'resolvePayersByRef',
+  ])
+);
+
+vi.mock('./src/billing/claim-amounts', async (importOriginal) =>
+  wrapModule('src/billing/claim-amounts', await importOriginal(), [
+    'fetchClaimResponsesByClaimIds',
+    'fetchClaimEraLinks',
+  ])
+);
+
+vi.mock('./src/billing/payments', async (importOriginal) =>
+  wrapModule('src/billing/payments', await importOriginal(), ['recordBillingPatientPayment'])
+);
+
+vi.mock('./src/billing/search-billing-patient-ar-claims/handler', async (importOriginal) =>
+  wrapModule('src/billing/search-billing-patient-ar-claims/handler', await importOriginal(), [
+    'fetchAllActivePatientArClaims',
+  ])
+);
+
+vi.mock('./src/subscriptions/helpers', async (importOriginal) =>
+  wrapModule('src/subscriptions/helpers', await importOriginal(), ['patchTaskStatus'])
+);
+
+vi.mock('./src/subscriptions/task/validateRequestParameters', async (importOriginal) =>
+  wrapModule('src/subscriptions/task/validateRequestParameters', await importOriginal(), ['validateRequestParameters'])
+);
+
+vi.mock('./src/subscriptions/task/helpers', async (importOriginal) =>
+  wrapModule('src/subscriptions/task/helpers', await importOriginal(), ['wrapTaskHandler'])
+);
+
+vi.mock('./src/rcm/scheduled-outreach-config/helpers', async (importOriginal) =>
+  wrapModule('src/rcm/scheduled-outreach-config/helpers', await importOriginal(), [
+    'getOrCreateOutreachConfig',
+    'parsePlanDefinitionToActions',
+    'parseNotificationsTimeRestriction',
+  ])
+);
+
+vi.mock('./src/rcm/scheduled-outreach/producers/shared/produce-outreach-tasks', async (importOriginal) =>
+  wrapModule('src/rcm/scheduled-outreach/producers/shared/produce-outreach-tasks', await importOriginal(), [
+    'produceOutreachTasks',
+  ])
+);
+
+vi.mock('./src/rcm/invoice-config/helpers', async (importOriginal) =>
+  wrapModule('src/rcm/invoice-config/helpers', await importOriginal(), [
+    'getOrCreateInvoicingConfig',
+    'parseInvoicingConfig',
+  ])
+);
+
+vi.mock('./src/rcm/employers/candid-sync', async (importOriginal) =>
+  wrapModule('src/rcm/employers/candid-sync', await importOriginal(), [
+    'createCandidClientIfConfigured',
+    'createCandidEmployerPayer',
+    'updateCandidEmployerPayer',
+    'toggleCandidEmployerPayer',
+  ])
+);

--- a/packages/zambdas/vitest.unit-mocks.setup.ts
+++ b/packages/zambdas/vitest.unit-mocks.setup.ts
@@ -322,3 +322,18 @@ vi.mock('./src/rcm/employers/candid-sync', async (importOriginal) =>
     'toggleCandidEmployerPayer',
   ])
 );
+
+// ---------------------------------------------------------------------------------------
+// Deterministic mock-graph formation. candid and harvest genuinely cycle: real candid.ts
+// imports src/ehr/shared/harvest, and real harvest imports the src/shared barrel, which
+// re-exports candid. If a MOCKED module's factory is the first entry into that cycle, the
+// re-entrant import hits vitest's factory cycle guard, which hands back the RAW module —
+// baking unmocked exports into whichever namespace happened to be mid-construction and
+// silently killing vi.mocked(...) overrides for the rest of the worker. Entering through
+// the BARREL is safe: the barrel is not itself mocked, so its in-progress namespace is
+// resolved by ordinary use-site (call-time) bindings rather than the cycle guard, and
+// every submodule factory (candid → harvest → ...) completes with wrapped exports. Which
+// module gets imported first otherwise depends on file scheduling, so pin it here once
+// per worker.
+await import('./src/shared');
+await import('./src/ehr/shared/harvest');


### PR DESCRIPTION
10x speed up of unit tests in CI.

🤖 reported in the picture, but i looked at the step timing directly also.
<img width="1748" height="630" alt="image" src="https://github.com/user-attachments/assets/478a4355-5804-426e-af08-a428196f2233" />

We merged an improvement to the integration tests to use `--no-isolate` and it sped them up dramatically. Most of the time spent in our unit and integration tests has just been vitest loading up code, see "Why isolation was the whole cost" below which I have read.

This PR would adopt `--no-isolate` for our unit tests. It makes them a lot faster, but there is a real trade-off this time unlike with the integration tests. We have lots of mocks in the unit tests, and when we do not 'isolate' them, the mocks are shared and we have to manage them thoughtfully so different test files only use certain mocks. This is not a marginal cost from the looks of the PR. It looks to me like a real readability and writability tradeoff being made here.

This wouldn't actually bother me because I'm generating and reviewing unit tests these days, and I think the agent would have no trouble with it. But we really need to think about it as a team.

Another option for fixing the speed of these i think would be eliminating all barrel files from ottehr. The reason it's so slow to start up each test file is that each isolated runner has to load and execute most of the utils and zambdas code in case any of it has side effects, and because it's all imported through barrels. This would be an absolutely heinous 1000-line file PR. But I think it's a real option.

🤖 generated code and description below.

# Summary

Runs the zambdas unit suite with `--no-isolate` in CI, cutting the full run (303 files / 3,527 tests) from **~5 minutes to ~17–20 seconds** measured locally on an 8-core box. Since this suite is the biggest CPU consumer on the shared CI runner, the co-running suites should also see relief.

## Why isolation was the whole cost

With per-file isolation, vitest transforms and executes the entire module graph (utils, fhir, zod, luxon, ...) once per test file — ~14 of every 15 seconds of runtime was setup, not tests. `--no-isolate` shares one module registry per worker, but that broke the suite's mocking architecture: **whatever module instance is live when a shared module is first imported gets captured by every cached importer forever**. Per-file `vi.mock` factories silently produced dead handles (30 tests failed against *real* implementations, e.g. real `userMe` throwing `Invalid JWT`), and conversely one file's factory could leak into its neighbors.

## The architecture

**`packages/zambdas/vitest.unit-mocks.setup.ts`** (new) registers exactly ONE canonical mock per shared module (~28 modules):

- Every wrapped export is a `vi.fn` that **delegates to the real implementation by default** — files that never stub it keep exact production behavior.
- Tests set behavior per-test via `vi.mocked(fn).mockResolvedValue(...)`; an `afterEach` resets call history *and* implementation, so nothing leaks between tests or files.
- Mock namespaces are memoized on `globalThis`: setup files re-execute per test file while the module registry persists, so cached importers and fresh importers must see the *same* `vi.fn` instances.
- A guard throws loudly if a wrapped export disappears from its module, so the file can't silently drift.
- Mock-graph formation is pinned barrel-first: real `candid.ts` and `harvest` import each other through the `src/shared` barrel, and if a *mocked* module's factory is the first entry into that cycle, vitest's factory cycle-guard hands back the raw module — baking unmocked exports into the worker order-dependently.

**45 test files migrated**: per-file `vi.mock` factories deleted; defaults re-established in `beforeEach` against the canonical wrappers. The real `wrapHandler` (which handlers bake in at import time) now applies suite-wide, so tests that asserted raw throws assert the production `topLevelCatch` error envelope instead.

## Bugs found and fixed along the way

- **tinypool teardown race**: with `minWorkers < maxWorkers` under `--no-isolate`, idle-worker recycling races pool destruction and fails green runs with an unhandled `Terminating worker thread` rejection. The CI script pins `--minWorkers=6 --maxWorkers=6` (documented in `vitest.config.ts`).
- **Latent cross-file leaks** that isolation had been masking: an unrestored `DateTime.now` spy, per-test `fetch` stubs never unstubbed (now covered by `unstubGlobals: true`), and a whole-module `luxon` mock (replaced with `vi.useFakeTimers({toFake: ['Date']})`).

## Validation

- Full suite green in the CI configuration: 303 files / 3,527 tests, exit 0, no worker errors
- 8/8 full-suite runs green with shuffled file order (`--sequence.shuffle.files`, seeds 1–34)
- Full suite green in a **single shared worker** (maximum state sharing; 1GB per-fork heap cap holds)
- Default isolated mode still green and unchanged — local `vitest run` / `vitest watch` workflows are untouched
- Real CI script (with coverage) green in 32s locally; `tsc --noEmit` and eslint clean

## Test Plan

- [ ] CI `zambdas unit tests` job passes on this PR
- [ ] Compare the job's wall time against a recent develop run (~490s contended baseline)
- [ ] Confirm co-running suites on the shared runner don't regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6eKpkXzRSJkzsaXEF43e8

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6eKpkXzRSJkzsaXEF43e8)_