### PR TITLE
test(utils): certify conditional-paperwork mechanisms and pin enabled-page sets

### DIFF
--- a/packages/utils/lib/helpers/paperwork/tests/conditional-mechanisms.test.ts
+++ b/packages/utils/lib/helpers/paperwork/tests/conditional-mechanisms.test.ts
@@ -1,0 +1,453 @@
+import { Questionnaire, QuestionnaireItem, QuestionnaireResponse, QuestionnaireResponseItem } from 'fhir/r4b';
+import { describe, expect, it } from 'vitest';
+import { IntakeQuestionnaireItem } from '../../../types/data/paperwork/paperwork.types';
+import { prepareQuestionnaireResponseForHarvest } from '../../../types/data/paperwork/prepareQuestionnaireItemsForHarvest';
+import { mapQuestionnaireAndValueSetsToItemsList } from '../paperwork';
+import {
+  buildEnableWhenContext,
+  evalEnableWhen,
+  evalFilterWhen,
+  evalItemText,
+  evalRequired,
+  filterDisabledPages,
+  makeValidationSchema,
+} from '../validation';
+
+/**
+ * Mechanism tests for the conditional-paperwork PATTERNS the instance configs are built
+ * from, exercised on small synthetic questionnaires so each pattern is certified
+ * independently of any real page's content. Every pattern here corresponds to a live
+ * config construct:
+ *
+ *   - reason-for-visit page gating ......... attorney-mva-page ("Auto accident")
+ *   - service-category = / != gating ....... occ-med and workers-comp page sets
+ *   - compound `enableBehavior: all` ....... card-payment-page
+ *   - $status gating ....................... consent-forms-page
+ *   - nested gating inside a gated page .... attorney fields behind has-attorney
+ *   - cross-page requireWhen ............... workers-comp SSN
+ *   - textWhen substitution ................ payment-option display text
+ *   - filterWhen ........................... strip-on-save fields
+ *
+ * The flagship assertion is the hidden-page safety conjunction: a page disabled by its
+ * enableWhen must be simultaneously (a) evaluated as disabled, (b) stripped to a bare
+ * { linkId } by filterDisabledPages (the submit path erases its content), and (c) skipped
+ * entirely by whole-questionnaire validation, so its required fields cannot block submit.
+ */
+
+const TRIGGER_PAGE = 'trigger-page';
+const CONDITIONAL_PAGE = 'conditional-page';
+const REASON = 'reason-for-visit';
+const CATEGORY = 'service-category';
+const OCC_MED_PAYMENT = 'payment-option-occupational';
+
+const structure = (rawPages: QuestionnaireItem[]): IntakeQuestionnaireItem[] =>
+  mapQuestionnaireAndValueSetsToItemsList(rawPages, []);
+
+const triggerPage = (children: QuestionnaireItem[] = []): QuestionnaireItem => ({
+  linkId: TRIGGER_PAGE,
+  type: 'group',
+  item: [
+    { linkId: REASON, type: 'string' },
+    { linkId: CATEGORY, type: 'string' },
+    { linkId: OCC_MED_PAYMENT, type: 'string' },
+    ...children,
+  ],
+});
+
+const triggerAnswers = (answers: Partial<Record<string, string>>): QuestionnaireResponseItem => ({
+  linkId: TRIGGER_PAGE,
+  item: Object.entries(answers).map(([linkId, value]) => ({
+    linkId,
+    ...(value !== undefined ? { answer: [{ valueString: value }] } : {}),
+  })),
+});
+
+const disabledLinkIds = (result: QuestionnaireResponseItem[]): string[] =>
+  result.filter((page) => !('item' in page)).map((page) => page.linkId);
+
+describe('reason-for-visit page gating (the auto-accident pattern)', () => {
+  const pages = structure([
+    triggerPage(),
+    {
+      linkId: CONDITIONAL_PAGE,
+      type: 'group',
+      enableWhen: [{ question: `${TRIGGER_PAGE}.${REASON}`, operator: '=', answerString: 'Auto accident' }],
+      item: [{ linkId: 'attorney-name', type: 'string' }],
+    },
+  ]);
+
+  const responseFor = (reason?: string): QuestionnaireResponseItem[] => [
+    triggerAnswers({ [REASON]: reason }),
+    { linkId: CONDITIONAL_PAGE, item: [] },
+  ];
+
+  it('enables the page when the reason matches exactly', () => {
+    expect(disabledLinkIds(filterDisabledPages(pages, responseFor('Auto accident')))).toEqual([]);
+  });
+
+  it('disables the page for any other reason', () => {
+    expect(disabledLinkIds(filterDisabledPages(pages, responseFor('Fever')))).toEqual([CONDITIONAL_PAGE]);
+  });
+
+  it('disables the page while the reason is unanswered', () => {
+    expect(disabledLinkIds(filterDisabledPages(pages, responseFor(undefined)))).toEqual([CONDITIONAL_PAGE]);
+  });
+});
+
+describe('service-category page gating (the occ-med / workers-comp pattern)', () => {
+  const OCC_MED_ONLY_PAGE = 'occ-med-only-page';
+  const NON_OCC_MED_PAGE = 'non-occ-med-page';
+  const pages = structure([
+    triggerPage(),
+    {
+      linkId: OCC_MED_ONLY_PAGE,
+      type: 'group',
+      enableWhen: [{ question: `${TRIGGER_PAGE}.${CATEGORY}`, operator: '=', answerString: 'occupational-medicine' }],
+      item: [{ linkId: 'occ-med-field', type: 'string' }],
+    },
+    {
+      linkId: NON_OCC_MED_PAGE,
+      type: 'group',
+      enableWhen: [{ question: `${TRIGGER_PAGE}.${CATEGORY}`, operator: '!=', answerString: 'occupational-medicine' }],
+      item: [{ linkId: 'regular-field', type: 'string' }],
+    },
+  ]);
+
+  const responseFor = (category?: string): QuestionnaireResponseItem[] => [
+    triggerAnswers({ [CATEGORY]: category }),
+    { linkId: OCC_MED_ONLY_PAGE, item: [] },
+    { linkId: NON_OCC_MED_PAGE, item: [] },
+  ];
+
+  it('the = page and the != page are complementary for a matching category', () => {
+    expect(disabledLinkIds(filterDisabledPages(pages, responseFor('occupational-medicine')))).toEqual([
+      NON_OCC_MED_PAGE,
+    ]);
+  });
+
+  it('any other category flips both pages', () => {
+    expect(disabledLinkIds(filterDisabledPages(pages, responseFor('urgent-care')))).toEqual([OCC_MED_ONLY_PAGE]);
+  });
+
+  // An unanswered category behaves like "some other category": '=' pages hide, '!=' pages
+  // show. Instances relying on the category being prepopulated get the != pages by default.
+  it('an unanswered category disables = pages and enables != pages', () => {
+    expect(disabledLinkIds(filterDisabledPages(pages, responseFor(undefined)))).toEqual([OCC_MED_ONLY_PAGE]);
+  });
+});
+
+describe('compound gating with enableBehavior all (the card-payment pattern)', () => {
+  const pages = structure([
+    triggerPage(),
+    {
+      linkId: CONDITIONAL_PAGE,
+      type: 'group',
+      enableBehavior: 'all',
+      enableWhen: [
+        { question: `${TRIGGER_PAGE}.${CATEGORY}`, operator: '!=', answerString: 'workers-comp' },
+        { question: `${TRIGGER_PAGE}.${OCC_MED_PAYMENT}`, operator: '!=', answerString: 'Employer' },
+      ],
+      item: [{ linkId: 'card-field', type: 'string' }],
+    },
+  ]);
+
+  const responseFor = (category?: string, occMedPayment?: string): QuestionnaireResponseItem[] => [
+    triggerAnswers({ [CATEGORY]: category, [OCC_MED_PAYMENT]: occMedPayment }),
+    { linkId: CONDITIONAL_PAGE, item: [] },
+  ];
+
+  // The real config depends on this exact semantic: for a non-occ-med visit the occ-med
+  // payment question is never answered, and the page stays enabled only because a '!='
+  // condition against a missing answer evaluates true (pinned in enable-when-matrix).
+  it('is enabled when the second question is unanswered and the first passes', () => {
+    expect(disabledLinkIds(filterDisabledPages(pages, responseFor('urgent-care', undefined)))).toEqual([]);
+  });
+
+  it('is disabled when either condition fails', () => {
+    expect(disabledLinkIds(filterDisabledPages(pages, responseFor('workers-comp', undefined)))).toEqual([
+      CONDITIONAL_PAGE,
+    ]);
+    expect(disabledLinkIds(filterDisabledPages(pages, responseFor('occupational-medicine', 'Employer')))).toEqual([
+      CONDITIONAL_PAGE,
+    ]);
+  });
+
+  it('is enabled when both conditions pass', () => {
+    expect(disabledLinkIds(filterDisabledPages(pages, responseFor('occupational-medicine', 'Self')))).toEqual([]);
+  });
+});
+
+describe('$status page gating (the consent-page pattern)', () => {
+  const pages = structure([
+    triggerPage(),
+    {
+      linkId: CONDITIONAL_PAGE,
+      type: 'group',
+      enableBehavior: 'all',
+      enableWhen: [
+        { question: '$status', operator: '!=', answerString: 'completed' } as never,
+        { question: '$status', operator: '!=', answerString: 'amended' } as never,
+      ],
+      item: [{ linkId: 'signature', type: 'string', required: true }],
+    },
+  ]);
+
+  const qr = (status: QuestionnaireResponse['status']): QuestionnaireResponse => ({
+    resourceType: 'QuestionnaireResponse',
+    status,
+  });
+  const consentPage = pages.find((p) => p.linkId === CONDITIONAL_PAGE);
+
+  it('the page is enabled before first submit and disabled once completed or amended', () => {
+    const values = buildEnableWhenContext([triggerAnswers({})]);
+    expect(evalEnableWhen(consentPage as IntakeQuestionnaireItem, pages, values, undefined)).toBe(true);
+    expect(evalEnableWhen(consentPage as IntakeQuestionnaireItem, pages, values, qr('in-progress'))).toBe(true);
+    expect(evalEnableWhen(consentPage as IntakeQuestionnaireItem, pages, values, qr('completed'))).toBe(false);
+    expect(evalEnableWhen(consentPage as IntakeQuestionnaireItem, pages, values, qr('amended'))).toBe(false);
+  });
+
+  // filterDisabledPages deliberately strips $status conditions before evaluating, so a
+  // completed consent page is NOT normalized away — the visit-details view reads the
+  // consent signer straight from the QR after completion (see the comment in
+  // filterDisabledPages). Erasing it here would erase that data.
+  it('filterDisabledPages ignores $status conditions and keeps the completed page content', () => {
+    const response: QuestionnaireResponseItem[] = [triggerAnswers({}), { linkId: CONDITIONAL_PAGE, item: [] }];
+    expect(disabledLinkIds(filterDisabledPages(pages, response, qr('completed')))).toEqual([]);
+  });
+
+  // Whole-questionnaire validation, by contrast, evaluates $status conditions for real:
+  // once the QR is completed the page is skipped, so its required signature cannot block
+  // a later amend-flow submission.
+  it('whole-questionnaire validation enforces the page in-progress and skips it once completed', async () => {
+    const submission = [triggerAnswers({}), { linkId: CONDITIONAL_PAGE, item: [] }];
+    const schema = makeValidationSchema(pages, undefined);
+    await expect(
+      schema.validate(submission, { abortEarly: false, context: { questionnaireResponse: qr('in-progress') } })
+    ).rejects.toBeDefined();
+    await expect(
+      schema.validate(submission, { abortEarly: false, context: { questionnaireResponse: qr('completed') } })
+    ).resolves.toBeDefined();
+  });
+});
+
+describe('the hidden-page safety conjunction', () => {
+  // A conditional page whose only field is REQUIRED. When the page is disabled it must be
+  // (a) evaluated as disabled, (b) stripped by filterDisabledPages, and (c) skipped by
+  // whole-questionnaire validation so the unanswered required field cannot block submit.
+  const pages = structure([
+    triggerPage(),
+    {
+      linkId: CONDITIONAL_PAGE,
+      type: 'group',
+      enableWhen: [{ question: `${TRIGGER_PAGE}.${REASON}`, operator: '=', answerString: 'Auto accident' }],
+      item: [{ linkId: 'attorney-name', type: 'string', required: true }],
+    },
+  ]);
+  const conditionalPage = pages.find((p) => p.linkId === CONDITIONAL_PAGE);
+
+  it('disabled: not enabled, stripped on save, and exempt from validation', async () => {
+    const response: QuestionnaireResponseItem[] = [
+      triggerAnswers({ [REASON]: 'Fever' }),
+      { linkId: CONDITIONAL_PAGE, item: [] },
+    ];
+
+    const values = buildEnableWhenContext(response);
+    expect(evalEnableWhen(conditionalPage as IntakeQuestionnaireItem, pages, values)).toBe(false);
+
+    const filtered = filterDisabledPages(pages, response);
+    expect(filtered.find((p) => p.linkId === CONDITIONAL_PAGE)).toEqual({ linkId: CONDITIONAL_PAGE });
+
+    const schema = makeValidationSchema(pages, undefined);
+    await expect(schema.validate(response, { abortEarly: false })).resolves.toBeDefined();
+  });
+
+  it('enabled: kept on save and its required field enforced', async () => {
+    const missingRequired: QuestionnaireResponseItem[] = [
+      triggerAnswers({ [REASON]: 'Auto accident' }),
+      { linkId: CONDITIONAL_PAGE, item: [] },
+    ];
+
+    const values = buildEnableWhenContext(missingRequired);
+    expect(evalEnableWhen(conditionalPage as IntakeQuestionnaireItem, pages, values)).toBe(true);
+
+    const filtered = filterDisabledPages(pages, missingRequired);
+    expect(filtered.find((p) => p.linkId === CONDITIONAL_PAGE)?.item).toBeDefined();
+
+    const schema = makeValidationSchema(pages, undefined);
+    await expect(schema.validate(missingRequired, { abortEarly: false })).rejects.toBeDefined();
+
+    const answered: QuestionnaireResponseItem[] = [
+      triggerAnswers({ [REASON]: 'Auto accident' }),
+      { linkId: CONDITIONAL_PAGE, item: [{ linkId: 'attorney-name', answer: [{ valueString: 'Meg Mason' }] }] },
+    ];
+    await expect(schema.validate(answered, { abortEarly: false })).resolves.toBeDefined();
+  });
+});
+
+describe('nested item gating inside a page (the has-attorney pattern)', () => {
+  const HAS_ATTORNEY = 'has-attorney';
+  const FIRM_NAME = 'attorney-firm-name';
+  const pages = structure([
+    {
+      linkId: CONDITIONAL_PAGE,
+      type: 'group',
+      item: [
+        { linkId: HAS_ATTORNEY, type: 'string' },
+        {
+          linkId: FIRM_NAME,
+          type: 'string',
+          enableWhen: [{ question: HAS_ATTORNEY, operator: '=', answerString: 'I have an attorney' }],
+        },
+      ],
+    },
+  ]);
+  const firmItem = pages[0].item?.find((i) => i.linkId === FIRM_NAME);
+
+  const contextFor = (hasAttorney?: string): { [linkId: string]: QuestionnaireResponseItem } =>
+    buildEnableWhenContext([
+      {
+        linkId: CONDITIONAL_PAGE,
+        item: [{ linkId: HAS_ATTORNEY, ...(hasAttorney ? { answer: [{ valueString: hasAttorney }] } : {}) }],
+      },
+    ]);
+
+  it('shows the dependent field only when the gate answer matches', () => {
+    // buildEnableWhenContext hoists page children to the top level, so a bare linkId
+    // question resolves from a nested response.
+    const flatItems = pages.flatMap((p) => p.item ?? []);
+    expect(evalEnableWhen(firmItem as IntakeQuestionnaireItem, flatItems, contextFor('I have an attorney'))).toBe(true);
+    expect(evalEnableWhen(firmItem as IntakeQuestionnaireItem, flatItems, contextFor('No attorney'))).toBe(false);
+    expect(evalEnableWhen(firmItem as IntakeQuestionnaireItem, flatItems, contextFor(undefined))).toBe(false);
+  });
+});
+
+describe('cross-page requireWhen (the workers-comp SSN pattern)', () => {
+  const ssnItem: IntakeQuestionnaireItem = {
+    linkId: 'patient-ssn',
+    type: 'string',
+    acceptsMultipleAnswers: false,
+    alwaysFilter: false,
+    requireWhen: { question: `${TRIGGER_PAGE}.${CATEGORY}`, operator: '=', answerString: 'workers-comp' },
+  };
+
+  it('is required exactly when the cross-page condition holds', () => {
+    const requiredContext = buildEnableWhenContext([triggerAnswers({ [CATEGORY]: 'workers-comp' })]);
+    const optionalContext = buildEnableWhenContext([triggerAnswers({ [CATEGORY]: 'urgent-care' })]);
+    expect(evalRequired(ssnItem, requiredContext)).toBe(true);
+    expect(evalRequired(ssnItem, optionalContext)).toBe(false);
+    expect(evalRequired(ssnItem, buildEnableWhenContext([triggerAnswers({})]))).toBe(false);
+  });
+});
+
+describe('textWhen substitution (the payment-option display-text pattern)', () => {
+  const paymentLabel: IntakeQuestionnaireItem = {
+    linkId: 'payment-option-label',
+    type: 'display',
+    text: 'How would you like to pay for your visit?',
+    acceptsMultipleAnswers: false,
+    alwaysFilter: false,
+    textWhen: [
+      {
+        question: `${TRIGGER_PAGE}.${CATEGORY}`,
+        operator: '=',
+        answerString: 'workers-comp',
+        substituteText: 'Your visit is covered by workers compensation.',
+      },
+    ],
+  };
+
+  it('substitutes the text when the condition holds and falls back otherwise', () => {
+    const wcContext = buildEnableWhenContext([triggerAnswers({ [CATEGORY]: 'workers-comp' })]);
+    const ucContext = buildEnableWhenContext([triggerAnswers({ [CATEGORY]: 'urgent-care' })]);
+    expect(evalItemText(paymentLabel, wcContext)).toBe('Your visit is covered by workers compensation.');
+    expect(evalItemText(paymentLabel, ucContext)).toBe('How would you like to pay for your visit?');
+  });
+});
+
+describe('filterWhen (the strip-on-save pattern)', () => {
+  const filtered: IntakeQuestionnaireItem = {
+    linkId: 'search-widget-state',
+    type: 'string',
+    acceptsMultipleAnswers: false,
+    alwaysFilter: false,
+    filterWhen: [
+      { question: 'manual-entry', operator: '=', answerBoolean: true },
+      { question: 'other-flag', operator: '=', answerBoolean: true },
+    ],
+  };
+
+  it('ORs its conditions: any one holding filters the answer', () => {
+    const manualOn = { 'manual-entry': { answer: [{ valueBoolean: true }] } };
+    const otherOn = { 'other-flag': { answer: [{ valueBoolean: true }] } };
+    const neither = { 'manual-entry': { answer: [{ valueBoolean: false }] } };
+    expect(evalFilterWhen(filtered, manualOn)).toBe(true);
+    expect(evalFilterWhen(filtered, otherOn)).toBe(true);
+    expect(evalFilterWhen(filtered, neither)).toBe(false);
+  });
+
+  it('an item with no filterWhen never filters', () => {
+    const plain: IntakeQuestionnaireItem = {
+      linkId: 'plain',
+      type: 'string',
+      acceptsMultipleAnswers: false,
+      alwaysFilter: false,
+    };
+    expect(evalFilterWhen(plain, {})).toBe(false);
+  });
+});
+
+describe('item-level harvest filtering respects enableWhen', () => {
+  // The harvest pipeline flattens page children and drops answers whose item definition
+  // is disabled by enableWhen — the item-level half of "hidden content never harvests"
+  // (the page-level half is filterDisabledPages stripping on submit, above).
+  const questionnaire: Questionnaire = {
+    resourceType: 'Questionnaire',
+    status: 'active',
+    item: [
+      {
+        linkId: CONDITIONAL_PAGE,
+        type: 'group',
+        item: [
+          { linkId: 'gate', type: 'boolean' },
+          {
+            linkId: 'gated-field',
+            type: 'string',
+            enableWhen: [{ question: 'gate', operator: '=', answerBoolean: true }],
+          },
+          { linkId: 'plain-field', type: 'string' },
+        ],
+      },
+    ],
+  };
+
+  const responseFor = (gate: boolean): QuestionnaireResponseItem[] => [
+    {
+      linkId: CONDITIONAL_PAGE,
+      item: [
+        { linkId: 'gate', answer: [{ valueBoolean: gate }] },
+        { linkId: 'gated-field', answer: [{ valueString: 'stale answer' }] },
+        { linkId: 'plain-field', answer: [{ valueString: 'kept' }] },
+      ],
+    },
+  ];
+
+  it('drops answers to items whose enableWhen fails and keeps the rest', () => {
+    const harvested = prepareQuestionnaireResponseForHarvest({
+      questionnaireResponseItems: responseFor(false),
+      sourceQuestionnaire: questionnaire,
+      options: { filterByEnableWhen: true },
+    });
+    const linkIds = harvested.map((i) => i.linkId);
+    expect(linkIds).not.toContain('gated-field');
+    expect(linkIds).toContain('plain-field');
+  });
+
+  it('keeps the gated answer when its condition holds', () => {
+    const harvested = prepareQuestionnaireResponseForHarvest({
+      questionnaireResponseItems: responseFor(true),
+      sourceQuestionnaire: questionnaire,
+      options: { filterByEnableWhen: true },
+    });
+    expect(harvested.map((i) => i.linkId)).toContain('gated-field');
+  });
+});

