### PR TITLE
Fix insurance carrier sourcing in E2E tests to use payer list

### DIFF
--- a/apps/ehr/tests/e2e-utils/resource-handler.ts
+++ b/apps/ehr/tests/e2e-utils/resource-handler.ts
@@ -521,8 +521,8 @@ export class ResourceHandler {
       }s — harvest did not create the expected Coverage resources. Before suspecting the harvest ` +
         `subscriptions: check the log above for "Error processing paperwork" (paperwork patch/submit ` +
         `failures are logged but swallowed, and an unsubmitted QuestionnaireResponse never triggers ` +
-        `harvest), and verify the env has payer Organizations ` +
-        `(Organization?active=true&type=...|pay) — an empty payer list invalidates the ` +
+        `harvest), and verify the insurance-carrier answers resolved — carriers are sourced from the ` +
+        `Oystehr payer list (oystehr.rcm.listPayers), and an unresolved carrier invalidates the ` +
         `payment-option-page patch.`
     );
   }

--- a/apps/ehr/tests/e2e-utils/resource-handler.ts
+++ b/apps/ehr/tests/e2e-utils/resource-handler.ts
@@ -518,7 +518,12 @@ export class ResourceHandler {
     throw new Error(
       `Patient ${patientId} only had ${count}/${expectedCount} active coverages after ${
         (maxAttempts * delayMs) / 1000
-      }s — harvest did not create the expected Coverage resources`
+      }s — harvest did not create the expected Coverage resources. Before suspecting the harvest ` +
+        `subscriptions: check the log above for "Error processing paperwork" (paperwork patch/submit ` +
+        `failures are logged but swallowed, and an unsubmitted QuestionnaireResponse never triggers ` +
+        `harvest), and verify the env has payer Organizations ` +
+        `(Organization?active=true&type=...|pay) — an empty payer list invalidates the ` +
+        `payment-option-page patch.`
     );
   }
 

--- a/apps/ehr/tests/e2e/specs/patientRecordPageInsuranceSection.spec.ts
+++ b/apps/ehr/tests/e2e/specs/patientRecordPageInsuranceSection.spec.ts
@@ -737,6 +737,18 @@ async function buildResourceHandler(): Promise<[ResourceHandler, string, string]
       ],
     })
   ).unbundle();
