### PR TITLE
Add retry logic for template holder list version conflicts

### DIFF
--- a/packages/utils/lib/fhir/helpers.ts
+++ b/packages/utils/lib/fhir/helpers.ts
@@ -1644,6 +1644,18 @@ export function makeCptCodeDisplay(cptCode: CPTCodeDTO): string {
 const OPTIMISTIC_LOCK_MAX_RETRIES = 3;
 
 /**
+ * True when an error thrown by the Oystehr SDK represents an optimistic-locking version
+ * conflict (HTTP 412 Precondition Failed from an If-Match header), meaning the resource
+ * changed between read and write and the operation can be safely re-read and retried.
+ */
+export function isVersionConflictError(error: unknown): boolean {
+  const err = error as { code?: unknown; statusCode?: unknown; message?: unknown } | null | undefined;
+  return (
+    err?.code === 412 || err?.statusCode === 412 || (typeof err?.message === 'string' && err.message.includes('412'))
+  );
+}
+
+/**
  * Patches a FHIR resource with optimistic locking (E-tag).
  *
  * Uses the resource's versionId as an If-Match header so the FHIR server
@@ -1671,8 +1683,7 @@ export async function patchWithOptimisticLock<T extends FhirResource & { id: str
       );
       return;
     } catch (error: any) {
-      const is412 = error?.code === 412 || error?.statusCode === 412 || error?.message?.includes('412');
-      if (!is412 || attempt === OPTIMISTIC_LOCK_MAX_RETRIES - 1) {
+      if (!isVersionConflictError(error) || attempt === OPTIMISTIC_LOCK_MAX_RETRIES - 1) {
         throw error;
       }
       console.log(

--- a/packages/utils/lib/fhir/helpers.ts
+++ b/packages/utils/lib/fhir/helpers.ts
@@ -1656,6 +1656,33 @@ export function isVersionConflictError(error: unknown): boolean {
 }
 
 /**
+ * Runs an optimistically-locked FHIR write, retrying on version conflict (412).
+ *
+ * The callback re-runs from scratch on each attempt and is responsible for re-reading the
+ * If-Match-guarded resource itself, so every retry writes against the current version instead
+ * of the one that just lost the race. Non-conflict errors, and a conflict on the final
+ * attempt, are rethrown. Prefer patchWithOptimisticLock for a plain single-resource PATCH;
+ * this is the underlying engine for writes it can't express (e.g. a transaction that pairs
+ * the guarded PATCH with other requests).
+ */
+export async function withVersionConflictRetries<T>(
+  fn: (attempt: number) => Promise<T>,
+  opts?: { maxAttempts?: number; onConflict?: (attempt: number) => void }
+): Promise<T> {
+  const maxAttempts = opts?.maxAttempts ?? OPTIMISTIC_LOCK_MAX_RETRIES;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn(attempt);
+    } catch (error) {
+      if (attempt >= maxAttempts || !isVersionConflictError(error)) {
+        throw error;
+      }
+      opts?.onConflict?.(attempt);
+    }
+  }
+}
+
+/**
  * Patches a FHIR resource with optimistic locking (E-tag).
  *
  * Uses the resource's versionId as an If-Match header so the FHIR server
@@ -1671,29 +1698,29 @@ export async function patchWithOptimisticLock<T extends FhirResource & { id: str
   const { resourceType } = initialResource;
   let current = initialResource;
 
-  for (let attempt = 0; attempt < OPTIMISTIC_LOCK_MAX_RETRIES; attempt++) {
-    const operations = await computeOps(current);
-    if (operations.length === 0) return;
+  await withVersionConflictRetries(
+    async (attempt) => {
+      if (attempt > 1) {
+        current = (await oystehr.fhir.get<T>({ resourceType, id: current.id } as any)) as T;
+      }
+      const operations = await computeOps(current);
+      if (operations.length === 0) return;
 
-    const versionId = current.meta?.versionId;
-    try {
+      const versionId = current.meta?.versionId;
       await oystehr.fhir.patch(
         { resourceType, id: current.id, operations },
         versionId ? { optimisticLockingVersionId: versionId } : undefined
       );
-      return;
-    } catch (error: any) {
-      if (!isVersionConflictError(error) || attempt === OPTIMISTIC_LOCK_MAX_RETRIES - 1) {
-        throw error;
-      }
-      console.log(
-        `${resourceType}/${current.id} PATCH conflict (412), re-fetching and retrying (attempt ${attempt + 1}/${
-          OPTIMISTIC_LOCK_MAX_RETRIES - 1
-        })`
-      );
-      current = (await oystehr.fhir.get<T>({ resourceType, id: current.id } as any)) as T;
+    },
+    {
+      onConflict: (attempt) =>
+        console.log(
+          `${resourceType}/${current.id} PATCH conflict (412), re-fetching and retrying (attempt ${attempt}/${
+            OPTIMISTIC_LOCK_MAX_RETRIES - 1
+          })`
+        ),
     }
-  }
+  );
 }
 
 export function makeOptimisticLockIfMatchHeader(res: FhirResource | string): string | undefined {

--- a/packages/utils/lib/fhir/helpers.withVersionConflictRetries.test.ts
+++ b/packages/utils/lib/fhir/helpers.withVersionConflictRetries.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { isVersionConflictError, withVersionConflictRetries } from './helpers';
+
+const conflict = (): Error => Object.assign(new Error('Precondition Failed'), { code: 412 });
+
+describe('isVersionConflictError', () => {
+  it('classifies errors carrying a 412 code, statusCode, or message', () => {
+    expect(isVersionConflictError({ code: 412 })).toBe(true);
+    expect(isVersionConflictError({ statusCode: 412 })).toBe(true);
+    expect(isVersionConflictError(new Error('request failed with status 412'))).toBe(true);
+  });
+
+  it('does not classify other errors, including non-string messages', () => {
+    expect(isVersionConflictError({ code: 409 })).toBe(false);
+    expect(isVersionConflictError(new Error('boom'))).toBe(false);
+    expect(isVersionConflictError({ message: 412 })).toBe(false);
+    expect(isVersionConflictError(undefined)).toBe(false);
+    expect(isVersionConflictError(null)).toBe(false);
+  });
+});
+
+describe('withVersionConflictRetries', () => {
+  it('returns the callback result without retrying on success', async () => {
+    const fn = vi.fn().mockResolvedValue('done');
+    await expect(withVersionConflictRetries(fn)).resolves.toBe('done');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(1);
+  });
+
+  it('retries on a version conflict and reports each conflict with its attempt number', async () => {
+    const fn = vi.fn().mockRejectedValueOnce(conflict()).mockRejectedValueOnce(conflict()).mockResolvedValue('done');
+    const onConflict = vi.fn();
+    await expect(withVersionConflictRetries(fn, { onConflict })).resolves.toBe('done');
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(fn).toHaveBeenNthCalledWith(3, 3);
+    expect(onConflict.mock.calls).toEqual([[1], [2]]);
+  });
+
+  it('rethrows a conflict once the attempts are exhausted (3 by default)', async () => {
+    const fn = vi.fn().mockRejectedValue(conflict());
+    await expect(withVersionConflictRetries(fn)).rejects.toMatchObject({ code: 412 });
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('respects a caller-provided maxAttempts', async () => {
+    const fn = vi.fn().mockRejectedValue(conflict());
+    await expect(withVersionConflictRetries(fn, { maxAttempts: 5 })).rejects.toMatchObject({ code: 412 });
+    expect(fn).toHaveBeenCalledTimes(5);
+  });
+
+  it('rethrows non-conflict errors immediately without retrying', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('boom'));
+    const onConflict = vi.fn();
+    await expect(withVersionConflictRetries(fn, { onConflict })).rejects.toThrow('boom');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onConflict).not.toHaveBeenCalled();
+  });
+});

--- a/packages/zambdas/src/ehr/admin-create-template/index.ts
+++ b/packages/zambdas/src/ehr/admin-create-template/index.ts
@@ -522,13 +522,6 @@ const performEffect = async (
   console.log('Creating template with', listToCreate.contained!.length, 'contained resources');
   const listToCreateFullUrl = `urn:uuid:${uuidV4()}`;
 
-  // The holder PATCH carries If-Match, so racing template creates/deletes surface as a version
-  // conflict (412) instead of silently overwriting each other's holder entries. The transaction
-  // is atomic — a conflicted attempt leaves nothing behind — so re-read the holder and retry.
-  // Retries re-read by id: findHolderList goes through search, which can keep serving the same
-  // stale holder version under write load, while a direct read always returns the current one.
-  // (patchWithOptimisticLock can't be used here: the guarded PATCH must land in the same
-  // transaction as the template POST so a failure can never orphan the new template.)
   let holderId: string | undefined;
 
   const createdList = await withVersionConflictRetries(

--- a/packages/zambdas/src/ehr/admin-create-template/index.ts
+++ b/packages/zambdas/src/ehr/admin-create-template/index.ts
@@ -16,6 +16,7 @@ import {
 import { DateTime } from 'luxon';
 import { chartDataTagSystem, GLOBAL_TEMPLATE_IN_PERSON_CODE_SYSTEM } from 'utils/lib/fhir/constants';
 import {
+  isVersionConflictError,
   makeOptimisticLockIfMatchHeader,
   resourceHasTagSystem,
   transactionWasSuccessful,
@@ -520,38 +521,70 @@ const performEffect = async (
   // Add the new template to the global templates holder list so it's discoverable and create the template itself. No orphaned templates
   console.log('Creating template with', listToCreate.contained!.length, 'contained resources');
   const listToCreateFullUrl = `urn:uuid:${uuidV4()}`;
-  const holderList = await findHolderList(oystehr);
-  if (!holderList) throw new Error('No global templates holder list found — cannot link template');
 
-  const transactionResponse = await oystehr.fhir.transaction<List>({
-    requests: [
-      {
-        method: 'POST',
-        url: '/List',
-        resource: listToCreate,
-        fullUrl: listToCreateFullUrl,
-      },
-      {
-        method: 'PATCH',
-        url: `List/${holderList.id}`,
-        operations: [
+  // The holder PATCH carries If-Match, so racing template creates/deletes surface as a version
+  // conflict (412) instead of silently overwriting each other's holder entries. The transaction
+  // is atomic — a conflicted attempt leaves nothing behind — so re-read the holder and retry.
+  // Retries re-read by id: findHolderList goes through search, which can keep serving the same
+  // stale holder version under write load, while a direct read always returns the current one.
+  const MAX_HOLDER_LINK_ATTEMPTS = 3;
+  let createdList: List | undefined;
+  let holderId: string | undefined;
+
+  for (let attempt = 1; attempt <= MAX_HOLDER_LINK_ATTEMPTS; attempt++) {
+    const holderList = holderId
+      ? await oystehr.fhir.get<List>({ resourceType: 'List', id: holderId })
+      : await findHolderList(oystehr);
+    if (!holderList?.id) throw new Error('No global templates holder list found — cannot link template');
+    holderId = holderList.id;
+
+    try {
+      const transactionResponse = await oystehr.fhir.transaction<List>({
+        requests: [
           {
-            op: 'add',
-            path: holderList.entry ? '/entry/-' : '/entry',
-            value: { item: { reference: listToCreateFullUrl } },
+            method: 'POST',
+            url: '/List',
+            resource: listToCreate,
+            fullUrl: listToCreateFullUrl,
+          },
+          {
+            method: 'PATCH',
+            url: `List/${holderList.id}`,
+            operations: [
+              {
+                op: 'add',
+                path: holderList.entry ? '/entry/-' : '/entry',
+                value: { item: { reference: listToCreateFullUrl } },
+              },
+            ],
+            ifMatch: makeOptimisticLockIfMatchHeader(holderList),
           },
         ],
-        ifMatch: makeOptimisticLockIfMatchHeader(holderList),
-      },
-    ],
-  });
+      });
 
-  if (!transactionWasSuccessful(transactionResponse)) {
-    console.error(`This was failed transactionResponse: `, JSON.stringify(transactionResponse));
-    throw new Error('Unable to create template or add it to template holder');
+      if (!transactionWasSuccessful(transactionResponse)) {
+        // Some failure surfaces put the per-entry status in the bundle instead of throwing;
+        // classify an embedded 412 as a retryable conflict like a thrown one.
+        if (transactionResponse.entry?.some((entry) => entry.response?.status?.startsWith('412'))) {
+          throw new Error('Holder list version conflict (412) while linking template');
+        }
+        console.error(`This was failed transactionResponse: `, JSON.stringify(transactionResponse));
+        throw new Error('Unable to create template or add it to template holder');
+      }
+
+      createdList = transactionResponse.unbundle().find((list) => list.id !== holderList.id);
+      break;
+    } catch (error) {
+      if (attempt === MAX_HOLDER_LINK_ATTEMPTS || !isVersionConflictError(error)) throw error;
+      console.log(
+        `Holder list version conflict while linking template (attempt ${attempt}/${MAX_HOLDER_LINK_ATTEMPTS}), re-reading and retrying`
+      );
+    }
   }
 
-  const createdList = transactionResponse.unbundle().find((list) => list.id !== holderList.id)!;
+  if (!createdList) {
+    throw new Error('Unable to create template or add it to template holder');
+  }
 
   console.log('Created template:', createdList.id, createdList.title);
   console.log('Added template to holder list');

--- a/packages/zambdas/src/ehr/admin-create-template/index.ts
+++ b/packages/zambdas/src/ehr/admin-create-template/index.ts
@@ -16,10 +16,10 @@ import {
 import { DateTime } from 'luxon';
 import { chartDataTagSystem, GLOBAL_TEMPLATE_IN_PERSON_CODE_SYSTEM } from 'utils/lib/fhir/constants';
 import {
-  isVersionConflictError,
   makeOptimisticLockIfMatchHeader,
   resourceHasTagSystem,
   transactionWasSuccessful,
+  withVersionConflictRetries,
 } from 'utils/lib/fhir/helpers';
 import { isExternalLabServiceRequest, isPSCOrder } from 'utils/lib/helpers/labs/helpers';
 import { CODE_SYSTEM_ICD_10 } from 'utils/lib/helpers/rcm/constants';
@@ -527,18 +527,18 @@ const performEffect = async (
   // is atomic — a conflicted attempt leaves nothing behind — so re-read the holder and retry.
   // Retries re-read by id: findHolderList goes through search, which can keep serving the same
   // stale holder version under write load, while a direct read always returns the current one.
-  const MAX_HOLDER_LINK_ATTEMPTS = 3;
-  let createdList: List | undefined;
+  // (patchWithOptimisticLock can't be used here: the guarded PATCH must land in the same
+  // transaction as the template POST so a failure can never orphan the new template.)
   let holderId: string | undefined;
 
-  for (let attempt = 1; attempt <= MAX_HOLDER_LINK_ATTEMPTS; attempt++) {
-    const holderList = holderId
-      ? await oystehr.fhir.get<List>({ resourceType: 'List', id: holderId })
-      : await findHolderList(oystehr);
-    if (!holderList?.id) throw new Error('No global templates holder list found — cannot link template');
-    holderId = holderList.id;
+  const createdList = await withVersionConflictRetries(
+    async () => {
+      const holderList = holderId
+        ? await oystehr.fhir.get<List>({ resourceType: 'List', id: holderId })
+        : await findHolderList(oystehr);
+      if (!holderList?.id) throw new Error('No global templates holder list found — cannot link template');
+      holderId = holderList.id;
 
-    try {
       const transactionResponse = await oystehr.fhir.transaction<List>({
         requests: [
           {
@@ -572,15 +572,15 @@ const performEffect = async (
         throw new Error('Unable to create template or add it to template holder');
       }
 
-      createdList = transactionResponse.unbundle().find((list) => list.id !== holderList.id);
-      break;
-    } catch (error) {
-      if (attempt === MAX_HOLDER_LINK_ATTEMPTS || !isVersionConflictError(error)) throw error;
-      console.log(
-        `Holder list version conflict while linking template (attempt ${attempt}/${MAX_HOLDER_LINK_ATTEMPTS}), re-reading and retrying`
-      );
+      return transactionResponse.unbundle().find((list) => list.id !== holderList.id);
+    },
+    {
+      onConflict: (attempt) =>
+        console.log(
+          `Holder list version conflict while linking template (attempt ${attempt}), re-reading and retrying`
+        ),
     }
-  }
+  );
 
   if (!createdList) {
     throw new Error('Unable to create template or add it to template holder');

--- a/packages/zambdas/src/ehr/admin-delete-template/index.ts
+++ b/packages/zambdas/src/ehr/admin-delete-template/index.ts
@@ -1,6 +1,8 @@
 import Oystehr from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
+import { Operation } from 'fast-json-patch';
 import { List } from 'fhir/r4b';
+import { patchWithOptimisticLock } from 'utils/lib/fhir/helpers';
 import { getSecret, SecretsKeys } from 'utils/lib/secrets';
 import { AdminDeleteTemplateInput } from 'utils/lib/types/data/admin-template.types';
 import { checkOrCreateM2MClientToken } from '../../shared/auth';
@@ -50,15 +52,26 @@ const performEffect = async (
 
   verifyIsTemplate(templateList, templateId);
 
-  // Remove the template reference from the holder list
+  // Remove the template reference from the holder list.
+  //
+  // The holder is shared, mutable state: admin-create-template links new templates into it
+  // (PATCH + If-Match) while deletes unlink theirs, and both can run concurrently. This used
+  // to read the holder through search and PUT the whole filtered resource back with no version
+  // guard, so a stale read could silently erase an entry another process had just added — after
+  // which apply-template could no longer discover that template by name. Two guards close that:
+  //   1. re-read the holder by id: findHolderList goes through search, which can serve a stale
+  //      version under write load, and computing the removal from a stale entry array could
+  //      skip the removal entirely (leaving a dangling reference to the deleted template);
+  //   2. patchWithOptimisticLock: removes by index with If-Match, re-fetching and recomputing
+  //      on a version conflict — so a concurrent holder write means retry, not clobber.
   const holderList = await findHolderList(oystehr);
 
-  if (holderList) {
-    const updatedEntries = (holderList.entry ?? []).filter((entry) => entry.item.reference !== `List/${templateId}`);
-    await oystehr.fhir.update<List>({
-      ...holderList,
-      entry: updatedEntries,
-    });
+  if (holderList?.id) {
+    const holderId = holderList.id;
+    const currentHolder = await oystehr.fhir.get<List>({ resourceType: 'List', id: holderId });
+    await patchWithOptimisticLock(oystehr, { ...currentHolder, id: holderId }, (holder) =>
+      makeRemoveTemplateFromHolderOps(holder, templateId)
+    );
     console.log('Removed template from holder list');
   }
 
@@ -70,4 +83,18 @@ const performEffect = async (
   return {
     message: `Template "${templateList.title}" deleted successfully`,
   };
+};
+
+// JSON Patch removes by array index, so the ops must be computed against the exact holder
+// version the If-Match header pins (patchWithOptimisticLock recomputes them on retry).
+// Indices are emitted in descending order so each remove leaves the earlier ones valid.
+export const makeRemoveTemplateFromHolderOps = (holderList: List, templateId: string): Operation[] => {
+  const entries = holderList.entry ?? [];
+  const ops: Operation[] = [];
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i].item.reference === `List/${templateId}`) {
+      ops.push({ op: 'remove', path: `/entry/${i}` });
+    }
+  }
+  return ops;
 };

--- a/packages/zambdas/src/ehr/admin-delete-template/index.ts
+++ b/packages/zambdas/src/ehr/admin-delete-template/index.ts
@@ -53,17 +53,6 @@ const performEffect = async (
   verifyIsTemplate(templateList, templateId);
 
   // Remove the template reference from the holder list.
-  //
-  // The holder is shared, mutable state: admin-create-template links new templates into it
-  // (PATCH + If-Match) while deletes unlink theirs, and both can run concurrently. This used
-  // to read the holder through search and PUT the whole filtered resource back with no version
-  // guard, so a stale read could silently erase an entry another process had just added — after
-  // which apply-template could no longer discover that template by name. Two guards close that:
-  //   1. re-read the holder by id: findHolderList goes through search, which can serve a stale
-  //      version under write load, and computing the removal from a stale entry array could
-  //      skip the removal entirely (leaving a dangling reference to the deleted template);
-  //   2. patchWithOptimisticLock: removes by index with If-Match, re-fetching and recomputing
-  //      on a version conflict — so a concurrent holder write means retry, not clobber.
   const holderList = await findHolderList(oystehr);
 
   if (holderList?.id) {

--- a/packages/zambdas/test/unit/admin-delete-template.test.ts
+++ b/packages/zambdas/test/unit/admin-delete-template.test.ts
@@ -1,0 +1,56 @@
+import { List } from 'fhir/r4b';
+import { GLOBAL_TEMPLATE_META_TAG_CODE_SYSTEM } from 'utils/lib/fhir/constants';
+import { describe, expect, test } from 'vitest';
+import { makeRemoveTemplateFromHolderOps } from '../../src/ehr/admin-delete-template/index';
+
+const makeHolderList = (referencedListIds: (string | undefined)[]): List => ({
+  resourceType: 'List',
+  id: 'holder-1',
+  status: 'current',
+  mode: 'working',
+  meta: { tag: [{ system: GLOBAL_TEMPLATE_META_TAG_CODE_SYSTEM, code: 'global-templates' }] },
+  entry: referencedListIds.map((id) => ({
+    item: id ? { reference: `List/${id}` } : {},
+  })),
+});
+
+// The holder list is shared mutable state written by concurrent template creates and
+// deletes; delete removes its entry via patchWithOptimisticLock, which recomputes these
+// ops against the exact resource version its If-Match header pins. That contract makes
+// two properties load-bearing: indices must match the version passed in, and multiple
+// removes must be ordered so earlier ops don't shift the indices of later ones.
+describe('makeRemoveTemplateFromHolderOps', () => {
+  test('removes the single entry referencing the template', () => {
+    const holder = makeHolderList(['other-a', 'target', 'other-b']);
+    expect(makeRemoveTemplateFromHolderOps(holder, 'target')).toEqual([{ op: 'remove', path: '/entry/1' }]);
+  });
+
+  test('returns no ops when the template is not referenced (already unlinked by another writer)', () => {
+    const holder = makeHolderList(['other-a', 'other-b']);
+    expect(makeRemoveTemplateFromHolderOps(holder, 'target')).toEqual([]);
+  });
+
+  test('returns no ops when the holder has no entry array', () => {
+    const holder = makeHolderList([]);
+    delete holder.entry;
+    expect(makeRemoveTemplateFromHolderOps(holder, 'target')).toEqual([]);
+  });
+
+  test('removes duplicate references in descending index order so earlier removes keep later indices valid', () => {
+    const holder = makeHolderList(['target', 'other-a', 'target']);
+    expect(makeRemoveTemplateFromHolderOps(holder, 'target')).toEqual([
+      { op: 'remove', path: '/entry/2' },
+      { op: 'remove', path: '/entry/0' },
+    ]);
+  });
+
+  test('ignores entries without an item reference', () => {
+    const holder = makeHolderList([undefined, 'target']);
+    expect(makeRemoveTemplateFromHolderOps(holder, 'target')).toEqual([{ op: 'remove', path: '/entry/1' }]);
+  });
+
+  test('does not match a template id that is a prefix or suffix of another reference', () => {
+    const holder = makeHolderList(['target-longer', 'target']);
+    expect(makeRemoveTemplateFromHolderOps(holder, 'target')).toEqual([{ op: 'remove', path: '/entry/1' }]);
+  });
+});


### PR DESCRIPTION
I have seen this test flake show up on a few PRs recently and wanted to get it fixed. 

🤖 generated fix and comment below for [OTR-3267: zambda integration test flake with global templates](https://linear.app/zapehr/issue/OTR-3267/zambda-integration-test-flake-with-global-templates). I have read and reviewed the code; I made the agent fix code reuse issues and too-noisy-comment issues.

## Summary

Adds optimistic locking with retry logic to template creation and deletion operations to prevent race conditions when multiple processes concurrently modify the shared global templates holder list. This ensures that concurrent template creates and deletes don't silently overwrite each other's holder entries.

## Key Changes

- **Template Creation (`admin-create-template`)**: Wrapped the transaction that links a new template into the holder list with retry logic. On version conflict (HTTP 412), the operation re-reads the holder list by ID and retries up to 3 times. This prevents stale reads from search from causing the transaction to fail or silently lose concurrent updates.

- **Template Deletion (`admin-delete-template`)**: Replaced the unsafe PUT-based holder update with `patchWithOptimisticLock`, which uses JSON Patch operations with If-Match headers. Added `makeRemoveTemplateFromHolderOps()` to compute removal operations by array index in descending order, ensuring indices remain valid across multiple removes.

- **Shared Utility (`isVersionConflictError`)**: Extracted version conflict detection into a reusable helper function in `packages/utils/lib/fhir/helpers.ts` to classify HTTP 412 errors from the Oystehr SDK.

- **Test Coverage**: Added comprehensive unit tests for `makeRemoveTemplateFromHolderOps()` covering single/multiple removals, missing entries, and edge cases.

## Implementation Details

- The holder list is shared mutable state written by concurrent processes. Both create and delete now use If-Match headers to detect conflicts and retry rather than silently overwriting.
- Template creation retries re-read the holder by ID (not search) on conflict, since search can serve stale versions under write load.
- Template deletion computes removal operations against the exact holder version pinned by If-Match, recomputing on retry to ensure indices match.
- Removal operations are emitted in descending index order so earlier removes don't shift indices of later ones.

https://claude.ai/code/session_016A8svodxghoRFzfXaD3YXJ