### PR TITLE
chore(zambdas): drop verbose comments from the barrel-mock fixes

### DIFF
--- a/packages/zambdas/test/rcm/scheduled-outreach/produce-outreach-tasks.test.ts
+++ b/packages/zambdas/test/rcm/scheduled-outreach/produce-outreach-tasks.test.ts
@@ -35,12 +35,6 @@ const mockPatientWithValidContacts = {
   ],
 };
 
-// Must target the deep path, not the `utils` barrel: production imports
-// FEATURE_FLAGS_CONFIG from 'utils/lib/ottehr-config/feature-flags', so a
-// mock on 'utils' resolves a module nothing under test imports and silently
-// stops intercepting. Spread the real config and pin only the two flags these
-// tests depend on — per-customer configs ship them false, which makes
-// produceOutreachTasks return early and every assertion below fail.
 vi.mock('utils/lib/ottehr-config/feature-flags', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {

--- a/packages/zambdas/test/unit/create-billing-invoices-tasks.test.ts
+++ b/packages/zambdas/test/unit/create-billing-invoices-tasks.test.ts
@@ -29,14 +29,6 @@ vi.mock('../../src/billing/search-billing-patient-ar-claims/handler', () => ({
   fetchAllActivePatientArClaims: (...args: unknown[]) => mockFetchAllActivePatientArClaims(...args),
 }));
 
-// These tests assert the *enabled* invoicing path, so the flag has to be on
-// regardless of whichever ottehr-config the run happens to compile against.
-// `ottehrBillingInvoicingEnabled` is optional in FeatureFlagsConfigSchema, so
-// a per-customer config that omits it leaves it undefined — and
-// isOttehrBillingInvoicingEnabled coerces that to false, making the handler
-// short-circuit with "disabled" before it ever reaches the assertions below.
-// Mock the module production actually imports: the `utils` barrel is gone, so
-// FEATURE_FLAGS_CONFIG is only reachable at its deep path.
 vi.mock('utils/lib/ottehr-config/feature-flags', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {


### PR DESCRIPTION
Follow-up to #9062, which merged before the comments came off.

Removes the two explanatory comment blocks added above the feature-flag mocks in `create-billing-invoices-tasks.test.ts` and `produce-outreach-tasks.test.ts`. They were noise — neither file carries prose comments otherwise, just `// ── Mocks ──` section dividers.

Comment-only deletion: 14 lines removed, no code changed. The three affected test files still pass (39/39).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYbfCGDshfUBu1a5Ssf262)_