### PR TITLE
fix(ai): no transcript for silent recordings (OTR-3239)

### DIFF
--- a/packages/zambdas/src/shared/ai.ts
+++ b/packages/zambdas/src/shared/ai.ts
@@ -25,8 +25,12 @@ import { assertDefined } from './helpers';
 import { parseCreatedResourcesBundle, saveResourceRequest } from './resources.helpers';
 import { createPresignedUrl } from './z3Utils';
 
+export const NO_SPEECH_DETECTED = 'NO_SPEECH_DETECTED';
+
 export const TRANSCRIPT_PROMPT =
-  'give a transcript of this file, include only the transcript without other input, include who the speaker is with labels for the provider and the patient';
+  'Give a transcript of this file, include only the transcript without other input, include who the speaker is ' +
+  'with labels for the provider and the patient. If the audio contains just silence or background noise, ' +
+  `respond with "${NO_SPEECH_DETECTED}"`;
 
 export class ClaudeClient {
   chatbot: ChatAnthropic;
@@ -276,6 +280,13 @@ export async function transcribeAndCreateResourcesFromZ3Audio(
     [{ text: TRANSCRIPT_PROMPT }, { inlineData: { mimeType, data: fileBase64 } }],
     secrets
   );
+
+  if (transcript === NO_SPEECH_DETECTED) {
+    console.log(
+      `[transcribeAndCreateResourcesFromZ3Audio] No speech detected in recording z3URL=${args.z3URL}; skipping AI resource creation`
+    );
+    return 'no speech detected; skipped AI resource creation';
+  }
 
   return createResourcesFromAiInterview(
     oystehr,


### PR DESCRIPTION
## Summary
- Virtual (telemed) calls with no speech (e.g. patient never connects audio) were producing a fabricated AI transcript and ambient-scribe notes, since Vertex AI (Gemini) would hallucinate plausible dialogue for silent audio.
- The transcription prompt now instructs the model to return a sentinel value when the audio contains only silence/background noise, and `transcribeAndCreateResourcesFromZ3Audio` skips creating the DocumentReference/Observations when that sentinel comes back.

Linear: OTR-3239

## Test plan
- [ ] Start a telemed visit, connect without unmuting/speaking, hang up, and confirm no transcript/AI notes are generated in the Oystehr AI tab
- [ ] Confirm a normal call with actual dialogue still produces a transcript and AI-suggested chart fields as before