### PR TITLE
Paperwork flow bugs

### DIFF
--- a/config/oystehr-core/zambdas.json
+++ b/config/oystehr-core/zambdas.json
@@ -2691,7 +2691,7 @@
         "resourceType": "Subscription",
         "status": "active",
         "reason": "paperwork harvest",
-        "criteria": "QuestionnaireResponse?status=completed,amended&questionnaire=https://ottehr.com/FHIR/Questionnaire/intake-paperwork-inperson,https://ottehr.com/FHIR/Questionnaire/intake-paperwork-virtual",
+        "criteria": "QuestionnaireResponse?status=completed,amended",
         "channel": {
           "type": "rest-hook",
           "endpoint": "zapehr-lambda:#{ref/zambdas/SUB-INTAKE-HARVEST/id}"

--- a/packages/utils/lib/fhir/questionnaires.ts
+++ b/packages/utils/lib/fhir/questionnaires.ts
@@ -91,6 +91,10 @@ export const isIntakePaperworkQuestionnaireResponse = (qr: QuestionnaireResponse
   if (!questionnaireUrl) {
     return false;
   }
+  return isOttehrManagedIntakeQuestionnaire(questionnaireUrl);
+};
+
+export const isOttehrManagedIntakeQuestionnaire = (questionnaireUrl: string): boolean => {
   return (
     questionnaireUrl.startsWith(IN_PERSON_INTAKE_PAPERWORK_URL) ||
     questionnaireUrl.startsWith(VIRTUAL_INTAKE_PAPERWORK_URL)

--- a/packages/zambdas/src/ehr/paperwork-flow/list/index.ts
+++ b/packages/zambdas/src/ehr/paperwork-flow/list/index.ts
@@ -90,7 +90,9 @@ async function performEffect(oystehr: Oystehr, secrets: Secrets | null): Promise
 
         const serviceIds = servicesByFlowUrlMap.get(flowUrl);
         const ottehrManagedServiceIds = ottehrManagedServicesFromQ(flow);
-        const services = [...ottehrManagedServiceIds, ...(serviceIds ? Array.from(serviceIds) : [])];
+        const servicesAll = [...ottehrManagedServiceIds, ...(serviceIds ? Array.from(serviceIds) : [])];
+        // dedupe, flows that have both inperson and virtual will pick up the service twice
+        const services = Array.from(new Map(servicesAll.map((service) => [service.id, service])).values());
 
         const paperworkFlow: PaperworkFlow = {
           ...paperworkFlowQuestionnaire,

--- a/packages/zambdas/src/subscriptions/questionnaire-response/sub-intake-harvest/index.ts
+++ b/packages/zambdas/src/subscriptions/questionnaire-response/sub-intake-harvest/index.ts
@@ -1,8 +1,9 @@
 import Oystehr, { BatchInputPatchRequest, BatchInputPostRequest } from '@oystehr/sdk';
 import { captureException } from '@sentry/aws-serverless';
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { Appointment, Coding, Encounter, Location, Observation, Patient, Task } from 'fhir/r4b';
+import { Appointment, Coding, Encounter, Location, Observation, Patient, Questionnaire, Task } from 'fhir/r4b';
 import { FHIR_APPOINTMENT_INTAKE_HARVESTING_COMPLETED_TAG } from 'utils/lib/fhir/constants';
+import { getCanonicalQuestionnaire, isOttehrManagedIntakeQuestionnaire } from 'utils/lib/fhir/questionnaires';
 import { getPatchOperationsForNewMetaTags } from 'utils/lib/fhir/resourcePatch';
 import { getSecret, SecretsKeys } from 'utils/lib/secrets';
 import { ADDITIONAL_QUESTIONS_META_SYSTEM } from 'utils/lib/types/api/chart-data/chart-data.types';
@@ -43,15 +44,62 @@ export const index = wrapHandler('sub-intake-harvest', async (input: ZambdaInput
   }
 
   const oystehr = createClinicalOystehrClient(oystehrToken, secrets);
-  const response = await performEffect(validatedParameters, oystehr);
+
+  const effectInput = await complexValidation(validatedParameters, oystehr);
+
+  const response = await performEffect(effectInput, oystehr);
+
   return {
     statusCode: 200,
     body: JSON.stringify(response),
   };
 });
 
+// validate that this questionnaire is a candidate for sub-intake-harvest
+// with the introduction of flows its, the subscription criteria was broadened
+// this logic will determine if the QuestionnaireResponse that triggered the invocation is actually a candidate
+const complexValidation = async (
+  input: QRSubscriptionInput,
+  oystehr: Oystehr
+): Promise<QRSubscriptionInput | undefined> => {
+  const { qr } = input;
+  const questionnaireUrl = qr.questionnaire;
+
+  if (!questionnaireUrl) return;
+
+  if (isOttehrManagedIntakeQuestionnaire(questionnaireUrl)) return input;
+
+  const [url, version] = questionnaireUrl.split('|');
+  if (!url || !version) return;
+
+  const canonicalUrl = { url, version };
+
+  let questionnaire: Questionnaire | undefined;
+  try {
+    questionnaire = await getCanonicalQuestionnaire(canonicalUrl, oystehr);
+  } catch (e) {
+    // I don't think this should happen but I don't see a reason to error,
+    // we will just treat this case an "un-harvestable" and return undefined
+    console.log(`could not find Questionnaire for ${canonicalUrl.url}|${canonicalUrl.version}`, e);
+    return;
+  }
+
+  // we must check the questionnaire to see if
+  // // 1) there is a derivedFrom attribute and if so
+  // // 2) it is an ottehr managed intake questionnaire
+
+  if (!questionnaire.derivedFrom) return;
+
+  const containsHarvestableQ = questionnaire.derivedFrom.some((q) => isOttehrManagedIntakeQuestionnaire(q));
+  if (!containsHarvestableQ) return;
+
+  return input;
+};
+
 // this is exported to facilitate integration testing
-export const performEffect = async (input: QRSubscriptionInput, oystehr: Oystehr): Promise<string> => {
+export const performEffect = async (input: QRSubscriptionInput | undefined, oystehr: Oystehr): Promise<string> => {
+  if (!input) return 'No harvesting needed';
+
   const { qr, secrets } = input;
 
   if (qr.status !== 'completed' && qr.status !== 'amended') {


### PR DESCRIPTION
Two bug fixes here: 
One to fix sending duplicate services in a flow to the front end 
The other is that the we need some way to ensure that the `subscriptions/questionnaire-response/sub-intake-harvest/index.ts` runs for flows when the flow contains either in-person or virtual intake questionnaires