### PR TITLE
tweak(billing): Search MRN and friendly ID by identifier for claims + patients

### DIFF
--- a/apps/billing/src/pages/ClaimsList.tsx
+++ b/apps/billing/src/pages/ClaimsList.tsx
@@ -179,7 +179,6 @@ export default function ClaimsList(): ReactElement {
     if (!groupKey) {
       return ALL_CLAIM_STATUS_OPTIONS_2;
     }
-    console.log('colin', arStageFilter, groupKey);
     return ALL_CLAIM_STATUS_OPTIONS_BY_GROUP[groupKey];
   }, [arStageFilter]);
 

--- a/packages/zambdas/src/billing/search-billing-claims/index.ts
+++ b/packages/zambdas/src/billing/search-billing-claims/index.ts
@@ -34,6 +34,8 @@ import {
   resolvePayersByRef,
   resourceDisplayName,
   sortClaimInsurance,
+  SOURCE_FRIENDLY_PATIENT_ID_SYSTEM,
+  SOURCE_IDENTIFIER_SYSTEM,
 } from '../shared';
 import { SearchBillingClaimsParams, validateRequestParameters } from './validateRequestParameters';
 
@@ -163,7 +165,6 @@ async function performEffect(
     total = matching.length;
     pageClaims = matching.slice(offset, offset + pageSize);
   } else {
-    console.log('colin', filterParams);
     const bundle = await oystehr.fhir.search<Claim>({
       resourceType: 'Claim',
       params: [
@@ -219,13 +220,7 @@ export const claimMatchesServiceDateRange = (claim: Claim, from?: string, to?: s
 export const CLAIM_SEARCH_TEXT_MATCH_LIMIT = 1000;
 export const CLAIM_SEARCH_TEXT_CONCURRENCY = 4;
 
-export function buildClaimSearchTextQueries({
-  searchText,
-  patientIds = [],
-}: {
-  searchText: string;
-  patientIds?: string[];
-}): ClaimSearchParam[][] {
+export function buildClaimSearchTextQueries({ searchText }: { searchText: string }): ClaimSearchParam[][] {
   const text = searchText.trim();
   if (!text) return [];
 
@@ -266,6 +261,18 @@ export function buildClaimSearchTextQueries({
         value: `${CLAIM_PCN_IDENTIFIER_SYSTEM}|${text}`,
       },
     ],
+    [
+      {
+        name: 'patient.identifier',
+        value: `${SOURCE_IDENTIFIER_SYSTEM}|${text}`,
+      },
+    ],
+    [
+      {
+        name: 'patient.identifier',
+        value: `${SOURCE_FRIENDLY_PATIENT_ID_SYSTEM}|${text}`,
+      },
+    ],
   ];
 
   if (isValidUUID(text)) {
@@ -276,8 +283,6 @@ export function buildClaimSearchTextQueries({
       },
     ]);
   }
-
-  if (patientIds.length > 0) queries.push([patientSearchParam(patientIds)]);
 
   const pcnClaimId = claimIdFromPcn(text);
   if (pcnClaimId) {
@@ -336,14 +341,7 @@ export async function searchClaimsBySearchText({
     },
   ];
 
-  const patientIds = isValidUUID(searchText.trim())
-    ? await resolveLinkedPatientIds({
-        oystehr,
-        patientId: searchText.trim(),
-      })
-    : [];
-
-  const clauses = buildClaimSearchTextQueries({ searchText, patientIds });
+  const clauses = buildClaimSearchTextQueries({ searchText });
 
   const claims: Claim[] = [];
   const truncatedClauses: string[] = [];

--- a/packages/zambdas/src/billing/search-billing-patients/index.ts
+++ b/packages/zambdas/src/billing/search-billing-patients/index.ts
@@ -10,7 +10,8 @@ import {
   EXCLUDE_WORKING_COPIES_PARAMS,
   fhirName,
   formatAddress,
-  searchPatientsByClinicalIds,
+  SOURCE_FRIENDLY_PATIENT_ID_SYSTEM,
+  SOURCE_IDENTIFIER_SYSTEM,
 } from '../shared';
 import { SearchBillingPatientsParams, validateRequestParameters } from './validateRequestParameters';
 
@@ -41,32 +42,16 @@ async function performEffect(
   ];
   if (params.name) searchParams.push({ name: 'name', value: params.name });
   if (params.dob) searchParams.push({ name: 'birthdate', value: params.dob });
+  if (params.uuid) searchParams.push({ name: 'identifier', value: `${SOURCE_IDENTIFIER_SYSTEM}|${params.uuid}` });
+  if (params.identifier)
+    searchParams.push({ name: 'identifier', value: `${SOURCE_FRIENDLY_PATIENT_ID_SYSTEM}|${params.identifier}` });
 
-  let results: Patient[] = [];
-  let total: number = 0;
-  if (params.uuid || params.identifier) {
-    const searchAll = await searchPatientsByClinicalIds({
-      oystehr,
-      baseSearchParams: searchParams,
-      offset,
-      pageSize,
-      uuid: params.uuid,
-      friendlyId: params.identifier,
-    });
-    total = searchAll.total;
-    results = searchAll.results;
-  } else {
-    const response = await oystehr.fhir.search<Patient>({
-      resourceType: 'Patient',
-      params: [
-        ...searchParams,
-        { name: '_count', value: String(pageSize) },
-        { name: '_offset', value: String(offset) },
-      ],
-    });
-    total = response.total ?? 0;
-    results = response.unbundle();
-  }
+  const response = await oystehr.fhir.search<Patient>({
+    resourceType: 'Patient',
+    params: [...searchParams, { name: '_count', value: String(pageSize) }, { name: '_offset', value: String(offset) }],
+  });
+  const total = response.total ?? 0;
+  const results = response.unbundle();
 
   const patients = results.map((p) => {
     const clinicalFriendlyId = clinicalFriendlyIdOfCopy(p);

--- a/packages/zambdas/test/integration/billing/search-billing-claims.test.ts
+++ b/packages/zambdas/test/integration/billing/search-billing-claims.test.ts
@@ -214,11 +214,6 @@ describe('search-billing-claims search text', () => {
     expect(await idsFor(patientGiven)).toEqual([createdClaimIds[0]]);
   }, 60_000);
 
-  it('finds the claim by the patient id shown in the UI, not just the copy the claim references', async () => {
-    expect(await idsFor(patientId)).toEqual([createdClaimIds[0]]);
-    expect(await idsFor(claimPatientId)).toEqual([createdClaimIds[0]]);
-  }, 60_000);
-
   it('finds the claim by the billing provider name', async () => {
     expect(await idsFor(unique)).toContain(createdClaimIds[0]);
     expect(await idsFor(billingOrgName)).toEqual([createdClaimIds[0]]);

--- a/packages/zambdas/test/unit/billing/search-billing-claims-search-text.test.ts
+++ b/packages/zambdas/test/unit/billing/search-billing-claims-search-text.test.ts
@@ -33,7 +33,7 @@ const clauseFor = (searchText: string, name: string): { name: string; value: str
 
 describe('buildClaimSearchTextQueries', () => {
   it('searches every name field plus the PCN identifier, and no token clause, for a plain name', () => {
-    expect(clauseNames('Smith')).toEqual([...NAME_CLAUSES, 'identifier']);
+    expect(clauseNames('Smith')).toEqual([...NAME_CLAUSES, 'identifier', 'patient.identifier', 'patient.identifier']);
   });
 
   it('sends the same text to each name clause, so either half of a name matches', () => {
@@ -60,24 +60,17 @@ describe('buildClaimSearchTextQueries', () => {
   });
 
   it('adds a claim id clause for a uuid', () => {
-    expect(clauseNames(CLAIM_ID)).toEqual([...NAME_CLAUSES, 'identifier', '_id']);
+    expect(clauseNames(CLAIM_ID)).toEqual([
+      ...NAME_CLAUSES,
+      'identifier',
+      'patient.identifier',
+      'patient.identifier',
+      '_id',
+    ]);
     expect(clauseFor(CLAIM_ID, '_id')).toEqual([
       {
         name: '_id',
         value: CLAIM_ID,
-      },
-    ]);
-  });
-
-  it('searches every linked patient id when the caller resolved them', () => {
-    const queries = buildClaimSearchTextQueries({
-      searchText: PATIENT_ID,
-      patientIds: [PATIENT_ID, 'copy-1', 'copy-2'],
-    });
-    expect(queries.flat().filter((p) => p.name === 'patient')).toEqual([
-      {
-        name: 'patient',
-        value: `Patient/${PATIENT_ID},Patient/copy-1,Patient/copy-2`,
       },
     ]);
   });
@@ -88,7 +81,13 @@ describe('buildClaimSearchTextQueries', () => {
   });
 
   it('restores a dash-stripped PCN into a claim id clause', () => {
-    expect(clauseNames(MINIFIED_CLAIM_ID)).toEqual([...NAME_CLAUSES, 'identifier', '_id']);
+    expect(clauseNames(MINIFIED_CLAIM_ID)).toEqual([
+      ...NAME_CLAUSES,
+      'identifier',
+      'patient.identifier',
+      'patient.identifier',
+      '_id',
+    ]);
     expect(clauseFor(MINIFIED_CLAIM_ID, '_id')).toEqual([
       {
         name: '_id',
@@ -98,15 +97,14 @@ describe('buildClaimSearchTextQueries', () => {
   });
 
   it('keeps the fan-out to at most eight clauses', () => {
-    expect(buildClaimSearchTextQueries({ searchText: 'Smith' })).toHaveLength(6);
-    expect(buildClaimSearchTextQueries({ searchText: MINIFIED_CLAIM_ID })).toHaveLength(7);
-    expect(buildClaimSearchTextQueries({ searchText: CLAIM_ID })).toHaveLength(7);
+    expect(buildClaimSearchTextQueries({ searchText: 'Smith' })).toHaveLength(8);
+    expect(buildClaimSearchTextQueries({ searchText: MINIFIED_CLAIM_ID })).toHaveLength(9);
+    expect(buildClaimSearchTextQueries({ searchText: CLAIM_ID })).toHaveLength(9);
     expect(
       buildClaimSearchTextQueries({
         searchText: CLAIM_ID,
-        patientIds: [CLAIM_ID],
       })
-    ).toHaveLength(8);
+    ).toHaveLength(9);
   });
 
   it('trims the text and searches nothing when it is blank', () => {
@@ -199,9 +197,6 @@ const claimSearchCalls = (search: Mock): SearchParam[][] =>
 const paramNamed = (params: SearchParam[], name: string): SearchParam | undefined =>
   params.find((param) => param.name === name);
 
-const clauseWith = (search: Mock, name: string): SearchParam[] | undefined =>
-  claimSearchCalls(search).find((params) => paramNamed(params, name));
-
 describe('describeClaimSearchClause', () => {
   it('names the parameter without echoing the searched text', () => {
     expect(
@@ -256,7 +251,7 @@ describe('searchClaimsBySearchText', () => {
       withServiceDateElements: false,
     });
 
-    expect(claimSearchCalls(search)).toHaveLength(6);
+    expect(claimSearchCalls(search)).toHaveLength(8);
     claimSearchCalls(search).forEach((params) => {
       expect(params).toContainEqual(AR_STAGE_FILTER);
       expect(paramNamed(params, '_elements')?.value).toBe('id,meta');
@@ -265,23 +260,6 @@ describe('searchClaimsBySearchText', () => {
       // Includes are what the page hydration is for; carrying them here would blow the response budget.
       expect(paramNamed(params, '_include')).toBeUndefined();
     });
-  });
-
-  it('passes reference values unencoded, which is what Oystehr matches on', async () => {
-    const { oystehr, search } = stubClient({
-      personLinks: [[PATIENT_ID, 'copy-1', 'copy-2']],
-    });
-
-    await searchClaimsBySearchText({
-      oystehr,
-      searchText: PATIENT_ID,
-      filterParams: [],
-      withServiceDateElements: false,
-    });
-
-    expect(paramNamed(clauseWith(search, 'patient') ?? [], 'patient')?.value).toBe(
-      `Patient/${PATIENT_ID},Patient/copy-1,Patient/copy-2`
-    );
   });
 
   it('asks for the fields the in-memory service date filter needs when a range is active', async () => {
@@ -297,66 +275,6 @@ describe('searchClaimsBySearchText', () => {
     claimSearchCalls(search).forEach((params) =>
       expect(paramNamed(params, '_elements')?.value).toBe('id,meta,created,item')
     );
-  });
-
-  it('widens a typed patient id to the working copies its claims reference', async () => {
-    const { oystehr, search } = stubClient({
-      personLinks: [[PATIENT_ID, 'copy-1']],
-    });
-
-    await searchClaimsBySearchText({
-      oystehr,
-      searchText: PATIENT_ID,
-      filterParams: [],
-      withServiceDateElements: false,
-    });
-
-    expect(search).toHaveBeenCalledWith({
-      resourceType: 'Person',
-      params: [
-        {
-          name: 'link',
-          value: `Patient/${PATIENT_ID}`,
-        },
-      ],
-    });
-    expect(paramNamed(clauseWith(search, 'patient') ?? [], 'patient')?.value).toBe(
-      `Patient/${PATIENT_ID},Patient/copy-1`
-    );
-  });
-
-  it('unions the links across every Person the patient has, not just the first', async () => {
-    const { oystehr, search } = stubClient({
-      personLinks: [
-        [PATIENT_ID, 'copy-1'],
-        [PATIENT_ID, 'copy-2'],
-        [PATIENT_ID, 'copy-3'],
-      ],
-    });
-
-    await searchClaimsBySearchText({
-      oystehr,
-      searchText: PATIENT_ID,
-      filterParams: [],
-      withServiceDateElements: false,
-    });
-
-    expect(paramNamed(clauseWith(search, 'patient') ?? [], 'patient')?.value).toBe(
-      `Patient/${PATIENT_ID},Patient/copy-1,Patient/copy-2,Patient/copy-3`
-    );
-  });
-
-  it('still searches the typed id when no Person links it, so a working copy id works directly', async () => {
-    const { oystehr, search } = stubClient();
-
-    await searchClaimsBySearchText({
-      oystehr,
-      searchText: PATIENT_ID,
-      filterParams: [],
-      withServiceDateElements: false,
-    });
-
-    expect(paramNamed(clauseWith(search, 'patient') ?? [], 'patient')?.value).toBe(`Patient/${PATIENT_ID}`);
   });
 
   it('does not look up a Person for text that is not a uuid', async () => {
@@ -463,7 +381,7 @@ describe('searchClaimsBySearchText', () => {
       filterParams: [],
       withServiceDateElements: false,
     });
-    expect(claimSearchCalls(search)).toHaveLength(8);
+    expect(claimSearchCalls(search)).toHaveLength(9);
   });
 
   // One rejected clause must not empty the whole search, and it has to be loud.


### PR DESCRIPTION
This PR removes the ability to search by billing app patient ID or billing app working copy patient ID in the big box, but enables searching by clinical MRN and friendly ID once #9072 is applied to all environments.