--- a/packages/utils/lib/helpers/paperwork/tests/enabled-page-scenarios.test.ts
+++ b/packages/utils/lib/helpers/paperwork/tests/enabled-page-scenarios.test.ts
@@ -1,0 +1,187 @@
+import { Questionnaire, QuestionnaireResponseItem } from 'fhir/r4b';
+import { assert, describe, expect, it } from 'vitest';
+import { BOOKING_CONFIG } from '../../../ottehr-config/booking';
+import { IN_PERSON_INTAKE_PAPERWORK_QUESTIONNAIRE } from '../../../ottehr-config/intake-paperwork';
+import { VIRTUAL_INTAKE_PAPERWORK_QUESTIONNAIRE } from '../../../ottehr-config/intake-paperwork-virtual';
+import { OCC_MED_EMPLOYER_PAY_OPTION, OCC_MED_SELF_PAY_OPTION } from '../../../ottehr-config/value-sets';
+import { IntakeQuestionnaireItem } from '../../../types/data/paperwork/paperwork.types';
+import { mapQuestionnaireAndValueSetsToItemsList } from '../paperwork';
+import { filterDisabledPages } from '../validation';
+
+/**
+ * The enabled-page-set scenario matrix: for every service category the booking config
+ * declares (× reason-for-visit × occ-med payment option), assert EXACTLY which pages of
+ * the real generated questionnaires are disabled. This pins the paperwork's page-level
+ * shape per scenario — the thing per-instance e2e used to walk a browser to observe —
+ * as a fast, deterministic table.
+ *
+ * Assertions are written as exact disabled-page sets (not enabled sets) so adding a new
+ * unconditional page never breaks them, while any change to conditional behavior does.
+ * The category list is read from BOOKING_CONFIG, so when an instance overlay adds a
+ * category, this suite fails loudly until an expectation for it is added.
+ */
+
+const CONTACT_PAGE = 'contact-information-page';
+const SERVICE_CATEGORY = 'appointment-service-category';
+const REASON_FOR_VISIT = 'reason-for-visit';
+const OCC_MED_PAYMENT_PAGE = 'payment-option-occ-med-page';
+const OCC_MED_PAYMENT_QUESTION = 'payment-option-occupational';
+
+const PAGES = {
+  paymentOption: 'payment-option-page',
+  occMedPaymentOption: OCC_MED_PAYMENT_PAGE,
+  occMedEmployer: 'occupational-medicine-employer-information-page',
+  cardPayment: 'card-payment-page',
+  wcEmployer: 'employer-information-page',
+  attorney: 'attorney-mva-page',
+  consent: 'consent-forms-page',
+  pcp: 'primary-care-physician-page',
+} as const;
+
+interface Scenario {
+  category?: string;
+  reasonForVisit?: string;
+  occMedPayment?: string;
+}
+
+interface ModeUnderTest {
+  mode: string;
+  pages: IntakeQuestionnaireItem[];
+}
+
+const structureMode = (mode: string, questionnaire: Questionnaire): ModeUnderTest => ({
+  mode,
+  pages: mapQuestionnaireAndValueSetsToItemsList(questionnaire.item ?? [], []),
+});
+
+const MODES: ModeUnderTest[] = [
+  structureMode('in-person', IN_PERSON_INTAKE_PAPERWORK_QUESTIONNAIRE()),
+  structureMode('virtual', VIRTUAL_INTAKE_PAPERWORK_QUESTIONNAIRE()),
+];
+
+const buildScenarioResponse = (pages: IntakeQuestionnaireItem[], scenario: Scenario): QuestionnaireResponseItem[] =>
+  pages.map((page) => {
+    if (page.linkId === CONTACT_PAGE) {
+      return {
+        linkId: CONTACT_PAGE,
+        item: [
+          {
+            linkId: SERVICE_CATEGORY,
+            ...(scenario.category ? { answer: [{ valueString: scenario.category }] } : {}),
+          },
+          {
+            linkId: REASON_FOR_VISIT,
+            ...(scenario.reasonForVisit ? { answer: [{ valueString: scenario.reasonForVisit }] } : {}),
+          },
+          { linkId: 'patient-will-be-18', answer: [{ valueBoolean: true }] },
+        ],
+      };
+    }
+    if (page.linkId === OCC_MED_PAYMENT_PAGE && scenario.occMedPayment) {
+      return {
+        linkId: OCC_MED_PAYMENT_PAGE,
+        item: [{ linkId: OCC_MED_PAYMENT_QUESTION, answer: [{ valueString: scenario.occMedPayment }] }],
+      };
+    }
+    return { linkId: page.linkId, item: [] };
+  });
+
+const disabledPagesFor = (pages: IntakeQuestionnaireItem[], scenario: Scenario): string[] => {
+  const result = filterDisabledPages(pages, buildScenarioResponse(pages, scenario));
+  return result
+    .filter((page) => !('item' in page))
+    .map((page) => page.linkId)
+    .sort();
+};
+
+const sorted = (linkIds: string[]): string[] => [...linkIds].sort();
+
+/**
+ * Expected disabled-page sets per category, before applying the reason-for-visit and
+ * occ-med payment modifiers. Keyed by the category codes the booking config declares —
+ * a new category in an instance overlay fails the guard test below until its
+ * expectation is added here.
+ */
+const BASELINE_DISABLED_BY_CATEGORY: Record<string, string[]> = {
+  'urgent-care': [PAGES.occMedPaymentOption, PAGES.occMedEmployer, PAGES.wcEmployer, PAGES.attorney],
+  'occupational-medicine': [PAGES.paymentOption, PAGES.wcEmployer, PAGES.attorney],
+  'workers-comp': [PAGES.occMedPaymentOption, PAGES.occMedEmployer, PAGES.cardPayment, PAGES.attorney],
+};
+
+describe('conditional pages exist in both service modes', () => {
+  for (const { mode, pages } of MODES) {
+    it(`${mode} questionnaire contains every page the matrix pins`, () => {
+      const pageLinkIds = new Set(pages.map((p) => p.linkId));
+      for (const linkId of Object.values(PAGES)) {
+        expect(pageLinkIds, `expected ${mode} questionnaire to contain ${linkId}`).toContain(linkId);
+      }
+    });
+  }
+});
+
+describe('every configured service category has a pinned expectation', () => {
+  it('BOOKING_CONFIG categories are all covered by the matrix', () => {
+    const configuredCodes = BOOKING_CONFIG.serviceCategories.map((sc) => sc.category.code);
+    expect(configuredCodes.length).toBeGreaterThan(0);
+    for (const code of configuredCodes) {
+      assert(
+        code !== undefined && BASELINE_DISABLED_BY_CATEGORY[code] !== undefined,
+        `service category '${code}' has no expected disabled-page set in this matrix — ` +
+          `add one so its paperwork shape is certified`
+      );
+    }
+  });
+});
+
+describe.each(MODES.map((m) => [m.mode, m] as const))('enabled-page sets — %s', (_mode, { pages }) => {
+  describe.each(Object.entries(BASELINE_DISABLED_BY_CATEGORY))('category %s', (category, baselineDisabled) => {
+    it('pins the disabled-page set for an ordinary reason for visit', () => {
+      expect(disabledPagesFor(pages, { category, reasonForVisit: 'Fever' })).toEqual(sorted(baselineDisabled));
+    });
+
+    it('an Auto accident reason additionally enables the attorney page', () => {
+      const expected = baselineDisabled.filter((linkId) => linkId !== PAGES.attorney);
+      expect(disabledPagesFor(pages, { category, reasonForVisit: 'Auto accident' })).toEqual(sorted(expected));
+    });
+  });
+
+  describe('occupational medicine payment variants', () => {
+    it('employer pay additionally disables the card-payment page', () => {
+      const expected = [...BASELINE_DISABLED_BY_CATEGORY['occupational-medicine'], PAGES.cardPayment];
+      expect(
+        disabledPagesFor(pages, {
+          category: 'occupational-medicine',
+          reasonForVisit: 'Fever',
+          occMedPayment: OCC_MED_EMPLOYER_PAY_OPTION,
+        })
+      ).toEqual(sorted(expected));
+    });
+
+    it('self pay keeps the card-payment page enabled', () => {
+      expect(
+        disabledPagesFor(pages, {
+          category: 'occupational-medicine',
+          reasonForVisit: 'Fever',
+          occMedPayment: OCC_MED_SELF_PAY_OPTION,
+        })
+      ).toEqual(sorted(BASELINE_DISABLED_BY_CATEGORY['occupational-medicine']));
+    });
+
+    // With no payment answer yet (mid-flow), the card-payment page is enabled: its
+    // '!= employer' condition evaluates true against a missing answer. Pinned so the
+    // engine semantics the config leans on can't silently change.
+    it('an unanswered payment option leaves the card-payment page enabled', () => {
+      expect(disabledPagesFor(pages, { category: 'occupational-medicine', reasonForVisit: 'Fever' })).toEqual(
+        sorted(BASELINE_DISABLED_BY_CATEGORY['occupational-medicine'])
+      );
+    });
+  });
+
+  // Before prepopulation lands (or for a category-less booking), the paperwork behaves
+  // like a plain visit: category '=' pages hide, '!=' pages show.
+  it('an unanswered service category matches the urgent-care shape', () => {
+    expect(disabledPagesFor(pages, { reasonForVisit: 'Fever' })).toEqual(
+      sorted(BASELINE_DISABLED_BY_CATEGORY['urgent-care'])
+    );
+  });
+});


