### PR TITLE
fix: "Signed electronically by" on faxed unsigned notes

### DIFF
--- a/packages/zambdas/src/shared/fax/collect-visit-documents.ts
+++ b/packages/zambdas/src/shared/fax/collect-visit-documents.ts
@@ -183,9 +183,10 @@ export async function buildProgressNoteBytes(args: {
   token: string;
   secrets: Secrets | null;
   visitResources: FullAppointmentResourcePackage;
+  signed: boolean;
 }): Promise<Uint8Array> {
-  const { oystehr, token, secrets, visitResources } = args;
-  const input = await assembleProgressNoteInput(oystehr, token, visitResources);
+  const { oystehr, token, secrets, visitResources, signed } = args;
+  const input = await assembleProgressNoteInput(oystehr, token, visitResources, { signed });
   return createProgressNotePdfBytes(input, secrets, token);
 }
 
@@ -234,16 +235,19 @@ export async function collectFaxParts(args: {
 
     if (kind === 'progress-note') {
       const existing = partsFromDocRefs(kind, documents['progress-note']);
-      if (existing.length > 0) {
+      const noteIsSigned = existing.length > 0;
+
+      if (noteIsSigned) {
         parts.push(existing[0]);
       } else {
         console.log(`No visit note DocumentReference for appointment ${appointmentId}; regenerating for the packet`);
         parts.push({
           kind,
           title: FAX_DOCUMENT_LABELS[kind],
-          bytes: await buildProgressNoteBytes({ oystehr, token, secrets, visitResources }),
+          bytes: await buildProgressNoteBytes({ oystehr, token, secrets, visitResources, signed: noteIsSigned }),
         });
       }
+
       continue;
     }
 

--- a/packages/zambdas/src/shared/pdf/assemble-progress-note-input.ts
+++ b/packages/zambdas/src/shared/pdf/assemble-progress-note-input.ts
@@ -24,7 +24,10 @@ import { FullAppointmentResourcePackage } from './visit-details-pdf/types';
 export async function assembleProgressNoteInput(
   oystehr: Oystehr,
   token: string,
-  visitResources: FullAppointmentResourcePackage
+  visitResources: FullAppointmentResourcePackage,
+  options?: {
+    signed?: boolean;
+  }
 ): Promise<ProgressNoteInput> {
   const { encounter, patient, appointment } = visitResources;
   if (!patient) throw new Error(`No patient found for encounter ${encounter?.id}`);
@@ -68,5 +71,6 @@ export async function assembleProgressNoteInput(
     upcomingFollowUps,
     erxPharmacies,
     signatures,
+    signed: options?.signed,
   };
 }

--- a/packages/zambdas/src/shared/pdf/progress-note-pdf.ts
+++ b/packages/zambdas/src/shared/pdf/progress-note-pdf.ts
@@ -184,6 +184,7 @@ const composeProgressNoteData: DataComposer<ProgressNoteInput, ProgressNoteData>
       appointmentPackage,
       visit,
       signatures: input.signatures,
+      signed: input.signed,
     }),
   };
 };

--- a/packages/zambdas/src/shared/pdf/sections/visit-note/signature.ts
+++ b/packages/zambdas/src/shared/pdf/sections/visit-note/signature.ts
@@ -9,19 +9,23 @@ interface SignatureComposerInput {
   appointmentPackage: FullAppointmentResourcePackage;
   visit: VisitDetailsForProgressNote;
   signatures?: ProgressNoteSignatures;
+  signed?: boolean;
 }
