### PR TITLE
Fix radiology section in discharge summary and visit note pdfs

### DIFF
--- a/packages/zambdas/src/shared/pdf/sections/discharge-summary/radiology.ts
+++ b/packages/zambdas/src/shared/pdf/sections/discharge-summary/radiology.ts
@@ -33,7 +33,7 @@ export const composeRadiology: DataComposer<{ allChartData: AllChartData }, Radi
     .filter((order) => !order.finalReport)
     .map((order) => order.studyType);
 
-  return { radiology, radiologyOrders: pendingOrderNames };
+  return { radiology, pendingRadiologyOrders: pendingOrderNames };
 };
 
 export const createRadiologySection = <TData extends { radiology?: RadiologyData }>(): PdfSection<


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-3203/ehr-pending-radiology-order-isnt-displayed-on-progress-note-and-on