### PR TITLE
Run the unit/component test job on a 16-core runner (2.1x faster)

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   automated-tests:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 40
     permissions:
       id-token: write # Required for OIDC


### PR DESCRIPTION
One-line change: `automated-tests` moves from `ubuntu-latest-8-cores` to `ubuntu-latest-16-cores`. Turbo caching stays on — the `TURBO_FORCE` skips used for measurement are not in this branch.

## Why

The unit/component suites are CPU-bound and were contending badly on 8 cores. Measured cache-free on identical code (`nproc` confirmed 16):

| | 8 cores | 16 cores | |
|---|---|---|---|
| **test step (wall)** | **299s** | **140s** | **2.13x** |
| summed task time | 851s | 355s | 2.40x |

Summed task time dropping 2.4x is the important number: the same work ran ~2.4x faster *per task*, not merely more of it at once. That rules out "we just bought more parallelism" and confirms the 8-core box was thrashing.

Per task:

| task | 8 cores | 16 cores |
|---|---|---|
| ehr component | 222.9s | 103.0s |
| zambdas unit | 188.2s | 74.6s |
| billing component | 184.2s | 69.0s |
| ehr unit | 79.9s | 28.4s |
| intake component | 55.4s | 22.2s |
| utils | 15.9s | 6.6s |

Roughly cost-neutral: the runner bills ~2x per minute for a ~2.1x shorter step.

## Tuning was measured and rejected

Turbo `--concurrency` x vitest `--maxWorkers` were swept on the 16-core runner. Every variant was ~12% *slower* than leaving the defaults alone:

| config | wall |
|---|---|
| untouched (this PR) | **140.2s** |
| c16-w1 | 156.1s |
| c4-w8 | 156.4s |
| c6-w4 | 156.9s |
| c10-w3 | 157.6s |

So no worker plumbing is added — the defaults are the fastest of the five combinations tried.

`integration-tests` deliberately stays on `ubuntu-latest`: it is I/O-bound on FHIR round-trips, so cores don't help.

## Still on the table

`ehr component` remains the critical path at 103s and only reaches ~2.5x parallelism, so the 16 cores aren't saturated. Sharding that one task across matrix jobs is the next lever, untested here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6eKpkXzRSJkzsaXEF43e8)_