### PR TITLE
EHR. Wrap chart header on small screens

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/Header.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/Header.tsx
@@ -77,7 +77,6 @@ const HeaderWrapper = styled(Box)(({ theme }) => ({
   padding: '8px 16px 8px 0',
   borderBottom: `1px solid ${theme.palette.divider}`,
   boxShadow: '0px 2px 4px -1px #00000033',
-  overflowX: 'hidden',
 }));
 
 const PatientName = styled(Typography)(({ theme }) => ({
@@ -400,20 +399,8 @@ export const Header = (): JSX.Element => {
         <Grid container spacing={2} sx={{ padding: '0 18px 0 4px' }}>
           <Grid item xs={12}>
             <Grid container alignItems="center" justifyContent="space-between" wrap="nowrap">
-              <Grid item sx={{ flex: '1 1 0', minWidth: 0 }}>
-                <Grid
-                  container
-                  alignItems="center"
-                  spacing={2}
-                  wrap="nowrap"
-                  sx={{
-                    overflowX: 'auto',
-                    overflowY: 'hidden',
-                    scrollbarWidth: 'thin',
-                    '&::-webkit-scrollbar': { height: '4px', width: 0 },
-                    '&::-webkit-scrollbar-thumb': { borderRadius: '2px', backgroundColor: 'rgba(0,0,0,0.2)' },
-                  }}
-                >
+              <Grid item>
+                <Grid container alignItems="center" spacing={2}>
                   <Grid item>
                     {isFollowup ? (
                       getFollowupStatusChip(getAnnotationFollowupStatusLabel(encounter?.status))


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-3201/chart-header-shouldnt-be-cut

To my mind, making something scrollable especially on small screens isn't the best thing. It's far better from UX prospective just wrap some items on the "next line".

<img width="1844" height="1080" alt="image" src="https://github.com/user-attachments/assets/39895249-1128-45bf-b793-2c9445ead450" />