+  // Fail fast with the real cause: on an env with no payer Organizations the carriers below become
+  // undefined, patch-paperwork rejects the payment-option-page answers, the QR never completes, and
+  // every test in this file dies 60s later behind a misleading "harvest did not create Coverages"
+  // timeout instead of this message.
+  if (insuranceCarriersOptions.length < 2) {
+    throw new Error(
+      `Expected at least 2 active payer Organizations on this environment ` +
+        `(Organization?active=true&type=${ORG_TYPE_CODE_SYSTEM}|${ORG_TYPE_PAYER_CODE}) but found ` +
+        `${insuranceCarriersOptions.length}. The env is missing insurance-payer seed data — run ` +
+        `\`npm run update-insurances-and-payer-orgs <env>\` in packages/zambdas to seed it.`
+    );
+  }
   const ic1 = insuranceCarriersOptions.at(0);
   const ic2 = insuranceCarriersOptions.at(1);
   insuranceCarrier1 = {

--- a/apps/ehr/tests/e2e/specs/patientRecordPageInsuranceSection.spec.ts
+++ b/apps/ehr/tests/e2e/specs/patientRecordPageInsuranceSection.spec.ts
@@ -1,7 +1,6 @@
 import { test } from '@playwright/test';
 import { Organization, QuestionnaireItemAnswerOption } from 'fhir/r4b';
 import { DateTime } from 'luxon';
-import { createReference } from 'utils/lib/fhir/helpers';
 import { hasAttorneyInformationPage, hasEmployerInformationPage } from 'utils/lib/helpers/create-demo-visits';
 import {
   getAttorneyInformationStepAnswers,
@@ -10,13 +9,13 @@ import {
   getEmergencyContactStepAnswers,
   getEmployerInformationStepAnswers,
   getPatientDetailsStepAnswers,
+  getPayerId,
   getPaymentOptionInsuranceAnswers,
   getPrimaryCarePhysicianStepAnswers,
   getResponsiblePartyStepAnswers,
   isoToDateObject,
 } from 'utils/lib/helpers/helpers';
 import { PATIENT_RECORD_CONFIG } from 'utils/lib/ottehr-config/patient-record';
-import { ORG_TYPE_CODE_SYSTEM, ORG_TYPE_PAYER_CODE } from 'utils/lib/types/constants';
 import {
   PATIENT_INSURANCE_MEMBER_ID,
   PATIENT_INSURANCE_MEMBER_ID_2,
@@ -722,51 +721,41 @@ async function buildResourceHandler(): Promise<[ResourceHandler, string, string]
     return answers;
   });
   const oystehr = await ResourceHandler.getOystehr();
-  const insuranceCarriersOptions = (
-    await oystehr.fhir.search<Organization>({
-      resourceType: 'Organization',
-      params: [
-        {
-          name: 'active',
-          value: 'true',
-        },
-        {
-          name: 'type',
-          value: `${ORG_TYPE_CODE_SYSTEM}|${ORG_TYPE_PAYER_CODE}`,
-        },
-      ],
-    })
-  ).unbundle();
-  // Fail fast with the real cause: on an env with no payer Organizations the carriers below become
-  // undefined, patch-paperwork rejects the payment-option-page answers, the QR never completes, and
-  // every test in this file dies 60s later behind a misleading "harvest did not create Coverages"
-  // timeout instead of this message.
-  if (insuranceCarriersOptions.length < 2) {
+  // Carriers come from the Oystehr payer list — the same backing source as the intake paperwork
+  // options (get-patient-insurance-payers) and the EHR patient-record carrier field
+  // (get-all-insurance-payers with prependIdentifier). Payer-type FHIR Organizations are the
+  // legacy source and are no longer seeded on new environments, so sourcing carriers from them
+  // here made every test in this file fail on envs that only have the payer list.
+  const payersPage = await oystehr.rcm.listPayers({ limit: 50 });
+  const payersById = new Map<string, Organization>();
+  for (const payer of payersPage.data) {
+    const payerId = getPayerId(payer);
+    const payerName = payer.alias?.[0] ?? payer.name;
+    if (typeof payerId === 'string' && typeof payerName === 'string' && !payersById.has(payerId)) {
+      payersById.set(payerId, payer);
+    }
+  }
+  const [payer1, payer2] = [...payersById.values()];
+  if (!payer1 || !payer2) {
     throw new Error(
-      `Expected at least 2 active payer Organizations on this environment ` +
-        `(Organization?active=true&type=${ORG_TYPE_CODE_SYSTEM}|${ORG_TYPE_PAYER_CODE}) but found ` +
-        `${insuranceCarriersOptions.length}. The env is missing insurance-payer seed data — run ` +
-        `\`npm run update-insurances-and-payer-orgs <env>\` in packages/zambdas to seed it.`
+      `Expected the Oystehr payer list (oystehr.rcm.listPayers) to contain at least 2 usable payers ` +
+        `but found ${payersById.size} of ${payersPage.data.length} listed. The insurance paperwork and ` +
+        `patient-record carrier options are built from this list, so these tests cannot run without it.`
     );
   }
-  const ic1 = insuranceCarriersOptions.at(0);
-  const ic2 = insuranceCarriersOptions.at(1);
-  insuranceCarrier1 = {
+  const toCarrierAnswer = (payer: Organization): QuestionnaireItemAnswerOption => ({
     valueReference: {
-      reference: ic1 && createReference(ic1).reference,
-      display: ic1?.name,
+      reference: oystehr.rcm.constructPayerUrl({ id: getPayerId(payer)! }),
+      display: `${payer.alias?.[0] ?? payer.name}`,
     },
-  };
-  insuranceCarrier2 = {
-    valueReference: {
-      reference: ic2 && createReference(ic2).reference,
-      display: ic2?.name,
-    },
-  };
-  // these are old Organization references so they show up as historical
-  const insuranceCarrier1ForResult = `${ic1?.name} (historical)`;
-  const insuranceCarrier2ForResult = `${ic2?.name} (historical)`;
-  console.log('carrier: ', JSON.stringify(insuranceCarrier1ForResult));
+  });
+  insuranceCarrier1 = toCarrierAnswer(payer1);
+  insuranceCarrier2 = toCarrierAnswer(payer2);
+  // The EHR patient-record field labels its options "<payerId> - <name>" (prependIdentifier), and
+  // because these payers are in the current list the value renders without a "(historical)" suffix.
+  const insuranceCarrier1ForResult = `${getPayerId(payer1)} - ${payer1.alias?.[0] ?? payer1.name}`;
+  const insuranceCarrier2ForResult = `${getPayerId(payer2)} - ${payer2.alias?.[0] ?? payer2.name}`;
+  console.log('carriers: ', JSON.stringify([insuranceCarrier1ForResult, insuranceCarrier2ForResult]));
 
   return [resourceHandler, insuranceCarrier1ForResult ?? '', insuranceCarrier2ForResult ?? ''];
 }

--- a/packages/utils/lib/helpers/create-demo-visits.ts
+++ b/packages/utils/lib/helpers/create-demo-visits.ts
@@ -670,7 +670,10 @@ export async function makeSequentialPaperworkPatches(
     });
 
     if (!response.ok) {
-      throw new Error(`Failed to patch paperwork with linkId: ${answer.linkId}`);
+      const body = await response.text().catch(() => '<unreadable body>');
+      throw new Error(
+        `Failed to patch paperwork with linkId: ${answer.linkId} — ${response.status} ${response.statusText}: ${body}`
+      );
     }
   }, Promise.resolve() as Promise<void>);
 }


