### PR TITLE
fix(ehr): interpret tracking-board date filters in the resource's timezone

### DIFF
--- a/apps/ehr/src/components/Slots.tsx
+++ b/apps/ehr/src/components/Slots.tsx
@@ -49,9 +49,9 @@ export function Slots({ slots, timezone, selectedSlot, setSelectedSlot, loading 
               onClick={() => setSelectedSlot(slot)}
               data-testid={dataTestIds.slots.slot}
               // Exposes the slot's local date so e2e tests can match the tracking-board
-              // date filter to it (the filter defaults to "today in the location TZ",
-              // but the first available slot may land on tomorrow when the day's
-              // schedule is past closing time).
+              // date filter to it. The filter interprets dates in the location's TZ but
+              // defaults to the browser's today, and the first available slot may land
+              // on tomorrow when the day's schedule is past closing time.
               data-slot-date={startDateTimezoneAdjusted.toFormat('MM/dd/yyyy')}
             >
               {startDateTimezoneAdjusted.toFormat('h:mm a')}

--- a/apps/ehr/tests/e2e/page/AddPatientPage.ts
+++ b/apps/ehr/tests/e2e/page/AddPatientPage.ts
@@ -123,9 +123,14 @@ export class AddPatientPage {
     // Read the slot's local date BEFORE clicking — the data attribute is on the
     // slot button and the component should not unmount it on click, but reading
     // first avoids any race with state updates.
-    const date = (await buttonLocator.getAttribute('data-slot-date')) ?? '';
+    const date = await buttonLocator.getAttribute('data-slot-date');
     await buttonLocator.click();
     const time = (await buttonLocator.textContent()) ?? '';
+    if (!date) {
+      throw new Error(
+        'slot button is missing data-slot-date — cannot align the visits-board date filter with the slot day'
+      );
+    }
     return { time, date };
   }
 

--- a/apps/ehr/tests/e2e/specs/addPatientPage.spec.ts
+++ b/apps/ehr/tests/e2e/specs/addPatientPage.spec.ts
@@ -100,10 +100,12 @@ test.describe('For new patient', () => {
 
     const visitsPage = await expectVisitsPage(page);
     await visitsPage.selectLocation(ENV_LOCATION_NAME!);
-    // The first available slot may roll to tomorrow when the day's schedule is past
-    // closing time. The tracking-board date filter defaults to today in the location's
-    // timezone, so without this it'd show zero rows even though the appointment exists.
-    if (slotDate) await visitsPage.selectDate(slotDate);
+    // The slot may land on a different local day than the board's default filter (the browser's
+    // today): past closing time it rolls to tomorrow, and late-evening slots belong to a local day
+    // a UTC browser has already left behind. data-slot-date is the slot's day in the location's
+    // timezone — the same way the board filter interprets dates — so always align the filter to it.
+    // (Guaranteed non-empty for pre-book: selectFirstAvailableSlot throws when the attribute is missing.)
+    await visitsPage.selectDate(slotDate!);
     await visitsPage.clickPrebookedTab();
     await visitsPage.verifyVisitPresent(appointmentId);
   });
@@ -207,7 +209,7 @@ async function createAppointment(
   if (visitType !== VISIT_TYPES.WALK_IN) {
     const slot = await addPatientPage.selectFirstAvailableSlot();
     slotTime = slot.time;
-    slotDate = slot.date || undefined;
+    slotDate = slot.date;
   }
 
   const appointmentCreationResponse = waitForResponseWithData(page, /\/create-appointment\//);

--- a/apps/ehr/tests/e2e/specs/in-person/inPersonVisit.spec.ts
+++ b/apps/ehr/tests/e2e/specs/in-person/inPersonVisit.spec.ts
@@ -162,9 +162,9 @@ test.describe('In-person visit', async () => {
       const visitsPage = await openVisitsPage(page);
       await visitsPage.selectLocation(ENV_LOCATION_NAME!);
       // Match the tracking-board date filter to the appointment's local date in the
-      // location's timezone. The filter defaults to today; when the test runs late
-      // enough that the appointment landed on tomorrow (in the location TZ), the
-      // appointment exists but is hidden by the filter.
+      // location's timezone — the filter interprets dates in that TZ, so this selection
+      // is exact. The filter's default is the browser's today, which diverges from the
+      // location's day around midnight in either zone (UTC browsers: 00:00-05:00Z).
       const location = resourceHandler.appointmentLocation;
       const appointmentStart = resourceHandler.appointment.start;
       if (location && appointmentStart) {

--- a/packages/zambdas/src/ehr/get-appointments/helpers.ts
+++ b/packages/zambdas/src/ehr/get-appointments/helpers.ts
@@ -215,6 +215,24 @@ interface AppointmentQueryInput {
   group?: HealthcareService;
 }
 
+/**
+ * Converts an inclusive [searchDateFrom, searchDateTo] calendar-day range into a UTC instant
+ * window, interpreting the days in the given IANA timezone. Exported for unit tests.
+ */
+export const getAppointmentSearchWindow = ({
+  searchDateFrom,
+  searchDateTo,
+  timezone,
+}: {
+  searchDateFrom: string;
+  searchDateTo: string;
+  timezone: string;
+}): { startDay: string | null; endDay: string | null } => {
+  const startDay = DateTime.fromISO(searchDateFrom, { zone: timezone }).startOf('day').toUTC().toISO();
+  const endDay = DateTime.fromISO(searchDateTo, { zone: timezone }).endOf('day').toUTC().toISO();
+  return { startDay, endDay };
+};
+
 export const getAppointmentQueryInput = async (input: {
   oystehr: Oystehr;
   resourceId: string;
@@ -223,10 +241,30 @@ export const getAppointmentQueryInput = async (input: {
   searchDateTo: string;
   timezone: string;
 }): Promise<AppointmentQueryInput> => {
-  const { searchDateFrom, searchDateTo, timezone } = input;
+  const { oystehr, resourceId, resourceType, searchDateFrom, searchDateTo, timezone } = input;
 
-  const startDay = DateTime.fromISO(searchDateFrom, { zone: timezone }).startOf('day').toUTC().toISO();
-  const endDay = DateTime.fromISO(searchDateTo, { zone: timezone }).endOf('day').toUTC().toISO();
+  // The tracking board renders each row's time in the queried resource's own timezone, so a date
+  // filter of "08/13" must mean that resource's local Aug 13 — otherwise the filter and the display
+  // disagree. Interpreting the date in the caller's timezone shifted the window by the offset
+  // difference: a browser in UTC (CI, or any admin east of the clinic) asking for 08/13 at an
+  // America/New_York location built a UTC-day window that excluded appointments whose local time
+  // was 8pm-midnight (00:00-04:00Z on the next UTC day). Resolve the resource's timezone (cheap —
+  // timezoneMap caches it) and interpret the dates there; the caller's timezone stays as the
+  // fallback for resources without one.
+  let resourceTimezone: string | undefined;
+  try {
+    resourceTimezone = await getTimezone({ oystehr, resourceType, resourceId });
+  } catch (error) {
+    console.error(
+      `failed to resolve timezone for ${resourceType}/${resourceId}; falling back to request timezone`,
+      error
+    );
+  }
+  const { startDay, endDay } = getAppointmentSearchWindow({
+    searchDateFrom,
+    searchDateTo,
+    timezone: resourceTimezone ?? timezone,
+  });
 
   const { actorParams, healthcareService } = await getActorParamsForAppointmentQueryInput(input);
 

--- a/packages/zambdas/test/get-appointments-search-window.test.ts
+++ b/packages/zambdas/test/get-appointments-search-window.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest';
+import { getAppointmentSearchWindow } from '../src/ehr/get-appointments/helpers';
+
+// Regression coverage: tracking-board date filters are calendar days in the *queried resource's*
+// timezone. Before the window was zoned to the resource, the client's (browser) timezone was used;
+// a UTC browser asking for "2026-08-13" at an America/New_York clinic produced a UTC-day window
+// that excluded appointments booked 8pm-midnight local — which is 00:00-04:00Z on the next UTC
+// day. CI browsers run in UTC, so the EHR e2e board tests failed every night between roughly
+// 00:00 and 05:00 UTC and passed all day.
+describe('getAppointmentSearchWindow', () => {
+  test('builds the window for the local day in the given timezone', () => {
+    const { startDay, endDay } = getAppointmentSearchWindow({
+      searchDateFrom: '2026-08-13',
+      searchDateTo: '2026-08-13',
+      timezone: 'America/New_York',
+    });
+    expect(startDay).toBe('2026-08-13T04:00:00.000Z');
+    expect(endDay).toBe('2026-08-14T03:59:59.999Z');
+  });
+
+  test('late-evening local appointment falls inside its local day window (the night-window regression)', () => {
+    // 10:15pm Aug 13 at an America/New_York clinic = 02:15Z Aug 14. All values are UTC ISO strings
+    // of equal precision, so lexicographic comparison is instant comparison.
+    const appointmentStart = '2026-08-14T02:15:00.000Z';
+
+    const clinicDay = getAppointmentSearchWindow({
+      searchDateFrom: '2026-08-13',
+      searchDateTo: '2026-08-13',
+      timezone: 'America/New_York',
+    });
+    expect(appointmentStart >= clinicDay.startDay! && appointmentStart <= clinicDay.endDay!).toBe(true);
+
+    // The old behavior — the same date interpreted in the browser's UTC — excluded it.
+    const utcDay = getAppointmentSearchWindow({
+      searchDateFrom: '2026-08-13',
+      searchDateTo: '2026-08-13',
+      timezone: 'UTC',
+    });
+    expect(appointmentStart >= utcDay.startDay! && appointmentStart <= utcDay.endDay!).toBe(false);
+  });
+
+  test('multi-day range spans from the first day start to the last day end', () => {
+    const { startDay, endDay } = getAppointmentSearchWindow({
+      searchDateFrom: '2026-08-12',
+      searchDateTo: '2026-08-13',
+      timezone: 'America/New_York',
+    });
+    expect(startDay).toBe('2026-08-12T04:00:00.000Z');
+    expect(endDay).toBe('2026-08-14T03:59:59.999Z');
+  });
+});


### PR DESCRIPTION
## Problem

`get-appointments` converted the tracking board's `dateFrom`/`dateTo` into a UTC instant window using the **caller's (browser) timezone**, while the board renders every row in the **queried resource's own** timezone. Filter and display therefore disagreed for any browser east of the clinic, shifted by the offset difference.

Concretely: a UTC browser asking for `08/13` at an `America/New_York` location built the window `08/13T00:00Z → 08/13T23:59Z`. That excludes appointments booked 8pm–midnight local time, which are `00:00–04:00Z` on the *next* UTC day. The appointment exists, the date the user picked is correct, and the row is simply invisible.

## Impact

- **Users:** anyone whose browser sits east of the clinic — traveling staff, a multi-timezone org, an admin covering an ET site from Europe — silently loses late-evening rows from the board.
- **CI:** Playwright runners are UTC, so the `addPatientPage:89` and `inPersonVisit:157` board-row assertions failed every night between roughly 00:00 and 05:00 UTC and passed the rest of the day.

## Change

- **`packages/zambdas/src/ehr/get-appointments/helpers.ts`** — resolve the queried resource's timezone through the existing in-file `getTimezone` (cheap: `timezoneMap` caches it) and build the day window in that zone. The request timezone remains the fallback for resources that have none, and a failed lookup logs and falls back rather than failing the request.
- Extracted the window math into an exported **`getAppointmentSearchWindow`** so it can be unit-tested without a live Oystehr client.
- **`packages/zambdas/test/get-appointments-search-window.test.ts`** (new) — three cases, the middle one pinning the regression directly: a 10:15pm `America/New_York` appointment (`02:15Z` the next day) must fall inside its local day's window, *and* the old UTC interpretation of the same date must exclude it. Plus single-day boundaries and a multi-day range.
- **e2e** — `addPatientPage` now always aligns the board's date filter to the slot's `data-slot-date` instead of only when the value happened to be truthy; `AddPatientPage.selectFirstAvailableSlot` throws if the attribute is missing rather than returning `''` and silently skipping the alignment. The attribute is rendered unconditionally, so a missing value means the page changed and the test should say so. (Only the pre-book test selects a date; the walk-in test never calls `selectDate`.)
- Corrected comments in `Slots.tsx` and both specs that described the filter default as "today in the location TZ". The default is the **browser's** today; only the *interpretation* is the location's zone. That mis-description is what made the original window bug easy to miss.

## Testing

- New zambda unit tests pass: `cd packages/zambdas && npx vitest run --project unit`
- Both previously-flaky specs pass in CI on this PR: `addPatientPage:89` and `inPersonVisit:157` are green in the EHR e2e run (159 passed / 1 failed, the single failure being an unrelated `admin/paymentLocations.spec.ts` flake).
- Rebased onto current `develop` (`2e5d607a`) so CI runs against the latest base.

## Relationship to #9160

#9160 was an unrelated E2E fix (insurance carrier sourcing); it never changed the CI schedule or any product code for this bug. The night-window flake was only *sidestepped* there, by rerunning the pipeline after the UTC/ET dates realigned — which produced a full-green signal without touching the cause. This PR is the actual fix, so there is nothing from #9160 to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3mPuapKpZgog67xQAkAoF