### PR TITLE
fix(zambdas): repair three unit tests left behind by the barrel elimination

### DIFF
--- a/packages/zambdas/test/rcm/scheduled-outreach/produce-outreach-tasks.test.ts
+++ b/packages/zambdas/test/rcm/scheduled-outreach/produce-outreach-tasks.test.ts
@@ -35,24 +35,21 @@ const mockPatientWithValidContacts = {
   ],
 };
 
-vi.mock('utils', async (importOriginal) => {
+// Must target the deep path, not the `utils` barrel: production imports
+// FEATURE_FLAGS_CONFIG from 'utils/lib/ottehr-config/feature-flags', so a
+// mock on 'utils' resolves a module nothing under test imports and silently
+// stops intercepting. Spread the real config and pin only the two flags these
+// tests depend on — per-customer configs ship them false, which makes
+// produceOutreachTasks return early and every assertion below fail.
+vi.mock('utils/lib/ottehr-config/feature-flags', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
     FEATURE_FLAGS_CONFIG: {
+      ...(actual.FEATURE_FLAGS_CONFIG as Record<string, unknown>),
       automatedPatientOutreachEnabled: true,
       mailingPaperStatementsEnabled: true,
     },
-  };
-});
-
-vi.mock('../../../src/shared', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    checkOrCreateM2MClientToken: vi.fn().mockResolvedValue('mock-token'),
-    createClinicalOystehrClient: vi.fn(() => mockOystehrClient),
-    wrapHandler: (_name: string, fn: (...args: unknown[]) => unknown) => fn,
   };
 });
 

