### PR TITLE
test(ui-components): add vitest rig so package tests run in turbo and CI

### DIFF
--- a/packages/ui-components/lib/components/paperwork/form-components/FieldHelperText.test.tsx
+++ b/packages/ui-components/lib/components/paperwork/form-components/FieldHelperText.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FieldHelperText } from './FieldHelperText';
+
+// Seed test for the ui-components vitest rig. Beyond proving the pipeline
+// (happy-dom + react + tsconfig paths) works in this package, it pins the
+// `${name}-helper-text` id contract that intake e2e locators select on.
+describe('FieldHelperText', () => {
+  it('renders the error message under the `${name}-helper-text` id when hasError is set', () => {
+    const { container } = render(
+      <FieldHelperText name="patient-first-name" hasError={true} errorMessage="First name is required" />
+    );
+
+    const helperText = container.querySelector('#patient-first-name-helper-text');
+    expect(helperText).not.toBeNull();
+    expect(helperText?.textContent).toBe('First name is required');
+  });
+
+  it('renders an empty helper node instead of the error message when hasError is false', () => {
+    const { container } = render(
+      <FieldHelperText name="patient-first-name" hasError={false} errorMessage="First name is required" />
+    );
+
+    const helperText = container.querySelector('#patient-first-name-helper-text');
+    expect(helperText).not.toBeNull();
+    expect(helperText?.textContent).toBe('');
+  });
+
+  it('renders helper text with the info icon by default', () => {
+    const { container } = render(
+      <FieldHelperText name="patient-email" hasError={false} helperText="We only use this for visit updates" />
+    );
+
+    expect(screen.getByText('We only use this for visit updates')).toBeDefined();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('omits the info icon when showHelperTextIcon is false', () => {
+    const { container } = render(
+      <FieldHelperText
+        name="patient-email"
+        hasError={false}
+        helperText="We only use this for visit updates"
+        showHelperTextIcon={false}
+      />
+    );
+
+    expect(screen.getByText('We only use this for visit updates')).toBeDefined();
+    expect(container.querySelector('svg')).toBeNull();
+  });
+});

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -11,6 +11,8 @@
   "scripts": {
     "start": "vite",
     "build": "concurrently --kill-others-on-fail \"tsc\" \"vite build\"",
+    "test": "vitest run --config ./vitest.config.ts",
+    "test:ci": "vitest run --config ./vitest.config.ts --coverage --passWithNoTests --reporter=dot --reporter=github-actions",
     "lint": "NODE_OPTIONS='--max-old-space-size=8192' eslint --ext .ts,.tsx,.js,.jsx --report-unused-disable-directives --max-warnings 0 .",
     "lint:fix": "NODE_OPTIONS='--max-old-space-size=8192' eslint --ext .ts,.tsx,.js,.jsx --report-unused-disable-directives --max-warnings 0 --fix .",
     "preview": "vite preview"

--- a/packages/ui-components/vitest.config.ts
+++ b/packages/ui-components/vitest.config.ts
@@ -7,7 +7,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       environment: 'happy-dom',
-      setupFiles: ['../test-utils/lib/no-network.setup.ts'],
+      setupFiles: ['../test-utils/lib/no-network.setup.ts', './vitest.setup.ts'],
       coverage: {
         provider: 'v8',
         reporter: ['lcov', 'text-summary', 'json'],

--- a/packages/ui-components/vitest.setup.ts
+++ b/packages/ui-components/vitest.setup.ts
@@ -1,0 +1,9 @@
+import * as matchers from '@testing-library/jest-dom/matchers';
+import { cleanup } from '@testing-library/react';
+import { afterEach, expect } from 'vitest';
+
+expect.extend(matchers);
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
I have reviewed this and think it's ready to go. It adds the ability to do run component tests in ui-components package, and there's an initial test that flexes the functionality.

🤖 generated code and description.

**Stack 1/3** of the paperwork factory-certification work (see `docs/paperwork-testing-strategy.md` on `claude/paperwork-testing-strategy-6txb0w`, §5 "PR decomposition"). Merge this one first; the two PRs stacked on it retarget automatically when this branch is deleted on merge.

## What

`packages/ui-components` had a `vitest.config.ts` but no `test` script, so nothing in the package ever ran under `turbo test` or the `automated-tests` workflow — the entire paperwork renderer lives here with zero executable tests.

- Add `test` and `test:ci` scripts matching the intake app's conventions (`test:ci` is what `automated-tests.yml` invokes via turbo).
- Add `vitest.setup.ts` registering testing-library cleanup and jest-dom matchers, mirroring `apps/intake/tests/component/setup.ts` (without cleanup, renders leak across tests since the repo runs vitest with `globals: false`).
- Seed the rig with `FieldHelperText.test.tsx` — four render tests that also pin the `${name}-helper-text` element-id contract the intake e2e locators select on.

## Verification

- `npm run test` and `npm run test:ci` in `packages/ui-components`: 1 file, 4 tests passing (with coverage under `test:ci`).
- New files pass `eslint --max-warnings 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gi6xrcRXg1MuDceiDv7xw2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi6xrcRXg1MuDceiDv7xw2)_