### PR DESCRIPTION
🤖 

**PR 4 of the paperwork factory-certification plan** (`docs/paperwork-testing-strategy.md` on `claude/paperwork-testing-strategy-6txb0w`, Tier 2). Independent of PRs 5 and 6 — not stacked.

## What

Two suites in `packages/utils` (44 tests) certifying the conditional *patterns* every instance config is assembled from — so the auto-accident rule, the occ-med/workers-comp page sets, and every other gating construct are proven as mechanisms, independent of any one customer's page content.

**`conditional-mechanisms.test.ts`** — each pattern on small synthetic questionnaires:
- reason-for-visit page gating (the `attorney-mva-page` pattern), including the unanswered case
- service-category `=` / `!=` gating and their complementarity, including that an unanswered category behaves like "some other category"
- compound `enableBehavior: all` gating (the `card-payment-page` pattern) — explicitly pinning that the real config **relies on** `'!='` matching a missing answer
- `$status` gating (consent): enabled before first submit, disabled once completed/amended — plus the deliberate asymmetry that `filterDisabledPages` strips `$status` conditions (consent-signer data must survive completion) while whole-questionnaire validation honors them
- nested item gating inside a page (`has-attorney`), cross-page `requireWhen` (the workers-comp SSN pattern), `textWhen` substitution, `filterWhen` OR semantics, and item-level harvest filtering via `prepareQuestionnaireResponseForHarvest`
- **the hidden-page safety conjunction**: a disabled page is simultaneously evaluated as disabled, stripped to a bare `{linkId}` on save, and skipped by whole-questionnaire validation so its required fields can never block submit — with the enabled case as positive control

**`enabled-page-scenarios.test.ts`** — the exact disabled-page set of the **real generated questionnaires** (both service modes) for every service category the booking config declares, crossed with reason-for-visit and occ-med payment variants. Design choices that keep it maintainable:
- expectations are exact *disabled* sets, so adding an unconditional page never breaks them while any conditional-behavior change does
- the category list is read from `BOOKING_CONFIG`, so an instance overlay that adds a category fails loudly until the matrix covers it
- pins the mid-flow state (unanswered occ-med payment ⇒ card-payment enabled) and the pre-prepopulation state (unanswered category ⇒ the urgent-care shape)

## Verification

- 44 new tests pass; the full `packages/utils` paperwork suite (184 tests across 7 files) passes together; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gi6xrcRXg1MuDceiDv7xw2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi6xrcRXg1MuDceiDv7xw2)_