### PR TITLE
Tasks. Default to 'Pending' & 'In Progress' tasks

### DIFF
--- a/apps/ehr/src/features/tasks/pages/Tasks.tsx
+++ b/apps/ehr/src/features/tasks/pages/Tasks.tsx
@@ -128,7 +128,7 @@ export const Tasks: React.FC = () => {
             id: searchParams.get('location'),
           }
         : null,
-      status: searchParams.get('status'),
+      status: searchParams.get('status')?.split(','),
     };
     methods.reset(filtersValues);
   }, [searchParams, methods]);
@@ -140,12 +140,17 @@ export const Tasks: React.FC = () => {
       },
       callback: ({ values }) => {
         const queryParams = new URLSearchParams();
-        const filtersToPersist: Record<string, string> = {};
+        const filtersToPersist: Record<string, string | string[]> = {};
         for (const key in values) {
           const value = values[key]?.id ?? values[key];
           if (value) {
-            queryParams.set(key, value);
-            filtersToPersist[key] = value;
+            if (!Array.isArray(value)) {
+              queryParams.set(key, value);
+              filtersToPersist[key] = value;
+            } else if (value.length > 0) {
+              queryParams.set(key, value.join(','));
+              filtersToPersist[key] = value;
+            }
           }
         }
         setSearchParams(queryParams);
@@ -165,7 +170,8 @@ export const Tasks: React.FC = () => {
       const filters = JSON.parse(persistedFilters);
       const queryParams = new URLSearchParams();
       for (const key in filters) {
-        queryParams.set(key, filters[key]);
+        const value = filters[key];
+        queryParams.set(key, Array.isArray(value) ? value.join(',') : value);
       }
       setSearchParams(queryParams);
     }
@@ -228,6 +234,7 @@ export const Tasks: React.FC = () => {
               <SelectInput
                 name="status"
                 label="Status"
+                multiple={true}
                 options={Object.keys(TASK_STATUS_LABEL)}
                 getOptionLabel={(option) => TASK_STATUS_LABEL[option]}
               />

--- a/apps/ehr/src/features/tasks/pages/Tasks.tsx
+++ b/apps/ehr/src/features/tasks/pages/Tasks.tsx
@@ -157,7 +157,7 @@ export const Tasks: React.FC = () => {
         if (Object.keys(filtersToPersist).length > 0) {
           localStorage.setItem(LOCAL_STORAGE_FILTERS_KEY, JSON.stringify(filtersToPersist));
         } else {
-          localStorage.removeItem(LOCAL_STORAGE_FILTERS_KEY);
+          localStorage.setItem(LOCAL_STORAGE_FILTERS_KEY, JSON.stringify({}));
         }
       },
     });
@@ -173,6 +173,11 @@ export const Tasks: React.FC = () => {
         const value = filters[key];
         queryParams.set(key, Array.isArray(value) ? value.join(',') : value);
       }
+      setSearchParams(queryParams);
+    }
+    if (searchParams.size === 0 && persistedFilters == null) {
+      const queryParams = new URLSearchParams();
+      queryParams.set('status', 'ready,in-progress');
       setSearchParams(queryParams);
     }
   }, [searchParams, setSearchParams]);


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-1172/clinical-tasks-default-to-display-pending-and-in-progress-tasks

Make "Status" to be multi-select. If there is no previous state, default clinical tasks to display pending & in progress tasks instead of 'all tasks'.