+
+const PENDING_SIGNATURE_TEXT = 'Pending provider signature';
 
 export const composeSignature: DataComposer<SignatureComposerInput, SignatureData> = ({
   appointmentPackage,
   visit,
   signatures,
+  signed,
 }) => {
   const { timezone } = appointmentPackage;
 
-  // The visit-note PDF is only generated once a note is signed, so the signed line always renders.
-  // Prefer the `author` Provenance (accurate signer + original sign time, stable across re-generation
-  // after supervisor approval); fall back to the attending provider and the current time when none
-  // exists (the non-supervisor sign flow writes no Provenance).
+  if (signed === false) {
+    return { pendingSignature: PENDING_SIGNATURE_TEXT };
+  }
+
   const fallbackProviderName = visit.visitType === 'initial' ? visit.provider : visit.provider?.name ?? '';
   const signedName = signatures?.signedBy?.name || fallbackProviderName;
   const signedDateTime = formatDateTimeToZone(
@@ -48,11 +52,17 @@ export const createSignatureSection = <TData extends { signature: SignatureData 
 > => {
   return createConfiguredSection(null, () => ({
     dataSelector: (data) => data.signature,
-    shouldRender: (data) => !!(data.signedBy || data.approvedBy),
+    shouldRender: (data) => !!(data.signedBy || data.approvedBy || data.pendingSignature),
     render: (client, data, styles) => {
+      if (data.pendingSignature) {
+        drawRegularText(client, styles, data.pendingSignature);
+        return;
+      }
+
       if (data.signedBy) {
         drawRegularText(client, styles, data.signedBy);
       }
+
       if (data.approvedBy) {
         drawRegularText(client, styles, data.approvedBy);
       }

--- a/packages/zambdas/src/shared/pdf/types.ts
+++ b/packages/zambdas/src/shared/pdf/types.ts
@@ -1037,6 +1037,8 @@ export interface SignatureData extends PdfData {
   signedBy?: string;
   /** "Approved by {provider} on {date} {time}" — present only when supervisor-approved. */
   approvedBy?: string;
+  /** Placeholder shown instead of the signed line when the note isn't signed yet (e.g. a faxed draft). */
+  pendingSignature?: string;
 }
 
 export interface ProgressNoteInput {
@@ -1049,6 +1051,7 @@ export interface ProgressNoteInput {
   serviceCategories?: ServiceCategoryCatalogEntry[];
   erxPharmacies?: Record<string, ErxGetPharmacyResponse>;
   signatures?: ProgressNoteSignatures;
+  signed?: boolean;
 }
 
 export interface ProgressNoteData extends PdfData {

--- a/packages/zambdas/src/subscriptions/task/sub-visit-note-pdf-and-email/index.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-visit-note-pdf-and-email/index.ts
@@ -46,6 +46,7 @@ let oystehr: Oystehr;
 let taskId: string | undefined;
 
 const ZAMBDA_NAME = 'sub-visit-note-pdf-and-email';
+
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   try {
     console.group('validateRequestParameters');
@@ -105,8 +106,10 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     // Follow-up visits get a differently-titled visit note and no completion email.
     const isFollowupTask = isFollowupEncounter(encounter);
 
-    // Assembled the same way as the outbound-fax copy, so the two can never diverge.
-    const progressNoteInput = await assembleProgressNoteInput(oystehr, oystehrToken, visitResources);
+    const progressNoteInput = await assembleProgressNoteInput(oystehr, oystehrToken, visitResources, {
+      signed: true,
+    });
+
     console.log('Chart data received');
 
     try {

--- a/packages/zambdas/test/unit/signature-pdf.test.ts
+++ b/packages/zambdas/test/unit/signature-pdf.test.ts
@@ -55,6 +55,27 @@ describe('composeSignature', () => {
     expect(approvedBy).toBeUndefined();
   });
 
+  test('shows a pending placeholder (no signed line) when the note is not signed', () => {
+    const signatures: ProgressNoteSignatures = {
+      signedBy: { name: 'Resident, Ray | MD', dateTimeISO: '2026-06-07T15:30:00.000Z' },
+    };
+
+    const result = composeSignature({ appointmentPackage, visit: initialVisit, signatures, signed: false });
+
+    expect(result.pendingSignature).toBe('Pending provider signature');
+    expect(result.signedBy).toBeUndefined();
+    expect(result.approvedBy).toBeUndefined();
+  });
+
+  test('still signs when signed is true or omitted', () => {
+    const explicit = composeSignature({ appointmentPackage, visit: initialVisit, signatures: undefined, signed: true });
+    const legacy = composeSignature({ appointmentPackage, visit: initialVisit, signatures: undefined });
+
+    expect(explicit.signedBy).toMatch(/^Signed electronically by Attending, Doc \| MD on /);
+    expect(explicit.pendingSignature).toBeUndefined();
+    expect(legacy.signedBy).toMatch(/^Signed electronically by Attending, Doc \| MD on /);
+  });
+
   test('uses the follow-up provider name for follow-up visits', () => {
     const followupVisit: VisitDetailsForProgressNote = {
       visitType: 'followup',


### PR DESCRIPTION
An outbound fax of an unsigned visit regenerates the progress note on the fly, but the signature composer assumed the note is only ever generated after signing and always drew a "Signed electronically by ..." line (falling back to the attending provider + current time).

Thread an explicit `signed` flag into assembleProgressNoteInput. The fax derives it from whether a signed note DocumentReference (75498-6) exists for the visit — the DocRef is created only by the visit-note subscription at signing — so a regenerated draft renders "Pending provider signature" instead. The subscription passes signed: true (it only runs post-sign).