### PR DESCRIPTION
The deal is that e2e4 and e2e5 never got set up with FHIR Organizations to represent payers. The features work, but the tests do not, because they were never upgraded from using the FHIR Organization approach to the payer list endpoint approach. This PR changes to use payer list which will work on all envs.

## Summary

Updates the patient record insurance section E2E tests to source insurance carriers from the Oystehr payer list (`oystehr.rcm.listPayers`) instead of legacy FHIR Organization resources with payer-type codes. This fixes test failures on environments that only have the payer list and no legacy payer-type Organizations.

## Key Changes

- **Insurance carrier sourcing**: Changed from querying FHIR Organizations with `ORG_TYPE_PAYER_CODE` to using `oystehr.rcm.listPayers()`, which is the same backing source used by intake paperwork and the EHR patient-record carrier field
- **Carrier reference construction**: Updated to use `oystehr.rcm.constructPayerUrl()` instead of `createReference()` for building carrier references
- **Carrier display labels**: Changed from legacy format (e.g., "Carrier Name (historical)") to current format (e.g., "payerId - Carrier Name") to match what the EHR patient-record field displays
- **Error handling**: Enhanced error messages in `makeSequentialPaperworkPatches()` to include HTTP status and response body for better debugging of paperwork patch failures
- **Diagnostic logging**: Improved error messages in `ResourceHandler.waitForActiveCoverages()` with guidance on checking paperwork patch failures and carrier resolution issues

## Implementation Details

- Added `getPayerId()` helper import to extract payer IDs from payer objects
- Removed unused imports (`createReference`, `ORG_TYPE_CODE_SYSTEM`, `ORG_TYPE_PAYER_CODE`)
- Added validation to ensure at least 2 usable payers are available before running tests
- Deduplicates payers by ID to handle potential duplicates in the payer list
- Includes detailed comments explaining why the payer list is the correct source for carriers

https://claude.ai/code/session_01Y3mPuapKpZgog67xQAkAoF