### PR TITLE
fix: pass non-local ENVIRONMENT in Sentry-asserting claim-history uni…

### DIFF
--- a/packages/zambdas/test/unit/billing/get-billing-claim-history.test.ts
+++ b/packages/zambdas/test/unit/billing/get-billing-claim-history.test.ts
@@ -226,7 +226,7 @@ describe('get-billing-claim-history performEffect', () => {
     };
     const oystehr = makeOystehr({ Provenance: () => pagedBundle([bad, good], [practitionerU1]) });
 
-    const { entries } = await performEffect(oystehr, { claimId: 'c1', secrets: null });
+    const { entries } = await performEffect(oystehr, { claimId: 'c1', secrets: { ENVIRONMENT: 'staging' } });
 
     expect(entries).toHaveLength(2);
     expect(entries.find((e) => e.id === 'bad')?.changes).toEqual([]);
@@ -244,7 +244,7 @@ describe('get-billing-claim-history performEffect', () => {
     } as Provenance;
     const oystehr = makeOystehr({ Provenance: () => pagedBundle([malformed]) });
 
-    const { entries } = await performEffect(oystehr, { claimId: 'c1', secrets: null });
+    const { entries } = await performEffect(oystehr, { claimId: 'c1', secrets: { ENVIRONMENT: 'staging' } });
 
     // Graceful: the entry is still returned (with its changes) rather than crashing the view.
     expect(entries).toHaveLength(1);


### PR DESCRIPTION
…t tests

Tests that verify captureException is called via reportAnomaly → sendErrors were passing secrets: null, causing getOptionalSecret to fall back to process.env['ENVIRONMENT'] = 'local'. sendErrors returns early for the 'local' environment, so captureException was never reached and the assertions failed.

Use secrets: { ENVIRONMENT: 'staging' } in the two tests that assert on captureException so that sendErrors exercises the reporting path as intended.

Fixes: https://github.com/masslight/hosted-ottehr-builds/actions/runs/31374751545