--- a/packages/zambdas/test/unit/billing/get-billing-claim-history.test.ts
+++ b/packages/zambdas/test/unit/billing/get-billing-claim-history.test.ts
@@ -226,7 +226,7 @@ describe('get-billing-claim-history performEffect', () => {
     };
     const oystehr = makeOystehr({ Provenance: () => pagedBundle([bad, good], [practitionerU1]) });
 
-    const { entries } = await performEffect(oystehr, { claimId: 'c1', secrets: null });
+    const { entries } = await performEffect(oystehr, { claimId: 'c1', secrets: { ENVIRONMENT: 'staging' } });
 
     expect(entries).toHaveLength(2);
     expect(entries.find((e) => e.id === 'bad')?.changes).toEqual([]);
@@ -244,7 +244,7 @@ describe('get-billing-claim-history performEffect', () => {
     } as Provenance;
     const oystehr = makeOystehr({ Provenance: () => pagedBundle([malformed]) });
 
-    const { entries } = await performEffect(oystehr, { claimId: 'c1', secrets: null });
+    const { entries } = await performEffect(oystehr, { claimId: 'c1', secrets: { ENVIRONMENT: 'staging' } });
 
     // Graceful: the entry is still returned (with its changes) rather than crashing the view.
     expect(entries).toHaveLength(1);

--- a/packages/zambdas/test/unit/create-billing-invoices-tasks.test.ts
+++ b/packages/zambdas/test/unit/create-billing-invoices-tasks.test.ts
@@ -29,6 +29,25 @@ vi.mock('../../src/billing/search-billing-patient-ar-claims/handler', () => ({
   fetchAllActivePatientArClaims: (...args: unknown[]) => mockFetchAllActivePatientArClaims(...args),
 }));
 
+// These tests assert the *enabled* invoicing path, so the flag has to be on
+// regardless of whichever ottehr-config the run happens to compile against.
+// `ottehrBillingInvoicingEnabled` is optional in FeatureFlagsConfigSchema, so
+// a per-customer config that omits it leaves it undefined — and
+// isOttehrBillingInvoicingEnabled coerces that to false, making the handler
+// short-circuit with "disabled" before it ever reaches the assertions below.
+// Mock the module production actually imports: the `utils` barrel is gone, so
+// FEATURE_FLAGS_CONFIG is only reachable at its deep path.
+vi.mock('utils/lib/ottehr-config/feature-flags', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    FEATURE_FLAGS_CONFIG: {
+      ...(actual.FEATURE_FLAGS_CONFIG as Record<string, unknown>),
+      ottehrBillingInvoicingEnabled: true,
+    },
+  };
+});
+
 type ZambdaHandler = (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
 
 let handler!: ZambdaHandler;


### PR DESCRIPTION
Fixes some spots in unit tests that didn't update their mocks when we got rid of barrel files on Friday.

🤖 generated code and description below.

## Summary

`37f3ffe892` ("Eliminate barrel files in zambdas and utils") moved production imports off the `utils` and `src/shared` barrels and deleted `packages/zambdas/src/shared/index.ts`. Three test files kept mocking the old specifiers.

`vi.mock()` on a module nothing imports any more doesn't fail — it just silently stops intercepting. So these tests quietly started exercising the real `FEATURE_FLAGS_CONFIG` instead of their fixtures. That's invisible on the default config, where the relevant flags are all on, and breaks wherever a deployment config turns them off or omits them. **16 tests across the three files fail in that configuration.**

## The three fixes

**`test/unit/create-billing-invoices-tasks.test.ts`** — had no feature-flag mock at all. `ottehrBillingInvoicingEnabled` is `.optional()` in `FeatureFlagsConfigSchema`, so a config omitting it leaves it `undefined`, and `isOttehrBillingInvoicingEnabled` coerces that to `false` — the handler short-circuits with `"disabled"` before reaching any assertion. Added a mock on `utils/lib/ottehr-config/feature-flags` (the path production actually imports) pinning the flag on, spreading the real config so unrelated flags keep their values.

**`test/rcm/scheduled-outreach/produce-outreach-tasks.test.ts`** — mocked the `utils` barrel, which still resolves but is no longer what production imports; `produce-outreach-tasks.ts` reads `FEATURE_FLAGS_CONFIG` from `utils/lib/ottehr-config/feature-flags`. Repointed the mock there.

Also removed the `vi.mock('../../../src/shared', ...)` block. That barrel no longer exists, and none of the three symbols it stubbed — `checkOrCreateM2MClientToken`, `createClinicalOystehrClient`, `wrapHandler` — is referenced anywhere in the test or by the module under test. The `src/shared/helpers` mock stays: `getPatchBinary` is still imported from there.

**`test/unit/billing/get-billing-claim-history.test.ts`** — the two tests asserting on `captureException` passed `secrets: null`, so `getOptionalSecret` fell through to `process.env.ENVIRONMENT`, which CI sets to `local`. `sendErrors` returns early for `local`, so Sentry was never reached and both assertions saw 0 calls. Pass `{ ENVIRONMENT: 'staging' }` in just those two — the other ten `secrets: null` call sites don't touch Sentry and are left alone.

## Verification

Reproduced the failure first, then confirmed the fix, running against both configurations:

| | before | after |
|---|---|---|
| flags on (default config) | 39 passed | 39 passed, 3/3 consecutive runs |
| flags off / omitted | **16 failed**, 23 passed | 39 passed, 3/3 consecutive runs |

The 16-failure count matches what the nightly reported exactly.

Full `--project unit` run is green under both configurations — 3587 passed, 305 files. (Eight files fail to collect in my sandbox with `ENOENT: config/.env/local.json`; that reproduces identically on a clean `develop` checkout and is just the absence of populated local config here, not a regression.)

## Follow-up, not fixed here

Four more files carry the same stale-barrel pattern. None of them fails today, under either configuration, so I left them out of a fix PR — but every `src/shared` mock is now provably dead, which means these tests may be hitting real implementations where they intend to hit stubs:

- `packages/zambdas/test/unit/sub-export-invoices-csv.test.ts` — `vi.mock('../../src/shared', …)`
- `packages/zambdas/test/unit/create-invoices-tasks.test.ts` — `vi.mock('../../src/shared', …)`
- `packages/zambdas/test/unit/postgrid-get-letter.test.ts` — `vi.mock('utils', …)`
- `apps/ehr/tests/component/BillingCodesContainer.test.tsx` — `vi.mock('utils', …)`

Worth a sweep, ideally with a lint rule that rejects `vi.mock()` on a specifier no file in the package imports — the failure mode here is that a dead mock is indistinguishable from a working one until the ambient config shifts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYbfCGDshfUBu1a5Ssf262)_