### PR TITLE
EHR. Administered/Partly Administered/Not Administered buttons disappear after canceling the medication status modal

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/medication-administration/medication-editable-card/EditableMedicationCard.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/medication-administration/medication-editable-card/EditableMedicationCard.tsx
@@ -777,6 +777,7 @@ export const EditableMedicationCard: React.FC<{
           handleClose={() => {
             setIsConfirmSaveModalOpen(false);
             confirmedMedicationUpdateRequestRef.current = {};
+            typeRef.current = typeFromProps;
           }}
           handleConfirm={handleConfirmSave}
           description={''}


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2866/ehr-administeredpartly-administerednot-administered-buttons-disappear