### PR TITLE
feat(billing): Add status filter to claim list

### DIFF
--- a/apps/billing/package.json
+++ b/apps/billing/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "scripts": {
-    "start": "vite --mode $([ \"$ENV\" = \"local\" ] && echo default || echo ${ENV:-default})",
+    "start": "vite --force --mode $([ \"$ENV\" = \"local\" ] && echo default || echo ${ENV:-default})",
     "build": "tsc && vite build --mode default",
     "build:env": "ENV=$npm_config_env npm run build-skeleton",
     "build:local": "npm run build",

--- a/apps/billing/src/pages/ClaimsList.tsx
+++ b/apps/billing/src/pages/ClaimsList.tsx
@@ -17,15 +17,18 @@ import {
 } from '@mui/material';
 import { DataGridPro, GridColDef, GridPaginationModel, GridRowSelectionModel } from '@mui/x-data-grid-pro';
 import { enqueueSnackbar } from 'notistack';
-import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
+import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
+  ALL_CLAIM_STATUS_OPTIONS_2,
+  ALL_CLAIM_STATUS_OPTIONS_BY_GROUP,
   BillingClaimItem,
   BillingPatientOption,
   BillingPayerOption,
   BillingService,
   CLAIM_STATUS_FIELDS,
   CLAIM_STATUS_FIELDS_BY_KEY,
+  CLAIM_STATUS_GROUPS,
   CODE_SYSTEM_CLAIM_TYPE_CODES,
   formatClaimStatusValue,
   formatCurrency,
@@ -51,6 +54,7 @@ import { useApiClients } from '../hooks/useAppClients';
 interface Filters {
   searchText?: string;
   arStage?: string;
+  status?: string;
   tag?: string;
   createdFrom?: string;
   createdTo?: string;
@@ -150,6 +154,7 @@ export default function ClaimsList(): ReactElement {
 
   const [searchText, setSearchText] = useState('');
   const [arStageFilter, setArStageFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
   const [tagFilter, setTagFilter] = useState('');
   const [tagOptions, setTagOptions] = useState<{ id: string; name: string }[]>([]);
   const [createdFrom, setCreatedFrom] = useState('');
@@ -165,6 +170,18 @@ export default function ClaimsList(): ReactElement {
   const serviceDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
   const payerDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
   const patientDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const statusOptions = useMemo(() => {
+    if (!arStageFilter) {
+      return ALL_CLAIM_STATUS_OPTIONS_2;
+    }
+    const groupKey = CLAIM_STATUS_GROUPS.find((g) => g.arStageCode === arStageFilter)?.key;
+    if (!groupKey) {
+      return ALL_CLAIM_STATUS_OPTIONS_2;
+    }
+    console.log('colin', arStageFilter, groupKey);
+    return ALL_CLAIM_STATUS_OPTIONS_BY_GROUP[groupKey];
+  }, [arStageFilter]);
 
   useEffect(() => {
     return (): void => {
@@ -189,6 +206,7 @@ export default function ClaimsList(): ReactElement {
         };
         if (filters.searchText) params.searchText = filters.searchText;
         if (filters.arStage) params.arStage = filters.arStage;
+        if (filters.status) params.status = filters.status;
         if (filters.tag) params.tag = filters.tag;
         if (filters.createdFrom) params.createdFrom = filters.createdFrom;
         if (filters.createdTo) params.createdTo = filters.createdTo;
@@ -274,6 +292,7 @@ export default function ClaimsList(): ReactElement {
     (overrides?: Filters): Filters => ({
       searchText: overrides?.searchText ?? searchText,
       arStage: overrides?.arStage ?? arStageFilter,
+      status: overrides?.status ?? statusFilter,
       tag: overrides?.tag ?? tagFilter,
       createdFrom: overrides?.createdFrom ?? createdFrom,
       createdTo: overrides?.createdTo ?? createdTo,
@@ -287,6 +306,7 @@ export default function ClaimsList(): ReactElement {
     [
       searchText,
       arStageFilter,
+      statusFilter,
       tagFilter,
       createdFrom,
       createdTo,
@@ -321,6 +341,7 @@ export default function ClaimsList(): ReactElement {
   const clearFilters = (): void => {
     setSearchText('');
     setArStageFilter('');
+    setStatusFilter('');
     setTagFilter('');
     setCreatedFrom('');
     setCreatedTo('');
@@ -338,6 +359,7 @@ export default function ClaimsList(): ReactElement {
   const hasFilters =
     searchText ||
     arStageFilter ||
+    statusFilter ||
     tagFilter ||
     createdFrom ||
     createdTo ||
@@ -441,6 +463,25 @@ export default function ClaimsList(): ReactElement {
           >
             <MenuItem value="">All</MenuItem>
             {CLAIM_STATUS_FIELDS_BY_KEY.arStage.options.map((o) => (
+              <MenuItem key={o.code} value={o.code}>
+                {o.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl size="small" sx={{ minWidth: 180 }}>
+          <InputLabel>Status</InputLabel>
+          <Select
+            value={statusFilter}
+            label="Status"
+            onChange={(e) => {
+              setStatusFilter(e.target.value);
+              applyFilters({ status: e.target.value });
+            }}
+          >
+            <MenuItem value="">All</MenuItem>
+            {statusOptions.map((o) => (
               <MenuItem key={o.code} value={o.code}>
                 {o.label}
               </MenuItem>

--- a/packages/utils/lib/types/data/billing/billing.schemas.ts
+++ b/packages/utils/lib/types/data/billing/billing.schemas.ts
@@ -138,8 +138,8 @@ export const GetBillingProviderInputSchema = z.object({
 export const SearchBillingClaimsInputSchema = z.object({
   searchText: nonEmptyString.optional(),
   type: z.enum(CODE_SYSTEM_CLAIM_TYPE_CODE_NAMES).optional(),
-  status: nonEmptyString.optional(),
   arStage: nonEmptyString.optional(),
+  status: nonEmptyString.optional(),
   tag: nonEmptyString.optional(),
   createdFrom: nonEmptyString.optional(),
   createdTo: nonEmptyString.optional(),

--- a/packages/utils/lib/types/data/billing/claim-status.ts
+++ b/packages/utils/lib/types/data/billing/claim-status.ts
@@ -189,6 +189,7 @@ export const CLAIM_STATUS_FIELDS: ClaimStatusFieldDef[] = [
   },
 ];
 
+// Full field definitions by key
 export const CLAIM_STATUS_FIELDS_BY_KEY: Record<ClaimStatusFieldKey, ClaimStatusFieldDef> = CLAIM_STATUS_FIELDS.reduce(
   (acc, field) => {
     acc[field.key] = field;
@@ -196,6 +197,30 @@ export const CLAIM_STATUS_FIELDS_BY_KEY: Record<ClaimStatusFieldKey, ClaimStatus
   },
   {} as Record<ClaimStatusFieldKey, ClaimStatusFieldDef>
 );
+
+// All status options across ar stages
+export const ALL_CLAIM_STATUS_OPTIONS: ClaimStatusOption[] = CLAIM_STATUS_FIELDS.flatMap((field) => field.options);
+export const ALL_CLAIM_STATUS_OPTIONS_2: ClaimStatusOption[] = CLAIM_STATUS_FIELDS.reduce((acc, field) => {
+  if (!field.group) return acc;
+  acc.push(...field.options.filter((o) => !acc.some((ao) => ao.code === o.code)));
+  return acc;
+}, [] as ClaimStatusOption[]);
+
+// Status options grouped by group key
+export const ALL_CLAIM_STATUS_OPTIONS_BY_GROUP: Record<ClaimStatusGroupKey, ClaimStatusOption[]> =
+  CLAIM_STATUS_FIELDS.reduce(
+    (acc, field) => {
+      if (!field.group) {
+        return acc;
+      }
+      if (!acc[field.group]) {
+        acc[field.group] = [];
+      }
+      acc[field.group].push(...field.options);
+      return acc;
+    },
+    {} as Record<ClaimStatusGroupKey, ClaimStatusOption[]>
+  );
 
 // Flat map of every status field's resolved code for a claim.
 export type ClaimStatusValues = Record<ClaimStatusFieldKey, string>;

--- a/packages/zambdas/src/billing/search-billing-claims/index.ts
+++ b/packages/zambdas/src/billing/search-billing-claims/index.ts
@@ -23,7 +23,6 @@ import {
   claimIdFromPcn,
   ClaimSearchParam,
   createBillingClient,
-  CURRENT_STATUS_TAG_SYSTEM,
   determineRulesEngineForClaim,
   fhirName,
   findRef,
@@ -95,7 +94,12 @@ async function performEffect(
   ];
 
   if (params.type) filterParams.push({ name: '_tag', value: `${CODE_SYSTEM_CLAIM_TYPE}|${params.type}` });
-  if (params.status) filterParams.push({ name: '_tag', value: `${CURRENT_STATUS_TAG_SYSTEM}|${params.status}` });
+  if (params.status) {
+    filterParams.push({
+      name: '_tag',
+      value: `${CLAIM_STATUS_TAG_SYSTEMS.insuranceArStatus}|${params.status},${CLAIM_STATUS_TAG_SYSTEMS.insurancePaidStatus}|${params.status},${CLAIM_STATUS_TAG_SYSTEMS.adjudicationStatus}|${params.status},${CLAIM_STATUS_TAG_SYSTEMS.patientArStatus}|${params.status},${CLAIM_STATUS_TAG_SYSTEMS.patientPaidStatus}|${params.status},${CLAIM_STATUS_TAG_SYSTEMS.nonInsuranceArStatus}|${params.status},${CLAIM_STATUS_TAG_SYSTEMS.nonInsurancePaidStatus}|${params.status}`,
+    });
+  }
   if (params.arStage)
     filterParams.push({ name: '_tag', value: `${CLAIM_STATUS_TAG_SYSTEMS.arStage}|${params.arStage}` });
   if (params.createdFrom) filterParams.push({ name: 'created', value: `ge${params.createdFrom}` });
@@ -159,6 +163,7 @@ async function performEffect(
     total = matching.length;
     pageClaims = matching.slice(offset, offset + pageSize);
   } else {
+    console.log('colin', filterParams);
     const bundle = await oystehr.fhir.search<Claim>({
       resourceType: 'Claim',
       params: [


### PR DESCRIPTION
Adds status filter to claims list. Filters available statuses by selected AR stage filter. Allows selection of one status at a time, and searches across all status tags for selection.