### PR TITLE
tweak(billing): Throw rules engine errors instead of returning them

### DIFF
--- a/packages/zambdas/src/subscriptions/task/sub-rules-engine/index.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-rules-engine/index.ts
@@ -234,10 +234,7 @@ export async function performEffect(
 
   if (failure) {
     console.log(`[rules-engine] Claim/${claimId} held after rule "${failure.rule.name}" failed`);
-    return {
-      taskStatus: 'failed',
-      statusReason: `Rule "${failure.rule.name}" failed: ${failure.error}. The claim was held for review.`,
-    };
+    throw new Error(`Rule "${failure.rule.name}" failed: ${failure.error}. The claim was held for review.`);
   }
 
   if (heldBy) {

--- a/packages/zambdas/test/unit/billing/sub-rules-engine.test.ts
+++ b/packages/zambdas/test/unit/billing/sub-rules-engine.test.ts
@@ -228,15 +228,13 @@ describe('sub-rules-engine performEffect', () => {
       actions: [{ type: 'setField', field: 'renderingProvider.npi', value: '5555555555' }],
     });
 
-    const result = await performEffect(
-      oystehr,
-      { engine: 'claim-submission', claimId: 'claim-1', rules: [rule], model },
-      AGENT
+    await expect(
+      async () =>
+        await performEffect(oystehr, { engine: 'claim-submission', claimId: 'claim-1', rules: [rule], model }, AGENT)
+    ).rejects.toMatchInlineSnapshot(
+      `[Error: Rule "Rule bad" failed: could not set "renderingProvider.npi" — the field is unknown or read-only, the value is invalid, or the target is missing from this claim. The claim was held for review.]`
     );
 
-    expect(result.taskStatus).toBe('failed');
-    expect(result.statusReason).toContain('Rule "Rule bad" failed');
-    expect(result.statusReason).toContain('held for review');
     expect(submitClaimRcm).not.toHaveBeenCalled();
     const requests = transaction.mock.calls[0][0].requests;
     const claimPut = requests.find(


### PR DESCRIPTION
Two things happen after the error is thrown:

- The `sub-rules-engine` handler catches the error, adds a history Provenance holding the error message, and ensures the claim is held; it then rethrows
- The `wrapTaskHandler` helper catches the error, marks the task failed, and reports to sentry