### PR TITLE
feat(adhoc-reports): role-gated access, CSV export, and beta notice

### DIFF
--- a/apps/ehr/src/features/report-builder/hooks/useSandbox.ts
+++ b/apps/ehr/src/features/report-builder/hooks/useSandbox.ts
@@ -121,8 +121,6 @@ export function useSandbox({ code, data, schema, onError, onRendered }: UseSandb
     win.postMessage({ type: 'render', code, data, schema, muiLicenseKey: MUI_X_LICENSE_KEY }, '*');
   }, [code, data, schema]);
 
-  // Whitelisted integration events. The only v1 event is openLink: validate against the shared
-  // schema, build the URL on THIS side, open in a new tab (the frame itself has no allow-popups).
   const handleFrameEvent = useCallback((raw: unknown): void => {
     const parsed = AdHocFrameEventSchema.safeParse(raw);
     if (!parsed.success) {
@@ -134,6 +132,16 @@ export function useSandbox({ code, data, schema, onError, onRendered }: UseSandb
       const href = hrefForOpenLink(event.options);
       if (href) window.open(`${window.location.origin}${href}`, '_blank', 'noopener');
       else showAdHocDebugLog('sandbox', 'openLink rejected by the SPA whitelist', event.options);
+    } else if (event.event === 'exportData') {
+      const url = URL.createObjectURL(new Blob([event.csv], { type: 'text/csv;charset=utf-8;' }));
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = event.filename;
+      a.rel = 'noopener';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
     }
   }, []);
 

--- a/apps/ehr/src/features/report-builder/page/ReportBuilderPage.tsx
+++ b/apps/ehr/src/features/report-builder/page/ReportBuilderPage.tsx
@@ -37,6 +37,26 @@ export default function ReportBuilderPage(): React.ReactElement {
   const navigate = useNavigate();
   const rb = useReportBuilder();
 
+  if (!rb.canView) {
+    return (
+      <PageContainer>
+        <Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
+            <IconButton onClick={() => navigate('/reports')} sx={{ mr: 2 }}>
+              <ArrowBackIcon />
+            </IconButton>
+            <Typography variant="h4" component="h1" color="primary.dark" fontWeight={600}>
+              Ad-Hoc Report
+            </Typography>
+          </Box>
+          <Typography color="text.secondary">
+            You don’t have access to ad-hoc reports. Contact an administrator if you need access.
+          </Typography>
+        </Box>
+      </PageContainer>
+    );
+  }
+
   return (
     <PageContainer>
       <>
@@ -139,39 +159,43 @@ export default function ReportBuilderPage(): React.ReactElement {
             </Box>
           )}
 
-          <Typography variant="subtitle1" sx={{ mb: 1 }}>
-            Describe the report you want
-          </Typography>
-          <TextField
-            multiline
-            minRows={2}
-            fullWidth
-            placeholder="e.g. Bar chart of visits per provider; or average time from check-in to exam room by location"
-            value={rb.request}
-            onChange={(e) => rb.setRequest(e.target.value)}
-            sx={{ mb: 1 }}
-          />
-          {/* No separate refinement: editing the request above and regenerating IS the refinement. */}
-          <Box sx={{ mb: 2, display: 'flex', gap: 1 }}>
-            <Button
-              variant="contained"
-              onClick={rb.handleGenerate}
-              disabled={rb.generating || rb.loading || !rb.request.trim() || !rb.oystehrZambda}
-            >
-              {rb.generating || rb.loading ? (
-                <CircularProgress size={20} />
-              ) : rb.generatedCode ? (
-                'Regenerate report'
-              ) : (
-                'Generate report'
-              )}
-            </Button>
-            {rb.generatedCode && (
-              <Button variant="outlined" onClick={rb.handleReset} disabled={rb.generating || rb.loading}>
-                Reset
-              </Button>
-            )}
-          </Box>
+          {rb.canCreate && (
+            <>
+              <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                Describe the report you want
+              </Typography>
+              <TextField
+                multiline
+                minRows={2}
+                fullWidth
+                placeholder="e.g. Bar chart of visits per provider; or average time from check-in to exam room by location"
+                value={rb.request}
+                onChange={(e) => rb.setRequest(e.target.value)}
+                sx={{ mb: 1 }}
+              />
+              {/* No separate refinement: editing the request above and regenerating IS the refinement. */}
+              <Box sx={{ mb: 2, display: 'flex', gap: 1 }}>
+                <Button
+                  variant="contained"
+                  onClick={rb.handleGenerate}
+                  disabled={rb.generating || rb.loading || !rb.request.trim() || !rb.oystehrZambda}
+                >
+                  {rb.generating || rb.loading ? (
+                    <CircularProgress size={20} />
+                  ) : rb.generatedCode ? (
+                    'Regenerate report'
+                  ) : (
+                    'Generate report'
+                  )}
+                </Button>
+                {rb.generatedCode && (
+                  <Button variant="outlined" onClick={rb.handleReset} disabled={rb.generating || rb.loading}>
+                    Reset
+                  </Button>
+                )}
+              </Box>
+            </>
+          )}
 
           {rb.generateError && (
             <Box sx={{ mb: 2, p: 2, bgcolor: 'error.light', borderRadius: 1 }}>
@@ -231,9 +255,11 @@ export default function ReportBuilderPage(): React.ReactElement {
                     <Button size="small" onClick={() => rb.setShowCode(!rb.showCode)}>
                       {rb.showCode ? 'Hide generated code' : 'View generated code'}
                     </Button>
-                    <Button size="small" variant="outlined" startIcon={<SaveIcon />} onClick={rb.openSaveDialog}>
-                      {rb.loadedSavedId ? 'Save' : 'Save report'}
-                    </Button>
+                    {rb.canCreate && (
+                      <Button size="small" variant="outlined" startIcon={<SaveIcon />} onClick={rb.openSaveDialog}>
+                        {rb.loadedSavedId ? 'Save' : 'Save report'}
+                      </Button>
+                    )}
                   </Box>
 
                   <Collapse in={rb.showCode}>
@@ -259,10 +285,45 @@ export default function ReportBuilderPage(): React.ReactElement {
                   {rb.renderError && (
                     <Box sx={{ mb: 2, p: 2, bgcolor: 'warning.light', borderRadius: 1 }}>
                       <Typography variant="body2">
-                        The generated report failed to run: {rb.renderError}. Adjust your request and regenerate.
+                        The report failed to run: {rb.renderError}.{' '}
+                        {rb.canCreate ? 'Adjust your request and regenerate.' : 'Ask an administrator to rebuild it.'}
                       </Typography>
                     </Box>
                   )}
+
+                  <Box
+                    sx={{
+                      mb: 1,
+                      p: 1.5,
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1.25,
+                      bgcolor: '#fde5e7',
+                      border: '1px solid #ff6c6c',
+                      borderRadius: 1,
+                    }}
+                  >
+                    <Box
+                      component="span"
+                      sx={{
+                        px: 0.75,
+                        py: 0.25,
+                        borderRadius: 0.75,
+                        bgcolor: '#ff6c6c',
+                        color: 'common.white',
+                        fontWeight: 900,
+                        fontSize: '0.9rem',
+                        letterSpacing: '0.05em',
+                        flexShrink: 0,
+                      }}
+                    >
+                      AI
+                    </Box>
+                    <Typography variant="body2" sx={{ color: 'common.black', fontSize: '0.9rem', fontWeight: 500 }}>
+                      This is a beta feature. The report is generated by AI and can be incomplete or wrong. Check the
+                      results against the source data before acting on them.
+                    </Typography>
+                  </Box>
 
                   {/* The model's code runs here, sandboxed, over the fetched rows. */}
                   <ReportFrame

--- a/apps/ehr/src/features/report-builder/page/useReportBuilder.ts
+++ b/apps/ehr/src/features/report-builder/page/useReportBuilder.ts
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { DateTime } from 'luxon';
-import { useSnackbar } from 'notistack';
+import { enqueueSnackbar } from 'notistack';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
@@ -11,8 +11,10 @@ import {
   LlmDatasetSchema,
   SavedAdHocReportDefinition,
 } from 'utils';
+import { AD_HOC_REPORT_EDIT_ROLES, AD_HOC_REPORT_VIEW_ROLES } from 'utils';
 import { generateAdHocReport, inferAdHocReportLayers, listAdHocReports, saveAdHocReport } from '../../../api/api';
 import { useApiClients } from '../../../hooks/useAppClients';
+import useEvolveUser from '../../../hooks/useEvolveUser';
 import { AD_HOC_DATASETS, getDataset, otherDatasetsFor } from '../datasets/registry';
 import { showAdHocDebugLog } from '../debug';
 import { SANDBOX_TIMEOUT_MESSAGE } from '../hooks/useSandbox';
@@ -76,6 +78,8 @@ function partialWarningFor(rows: AdHocRow[]): string | null {
 
 type UseReportBuilder = {
   oystehrZambda: ReturnType<typeof useApiClients>['oystehrZambda'];
+  canView: boolean;
+  canCreate: boolean;
   datasetId: string;
   dateRange: AdHocDateRangeFilter;
   customDate: string;
@@ -126,7 +130,9 @@ export function useReportBuilder(): UseReportBuilder {
   const { oystehrZambda } = useApiClients();
   const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
-  const { enqueueSnackbar } = useSnackbar();
+  const user = useEvolveUser();
+  const canView = user?.hasRole(AD_HOC_REPORT_VIEW_ROLES) ?? false;
+  const canCreate = user?.hasRole(AD_HOC_REPORT_EDIT_ROLES) ?? false;
 
   const initialDatasetId = AD_HOC_DATASETS[0]?.id ?? 'encounters-comprehensive';
   const [datasetId, setDatasetId] = useState<string>(initialDatasetId);
@@ -330,6 +336,7 @@ export function useReportBuilder(): UseReportBuilder {
     },
     [oystehrZambda, datasetOptions, schema, inferOptions, fetchWithOptions, callGenerate]
   );
+
   orchestrateRef.current = orchestrate;
 
   // Consume a deferred regeneration on the render AFTER the saved-report loader committed the saved
@@ -344,12 +351,12 @@ export function useReportBuilder(): UseReportBuilder {
 
   // Editing the request and generating again IS the refinement flow — there is no separate one.
   const handleGenerate = useCallback((): void => {
-    if (!request.trim()) return;
+    if (!request.trim() || !canCreate) return;
     autoRetryRef.current = 0;
     autoFixedRef.current = false;
     setGeneratedCode(null);
     void orchestrate(request, true);
-  }, [request, orchestrate]);
+  }, [request, canCreate, orchestrate]);
 
   // When the generated code throws at runtime in the iframe, transparently regenerate once with the
   // failing code + error attached. After the budget is spent, surface the error. A watchdog
@@ -359,6 +366,7 @@ export function useReportBuilder(): UseReportBuilder {
     (message: string): void => {
       if (
         message !== SANDBOX_TIMEOUT_MESSAGE &&
+        canCreate &&
         autoRetryRef.current < MAX_AUTO_RETRIES &&
         !generating &&
         activeRequestRef.current
@@ -378,7 +386,7 @@ export function useReportBuilder(): UseReportBuilder {
       }
       setRenderError(message);
     },
-    [generating, generatedCode]
+    [canCreate, generating, generatedCode]
   );
 
   // Clear the generated report to start fresh. Keeps the fetched rows/schema and request text, so
@@ -400,7 +408,7 @@ export function useReportBuilder(): UseReportBuilder {
   useEffect(() => {
     const savedId = searchParams.get('saved');
 
-    if (!savedId || !oystehrZambda || loadAttemptedRef.current) return;
+    if (!savedId || !oystehrZambda || !canView || loadAttemptedRef.current) return;
 
     loadAttemptedRef.current = true;
 
@@ -449,16 +457,20 @@ export function useReportBuilder(): UseReportBuilder {
         autoRetryRef.current = 0;
 
         if ((saved.runtimeVersion ?? 0) !== ADHOC_RUNTIME_VERSION) {
-          showAdHocDebugLog('saved', 'runtime version mismatch — regenerating from prompt', {
+          showAdHocDebugLog('saved', 'runtime version mismatch', {
             saved: saved.runtimeVersion,
             current: ADHOC_RUNTIME_VERSION,
           });
 
-          enqueueSnackbar('This report was rebuilt for an updated report engine.', {
-            variant: 'info',
-          });
-          autoFixedRef.current = true;
-          setPendingRegenerate(saved.request);
+          if (!canCreate) {
+            setError('This report was built for an older report engine and needs an administrator to rebuild it.');
+          } else {
+            enqueueSnackbar('This report was rebuilt for an updated report engine.', {
+              variant: 'info',
+            });
+            autoFixedRef.current = true;
+            setPendingRegenerate(saved.request);
+          }
         } else {
           setGeneratedCode(saved.code);
           setGeneratedTitle(saved.title);
@@ -504,12 +516,12 @@ export function useReportBuilder(): UseReportBuilder {
   const handleRendered = useCallback((): void => {
     if (!autoFixedRef.current) return;
     autoFixedRef.current = false;
-    if (!oystehrZambda || !loadedSavedId || !generatedCode) return;
+    if (!canCreate || !oystehrZambda || !loadedSavedId || !generatedCode) return;
     void saveAdHocReport(oystehrZambda, {
       reportId: loadedSavedId,
       definition: buildDefinition(savedName || generatedTitle || 'Report', generatedCode),
     }).catch((e) => console.warn('Could not persist auto-fixed report', e));
-  }, [oystehrZambda, loadedSavedId, generatedCode, buildDefinition, savedName, generatedTitle]);
+  }, [canCreate, oystehrZambda, loadedSavedId, generatedCode, buildDefinition, savedName, generatedTitle]);
 
   const handleSave = useCallback(
     async (mode: 'update' | 'new'): Promise<void> => {
@@ -530,7 +542,7 @@ export function useReportBuilder(): UseReportBuilder {
         setSaving(false);
       }
     },
-    [oystehrZambda, generatedCode, savedName, loadedSavedId, buildDefinition, enqueueSnackbar]
+    [oystehrZambda, generatedCode, savedName, loadedSavedId, buildDefinition]
   );
 
   const openSaveDialog = useCallback((): void => {
@@ -540,6 +552,8 @@ export function useReportBuilder(): UseReportBuilder {
 
   return {
     oystehrZambda,
+    canView,
+    canCreate,
     datasetId,
     dateRange,
     customDate,

--- a/apps/ehr/src/features/report-builder/runtime/components/Table.tsx
+++ b/apps/ehr/src/features/report-builder/runtime/components/Table.tsx
@@ -1,4 +1,4 @@
-import { Box, Paper } from '@mui/material';
+import { Box, Button, Paper, Typography } from '@mui/material';
 import {
   DataGridPro,
   GridColDef,
@@ -7,9 +7,13 @@ import {
   GridToolbarContainer,
   GridToolbarDensitySelector,
   GridToolbarFilterButton,
+  useGridApiRef,
 } from '@mui/x-data-grid-pro';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import type { AdHocLinkRoute } from 'utils';
+// Deep import (not the 'utils' barrel) so the iframe bundle stays zod-free.
+import { MAX_EXPORT_CSV_LENGTH } from 'utils/lib/types/adhoc/sandbox/limits';
+import { sendFrameEvent } from '../messaging';
 import { formatValue, ValueFormat } from './format';
 import { Link } from './Link';
 
@@ -58,6 +62,8 @@ interface GridRow extends Record<string, unknown> {
 // values (rows are already typed; no string re-parsing). A `links` entry turns a column's cells
 // into whitelisted navigation events via <Link>.
 export function Table({ rows, columns, links, title, pageSize = 25, onRowClick }: TableProps): React.ReactElement {
+  const apiRef = useGridApiRef();
+  const [exportTooLarge, setExportTooLarge] = useState(false);
   const linkByField = useMemo(() => {
     const m = new Map<string, TableLink>();
     (links ?? []).forEach((l) => m.set(l.field, l));
@@ -113,9 +119,23 @@ export function Table({ rows, columns, links, title, pageSize = 25, onRowClick }
     return { gridColumns, gridRows };
   }, [columns, rows, linkByField]);
 
-  // No CSV export button: downloads need the `allow-downloads` sandbox flag, but the frame's sandbox
-  // is strictly `allow-scripts` (security contract). Export could return later as a whitelisted
-  // SPA-side event.
+  const handleExport = useCallback((): void => {
+    const csv = apiRef.current.getDataAsCsv();
+    if (!csv) return;
+    // Refuse oversized exports here (before the postMessage) — that's what the shared limit is for.
+    if (csv.length > MAX_EXPORT_CSV_LENGTH) {
+      setExportTooLarge(true);
+      return;
+    }
+    setExportTooLarge(false);
+    const base =
+      (title ?? 'report')
+        .replace(/[^\w.-]+/g, '_')
+        .replace(/^_+|_+$/g, '')
+        .slice(0, 100) || 'report';
+    sendFrameEvent({ event: 'exportData', filename: `${base}.csv`, csv });
+  }, [apiRef, title]);
+
   const Toolbar = useMemo(
     () =>
       function ToolbarInner(): React.ReactElement {
@@ -124,18 +144,27 @@ export function Table({ rows, columns, links, title, pageSize = 25, onRowClick }
             <GridToolbarColumnsButton />
             <GridToolbarFilterButton />
             <GridToolbarDensitySelector />
+            <Button size="small" onClick={handleExport}>
+              Export CSV
+            </Button>
           </GridToolbarContainer>
         );
       },
-    []
+    [handleExport]
   );
 
   return (
     <Box sx={{ mb: 1 }}>
+      {exportTooLarge && (
+        <Typography variant="body2" color="error" sx={{ mb: 0.5 }}>
+          This report is too large to export.
+        </Typography>
+      )}
       <Paper variant="outlined" sx={{ width: '100%' }}>
         {/* Known limitation: the filter/columns panels render in a portal inside the frame and can
             be clipped by the frame's height near the bottom of a short report. */}
         <DataGridPro
+          apiRef={apiRef}
           aria-label={title}
           autoHeight
           density="compact"

--- a/apps/ehr/src/pages/Reports.tsx
+++ b/apps/ehr/src/pages/Reports.tsx
@@ -29,10 +29,10 @@ import {
   useTheme,
 } from '@mui/material';
 import { captureException } from '@sentry/react';
-import { useSnackbar } from 'notistack';
+import { enqueueSnackbar } from 'notistack';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { RoleType, SavedAdHocReport } from 'utils';
+import { AD_HOC_REPORT_EDIT_ROLES, AD_HOC_REPORT_VIEW_ROLES, RoleType, SavedAdHocReport } from 'utils';
 import { deleteAdHocReport, listAdHocReports, saveAdHocReport } from '../api/api';
 import { useApiClients } from '../hooks/useAppClients';
 import useEvolveUser from '../hooks/useEvolveUser';
@@ -113,11 +113,13 @@ function ReportTile({ title, description, icon, onClick }: ReportTileProps): Rea
 
 function SavedReportTile({
   report,
+  canManage,
   onOpen,
   onRename,
   onDelete,
 }: {
   report: SavedAdHocReport;
+  canManage: boolean;
   onOpen: () => void;
   onRename: () => void;
   onDelete: () => void;
@@ -135,30 +137,32 @@ function SavedReportTile({
         cursor: 'pointer',
       }}
     >
-      <Box sx={{ position: 'absolute', top: 4, right: 4, zIndex: 2, display: 'flex' }}>
-        <Tooltip title="Edit">
-          <IconButton
-            size="small"
-            onClick={(e) => {
-              e.stopPropagation();
-              onRename();
-            }}
-          >
-            <EditIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Delete">
-          <IconButton
-            size="small"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete();
-            }}
-          >
-            <DeleteOutlineIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
-      </Box>
+      {canManage && (
+        <Box sx={{ position: 'absolute', top: 4, right: 4, zIndex: 2, display: 'flex' }}>
+          <Tooltip title="Edit">
+            <IconButton
+              size="small"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRename();
+              }}
+            >
+              <EditIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Delete">
+            <IconButton
+              size="small"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+            >
+              <DeleteOutlineIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      )}
       <CardActionArea
         onClick={onOpen}
         sx={{
@@ -186,7 +190,19 @@ function SavedReportTile({
             {report.name}
           </Typography>
           {report.description ? (
-            <Typography variant="body1" color="text.secondary" sx={{ lineHeight: 1.5 }}>
+            <Typography
+              variant="body1"
+              color="text.secondary"
+              title={report.description}
+              sx={{
+                lineHeight: 1.5,
+                display: '-webkit-box',
+                WebkitBoxOrient: 'vertical',
+                WebkitLineClamp: 4,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
               {report.description}
             </Typography>
           ) : (
@@ -206,6 +222,7 @@ interface ReportTileConfig {
   icon: React.ReactElement;
   path: string;
   adminOnly?: boolean;
+  requiredRoles?: RoleType[];
 }
 
 const REPORT_TILES: ReportTileConfig[] = [
@@ -233,7 +250,7 @@ const REPORT_TILES: ReportTileConfig[] = [
     description: 'Describe a report in plain language and the AI generates it over the encounters dataset',
     icon: <AutoAwesomeIcon />,
     path: '/reports/ad-hoc',
-    adminOnly: true,
+    requiredRoles: AD_HOC_REPORT_EDIT_ROLES,
   },
   {
     title: 'Daily Payments',
@@ -273,10 +290,10 @@ export default function Reports(): React.ReactElement {
   const navigate = useNavigate();
   const user = useEvolveUser();
   const isAdmin = user?.hasRole([RoleType.Administrator]) ?? false;
+  const canViewAdHoc = user?.hasRole(AD_HOC_REPORT_VIEW_ROLES) ?? false;
+  const canEditAdHoc = user?.hasRole(AD_HOC_REPORT_EDIT_ROLES) ?? false;
   const { oystehrZambda } = useApiClients();
-  const { enqueueSnackbar } = useSnackbar();
 
-  // Saved ad-hoc reports — same access gate as the Ad-Hoc Report tile (admin only).
   const [savedReports, setSavedReports] = useState<SavedAdHocReport[]>([]);
   const [loadingSaved, setLoadingSaved] = useState(false);
   const [savedError, setSavedError] = useState(false);
@@ -287,7 +304,7 @@ export default function Reports(): React.ReactElement {
   const [busy, setBusy] = useState(false);
 
   const refreshSaved = useCallback(async (): Promise<void> => {
-    if (!oystehrZambda || !isAdmin) return;
+    if (!oystehrZambda || !canViewAdHoc) return;
     setLoadingSaved(true);
     setSavedError(false);
     try {
@@ -300,7 +317,7 @@ export default function Reports(): React.ReactElement {
     } finally {
       setLoadingSaved(false);
     }
-  }, [oystehrZambda, isAdmin]);
+  }, [oystehrZambda, canViewAdHoc]);
 
   useEffect(() => {
     void refreshSaved();
@@ -323,7 +340,7 @@ export default function Reports(): React.ReactElement {
     } finally {
       setBusy(false);
     }
-  }, [oystehrZambda, deleteTarget, enqueueSnackbar]);
+  }, [oystehrZambda, deleteTarget]);
 
   const handleSaveEdit = useCallback(async (): Promise<void> => {
     if (!oystehrZambda || !renameTarget || !renameValue.trim()) return;
@@ -343,7 +360,7 @@ export default function Reports(): React.ReactElement {
     } finally {
       setBusy(false);
     }
-  }, [oystehrZambda, renameTarget, renameValue, descriptionValue, enqueueSnackbar, refreshSaved]);
+  }, [oystehrZambda, renameTarget, renameValue, descriptionValue, refreshSaved]);
 
   return (
     <PageContainer>
@@ -359,7 +376,9 @@ export default function Reports(): React.ReactElement {
           </Box>
 
           <Grid container spacing={3}>
-            {REPORT_TILES.filter((tile) => isAdmin || !tile.adminOnly).map((tile) => (
+            {REPORT_TILES.filter((tile) =>
+              tile.requiredRoles ? user?.hasRole(tile.requiredRoles) ?? false : isAdmin || !tile.adminOnly
+            ).map((tile) => (
               <Grid item xs={12} sm={6} md={4} lg={3} key={tile.path}>
                 <ReportTile
                   title={tile.title}
@@ -372,8 +391,7 @@ export default function Reports(): React.ReactElement {
             ))}
           </Grid>
 
-          {/* Saved ad-hoc reports — practice-wide, admin-gated like the Ad-Hoc Report tile. */}
-          {isAdmin && (loadingSaved || savedReports.length > 0 || savedError) && (
+          {canViewAdHoc && (loadingSaved || savedReports.length > 0 || savedError) && (
             <Box sx={{ mt: 5 }}>
               <Typography variant="h5" component="h2" gutterBottom color="primary.dark" fontWeight={600}>
                 Saved reports
@@ -394,6 +412,7 @@ export default function Reports(): React.ReactElement {
                     <Grid item xs={12} sm={6} md={4} lg={3} key={report.id}>
                       <SavedReportTile
                         report={report}
+                        canManage={canEditAdHoc}
                         onOpen={() => navigate(`/reports/ad-hoc?saved=${encodeURIComponent(report.id)}`)}
                         onRename={() => {
                           setRenameValue(report.name);

--- a/packages/utils/lib/types/adhoc/access.ts
+++ b/packages/utils/lib/types/adhoc/access.ts
@@ -1,0 +1,5 @@
+import { RoleType } from '../api/user.types';
+
+export const AD_HOC_REPORT_VIEW_ROLES: RoleType[] = [RoleType.Administrator];
+
+export const AD_HOC_REPORT_EDIT_ROLES: RoleType[] = [RoleType.Administrator];

--- a/packages/utils/lib/types/adhoc/index.ts
+++ b/packages/utils/lib/types/adhoc/index.ts
@@ -1,11 +1,4 @@
-// Shared ad-hoc report types, organized by the same domains as the app feature slice. One Zod
-// schema per data endpoint response is the single source of truth: it derives the TS types,
-// validates the endpoint response, and serializes the LLM-facing schema for the prompt.
-// datasets   — Zod row/I-O schemas per dataset + the LLM schema serialization
-// query      — opt-in depth (layers) + time-window selector
-// generation — the generate / infer endpoint contracts
-// sandbox    — the iframe ↔ SPA message contract (whitelisted events)
-// saved      — persisted report definition + CRUD I/O
+export * from './access';
 export * from './datasets/llm-schema';
 export * from './datasets/dataset';
 export * from './sandbox/events';

--- a/packages/utils/lib/types/adhoc/index.ts
+++ b/packages/utils/lib/types/adhoc/index.ts
@@ -1,4 +1,3 @@
-export * from './access';
 export * from './datasets/llm-schema';
 export * from './datasets/dataset';
 export * from './sandbox/events';

--- a/packages/utils/lib/types/adhoc/sandbox/events.ts
+++ b/packages/utils/lib/types/adhoc/sandbox/events.ts
@@ -3,6 +3,7 @@
 // of allowed events (this schema) and ignores everything else; later versions add new events (and
 // SPA → iframe replies) by extending the union, the shape does not change.
 import { z } from 'zod';
+import { MAX_EXPORT_CSV_LENGTH } from './limits';
 
 /** Routes a report link may target. The SPA owns the URL template per route; the generated code
  *  only ever names a route + an id, so a report cannot emit an arbitrary URL. */
@@ -24,5 +25,10 @@ export type OpenLinkOptions = z.infer<typeof OpenLinkOptionsSchema>;
 
 export const AdHocFrameEventSchema = z.discriminatedUnion('event', [
   z.object({ event: z.literal('openLink'), options: OpenLinkOptionsSchema }),
+  z.object({
+    event: z.literal('exportData'),
+    filename: z.string().min(1).max(200),
+    csv: z.string().max(MAX_EXPORT_CSV_LENGTH),
+  }),
 ]);
 export type AdHocFrameEvent = z.infer<typeof AdHocFrameEventSchema>;

--- a/packages/utils/lib/types/adhoc/sandbox/limits.ts
+++ b/packages/utils/lib/types/adhoc/sandbox/limits.ts
@@ -1,0 +1,1 @@
+export const MAX_EXPORT_CSV_LENGTH = 8 * 1024 * 1024;

--- a/packages/utils/lib/types/api/adhoc-report-access.ts
+++ b/packages/utils/lib/types/api/adhoc-report-access.ts
@@ -1,4 +1,4 @@
-import { RoleType } from '../api/user.types';
+import { RoleType } from './user.types';
 
 export const AD_HOC_REPORT_VIEW_ROLES: RoleType[] = [RoleType.Administrator];
 

--- a/packages/utils/lib/types/api/index.ts
+++ b/packages/utils/lib/types/api/index.ts
@@ -19,6 +19,7 @@ export * from './visits-overview-report.types';
 export * from './user-activation.types';
 export * from './encounter.types';
 export * from './action-logs.types';
+export * from './adhoc-report-access';
 export * from './get-appointments.types';
 export * from './get-employees';
 export * from './get-conversation.types';

--- a/packages/zambdas/src/ehr/adhoc-billing/index.ts
+++ b/packages/zambdas/src/ehr/adhoc-billing/index.ts
@@ -18,6 +18,7 @@ import {
   Resource,
 } from 'fhir/r4b';
 import {
+  AD_HOC_REPORT_VIEW_ROLES,
   AdHocBillingInput,
   AdHocBillingOutputSchema,
   AdHocBillingRow,
@@ -32,6 +33,8 @@ import {
   checkOrCreateM2MClientToken,
   createClinicalOystehrClient,
   fetchAllPages,
+  getUserToken,
+  requireUserWithRole,
   wrapHandler,
   ZambdaInput,
 } from '../../shared';
@@ -56,6 +59,8 @@ const round2 = (n: number): number => Math.round(n * 100) / 100;
 
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   const { secrets, ...params } = validateRequestParameters(input);
+
+  await requireUserWithRole(getUserToken(input), secrets, AD_HOC_REPORT_VIEW_ROLES);
 
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createClinicalOystehrClient(m2mToken, secrets);

--- a/packages/zambdas/src/ehr/adhoc-encounters/index.ts
+++ b/packages/zambdas/src/ehr/adhoc-encounters/index.ts
@@ -22,6 +22,7 @@ import {
 } from 'fhir/r4b';
 import { DateTime } from 'luxon';
 import {
+  AD_HOC_REPORT_VIEW_ROLES,
   AdHocEncounterRow,
   AdHocEncountersInput,
   AdHocEncountersOutputSchema,
@@ -48,6 +49,8 @@ import {
   checkOrCreateM2MClientToken,
   createClinicalOystehrClient,
   followUpTypeFromPerformerType,
+  getUserToken,
+  requireUserWithRole,
   wrapHandler,
   ZambdaInput,
 } from '../../shared';
@@ -150,6 +153,8 @@ const orderDisplay = (sr: ServiceRequest): string =>
 
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   const { secrets, ...params } = validateRequestParameters(input);
+
+  await requireUserWithRole(getUserToken(input), secrets, AD_HOC_REPORT_VIEW_ROLES);
 
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createClinicalOystehrClient(m2mToken, secrets);

--- a/packages/zambdas/src/ehr/adhoc-patients/index.ts
+++ b/packages/zambdas/src/ehr/adhoc-patients/index.ts
@@ -14,6 +14,7 @@ import {
 } from 'fhir/r4b';
 import { DateTime } from 'luxon';
 import {
+  AD_HOC_REPORT_VIEW_ROLES,
   AdHocPatientRow,
   AdHocPatientsInput,
   AdHocPatientsOutputSchema,
@@ -30,7 +31,14 @@ import {
   PATIENT_POINT_OF_DISCOVERY_URL,
   SERVICE_CATEGORY_SYSTEM,
 } from 'utils';
-import { checkOrCreateM2MClientToken, createClinicalOystehrClient, wrapHandler, ZambdaInput } from '../../shared';
+import {
+  checkOrCreateM2MClientToken,
+  createClinicalOystehrClient,
+  getUserToken,
+  requireUserWithRole,
+  wrapHandler,
+  ZambdaInput,
+} from '../../shared';
 import { fetchAppointmentReportResources, REPORT_ATTENDED_APPOINTMENT_STATUSES } from '../../shared/adhoc-report';
 import { validateOutputWithSchema } from '../../shared/validate-zod';
 import { validateRequestParameters } from './validateRequestParameters';
@@ -58,6 +66,8 @@ interface PatientAgg {
 
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   const { secrets, ...params } = validateRequestParameters(input);
+
+  await requireUserWithRole(getUserToken(input), secrets, AD_HOC_REPORT_VIEW_ROLES);
 
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createClinicalOystehrClient(m2mToken, secrets);

--- a/packages/zambdas/src/ehr/delete-adhoc-report/index.ts
+++ b/packages/zambdas/src/ehr/delete-adhoc-report/index.ts
@@ -1,6 +1,18 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { DeleteAdHocReportOutput, DeleteAdHocReportOutputSchema, FHIR_RESOURCE_NOT_FOUND } from 'utils';
-import { checkOrCreateM2MClientToken, createClinicalOystehrClient, wrapHandler, ZambdaInput } from '../../shared';
+import {
+  AD_HOC_REPORT_EDIT_ROLES,
+  DeleteAdHocReportOutput,
+  DeleteAdHocReportOutputSchema,
+  FHIR_RESOURCE_NOT_FOUND,
+} from 'utils';
+import {
+  checkOrCreateM2MClientToken,
+  createClinicalOystehrClient,
+  getUserToken,
+  requireUserWithRole,
+  wrapHandler,
+  ZambdaInput,
+} from '../../shared';
 import { savedAdHocReportExists } from '../../shared/saved-adhoc-report';
 import { validateOutputWithSchema } from '../../shared/validate-zod';
 import { validateRequestParameters } from './validateRequestParameters';
@@ -11,6 +23,8 @@ let m2mToken: string;
 
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   const { reportId, secrets } = validateRequestParameters(input);
+
+  await requireUserWithRole(getUserToken(input), secrets, AD_HOC_REPORT_EDIT_ROLES);
 
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createClinicalOystehrClient(m2mToken, secrets);

--- a/packages/zambdas/src/ehr/generate-adhoc-report/index.ts
+++ b/packages/zambdas/src/ehr/generate-adhoc-report/index.ts
@@ -1,5 +1,6 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
 import {
+  AD_HOC_REPORT_EDIT_ROLES,
   buildComponentsPromptSection,
   buildExecutionContractPromptSection,
   fixAndParseJsonObjectFromString,
@@ -12,7 +13,7 @@ import {
   REPORT_ROOT_NAME,
   Secrets,
 } from 'utils';
-import { wrapHandler, ZambdaInput } from '../../shared';
+import { getUserToken, requireUserWithRole, wrapHandler, ZambdaInput } from '../../shared';
 import { invokeChatbotVertexAI, VERTEX_AI_MODEL } from '../../shared/ai';
 import { validateOutputWithSchema } from '../../shared/validate-zod';
 import { validateRequestParameters } from './validateRequestParameters';
@@ -240,6 +241,9 @@ const performEffect = async (
 
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   const { secrets, ...params } = validateRequestParameters(input);
+
+  await requireUserWithRole(getUserToken(input), secrets, AD_HOC_REPORT_EDIT_ROLES);
+
   const output = await performEffect(params, secrets);
 
   return { statusCode: 200, body: JSON.stringify(output) };

--- a/packages/zambdas/src/ehr/infer-adhoc-report-layers/index.ts
+++ b/packages/zambdas/src/ehr/infer-adhoc-report-layers/index.ts
@@ -1,7 +1,12 @@
 import { captureException } from '@sentry/aws-serverless';
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { fixAndParseJsonObjectFromString, InferAdHocLayersOutput, InferAdHocLayersOutputSchema } from 'utils';
-import { wrapHandler, ZambdaInput } from '../../shared';
+import {
+  AD_HOC_REPORT_EDIT_ROLES,
+  fixAndParseJsonObjectFromString,
+  InferAdHocLayersOutput,
+  InferAdHocLayersOutputSchema,
+} from 'utils';
+import { getUserToken, requireUserWithRole, wrapHandler, ZambdaInput } from '../../shared';
 import { invokeChatbotVertexAI, VERTEX_AI_MODEL } from '../../shared/ai';
 import { validateOutputWithSchema } from '../../shared/validate-zod';
 import { validateRequestParameters } from './validateRequestParameters';
@@ -44,6 +49,8 @@ Return JSON: { "layerIds": ["<id>", ...] }  — an empty array if no optional la
 
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   const { layers, request, secrets } = validateRequestParameters(input);
+
+  await requireUserWithRole(getUserToken(input), secrets, AD_HOC_REPORT_EDIT_ROLES);
 
   const validIds = new Set(layers.map((l) => l.id));
   let layerIds: string[] = [];

--- a/packages/zambdas/src/ehr/list-adhoc-reports/index.ts
+++ b/packages/zambdas/src/ehr/list-adhoc-reports/index.ts
@@ -1,10 +1,17 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Basic } from 'fhir/r4b';
-import { ListAdHocReportsOutput, ListAdHocReportsOutputSchema, SavedAdHocReport } from 'utils';
+import {
+  AD_HOC_REPORT_VIEW_ROLES,
+  ListAdHocReportsOutput,
+  ListAdHocReportsOutputSchema,
+  SavedAdHocReport,
+} from 'utils';
 import {
   checkOrCreateM2MClientToken,
   createClinicalOystehrClient,
   fetchAllPages,
+  getUserToken,
+  requireUserWithRole,
   wrapHandler,
   ZambdaInput,
 } from '../../shared';
@@ -22,6 +29,8 @@ let m2mToken: string;
 
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   const { secrets } = validateRequestParameters(input);
+
+  await requireUserWithRole(getUserToken(input), secrets, AD_HOC_REPORT_VIEW_ROLES);
 
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createClinicalOystehrClient(m2mToken, secrets);

--- a/packages/zambdas/src/ehr/save-adhoc-report/index.ts
+++ b/packages/zambdas/src/ehr/save-adhoc-report/index.ts
@@ -1,7 +1,19 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Basic } from 'fhir/r4b';
-import { FHIR_RESOURCE_NOT_FOUND, SaveAdHocReportOutput, SaveAdHocReportOutputSchema } from 'utils';
-import { checkOrCreateM2MClientToken, createClinicalOystehrClient, wrapHandler, ZambdaInput } from '../../shared';
+import {
+  AD_HOC_REPORT_EDIT_ROLES,
+  FHIR_RESOURCE_NOT_FOUND,
+  SaveAdHocReportOutput,
+  SaveAdHocReportOutputSchema,
+} from 'utils';
+import {
+  checkOrCreateM2MClientToken,
+  createClinicalOystehrClient,
+  getUserToken,
+  requireUserWithRole,
+  wrapHandler,
+  ZambdaInput,
+} from '../../shared';
 import {
   makeSavedAdHocReportBasic,
   parseSavedAdHocReportBasic,
@@ -17,6 +29,8 @@ let m2mToken: string;
 
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   const { reportId, definition, secrets } = validateRequestParameters(input);
+
+  await requireUserWithRole(getUserToken(input), secrets, AD_HOC_REPORT_EDIT_ROLES);
 
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
   const oystehr = createClinicalOystehrClient(m2mToken, secrets);

--- a/packages/zambdas/src/shared/auth.ts
+++ b/packages/zambdas/src/shared/auth.ts
@@ -5,6 +5,7 @@ import {
   getNPIIdentifier,
   getPatientsForUser,
   getSecret,
+  MISSING_AUTH_TOKEN,
   NOT_AUTHORIZED,
   RoleType,
   Secrets,
@@ -13,6 +14,12 @@ import {
   userMe,
 } from 'utils';
 import { getAuth0Token } from './getAuth0Token';
+
+export const getUserToken = (input: { headers?: { Authorization?: string } }): string => {
+  const token = input.headers?.Authorization?.replace('Bearer ', '');
+  if (!token) throw MISSING_AUTH_TOKEN;
+  return token;
+};
 
 export async function getUser(token: string, secrets: Secrets | null): Promise<User> {
   let user: User;


### PR DESCRIPTION
- Gate ad-hoc reports by shared role lists (view vs. edit), enforced on frontend and in the create/read zambdas
- Add CSV export via a whitelisted SPA-side download event (sandbox stays allow-scripts)
- Add an "AI / beta" notice above the report frame
- Fix save/update toasts