### PR TITLE
feat: report builder - stronger request validation and other improvements

### DIFF
--- a/apps/ehr/src/features/report-builder/datasets/billing.ts
+++ b/apps/ehr/src/features/report-builder/datasets/billing.ts
@@ -7,13 +7,12 @@ import {
   BillingBaseRowSchema,
 } from 'utils/lib/types/adhoc/datasets/billing';
 import { layerOptions } from 'utils/lib/types/adhoc/datasets/dataset';
+import { AdHocLayer } from 'utils/lib/types/adhoc/query/layers';
 import { ADHOC_QUERY_STALE_MS, runAdHocReport, toLocalYmd } from '../query/dataset-query';
 import { buildLlmDatasetSchema } from './schema';
-import { AdHocDataset, AdHocDatasetOption, AdHocRow, FetchContext } from './types';
+import { AdHocDataset, AdHocRow, FetchContext } from './types';
 
-// One row per encounter, billing-focused. Base = visit/patient/location identity; opt-in layers add
-// financial/insurance subsets. Checkboxes derive from the Zod layer map (id/label/description).
-export const ADHOC_BILLING_OPTIONS: AdHocDatasetOption[] = layerOptions(BILLING_LAYERS);
+export const ADHOC_BILLING_OPTIONS: AdHocLayer[] = layerOptions(BILLING_LAYERS);
 
 async function fetchAdHocBilling({
   oystehrZambda,
@@ -50,6 +49,9 @@ export const billingDataset: AdHocDataset = {
     'One row per encounter, focused on billing & revenue; optional patient-payment, insurance-coverage, ' +
     'charges/fee-schedule, and billing-code layers.',
   options: ADHOC_BILLING_OPTIONS,
+  layers: BILLING_LAYERS,
+  baseSchema: BillingBaseRowSchema,
+  internalFields: BILLING_INTERNAL_FIELDS,
   fetch: fetchAdHocBilling,
   buildSchema: (rows, options) => {
     const opts = options ?? {};

--- a/apps/ehr/src/features/report-builder/datasets/encounters.ts
+++ b/apps/ehr/src/features/report-builder/datasets/encounters.ts
@@ -7,13 +7,14 @@ import {
   ENCOUNTER_LAYERS,
   EncounterBaseRowSchema,
 } from 'utils/lib/types/adhoc/datasets/encounters';
+import { AdHocLayer } from 'utils/lib/types/adhoc/query/layers';
 import { VisitStatusLabel } from 'utils/lib/types/api/appointment.types';
 import { buildTrackingBoardPath } from '../../../pages/reports/trackingBoardLink';
 import { ADHOC_QUERY_STALE_MS, runAdHocReport, toLocalYmd } from '../query/dataset-query';
 import { buildLlmDatasetSchema } from './schema';
-import { AdHocDataset, AdHocDatasetOption, AdHocRow, FetchContext } from './types';
+import { AdHocDataset, AdHocRow, FetchContext } from './types';
 
-export const ADHOC_ENCOUNTERS_OPTIONS: AdHocDatasetOption[] = layerOptions(ENCOUNTER_LAYERS);
+export const ADHOC_ENCOUNTERS_OPTIONS: AdHocLayer[] = layerOptions(ENCOUNTER_LAYERS);
 
 function localizeEncounterRow(row: AdHocEncounterRow): AdHocEncounterRow {
   return {
@@ -61,6 +62,9 @@ export const adhocEncountersDataset: AdHocDataset = {
     'One row per encounter with visit, patient, contact, and location/provider detail; optional ' +
     'clinical codes, KPI timing, and AI-assistance layers.',
   options: ADHOC_ENCOUNTERS_OPTIONS,
+  layers: ENCOUNTER_LAYERS,
+  baseSchema: EncounterBaseRowSchema,
+  internalFields: ENCOUNTER_INTERNAL_FIELDS,
   fetch: fetchAdHocEncounters,
   buildSchema: (rows, options) => {
     const opts = options ?? {};

--- a/apps/ehr/src/features/report-builder/datasets/patients.ts
+++ b/apps/ehr/src/features/report-builder/datasets/patients.ts
@@ -7,14 +7,12 @@ import {
   PATIENT_LAYERS,
   PatientBaseRowSchema,
 } from 'utils/lib/types/adhoc/datasets/patients';
+import { AdHocLayer } from 'utils/lib/types/adhoc/query/layers';
 import { ADHOC_QUERY_STALE_MS, runAdHocReport, toLocalYmd } from '../query/dataset-query';
 import { buildLlmDatasetSchema } from './schema';
-import { AdHocDataset, AdHocDatasetOption, AdHocRow, FetchContext } from './types';
+import { AdHocDataset, AdHocRow, FetchContext } from './types';
 
-// One row per patient seen in the date range — patient-centric counterpart to the Encounters
-// dataset. Demographics + visit summary come back on every fetch; patient-bound clinical layers are
-// opt-in checkboxes, derived from the Zod layer map (id/label/description).
-export const ADHOC_PATIENTS_OPTIONS: AdHocDatasetOption[] = layerOptions(PATIENT_LAYERS);
+export const ADHOC_PATIENTS_OPTIONS: AdHocLayer[] = layerOptions(PATIENT_LAYERS);
 
 async function fetchAdHocPatients({
   oystehrZambda,
@@ -51,6 +49,9 @@ export const patientsDataset: AdHocDataset = {
     'One row per patient seen in the date range, with demographics and a summary of their visits; ' +
     'optional allergy, problem-list, and current-medication layers.',
   options: ADHOC_PATIENTS_OPTIONS,
+  layers: PATIENT_LAYERS,
+  baseSchema: PatientBaseRowSchema,
+  internalFields: PATIENT_INTERNAL_FIELDS,
   fetch: fetchAdHocPatients,
   buildSchema: (rows, options) => {
     const opts = options ?? {};

--- a/apps/ehr/src/features/report-builder/datasets/registry.ts
+++ b/apps/ehr/src/features/report-builder/datasets/registry.ts
@@ -1,17 +1,42 @@
+import { layerSchemas } from 'utils/lib/types/adhoc/datasets/dataset';
+import { llmFieldsFromZodObject } from 'utils/lib/types/adhoc/datasets/llm-schema';
+import { CatalogDataset } from 'utils/lib/types/adhoc/generation/infer.types';
 import { billingDataset } from './billing';
 import { adhocEncountersDataset } from './encounters';
 import { patientsDataset } from './patients';
 import { AdHocDataset } from './types';
 
-// Selectable-dataset registry. A new source is just another entry here.
 export const AD_HOC_DATASETS: AdHocDataset[] = [adhocEncountersDataset, patientsDataset, billingDataset];
 
 export function getDataset(id: string): AdHocDataset | undefined {
   return AD_HOC_DATASETS.find((d) => d.id === id);
 }
 
-// The other registered datasets (label + description), so a report can point the user elsewhere when
-// the active dataset can't carry a requested concept. Enriches the schema descriptor.
 export function otherDatasetsFor(id: string): { label: string; description: string }[] {
   return AD_HOC_DATASETS.filter((d) => d.id !== id).map((d) => ({ label: d.label, description: d.description }));
+}
+
+export function datasetCatalog(): CatalogDataset[] {
+  return AD_HOC_DATASETS.map((dataset) => {
+    const schemas = dataset.layers ? layerSchemas(dataset.layers) : {};
+    return {
+      id: dataset.id,
+      label: dataset.label,
+      description: dataset.description,
+      fields: dataset.baseSchema
+        ? llmFieldsFromZodObject(dataset.baseSchema, dataset.internalFields ?? []).map((f) => ({
+            name: f.name,
+            description: f.description,
+          }))
+        : [],
+      layers: (dataset.options ?? []).map((layer) => ({
+        id: layer.id,
+        label: layer.label,
+        description: layer.description,
+        fields: schemas[layer.id]
+          ? llmFieldsFromZodObject(schemas[layer.id]).map((f) => ({ name: f.name, description: f.description }))
+          : [],
+      })),
+    };
+  });
 }

--- a/apps/ehr/src/features/report-builder/datasets/registry.ts
+++ b/apps/ehr/src/features/report-builder/datasets/registry.ts
@@ -27,6 +27,7 @@ export function datasetCatalog(): CatalogDataset[] {
         ? llmFieldsFromZodObject(dataset.baseSchema, dataset.internalFields ?? []).map((f) => ({
             name: f.name,
             description: f.description,
+            fields: f.fields,
           }))
         : [],
       layers: (dataset.options ?? []).map((layer) => ({
@@ -34,7 +35,11 @@ export function datasetCatalog(): CatalogDataset[] {
         label: layer.label,
         description: layer.description,
         fields: schemas[layer.id]
-          ? llmFieldsFromZodObject(schemas[layer.id]).map((f) => ({ name: f.name, description: f.description }))
+          ? llmFieldsFromZodObject(schemas[layer.id]).map((f) => ({
+              name: f.name,
+              description: f.description,
+              fields: f.fields,
+            }))
           : [],
       })),
     };

--- a/apps/ehr/src/features/report-builder/datasets/types.ts
+++ b/apps/ehr/src/features/report-builder/datasets/types.ts
@@ -1,17 +1,14 @@
 import Oystehr from '@oystehr/sdk';
 import { QueryClient } from '@tanstack/react-query';
+import { AdHocLayerMap } from 'utils/lib/types/adhoc/datasets/dataset';
 import { AdHocRow, LlmDatasetSchema } from 'utils/lib/types/adhoc/datasets/llm-schema';
 import { AdHocLayer } from 'utils/lib/types/adhoc/query/layers';
+import { z } from 'zod';
 
 export type { AdHocRow };
 
-// An opt-in data layer (checkbox on the page); selected layers are passed to fetch + buildSchema.
-export type AdHocDatasetOption = AdHocLayer;
-
 export interface FetchContext {
   oystehrZambda: Oystehr;
-  // Window fetches go through queryClient.fetchQuery so identical requests are deduped/cached (no
-  // duplicate zambda calls from StrictMode re-runs or re-renders).
   queryClient: QueryClient;
   dateRange: { start: string; end: string };
   options?: Record<string, boolean>;
@@ -22,7 +19,10 @@ export interface AdHocDataset {
   id: string;
   label: string;
   description: string;
-  options?: AdHocDatasetOption[];
+  options?: AdHocLayer[];
+  layers?: AdHocLayerMap;
+  baseSchema?: z.ZodObject<z.ZodRawShape>;
+  internalFields?: readonly string[];
   fetch: (ctx: FetchContext) => Promise<AdHocRow[]>;
   buildSchema: (rows: AdHocRow[], options?: Record<string, boolean>) => LlmDatasetSchema;
 }

--- a/apps/ehr/src/features/report-builder/hooks/useSandbox.ts
+++ b/apps/ehr/src/features/report-builder/hooks/useSandbox.ts
@@ -89,6 +89,12 @@ export function useSandbox({ code, data, schema, onError, onRendered }: UseSandb
   const [rendering, setRendering] = useState(false);
   const [srcDoc, setSrcDoc] = useState<string | null>(null);
 
+  const finishRendering = useCallback((): void => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = null;
+    setRendering(false);
+  }, []);
+
   const handleLoad = useCallback((): void => {
     loadCountRef.current += 1;
     if (loadCountRef.current > 1 && !tornDownRef.current) {
@@ -97,18 +103,22 @@ export function useSandbox({ code, data, schema, onError, onRendered }: UseSandb
       if (frame) frame.srcdoc = '<!DOCTYPE html><html><body></body></html>';
       console.error('[AdHocReport] report frame attempted to navigate away — blanked for safety');
       captureException(new Error('Ad-hoc report frame attempted to navigate away — blanked for safety'));
+      finishRendering();
       onErrorRef.current('The report was stopped because it attempted to navigate away from the page.');
     }
-  }, []);
+  }, [finishRendering]);
 
   const postRender = useCallback(() => {
     const win = ref.current?.contentWindow;
     if (!readyRef.current || !win) return;
     if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => onErrorRef.current(SANDBOX_TIMEOUT_MESSAGE), TIMEOUT_MS);
+    timerRef.current = setTimeout(() => {
+      finishRendering();
+      onErrorRef.current(SANDBOX_TIMEOUT_MESSAGE);
+    }, TIMEOUT_MS);
     setRendering(true);
     win.postMessage({ type: 'render', code, data, schema, muiLicenseKey: MUI_X_LICENSE_KEY }, '*');
-  }, [code, data, schema]);
+  }, [code, data, schema, finishRendering]);
 
   const handleFrameEvent = useCallback((raw: unknown): void => {
     const parsed = AdHocFrameEventSchema.safeParse(raw);
@@ -165,8 +175,7 @@ export function useSandbox({ code, data, schema, onError, onRendered }: UseSandb
         readyRef.current = true;
         postRender();
       } else if (msg.type === 'rendered') {
-        if (timerRef.current) clearTimeout(timerRef.current);
-        setRendering(false);
+        finishRendering();
         if (typeof msg.height === 'number') setHeight(Math.min(Math.max(msg.height + 24, MIN_HEIGHT), MAX_HEIGHT));
         onRenderedRef.current?.();
       } else if (msg.type === 'resize') {
@@ -176,8 +185,7 @@ export function useSandbox({ code, data, schema, onError, onRendered }: UseSandb
           showAdHocDebugLog('sandbox', 'non-fatal error in a rendered report (ignored)', msg.message);
           return;
         }
-        if (timerRef.current) clearTimeout(timerRef.current);
-        setRendering(false);
+        finishRendering();
         const errorMessage = msg.message || 'The report code threw an error.';
         onErrorRef.current(errorMessage);
         captureException(new Error(errorMessage));
@@ -188,7 +196,7 @@ export function useSandbox({ code, data, schema, onError, onRendered }: UseSandb
       window.removeEventListener('message', handler);
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [postRender, handleFrameEvent]);
+  }, [postRender, handleFrameEvent, finishRendering]);
 
   // (Re)render whenever the code or data changes and the frame is ready.
   useEffect(() => {

--- a/apps/ehr/src/features/report-builder/hooks/useSandbox.ts
+++ b/apps/ehr/src/features/report-builder/hooks/useSandbox.ts
@@ -17,7 +17,6 @@ const CSP = [
   'img-src data: blob:',
   'font-src data:',
   "connect-src 'none'",
-  // Redundant with the sandbox (no allow-forms already blocks form submission) but explicit.
   "form-action 'none'",
 ].join('; ');
 
@@ -43,7 +42,7 @@ function buildSrcDoc(runtimeBundle: string): string {
 }
 
 let srcDocPromise: Promise<string> | null = null;
-// Load the runtime chunk + assemble the srcDoc once per app session; every frame reuses the string.
+
 function loadSrcDoc(): Promise<string> {
   return (srcDocPromise ??= import('virtual:adhoc-report-runtime').then((m) => buildSrcDoc(m.default)));
 }
@@ -52,29 +51,19 @@ const TIMEOUT_MS = 10000;
 const MIN_HEIGHT = 160;
 const MAX_HEIGHT = 4000;
 
-// Distinguishable timeout message: a watchdog timeout means "slow or stuck", NOT "wrong code" — the
-// caller shows it without regenerating (the code may be fine, merely slow here).
 export const SANDBOX_TIMEOUT_MESSAGE = 'Report timed out — the generated code may be too slow or stuck.';
 
-// Same DataGridPro license key the app uses — the frame is a separate window and activates its own copy.
 const MUI_X_LICENSE_KEY: string | undefined = import.meta.env.VITE_APP_MUI_X_LICENSE_KEY;
 
 export interface UseSandboxOptions {
-  /** The generated JSX artifact (the body of buildReport) — from generate or a saved report,
-   *  exactly as shown in the code preview. The frame's runtime transpiles it before execution. */
   code: string;
-  /** The fetched, Zod-validated rows. Provided to the frame at creation; never sent to the LLM. */
   data: AdHocRow[];
   schema: LlmDatasetSchema;
-  /** Generation/runtime failure inside the frame (drives the bounded auto-repair). */
   onError: (message: string) => void;
-  /** The report rendered cleanly. */
   onRendered?: () => void;
 }
 
 export interface UseSandbox {
-  /** Spread onto the <iframe>. Null until the runtime bundle chunk has loaded — the frame must not
-   *  be mounted before then (an empty-then-real srcDoc swap would look like a navigation). */
   frameProps: {
     ref: React.RefObject<HTMLIFrameElement>;
     sandbox: string;
@@ -83,6 +72,7 @@ export interface UseSandbox {
     style: React.CSSProperties;
     title: string;
   } | null;
+  rendering: boolean;
 }
 
 export function useSandbox({ code, data, schema, onError, onRendered }: UseSandboxOptions): UseSandbox {
@@ -96,12 +86,9 @@ export function useSandbox({ code, data, schema, onError, onRendered }: UseSandb
   const loadCountRef = useRef(0);
   const tornDownRef = useRef(false);
   const [height, setHeight] = useState(400);
-  // The runtime bundle is code-split into its own chunk; load it before mounting the frame.
+  const [rendering, setRendering] = useState(false);
   const [srcDoc, setSrcDoc] = useState<string | null>(null);
 
-  // Egress backstop: the srcdoc loads exactly once (nothing inside navigates the frame). A later
-  // load event means the frame navigated its own document — the one exfiltration channel CSP/sandbox
-  // can't block — so blank it.
   const handleLoad = useCallback((): void => {
     loadCountRef.current += 1;
     if (loadCountRef.current > 1 && !tornDownRef.current) {
@@ -119,6 +106,7 @@ export function useSandbox({ code, data, schema, onError, onRendered }: UseSandb
     if (!readyRef.current || !win) return;
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => onErrorRef.current(SANDBOX_TIMEOUT_MESSAGE), TIMEOUT_MS);
+    setRendering(true);
     win.postMessage({ type: 'render', code, data, schema, muiLicenseKey: MUI_X_LICENSE_KEY }, '*');
   }, [code, data, schema]);
 
@@ -146,8 +134,6 @@ export function useSandbox({ code, data, schema, onError, onRendered }: UseSandb
     }
   }, []);
 
-  // Pull the code-split runtime chunk once, then mount the frame. A load failure surfaces as a
-  // render error rather than a silently blank frame.
   useEffect(() => {
     let alive = true;
     void loadSrcDoc()
@@ -180,18 +166,18 @@ export function useSandbox({ code, data, schema, onError, onRendered }: UseSandb
         postRender();
       } else if (msg.type === 'rendered') {
         if (timerRef.current) clearTimeout(timerRef.current);
+        setRendering(false);
         if (typeof msg.height === 'number') setHeight(Math.min(Math.max(msg.height + 24, MIN_HEIGHT), MAX_HEIGHT));
         onRenderedRef.current?.();
       } else if (msg.type === 'resize') {
         if (typeof msg.height === 'number') setHeight(Math.min(Math.max(msg.height + 24, MIN_HEIGHT), MAX_HEIGHT));
       } else if (msg.type === 'error') {
-        // fatal=false: an interaction/async error of an ALREADY-RENDERED report — log it, but never
-        // regenerate (or overwrite) a working report over it.
         if (msg.fatal === false) {
           showAdHocDebugLog('sandbox', 'non-fatal error in a rendered report (ignored)', msg.message);
           return;
         }
         if (timerRef.current) clearTimeout(timerRef.current);
+        setRendering(false);
         const errorMessage = msg.message || 'The report code threw an error.';
         onErrorRef.current(errorMessage);
         captureException(new Error(errorMessage));
@@ -230,5 +216,5 @@ export function useSandbox({ code, data, schema, onError, onRendered }: UseSandb
     [handleLoad, height, srcDoc]
   );
 
-  return { frameProps };
+  return { frameProps, rendering };
 }

--- a/apps/ehr/src/features/report-builder/page/DatasetLayersInfo.tsx
+++ b/apps/ehr/src/features/report-builder/page/DatasetLayersInfo.tsx
@@ -1,0 +1,186 @@
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  Box,
+  Chip,
+  Collapse,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { Fragment, ReactElement, useState } from 'react';
+import { layerSchemas } from 'utils/lib/types/adhoc/datasets/dataset';
+import { llmFieldsFromZodObject } from 'utils/lib/types/adhoc/datasets/llm-schema';
+import { AD_HOC_DATASETS, getDataset } from '../datasets/registry';
+import { AdHocDataset } from '../datasets/types';
+
+interface FieldRow {
+  name: string;
+  type: string;
+  description: string;
+}
+
+interface LayerRow {
+  id: string;
+  label: string;
+  description: string;
+  loaded?: boolean;
+  fields: FieldRow[];
+}
+
+function layerRowsFor(dataset: AdHocDataset | undefined, loadedIds?: Record<string, boolean>): LayerRow[] {
+  const schemas = dataset?.layers ? layerSchemas(dataset.layers) : {};
+  return (dataset?.options ?? []).map((layer) => ({
+    id: layer.id,
+    label: layer.label,
+    description: layer.description ?? '',
+    ...(loadedIds ? { loaded: !!loadedIds[layer.id] } : {}),
+    fields: schemas[layer.id] ? llmFieldsFromZodObject(schemas[layer.id]) : [],
+  }));
+}
+
+function baseFieldsFor(dataset: AdHocDataset | undefined): FieldRow[] {
+  return dataset?.baseSchema ? llmFieldsFromZodObject(dataset.baseSchema, dataset.internalFields ?? []) : [];
+}
+
+function FieldsTable({ fields }: { fields: FieldRow[] }): ReactElement {
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>Field</TableCell>
+          <TableCell>Type</TableCell>
+          <TableCell>Description</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {fields.map((field) => (
+          <TableRow key={field.name}>
+            <TableCell sx={{ fontFamily: 'monospace' }}>{field.name}</TableCell>
+            <TableCell>{field.type}</TableCell>
+            <TableCell sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>{field.description}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function LayersTable({ layers, showStatus }: { layers: LayerRow[]; showStatus: boolean }): ReactElement {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell sx={{ width: 48 }} />
+          <TableCell>Layer</TableCell>
+          <TableCell>What it adds</TableCell>
+          {showStatus && <TableCell>Status</TableCell>}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {layers.map((layer) => {
+          const isOpen = expanded === layer.id;
+          return (
+            <Fragment key={layer.id}>
+              <TableRow>
+                <TableCell>
+                  {layer.fields.length > 0 && (
+                    <IconButton size="small" onClick={() => setExpanded(isOpen ? null : layer.id)}>
+                      {isOpen ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+                    </IconButton>
+                  )}
+                </TableCell>
+                <TableCell>{layer.label}</TableCell>
+                <TableCell sx={{ color: 'text.secondary' }}>{layer.description}</TableCell>
+                {showStatus && (
+                  <TableCell>
+                    <Chip
+                      size="small"
+                      label={layer.loaded ? 'Loaded' : 'Available'}
+                      color={layer.loaded ? 'success' : 'default'}
+                      variant={layer.loaded ? 'filled' : 'outlined'}
+                    />
+                  </TableCell>
+                )}
+              </TableRow>
+              <TableRow>
+                <TableCell sx={{ py: 0, border: 0 }} colSpan={showStatus ? 4 : 3}>
+                  <Collapse in={isOpen} unmountOnExit>
+                    <Box sx={{ py: 1, pl: 6 }}>
+                      <FieldsTable fields={layer.fields} />
+                    </Box>
+                  </Collapse>
+                </TableCell>
+              </TableRow>
+            </Fragment>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+export function DatasetLayersInfo({
+  datasetId,
+  datasetOptions,
+}: {
+  datasetId: string;
+  datasetOptions: Record<string, boolean>;
+}): ReactElement | null {
+  const layers = layerRowsFor(getDataset(datasetId), datasetOptions);
+  if (layers.length === 0) return null;
+
+  const loadedCount = layers.filter((layer) => layer.loaded).length;
+
+  return (
+    <Box sx={{ mt: 2, px: 2, pb: 2 }}>
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>
+        Optional data layers — {loadedCount} of {layers.length} loaded
+      </Typography>
+      <LayersTable layers={layers} showStatus />
+    </Box>
+  );
+}
+
+export function AllDatasetsInfo(): ReactElement {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  return (
+    <Box>
+      {AD_HOC_DATASETS.map((dataset) => {
+        const isOpen = expanded === dataset.id;
+        return (
+          <Box key={dataset.id} sx={{ mb: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <IconButton size="small" onClick={() => setExpanded(isOpen ? null : dataset.id)}>
+                {isOpen ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+              </IconButton>
+              <Typography variant="subtitle2">{dataset.label}</Typography>
+              <Typography variant="body2" color="text.secondary">
+                — {dataset.description}
+              </Typography>
+            </Box>
+            <Collapse in={isOpen} unmountOnExit>
+              <Box sx={{ pl: 5, py: 1 }}>
+                <Typography variant="caption" color="text.secondary">
+                  Always available
+                </Typography>
+                <FieldsTable fields={baseFieldsFor(dataset)} />
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 2 }}>
+                  Optional layers
+                </Typography>
+                <LayersTable layers={layerRowsFor(dataset)} showStatus={false} />
+              </Box>
+            </Collapse>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/apps/ehr/src/features/report-builder/page/DatasetLayersInfo.tsx
+++ b/apps/ehr/src/features/report-builder/page/DatasetLayersInfo.tsx
@@ -22,6 +22,8 @@ interface FieldRow {
   name: string;
   type: string;
   description: string;
+  /** Members of a record column, listed as their own rows so they are findable. */
+  fields?: { name: string; type: string; description: string }[];
 }
 
 interface LayerRow {
@@ -59,11 +61,20 @@ function FieldsTable({ fields }: { fields: FieldRow[] }): ReactElement {
       </TableHead>
       <TableBody>
         {fields.map((field) => (
-          <TableRow key={field.name}>
-            <TableCell sx={{ fontFamily: 'monospace' }}>{field.name}</TableCell>
-            <TableCell>{field.type}</TableCell>
-            <TableCell sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>{field.description}</TableCell>
-          </TableRow>
+          <Fragment key={field.name}>
+            <TableRow>
+              <TableCell sx={{ fontFamily: 'monospace' }}>{field.name}</TableCell>
+              <TableCell>{field.type}</TableCell>
+              <TableCell sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>{field.description}</TableCell>
+            </TableRow>
+            {(field.fields ?? []).map((member) => (
+              <TableRow key={`${field.name}.${member.name}`}>
+                <TableCell sx={{ fontFamily: 'monospace', pl: 4 }}>{`${field.name}[].${member.name}`}</TableCell>
+                <TableCell>{member.type}</TableCell>
+                <TableCell sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>{member.description}</TableCell>
+              </TableRow>
+            ))}
+          </Fragment>
         ))}
       </TableBody>
     </Table>

--- a/apps/ehr/src/features/report-builder/page/ReportBuilderPage.tsx
+++ b/apps/ehr/src/features/report-builder/page/ReportBuilderPage.tsx
@@ -31,6 +31,7 @@ import { AdHocDateRangeFilter } from 'utils/lib/types/adhoc/query/date-range';
 import PageContainer from '../../../layout/PageContainer';
 import { AD_HOC_DATASETS } from '../datasets/registry';
 import { ReportFrame } from '../sandbox/ReportFrame';
+import { AllDatasetsInfo, DatasetLayersInfo } from './DatasetLayersInfo';
 import { useReportBuilder } from './useReportBuilder';
 
 export default function ReportBuilderPage(): React.ReactElement {
@@ -197,6 +198,41 @@ export default function ReportBuilderPage(): React.ReactElement {
             </Box>
           )}
 
+          {rb.unavailableRequest && (
+            <Paper variant="outlined" sx={{ mb: 3, p: 2, borderColor: 'error.main' }}>
+              <Typography color="error" variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>
+                This report can&apos;t be built from the available data
+              </Typography>
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                Not found in any dataset: <strong>{rb.unavailableRequest.concepts.join(', ')}</strong>
+              </Typography>
+              {rb.unavailableRequest.hint && (
+                <Typography variant="body2" sx={{ mb: 2, fontStyle: 'italic' }}>
+                  {rb.unavailableRequest.hint}
+                </Typography>
+              )}
+              <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                What you can do
+              </Typography>
+              <Box component="ul" sx={{ mt: 0, mb: 2, pl: 3 }}>
+                <Typography component="li" variant="body2">
+                  Remove {rb.unavailableRequest.concepts.length > 1 ? 'those parts' : 'that part'} from your request and
+                  generate the rest.
+                </Typography>
+                <Typography component="li" variant="body2">
+                  If you meant a different field, use its exact name from the list below.
+                </Typography>
+                <Typography component="li" variant="body2">
+                  Another dataset may hold what you need — check the list below.
+                </Typography>
+              </Box>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                What the datasets do contain
+              </Typography>
+              <AllDatasetsInfo />
+            </Paper>
+          )}
+
           {rb.schema && rb.rows && (
             <>
               <Box sx={{ mb: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -237,6 +273,7 @@ export default function ReportBuilderPage(): React.ReactElement {
                       ))}
                     </TableBody>
                   </Table>
+                  <DatasetLayersInfo datasetId={rb.datasetId} datasetOptions={rb.datasetOptions} />
                 </Paper>
               </Collapse>
 

--- a/apps/ehr/src/features/report-builder/page/useReportBuilder.ts
+++ b/apps/ehr/src/features/report-builder/page/useReportBuilder.ts
@@ -12,17 +12,26 @@ import { AD_HOC_REPORT_EDIT_ROLES, AD_HOC_REPORT_VIEW_ROLES } from 'utils/lib/ty
 import { generateAdHocReport, inferAdHocReportLayers, listAdHocReports, saveAdHocReport } from '../../../api/api';
 import { useApiClients } from '../../../hooks/useAppClients';
 import useEvolveUser from '../../../hooks/useEvolveUser';
-import { AD_HOC_DATASETS, getDataset, otherDatasetsFor } from '../datasets/registry';
+import { AD_HOC_DATASETS, datasetCatalog, getDataset, otherDatasetsFor } from '../datasets/registry';
 import { showAdHocDebugLog } from '../debug';
 import { SANDBOX_TIMEOUT_MESSAGE } from '../hooks/useSandbox';
 
 // How many times to transparently regenerate after a runtime error before surfacing it to the user.
-// The iframe run over the real rows IS the validation pass (the zambda never executes code), so
-// this client loop is the design's "validate and regenerate on failure, bounded (~2-3 tries)":
 // 1 initial generation + up to 2 repairs.
 const MAX_AUTO_RETRIES = 2;
 
 type PreviousAttempt = NonNullable<GenerateAdHocReportInput['previousAttempt']>;
+
+interface InferResult {
+  options: Record<string, boolean>;
+  unavailable?: string[];
+  hint?: string;
+}
+
+export interface UnavailableRequest {
+  concepts: string[];
+  hint?: string;
+}
 
 function rangeFromControls(
   filter: AdHocDateRangeFilter,
@@ -75,6 +84,7 @@ type UseReportBuilder = {
   customEndDate: string;
   rows: AdHocRow[] | null;
   schema: LlmDatasetSchema | null;
+  datasetOptions: Record<string, boolean>;
   loading: boolean;
   error: string | null;
   request: string;
@@ -82,6 +92,7 @@ type UseReportBuilder = {
   generatedCode: string | null;
   generatedTitle: string | undefined;
   generateError: string | null;
+  unavailableRequest: UnavailableRequest | null;
   renderError: string | null;
   showSchema: boolean;
   showCode: boolean;
@@ -110,9 +121,6 @@ type UseReportBuilder = {
   openSaveDialog: () => void;
 };
 
-// Client-side pipeline (infer layers → fetch → generate → needsLayers backfill) + save/load. Fetch
-// stays client-side: rows reach the sandboxed iframe, never the LLM (which sees only the Zod schema).
-// No refinement; the only multi-turn path is the auto-repair (previousAttempt) on a runtime crash.
 export function useReportBuilder(): UseReportBuilder {
   const { oystehrZambda } = useApiClients();
   const queryClient = useQueryClient();
@@ -143,16 +151,12 @@ export function useReportBuilder(): UseReportBuilder {
   const [generatedCode, setGeneratedCode] = useState<string | null>(null);
   const [generatedTitle, setGeneratedTitle] = useState<string | undefined>(undefined);
   const [generateError, setGenerateError] = useState<string | null>(null);
+  const [unavailableRequest, setUnavailableRequest] = useState<UnavailableRequest | null>(null);
   const [renderError, setRenderError] = useState<string | null>(null);
   const [showSchema, setShowSchema] = useState(false);
   const [showCode, setShowCode] = useState(false);
-  // The request the current code was generated from — the auto-repair regenerates THIS, not
-  // whatever is currently typed in the box.
   const activeRequestRef = useRef('');
-  // Bounds transparent regenerations after a runtime crash, so broken code can't loop forever.
   const autoRetryRef = useRef(0);
-  // True once the current code is an auto-repair (or version regeneration) — a clean render then
-  // persists the fixed code back to the saved report so it doesn't repair itself on every open.
   const autoFixedRef = useRef(false);
 
   const [loadedSavedId, setLoadedSavedId] = useState<string | null>(null);
@@ -161,10 +165,6 @@ export function useReportBuilder(): UseReportBuilder {
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const loadAttemptedRef = useRef(false);
-  // A regeneration requested by the saved-report loader. It must NOT call orchestrate directly:
-  // right after the loader's setState calls, orchestrate (and fetchWithOptions inside it) still
-  // close over the PREVIOUS render's datasetId/dateRange/options/schema — it would fetch the wrong
-  // dataset. Deferring through state runs it on the next render, over the committed values.
   const [pendingRegenerate, setPendingRegenerate] = useState<string | null>(null);
 
   const getDateRangeIso = useCallback(
@@ -172,8 +172,6 @@ export function useReportBuilder(): UseReportBuilder {
     [customDate, customStartDate, customEndDate]
   );
 
-  // Fetch the dataset for `opts`, build the LLM schema (static Zod metadata only — no values leave
-  // the client), return both so a caller can use them without waiting for setState.
   const fetchWithOptions = useCallback(
     async (opts: Record<string, boolean>): Promise<{ rows: AdHocRow[]; schema: LlmDatasetSchema } | null> => {
       if (!oystehrZambda) return null;
@@ -217,33 +215,32 @@ export function useReportBuilder(): UseReportBuilder {
     setDatasetOptions(defaultOptionsFor(id));
   }, []);
 
-  // Which opt-in layers this request needs. Falls back to defaults; generate's needsLayers backfills misses.
   const inferOptions = useCallback(
-    async (message: string): Promise<Record<string, boolean>> => {
+    async (message: string): Promise<InferResult> => {
       const dataset = getDataset(datasetId);
       const layers = dataset?.options ?? [];
       const base = defaultOptionsFor(datasetId);
-      if (!oystehrZambda || layers.length === 0) return base;
+      if (!oystehrZambda || layers.length === 0) return { options: base };
       try {
-        const { layerIds } = await inferAdHocReportLayers(oystehrZambda, {
+        const { layerIds, unavailable, hint } = await inferAdHocReportLayers(oystehrZambda, {
           datasetId,
-          layers: layers.map((l) => ({ id: l.id, label: l.label, description: l.description })),
+          datasets: datasetCatalog(),
           request: message,
         });
+        if (unavailable?.length) return { options: base, unavailable, hint };
         const out = { ...base };
         layerIds.forEach((id) => {
           if (id in out) out[id] = true;
         });
-        return out;
+        return { options: out };
       } catch (e) {
         showAdHocDebugLog('infer', 'layer inference failed — using defaults', e);
-        return base;
+        return { options: base };
       }
     },
     [oystehrZambda, datasetId]
   );
 
-  // Send schema + request (never rows) to generate. Returns the result for the needsLayers backfill.
   const callGenerate = useCallback(
     async (
       message: string,
@@ -275,22 +272,25 @@ export function useReportBuilder(): UseReportBuilder {
     [oystehrZambda]
   );
 
-  // Lets the saved-report loader and the render-error repair re-invoke the pipeline via a ref.
   const orchestrateRef = useRef<(m: string, infer: boolean, prev?: PreviousAttempt) => Promise<void>>();
 
-  // infer → fetch → generate → (needsLayers) refetch + regenerate once. `infer` is false when the
-  // loaded data can be reused (auto-repair, saved-report regeneration).
   const orchestrate = useCallback(
     async (message: string, infer: boolean, previousAttempt?: PreviousAttempt): Promise<void> => {
       if (!oystehrZambda) return;
       setGenerating(true);
       setGenerateError(null);
       setRenderError(null);
+      setUnavailableRequest(null);
       try {
         let activeOpts = datasetOptions;
         let activeSchema = schema;
         if (infer) {
-          activeOpts = await inferOptions(message);
+          const inferred = await inferOptions(message);
+          if (inferred.unavailable?.length) {
+            setUnavailableRequest({ concepts: inferred.unavailable, hint: inferred.hint });
+            return;
+          }
+          activeOpts = inferred.options;
           const fetched = await fetchWithOptions(activeOpts);
           if (!fetched) return;
           activeSchema = fetched.schema;
@@ -302,7 +302,6 @@ export function useReportBuilder(): UseReportBuilder {
 
         const result = await callGenerate(message, activeSchema, previousAttempt);
 
-        // Safety net: the code named layers it needs that weren't loaded — fetch them and regenerate.
         const wanted = (result?.needsLayers ?? []).filter((id) => id in activeOpts && !activeOpts[id]);
         if (wanted.length) {
           const merged = { ...activeOpts };
@@ -322,9 +321,6 @@ export function useReportBuilder(): UseReportBuilder {
 
   orchestrateRef.current = orchestrate;
 
-  // Consume a deferred regeneration on the render AFTER the saved-report loader committed the saved
-  // dataset/range/options/schema — orchestrate now closes over the right values. infer=false: the
-  // loader already fetched the rows + schema for the saved criteria.
   useEffect(() => {
     if (!pendingRegenerate || loading || generating) return;
     const request = pendingRegenerate;
@@ -332,7 +328,6 @@ export function useReportBuilder(): UseReportBuilder {
     void orchestrate(request, false);
   }, [pendingRegenerate, loading, generating, orchestrate]);
 
-  // Editing the request and generating again IS the refinement flow — there is no separate one.
   const handleGenerate = useCallback((): void => {
     if (!request.trim() || !canCreate) return;
     autoRetryRef.current = 0;
@@ -341,10 +336,6 @@ export function useReportBuilder(): UseReportBuilder {
     void orchestrate(request, true);
   }, [request, canCreate, orchestrate]);
 
-  // When the generated code throws at runtime in the iframe, transparently regenerate once with the
-  // failing code + error attached. After the budget is spent, surface the error. A watchdog
-  // TIMEOUT is not a code failure (the code may be fine and merely slow here) — show it, never
-  // regenerate over it.
   const handleRenderError = useCallback(
     (message: string): void => {
       if (
@@ -372,12 +363,11 @@ export function useReportBuilder(): UseReportBuilder {
     [canCreate, generating, generatedCode]
   );
 
-  // Clear the generated report to start fresh. Keeps the fetched rows/schema and request text, so
-  // the user can tweak the request and regenerate without re-fetching.
   const handleReset = useCallback((): void => {
     setGeneratedCode(null);
     setGeneratedTitle(undefined);
     setGenerateError(null);
+    setUnavailableRequest(null);
     setRenderError(null);
     setLoadedSavedId(null);
     activeRequestRef.current = '';
@@ -385,9 +375,6 @@ export function useReportBuilder(): UseReportBuilder {
     autoFixedRef.current = false;
   }, []);
 
-  // Open from a saved tile (?saved=): load definition, set controls, re-fetch live data, re-run the
-  // saved code in the iframe. On a runtime-version mismatch the saved code was generated against an
-  // older execution contract — regenerate it from the saved prompt instead of running it.
   useEffect(() => {
     const savedId = searchParams.get('saved');
 
@@ -494,9 +481,8 @@ export function useReportBuilder(): UseReportBuilder {
     ]
   );
 
-  // When an auto-repaired (or version-regenerated) report renders cleanly, persist the fixed code
-  // back to the saved report so it doesn't repair itself again on every open.
   const handleRendered = useCallback((): void => {
+    setRenderError(null);
     if (!autoFixedRef.current) return;
     autoFixedRef.current = false;
     if (!canCreate || !oystehrZambda || !loadedSavedId || !generatedCode) return;
@@ -544,6 +530,7 @@ export function useReportBuilder(): UseReportBuilder {
     customEndDate,
     rows,
     schema,
+    datasetOptions,
     loading,
     error,
     request,
@@ -551,6 +538,7 @@ export function useReportBuilder(): UseReportBuilder {
     generatedCode,
     generatedTitle,
     generateError,
+    unavailableRequest,
     renderError,
     showSchema,
     showCode,

--- a/apps/ehr/src/features/report-builder/query/dataset-query.ts
+++ b/apps/ehr/src/features/report-builder/query/dataset-query.ts
@@ -3,18 +3,12 @@ import { DateTime } from 'luxon';
 import { StartAdHocReportInput } from 'utils/lib/types/adhoc/generation/report-task';
 import { getAdHocReportStatus, startAdHocReport } from '../../../api/api';
 
-// ISO instant → viewer-local yyyy-MM-dd, or null when absent/unparseable. utils' formatDate() does
-// the same parse/format but returns '-' on missing/invalid; here null must be preserved (date fields
-// are nullable and downstream treats null as "no date"), so this stays a small dedicated helper.
 export const toLocalYmd = (iso: string | null | undefined): string | null => {
   if (!iso) return null;
   const dt = DateTime.fromISO(iso);
   return dt.isValid ? dt.toFormat('yyyy-MM-dd') : null;
 };
 
-// How long a fetched dataset stays fresh in the react-query cache. Long enough that the whole
-// fetch→generate→needsLayers pipeline and StrictMode's dev double-invoke reuse the cached result
-// instead of re-hitting the zambda; short enough that a later manual re-fetch gets fresh data.
 export const ADHOC_QUERY_STALE_MS = 5 * 60 * 1000;
 
 export async function downloadReportData<T>(downloadUrl: string): Promise<T> {
@@ -28,9 +22,6 @@ export async function downloadReportData<T>(downloadUrl: string): Promise<T> {
 const ADHOC_POLL_INTERVAL_MS = 2000;
 const ADHOC_POLL_TIMEOUT_MS = 15 * 60 * 1000;
 
-// Kick off the async report Task, poll its status until terminal, then download and parse the data
-// file. The heavy fetch runs in a subscription worker (its own long timeout), so this client-facing
-// call stays a short kickoff plus lightweight status polls.
 export async function runAdHocReport<T>(oystehr: Oystehr, input: StartAdHocReportInput): Promise<T> {
   const { taskId } = await startAdHocReport(oystehr, input);
   const deadline = Date.now() + ADHOC_POLL_TIMEOUT_MS;

--- a/apps/ehr/src/features/report-builder/runtime/components/Table.tsx
+++ b/apps/ehr/src/features/report-builder/runtime/components/Table.tsx
@@ -7,13 +7,14 @@ import {
   GridToolbarContainer,
   GridToolbarDensitySelector,
   GridToolbarFilterButton,
+  GridValueGetterParams,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import React, { useCallback, useMemo, useState } from 'react';
 import type { AdHocLinkRoute } from 'utils/lib/types/adhoc/sandbox/events';
 import { MAX_EXPORT_CSV_LENGTH } from 'utils/lib/types/adhoc/sandbox/limits';
 import { sendFrameEvent } from '../messaging';
-import { formatValue, ValueFormat } from './format';
+import { cellText, formatValue, ValueFormat } from './format';
 import { Link } from './Link';
 
 export interface TableColumn {
@@ -22,8 +23,23 @@ export interface TableColumn {
   /** Header label; defaults to the field name. */
   label?: string;
   /** Value format: integer | number | percent | currency. */
-  format?: ValueFormat;
+  format?: ValueFormat | CellValue;
+  /** Computes the cell from the whole row, for a column that is not a plain row field. */
+  value?: CellValue;
 }
+
+type CellValue = (row: Record<string, unknown>) => unknown;
+
+// `value` is the documented accessor, but generated code also passes one as `format`. Honour either:
+// without this the column reads a row field that does not exist and every cell is silently blank.
+const accessorOf = (cfg?: TableColumn): CellValue | undefined => {
+  if (typeof cfg?.value === 'function') return cfg.value;
+  if (typeof cfg?.format === 'function') return cfg.format;
+  return undefined;
+};
+
+const namedFormatOf = (cfg?: TableColumn): ValueFormat | undefined =>
+  typeof cfg?.format === 'string' ? cfg.format : undefined;
 
 export interface TableLink {
   /** The displayed column whose cells become links. */
@@ -72,13 +88,30 @@ export function Table({ rows, columns, links, title, pageSize = 25, onRowClick }
   const { gridColumns, gridRows } = useMemo(() => {
     const fields = columns?.map((c) => c.field) ?? Object.keys(rows[0] ?? {});
     const configByField = new Map((columns ?? []).map((c) => [c.field, c]));
+
+    // An accessor written by the model can throw on some rows (an empty nested array, say). One bad
+    // row must not take the whole report down.
+    const cellValue = (field: string, row: Record<string, unknown>): unknown => {
+      const accessor = accessorOf(configByField.get(field));
+      if (!accessor) return row[field];
+      try {
+        return accessor(row);
+      } catch {
+        return undefined;
+      }
+    };
+
     const isNumeric = (field: string): boolean =>
-      rows.some((r) => typeof r[field] === 'number') &&
-      rows.every((r) => r[field] == null || typeof r[field] === 'number');
+      rows.some((r) => typeof cellValue(field, r) === 'number') &&
+      rows.every((r) => {
+        const value = cellValue(field, r);
+        return value == null || typeof value === 'number';
+      });
 
     const gridColumns: GridColDef[] = fields.map((field) => {
       const cfg = configByField.get(field);
-      const numeric = isNumeric(field) && !cfg?.format;
+      const namedFormat = namedFormatOf(cfg);
+      const numeric = isNumeric(field) && !namedFormat;
       const link = linkByField.get(field);
       return {
         field,
@@ -88,15 +121,10 @@ export function Table({ rows, columns, links, title, pageSize = 25, onRowClick }
         sortable: true,
         type: numeric ? 'number' : 'string',
         ...(numeric ? { headerAlign: 'right' as const, align: 'right' as const } : {}),
+        ...(numeric ? {} : { valueGetter: (params: GridValueGetterParams) => cellText(cellValue(field, params.row)) }),
         renderCell: (params: GridRenderCellParams) => {
-          const raw = params.row[field];
-          const display = cfg?.format
-            ? formatValue(raw, cfg.format)
-            : Array.isArray(raw)
-            ? raw.join(', ')
-            : raw == null
-            ? ''
-            : String(raw);
+          const raw = cellValue(field, params.row);
+          const display = namedFormat ? formatValue(raw, namedFormat) : cellText(raw);
           if (link) {
             // id from idField's value when given (e.g. link patientName by patientId), else this
             // cell's own value. The SPA owns the URL — never the generated code.

--- a/apps/ehr/src/features/report-builder/runtime/components/format.ts
+++ b/apps/ehr/src/features/report-builder/runtime/components/format.ts
@@ -6,6 +6,24 @@ import type { ValueFormat } from 'utils/lib/types/adhoc/generation/runtime-scope
 
 export type { ValueFormat };
 
+export function cellText(value: unknown): string {
+  if (value == null) return '';
+  if (Array.isArray(value)) {
+    return value
+      .map(cellText)
+      .filter((text) => text !== '')
+      .join(', ');
+  }
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([key, item]) => [key, cellText(item)] as const)
+      .filter(([, text]) => text !== '')
+      .map(([key, text]) => `${key}: ${text}`)
+      .join(', ');
+  }
+  return String(value);
+}
+
 export function formatValue(value: unknown, format?: ValueFormat): string {
   if (value == null) return '';
   const cleaned = typeof value === 'string' ? value.trim().replace(/^"(.*)"$/, '$1') : value;

--- a/apps/ehr/src/features/report-builder/sandbox/ReportFrame.tsx
+++ b/apps/ehr/src/features/report-builder/sandbox/ReportFrame.tsx
@@ -1,24 +1,19 @@
-import { Box, CircularProgress } from '@mui/material';
+import { Box, CircularProgress, Typography } from '@mui/material';
 import React from 'react';
 import { AdHocRow, LlmDatasetSchema } from 'utils/lib/types/adhoc/datasets/llm-schema';
 import { useSandbox } from '../hooks/useSandbox';
 
 interface ReportFrameProps {
-  /** The generated JSX artifact; the frame's runtime transpiles + executes it over `data`. */
   code: string;
   data: AdHocRow[];
   schema: LlmDatasetSchema;
   onError: (message: string) => void;
-  /** Fired when the generated code renders without throwing — lets the page persist an auto-repaired
-   *  report so it doesn't crash-then-retry on every open. */
   onRendered?: () => void;
 }
 
-// Thin view over useSandbox: the hook owns the frame content, the message protocol, and the event
-// whitelist; this component just places the iframe.
 export function ReportFrame({ code, data, schema, onError, onRendered }: ReportFrameProps): React.ReactElement {
-  const { frameProps } = useSandbox({ code, data, schema, onError, onRendered });
-  // frameProps is null until the code-split runtime chunk has loaded; don't mount the frame yet.
+  const { frameProps, rendering } = useSandbox({ code, data, schema, onError, onRendered });
+
   if (!frameProps) {
     return (
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 200 }}>
@@ -26,5 +21,29 @@ export function ReportFrame({ code, data, schema, onError, onRendered }: ReportF
       </Box>
     );
   }
-  return <iframe {...frameProps} />;
+
+  return (
+    <Box sx={{ position: 'relative' }}>
+      <iframe {...frameProps} />
+      {rendering && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 1,
+            bgcolor: 'background.paper',
+          }}
+        >
+          <CircularProgress size={24} />
+          <Typography variant="body2" color="text.secondary">
+            Building the report…
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
 }

--- a/config/oystehr-core/zambdas.json
+++ b/config/oystehr-core/zambdas.json
@@ -1222,6 +1222,7 @@
       "type": "subscription",
       "runtime": "nodejs22.x",
       "timeout": "900",
+      "memorySize": "3008",
       "src": "src/subscriptions/sub-adhoc-report/index",
       "zip": ".dist/zips/sub-adhoc-report.zip"
     },

--- a/packages/utils/lib/types/adhoc/datasets/billing.ts
+++ b/packages/utils/lib/types/adhoc/datasets/billing.ts
@@ -65,6 +65,24 @@ export const BILLING_LAYERS = {
       paymentCount: z.number().describe('Number of payments collected.'),
       paymentMethods: z.array(z.string()).describe('Distinct methods: "card"/"card-reader"/"cash"/"check".'),
       lastPaymentDate: z.string().nullable().describe('Date of the most recent payment (yyyy-MM-dd).'),
+      payments: z
+        .array(
+          z.object({
+            date: z
+              .string()
+              .describe(
+                "Full ISO instant the payment was taken. Format in the viewer's LOCAL timezone via " +
+                  'new Date(date); do NOT slice the ISO string (shows UTC).'
+              ),
+            amount: z.number().describe('Amount of THIS payment in USD.'),
+            method: z.string().describe('Method of THIS payment; "" when not recorded.'),
+          })
+        )
+        .describe(
+          'One record per individual payment, oldest first — use this for a payment-by-payment table. ' +
+            'paymentsCollected is their sum and paymentCount their length. Empty when the visit collected ' +
+            'nothing, which is a row worth showing when the request asks to include visits with no payment.'
+        ),
     }),
   },
   coverage: {

--- a/packages/utils/lib/types/adhoc/datasets/encounters.ts
+++ b/packages/utils/lib/types/adhoc/datasets/encounters.ts
@@ -184,6 +184,37 @@ export const ENCOUNTER_LAYERS = {
       medicationSources: z.array(z.enum(['eRx', 'in-house'])).describe('Parallel: source per entry.'),
       medicationCodes: z.array(z.string()).describe('Medispan dispensable-drug-id codes (eRx).'),
       medicationCount: z.number().describe('Total medications on the visit. 0 when none.'),
+      drugs: z
+        .array(
+          z.object({
+            name: z.string().describe('Drug display with strength, same value as in medications[].'),
+            source: z.enum(['eRx', 'in-house']).describe('Prescribed (eRx) or given in the clinic (in-house).'),
+            dose: z.number().nullable().describe('Amount given. Null for eRx.'),
+            units: z.string().nullable().describe('Unit of dose, e.g. "mg"/"mL". Null for eRx.'),
+            route: z.string().nullable().describe('Route code of administration. Null for eRx.'),
+            ndc: z.string().nullable().describe('NDC code entered at administration. Null when not entered.'),
+            lotNumber: z.string().nullable().describe('Lot number of the vial used. Null when not recorded.'),
+            expirationDate: z
+              .string()
+              .nullable()
+              .describe('Expiry of the vial used (yyyy-MM-dd). Null when not recorded.'),
+            manufacturer: z.string().nullable().describe('Manufacturer entered at administration. Null when none.'),
+            administeredAt: z
+              .string()
+              .nullable()
+              .describe(
+                'Full ISO instant the drug was given — NOT the visit date. Format via new Date(administeredAt); ' +
+                  'do NOT slice the ISO string. Null for eRx.'
+              ),
+          })
+        )
+        .describe(
+          'One record per drug, with the detail a recall or an audit needs: lot number, NDC, manufacturer, ' +
+            'expiry, dose and the time it was given. Lot, NDC, manufacturer and expiry are recorded ONLY for ' +
+            'in-house administration, and only when staff entered them; they are always null for eRx. They are ' +
+            'also absent when the order was marked as not administered — nothing was given, so no vial is tied ' +
+            'to the patient. Empty when no drugs on the visit.'
+        ),
     }),
   },
   vitals: {
@@ -295,6 +326,14 @@ export const ENCOUNTER_LAYERS = {
                 'VIS date (yyyy-MM-dd). A date means the VIS was given for this vaccine; null means it ' +
                   'was not. Always null for "recorded" history.'
               ),
+            lotNumber: z
+              .string()
+              .nullable()
+              .describe('Lot number of the vial used, for a recall. Null when not recorded or for history.'),
+            expirationDate: z
+              .string()
+              .nullable()
+              .describe('Expiry of the vial used (yyyy-MM-dd). Null when not recorded or for history.'),
           })
         )
         .describe(

--- a/packages/utils/lib/types/adhoc/datasets/encounters.ts
+++ b/packages/utils/lib/types/adhoc/datasets/encounters.ts
@@ -23,7 +23,34 @@ export const EncounterBaseRowSchema = z.object({
   visitType: z.enum(['In-Person', 'Telemed', 'Unknown']).describe('Visit modality.'),
   appointmentType: z.string().describe('Walk-in, pre-booked, or post-telemed.'),
   serviceCategory: z.string().describe('Service line (e.g. "Urgent Care").'),
-  visitStatus: z.string().describe('completed / arrived / cancelled / no-show …'),
+  visitStatus: z
+    .string()
+    .describe(
+      'CURRENT visit status only (completed / arrived / cancelled / no-show …). It carries NO history — ' +
+        'for the order of statuses use statusHistory.'
+    ),
+  statusHistory: z
+    .array(
+      z.object({
+        status: z.string().describe('Visit status at this step.'),
+        start: z
+          .string()
+          .nullable()
+          .describe(
+            "Full ISO instant this status began (null when unknown). Format in the user's LOCAL " +
+              'timezone via new Date(start); do NOT slice the ISO string (shows UTC).'
+          ),
+        end: z
+          .string()
+          .nullable()
+          .describe('Full ISO instant this status ended; null while it is still the current status.'),
+      })
+    )
+    .describe(
+      'Visit status transitions, oldest first. [0] = first status, last = current. This is the ONLY ' +
+        'source for anything about the ORDER of statuses (e.g. a status moving backward through the ' +
+        'workflow) or how long a status lasted. Empty when no history was recorded.'
+    ),
   encounterType: z.enum(['main', 'follow-up', 'scheduled-follow-up']).describe('Kind of encounter row.'),
   reason: z.string().describe('Reason for visit (free text).'),
   scheduledSlotMinutes: z.number().nullable().describe('Booked slot length in minutes.'),
@@ -98,7 +125,7 @@ export const ENCOUNTER_DOMAIN_FIELDS: readonly (keyof AdHocEncounterRow)[] = [
   'aiType',
   'labOrders',
   'imagingOrders',
-  'immunizations',
+  // Vaccine names sit inside `vaccines` records; value sampling only covers flat row fields.
   'nursingOrders',
   'resultNames',
   'medicationIngredients',
@@ -163,15 +190,72 @@ export const ENCOUNTER_LAYERS = {
     label: 'Vital signs',
     description: 'Temperature, heart rate, blood pressure, SpO₂, respiration, weight, height, and BMI.',
     schema: z.object({
-      temperatureF: z.number().nullable().describe('Temperature °F (most recent). Null if not taken.'),
-      heartRate: z.number().nullable().describe('Heart rate bpm (most recent). Null if not taken.'),
-      respirationRate: z.number().nullable().describe('Respiration /min (most recent). Null if not taken.'),
-      oxygenSaturation: z.number().nullable().describe('SpO₂ % (most recent). Null if not taken.'),
-      systolicBP: z.number().nullable().describe('Systolic BP mmHg (most recent). Null if not taken.'),
-      diastolicBP: z.number().nullable().describe('Diastolic BP mmHg (most recent). Null if not taken.'),
+      temperatureF: z
+        .number()
+        .nullable()
+        .describe('Temperature °F, MOST RECENT reading only — for the initial one use temperatureFReadings[0].'),
+      heartRate: z
+        .number()
+        .nullable()
+        .describe('Heart rate bpm, MOST RECENT reading only — for the initial one use heartRateReadings[0].'),
+      respirationRate: z
+        .number()
+        .nullable()
+        .describe('Respiration /min, MOST RECENT only — for the initial one use respirationRateReadings[0].'),
+      oxygenSaturation: z
+        .number()
+        .nullable()
+        .describe('SpO₂ %, MOST RECENT only — for the initial one use oxygenSaturationReadings[0].'),
+      systolicBP: z
+        .number()
+        .nullable()
+        .describe('Systolic BP mmHg, MOST RECENT only — for the initial one use bloodPressureReadings[0].systolic.'),
+      diastolicBP: z
+        .number()
+        .nullable()
+        .describe('Diastolic BP mmHg, MOST RECENT only — for the initial one use bloodPressureReadings[0].diastolic.'),
       weightKg: z.number().nullable().describe('Weight kg (most recent, normalized). Null if not taken.'),
       heightCm: z.number().nullable().describe('Height cm (most recent, normalized). Null if not taken.'),
       bmi: z.number().nullable().describe('BMI from weightKg/heightCm when both present. Null otherwise.'),
+      temperatureFReadings: z
+        .array(z.number())
+        .describe(
+          'Temperature readings in °F, oldest first (charted in °C, converted here). ' +
+            '[0] = initial screening. Empty if not taken.'
+        ),
+      heartRateReadings: z
+        .array(z.number())
+        .describe('Heart rate bpm readings, oldest first. [0] = initial screening. Empty if not taken.'),
+      respirationRateReadings: z
+        .array(z.number())
+        .describe('Respiration /min readings, oldest first. [0] = initial screening. Empty if not taken.'),
+      oxygenSaturationReadings: z
+        .array(z.number())
+        .describe('SpO₂ % readings, oldest first. [0] = initial screening. Empty if not taken.'),
+      systolicBPReadings: z
+        .array(z.number())
+        .describe(
+          'Systolic BP mmHg readings, oldest first. [0] = initial screening. The same index in ' +
+            'diastolicBPReadings is the SAME reading. Empty if not taken.'
+        ),
+      diastolicBPReadings: z
+        .array(z.number())
+        .describe(
+          'Diastolic BP mmHg readings, oldest first. [0] = initial screening. The same index in ' +
+            'systolicBPReadings is the SAME reading. Empty if not taken.'
+        ),
+      abnormalVitals: z
+        .array(z.string())
+        .describe(
+          'Vitals that were out of range on ANY reading of the visit, by the age-banded thresholds the ' +
+            'practice has configured. Applied at charting time, so the age band is the age on the visit ' +
+            'date. Includes the critical ones. Values: temperatureF, heartRate, respirationRate, ' +
+            'oxygenSaturation, bloodPressure, weightKg, heightCm. Empty if all readings were in range. ' +
+            'USE THIS instead of comparing readings to thresholds of your own.'
+        ),
+      criticalVitals: z
+        .array(z.string())
+        .describe('The subset of abnormalVitals that reached the CRITICAL level, not merely abnormal. Same values.'),
     }),
   },
   labs: {
@@ -192,10 +276,31 @@ export const ENCOUNTER_LAYERS = {
   },
   immunizations: {
     label: 'Immunizations',
-    description: 'Vaccines given/recorded on the visit (names + counts).',
+    description: 'Vaccines given or recorded on the visit, with VIS status.',
     schema: z.object({
-      immunizations: z.array(z.string()).describe('Vaccines given/recorded on the visit.'),
-      immunizationCount: z.number().describe('Number of vaccines on the visit. 0 when none.'),
+      vaccines: z
+        .array(
+          z.object({
+            name: z.string().describe('Vaccine name.'),
+            status: z
+              .enum(['administered', 'partially-administered', 'recorded'])
+              .describe(
+                'administered / partially-administered = given on THIS visit; ' +
+                  'recorded = charted history, not given here.'
+              ),
+            visDate: z
+              .string()
+              .nullable()
+              .describe(
+                'VIS date (yyyy-MM-dd). A date means the VIS was given for this vaccine; null means it ' +
+                  'was not. Always null for "recorded" history.'
+              ),
+          })
+        )
+        .describe(
+          'One record per vaccine on the visit. Count vaccines GIVEN with status !== "recorded"; ' +
+            'the VIS gap is status !== "recorded" && visDate === null. Empty when none.'
+        ),
     }),
   },
   disposition: {

--- a/packages/utils/lib/types/adhoc/datasets/llm-schema.ts
+++ b/packages/utils/lib/types/adhoc/datasets/llm-schema.ts
@@ -1,23 +1,25 @@
-// The LLM-facing schema and its derivation from the Zod row schemas.
-//
-// Each endpoint's Zod schema is the single source of truth: it validates the response, derives the
-// TS row type, and is serialized here for the generation prompt. The model sees field names, types,
-// descriptions, and — as a field's `values` — either a closed vocabulary (z.enum members) OR, for a
-// small whitelist of code/label fields, the distinct values present in the fetched rows (see
-// sampleDomains). That per-field opt-in domain is the only path by which real values reach the
-// model; no field outside the whitelist is sampled, and full rows never leave the client.
 import { z } from 'zod';
 
-/** One serialized field as the model sees it. `values` is a closed vocabulary (z.enum members) or a
- *  whitelisted, sampled code/label domain — see the module header and sampleDomains. */
+/** A field of an 'object[]' element. One level only, so related values (a vaccine and its VIS date)
+ *  stay in one record without the shape nesting arbitrarily deep. */
+export const LlmObjectFieldSchema = z.object({
+  name: z.string(),
+  type: z.enum(['string', 'number', 'boolean', 'string[]', 'number[]']),
+  description: z.string(),
+  nullable: z.boolean().optional(),
+  values: z.array(z.string()).optional(),
+});
+export type LlmObjectFieldSchema = z.infer<typeof LlmObjectFieldSchema>;
+
 export const LlmFieldSchema = z.object({
   name: z.string(),
-  type: z.enum(['string', 'number', 'boolean', 'string[]']),
+  type: z.enum(['string', 'number', 'boolean', 'string[]', 'number[]', 'object[]']),
   description: z.string(),
   /** True when the value may be null for some rows. */
   nullable: z.boolean().optional(),
   /** Closed vocabulary (z.enum members); for 'string[]' — the allowed element values. */
   values: z.array(z.string()).optional(),
+  fields: z.array(LlmObjectFieldSchema).optional(),
 });
 export type LlmFieldSchema = z.infer<typeof LlmFieldSchema>;
 
@@ -91,6 +93,16 @@ const toLlmField = (name: string, schema: z.ZodTypeAny, domains: Record<string, 
   if (inner instanceof z.ZodEnum) return { ...base, type: 'string', values: enumValues(inner) };
   if (inner instanceof z.ZodArray) {
     const element = unwrap(inner.element as z.ZodTypeAny).inner;
+    if (element instanceof z.ZodNumber) return { ...base, type: 'number[]' };
+    if (element instanceof z.ZodObject) {
+      const fields = llmFieldsFromZodObject(element, [], domains).map((field) => {
+        if (field.type === 'object[]') {
+          throw new Error(`llm-schema: nested object[] is not supported (field "${name}.${field.name}")`);
+        }
+        return field as LlmObjectFieldSchema;
+      });
+      return { ...base, type: 'object[]', fields };
+    }
     const values = enumValues(element) ?? sampled;
     return { ...base, type: 'string[]', ...(values ? { values } : {}) };
   }

--- a/packages/utils/lib/types/adhoc/generation/infer.types.ts
+++ b/packages/utils/lib/types/adhoc/generation/infer.types.ts
@@ -3,9 +3,16 @@
 // is "produce a report" and the model substitutes a near-miss field instead of refusing.
 import { z } from 'zod';
 
+const CatalogNestedFieldSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+});
+
 const CatalogFieldSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
+  /** Members of a record column: without them the classifier cannot see e.g. vaccines.lotNumber. */
+  fields: z.array(CatalogNestedFieldSchema).optional(),
 });
 
 const CatalogLayerSchema = z.object({

--- a/packages/utils/lib/types/adhoc/generation/infer.types.ts
+++ b/packages/utils/lib/types/adhoc/generation/infer.types.ts
@@ -1,20 +1,41 @@
-// Pre-fetch classifier: which opt-in layers a request needs. Non-fatal (generate's needsLayers backfills).
+// Pre-fetch classifier, one model call: pick the layers a request needs, and reject a request asking
+// for data no dataset carries. Rejection lives here, not at generation time, because there the task
+// is "produce a report" and the model substitutes a near-miss field instead of refusing.
 import { z } from 'zod';
+
+const CatalogFieldSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+});
+
+const CatalogLayerSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  fields: z.array(CatalogFieldSchema),
+});
+
+export const CatalogDatasetSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  fields: z.array(CatalogFieldSchema),
+  layers: z.array(CatalogLayerSchema),
+});
+export type CatalogDataset = z.infer<typeof CatalogDatasetSchema>;
 
 export const InferAdHocLayersInputSchema = z.object({
   datasetId: z.string().min(1),
-  layers: z.array(
-    z.object({
-      id: z.string(),
-      label: z.string(),
-      description: z.string().optional(),
-    })
-  ),
+  // Every dataset: judging "this exists nowhere" needs the full catalogue.
+  datasets: z.array(CatalogDatasetSchema),
   request: z.string().min(1),
 });
 export type InferAdHocLayersInput = z.infer<typeof InferAdHocLayersInputSchema>;
 
 export const InferAdHocLayersOutputSchema = z.object({
   layerIds: z.array(z.string()),
+  /** Non-empty means the request is rejected. */
+  unavailable: z.array(z.string()).optional(),
+  hint: z.string().optional(),
 });
 export type InferAdHocLayersOutput = z.infer<typeof InferAdHocLayersOutputSchema>;

--- a/packages/utils/lib/types/adhoc/generation/runtime-scope.catalog.ts
+++ b/packages/utils/lib/types/adhoc/generation/runtime-scope.catalog.ts
@@ -139,12 +139,17 @@ export const REPORT_COMPONENTS = {
   },
   Table: {
     props:
-      'rows={rowsArray} columns={[{ field, label?, format? }]} links={[{ field, route, idField? }]} ' +
+      'rows={rowsArray} columns={[{ field, label?, format?, value? }]} links={[{ field, route, idField? }]} ' +
       'title="…" pageSize={25} onRowClick={fn?}',
     summary:
       'a FULL interactive data grid (sorting, filtering, a column picker, pagination) rendered inside the frame.',
     rules: [
       'columns defaults to every key of the first row — usually pass an explicit list.',
+      `column "format" is a NAME (${VALUE_FORMATS.join('|')}), never a function.`,
+      'For a column that is NOT a plain row field, either add the field to each row when you build them, or ' +
+        'pass value={(row) => …} — a "field" no row carries renders an empty cell.',
+      'A cell value that is an array or an object is rendered readably (joined, "key: value"), so a nested ' +
+        'record does not have to be flattened first.',
       'NEVER render a raw HTML <table>; always use Report.Table.',
       'onRowClick gives the clicked row (for drill-down — see PATTERNS).',
       {

--- a/packages/utils/lib/types/adhoc/llm-schema.test.ts
+++ b/packages/utils/lib/types/adhoc/llm-schema.test.ts
@@ -82,10 +82,18 @@ describe('llm-schema serialization (Zod → prompt)', () => {
       Object.fromEntries(Object.keys(ENCOUNTER_LAYER_SCHEMAS).map((id) => [id, true])),
       ENCOUNTER_INTERNAL_FIELDS
     );
-    const allowedKeys = new Set(['name', 'type', 'description', 'nullable', 'values']);
+
+    const allowedKeys = new Set(['name', 'type', 'description', 'nullable', 'values', 'fields']);
+
     for (const field of fields) {
       for (const key of Object.keys(field)) {
         expect(allowedKeys.has(key)).toBe(true);
+      }
+
+      for (const nested of field.fields ?? []) {
+        for (const key of Object.keys(nested)) {
+          expect(allowedKeys.has(key)).toBe(true);
+        }
       }
     }
   });
@@ -100,6 +108,7 @@ describe('llm-schema serialization (Zod → prompt)', () => {
       appointmentType: 'walk-in',
       serviceCategory: 'Urgent Care',
       visitStatus: 'completed',
+      statusHistory: [{ status: 'completed', start: '2026-07-01T14:00:00Z', end: null }],
       encounterType: 'main',
       reason: 'cough',
       scheduledSlotMinutes: null,

--- a/packages/utils/lib/types/adhoc/saved/saved.types.ts
+++ b/packages/utils/lib/types/adhoc/saved/saved.types.ts
@@ -5,8 +5,7 @@ import { z } from 'zod';
 // Bump when the iframe runtime contract changes incompatibly (the execution contract the generated
 // code was written against). A saved report with an older version should be regenerated from its
 // prompt rather than run against a runtime it wasn't generated for.
-// v1: Chart.js + raw DOM function body. v2: React/JSX over the bundled Report components.
-export const ADHOC_RUNTIME_VERSION = 2;
+export const ADHOC_RUNTIME_VERSION = 3;
 
 export const SavedAdHocReportCriteriaSchema = z.object({
   dateRange: z.string(),

--- a/packages/zambdas/src/ehr/generate-adhoc-report/index.ts
+++ b/packages/zambdas/src/ehr/generate-adhoc-report/index.ts
@@ -21,8 +21,6 @@ import { ZambdaInput } from '../../shared/types/common';
 import { validateOutputWithSchema } from '../../shared/validate-zod';
 import { validateRequestParameters } from './validateRequestParameters';
 
-// The browser reports runtime failures with production-React's opaque TypeErrors; translate the
-// known ones into instructions the model can act on before they go into the repair prompt.
 export const explainRuntimeError = (message: string): string => {
   if (/null \(reading 'use[A-Z]/.test(message) || /Invalid hook call/i.test(message)) {
     return (
@@ -51,9 +49,6 @@ export const explainRuntimeError = (message: string): string => {
 
 const ZAMBDA_NAME = 'generate-adhoc-report';
 
-// Vertex model used to GENERATE the report code. Code generation benefits from a stronger model than
-// the default flash-lite, so this is split out for easy tuning — bump to a larger Gemini model
-// (one provisioned in this project) to improve generated-report quality.
 const REPORT_MODEL = VERTEX_AI_MODEL;
 
 const RESPONSE_SCHEMA = {
@@ -122,6 +117,23 @@ RULES:
   visit" as "patients with follow-up encounters"). Use the real field when one exists; if you must
   approximate, the approximation MUST be disclosed prominently; if you cannot reasonably approximate,
   say the concept is not available.
+- RESPECT A FIELD'S STATED QUALIFIER. A field means exactly what its description says, including any
+  temporal qualifier. A field documented as "(most recent)" is NOT the initial/first value, and a
+  field documented as the FIRST charting is NOT the latest. If the request asks for a first/initial
+  (or latest/final) value, use the field whose description says so; if no such field exists, treat the
+  request as unavailable per the rules above. NEVER relabel a field to match the wording of the
+  request.
+- A COUNT OF POPULATED COLUMNS IS NOT A COUNT OF EVENTS. Do not answer "how many X were done" by
+  counting how many fields on the row are non-null, or by counting rows when a row is not one X.
+  Only use a field that explicitly counts the thing asked about; otherwise report it as unavailable.
+- WHEN SOMETHING IS UNAVAILABLE, SAY IT WHERE IT CANNOT BE MISSED: render a Report.Note with
+  tone="warn" at the TOP of the report naming the requested metric and why it is not available. Never
+  bury it in a caption, and never emit a plausible-looking number (e.g. 0 or a repeated constant) in
+  its place — a wrong number that looks right is the worst possible outcome.
+- DISCLOSE THE RULES YOU APPLIED. Whenever you classify values (abnormal/critical/high/low/on-time,
+  etc.), state the exact thresholds in the report (a Report.Note is fine), because the reader cannot
+  otherwise tell what the flags mean. If the thresholds are not age-adjusted but the population
+  includes children, say so explicitly — adult vital-sign cutoffs misclassify pediatric patients.
 - AUTO-LOAD MISSING LAYERS — DON'T tell the user to enable anything. The schema may include
   "availableLayers" (opt-in data layers that EXIST but are NOT loaded; each has id/label/description)
   and "otherDatasets". When the requested concept is not in "fields" but clearly matches an

--- a/packages/zambdas/src/ehr/infer-adhoc-report-layers/index.ts
+++ b/packages/zambdas/src/ehr/infer-adhoc-report-layers/index.ts
@@ -1,6 +1,10 @@
 import { captureException } from '@sentry/aws-serverless';
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { InferAdHocLayersOutput, InferAdHocLayersOutputSchema } from 'utils/lib/types/adhoc/generation/infer.types';
+import {
+  CatalogDataset,
+  InferAdHocLayersOutput,
+  InferAdHocLayersOutputSchema,
+} from 'utils/lib/types/adhoc/generation/infer.types';
 import { AD_HOC_REPORT_EDIT_ROLES } from 'utils/lib/types/api/adhoc-report-access';
 import { fixAndParseJsonObjectFromString } from 'utils/lib/validation/json-fix';
 import { invokeChatbotVertexAI, VERTEX_AI_MODEL } from '../../shared/ai';
@@ -12,71 +16,150 @@ import { validateRequestParameters } from './validateRequestParameters';
 
 const ZAMBDA_NAME = 'infer-adhoc-report-layers';
 
-// A cheap pre-fetch classifier: given the opt-in data layers a dataset can load and a plain-language
-// report request, return ONLY the layer ids whose data the request actually needs. The client fetches
-// exactly those, so the heavy clinical layers are pulled on demand — no checkboxes, no over-fetching.
-// Failure is non-fatal upstream: the generate step's `needsLayers` still backfills any layer this miss.
+// A cheap pre-fetch classifier with two jobs in one call: pick the opt-in layers a request needs, and
+// reject a request that asks for data no dataset holds. The rejection lives here rather than at
+// generation time because there the model's task is "produce a report", so it tends to substitute a
+// near-miss field (attending provider for referring provider) instead of refusing. Picking layers is
+// a classification task, where "nothing covers this" is an ordinary answer.
 const RESPONSE_SCHEMA = {
   type: 'object',
   properties: {
     layerIds: { type: 'array', items: { type: 'string' } },
+    unavailable: { type: 'array', items: { type: 'string' } },
+    hint: { type: 'string' },
   },
-  required: ['layerIds'],
+  // "hint" is required so the model always writes one when it rejects; it is dropped below when
+  // nothing was rejected. Marking it optional made the model skip it exactly when it was needed.
+  required: ['layerIds', 'hint'],
 };
 
-const buildPrompt = (layers: { id: string; label: string; description?: string }[], request: string): string => {
+const renderFields = (fields: { name: string; description?: string }[], indent: string): string =>
+  fields.length === 0
+    ? `${indent}(none)`
+    : fields.map((f) => `${indent}- ${f.name}${f.description ? `: ${f.description}` : ''}`).join('\n');
+
+const renderCatalog = (datasets: CatalogDataset[], activeId: string): string =>
+  datasets
+    .map((dataset) => {
+      const head = `${dataset.id === activeId ? '* ' : '  '}DATASET ${dataset.id}: ${dataset.label}`;
+      const base = `    ALWAYS-PRESENT FIELDS:\n${renderFields(dataset.fields, '      ')}`;
+      const layers = dataset.layers.map(
+        (layer) =>
+          `    LAYER ${layer.id}: ${layer.label}${layer.description ? ` — ${layer.description}` : ''}\n` +
+          `${renderFields(layer.fields, '      ')}`
+      );
+      return [head, base, ...layers].join('\n');
+    })
+    .join('\n\n');
+
+const buildPrompt = (activeId: string, datasets: CatalogDataset[], request: string): string => {
   return `
-You select which optional DATA LAYERS to load for a clinical ad-hoc report, BEFORE the data is fetched.
+You prepare a clinical ad-hoc report BEFORE any data is fetched. You do two things.
 
-Each layer adds extra columns (and a heavier fetch) to a base dataset. Given the user's report request,
-return the ids of ONLY the layers whose data the report genuinely needs — the minimal set. The base
-dataset already includes visit, patient, location/provider, and registration fields, so do NOT request
-a layer for those. When in doubt about whether a borderline layer is needed, LEAVE IT OUT — a later
-step can still pull a missing layer on demand. Loading an unneeded layer only makes the fetch slower.
+JOB 1 — PICK THE LAYERS. Optional layers add columns (and a heavier fetch) to the active dataset,
+marked "*" below. Return the ids of ONLY the layers the request genuinely needs — the minimal set.
+Base fields are always present, so never request a layer for those. When a borderline layer is
+doubtful, LEAVE IT OUT: a later step can still pull a missing layer on demand.
 
-AVAILABLE LAYERS (choose ids from this list only):
-${layers.map((l) => `- ${l.id}: ${l.label}${l.description ? ` — ${l.description}` : ''}`).join('\n')}
+JOB 2 — REJECT WHAT THE DATA CANNOT ANSWER. List in "unavailable" every concept the request asks for
+that NO dataset holds — not in the active dataset, not in any other, not in any layer.
+
+REJECTING IS A LAST RESORT. It blocks the whole report, so a wrong rejection is worse than loading an
+unnecessary layer. Reject ONLY a fact that nobody recorded. Apply these tests in order, and stop at
+the first one that says AVAILABLE:
+
+TEST 1 — MEANING, NOT WORDING. Requests are written in everyday clinical language, never in field
+names. Match on what a field MEANS, per its description, not on how it is spelled. "Chief complaint"
+is the reason for the visit; "how long the visit took" is a duration field; "payer" is the insurance
+plan. If a field's description means the requested thing, it is AVAILABLE — no matter how differently
+it is named.
+
+TEST 2 — CAN IT BE COMPUTED? A metric does not need a field of its own. If it can be calculated from
+fields that exist, it is AVAILABLE: differences between dates, gaps between one patient's visits,
+counts, rates, averages, ordering, direction of change, "within N days", "first vs last". Computing
+is exactly the report's job. DECISIVE CHECK: if you could name a field the answer could be derived
+from, then it is AVAILABLE and you MUST NOT reject it — naming such a field and rejecting anyway is
+a contradiction.
+
+TEST 3 — IS IT ONLY PRESENTATION? Charts, tables, sorting, highlighting, colours and layout are never
+"unavailable". Filtering and grouping count as presentation ONLY when the thing filtered or grouped
+on passed test 1 or 2 — "by location" is fine because a location field exists. A filter on something
+nobody records ("excluding high-risk patients", "only patients with an interpreter") is a MISSING
+FACT, not presentation: judge it exactly as if it had been asked for as a column.
+
+ONLY THEN REJECT — and only for a NEAR MATCH or a MISSING RECORDED FACT. A field naming a different
+thing does not cover the request: "attending provider" is not "referring provider", a marketing
+"source" is not a referral source, a "most recent" value is not an initial one. Likewise reject an
+attribute nobody charts here at all (a pain score, a triage acuity level, an employer). Never let the
+report substitute one of these for the other.
+
+So: reject only when, after all three tests, the request needs a fact that is neither recorded in any
+dataset nor computable from what is recorded.
+
+Always return "hint". When "unavailable" is not empty it is one short sentence saying WHY the fact
+isn't recorded, and naming the closest real field only to contrast it — "The attending provider (who
+saw the patient) is recorded, but not who referred them." If nothing comes close, say so plainly:
+"No field records this." If you find yourself writing that a field "could be used to derive" the
+answer, then it IS available: drop the rejection and return the layers instead. Name real fields
+only, from the catalogue. Do not apologise and do not restate the request. When "unavailable" is
+empty, return an empty string for "hint".
+
+CATALOGUE (every dataset; "*" marks the active one):
+${renderCatalog(datasets, activeId)}
 
 USER REQUEST:
 """
 ${request}
 """
 
-Return JSON: { "layerIds": ["<id>", ...] }  — an empty array if no optional layer is needed.
+Return JSON: { "layerIds": ["<id>", ...], "unavailable": ["<concept>", ...], "hint": "<one sentence>" }
+"layerIds" is an empty array when no optional layer is needed. Omit "unavailable" and "hint" when
+every requested concept exists. Use ONLY layer ids from the active dataset.
 `;
 };
 
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
-  const { layers, request, secrets } = validateRequestParameters(input);
+  const { datasetId, datasets, request, secrets } = validateRequestParameters(input);
 
   await requireUserWithRole(getUserToken(input), secrets, AD_HOC_REPORT_EDIT_ROLES);
 
-  const validIds = new Set(layers.map((l) => l.id));
+  const activeLayers = datasets.find((d) => d.id === datasetId)?.layers ?? [];
+  const validIds = new Set(activeLayers.map((l) => l.id));
   let layerIds: string[] = [];
+  let unavailable: string[] = [];
+  let hint: string | undefined;
 
-  // Best-effort: a malformed/empty model response just yields no layers — the generate step's
-  // needsLayers backfill is the safety net, so we never hard-fail the report on a classifier miss.
   try {
     const raw = await invokeChatbotVertexAI(
-      [{ text: buildPrompt(layers, request) }],
+      [{ text: buildPrompt(datasetId, datasets, request) }],
       secrets,
       RESPONSE_SCHEMA,
       VERTEX_AI_MODEL
     );
-    const parsed = fixAndParseJsonObjectFromString(raw) as { layerIds?: unknown };
+    const parsed = fixAndParseJsonObjectFromString(raw) as {
+      layerIds?: unknown;
+      unavailable?: unknown;
+      hint?: unknown;
+    };
     if (Array.isArray(parsed?.layerIds)) {
       layerIds = parsed.layerIds.filter((id): id is string => typeof id === 'string' && validIds.has(id));
     }
+    if (Array.isArray(parsed?.unavailable)) {
+      unavailable = parsed.unavailable.filter((c): c is string => typeof c === 'string' && c.trim().length > 0);
+    }
+    if (typeof parsed?.hint === 'string' && parsed.hint.trim()) hint = parsed.hint.trim();
   } catch (e) {
-    // Designed degradation (the report proceeds with no pre-selected layers), but the failure must
-    // still surface so a persistent classifier problem doesn't go unnoticed.
     console.warn('infer-adhoc-report-layers: inference failed, returning no layers', e);
     captureException(e);
   }
 
   const output: InferAdHocLayersOutput = validateOutputWithSchema(
     InferAdHocLayersOutputSchema,
-    { layerIds: Array.from(new Set(layerIds)) },
+    {
+      layerIds: Array.from(new Set(layerIds)),
+      ...(unavailable.length ? { unavailable: Array.from(new Set(unavailable)) } : {}),
+      ...(unavailable.length && hint ? { hint } : {}),
+    },
     ZAMBDA_NAME
   );
   return { statusCode: 200, body: JSON.stringify(output) };

--- a/packages/zambdas/src/ehr/infer-adhoc-report-layers/index.ts
+++ b/packages/zambdas/src/ehr/infer-adhoc-report-layers/index.ts
@@ -33,10 +33,23 @@ const RESPONSE_SCHEMA = {
   required: ['layerIds', 'hint'],
 };
 
-const renderFields = (fields: { name: string; description?: string }[], indent: string): string =>
+type CatalogField = { name: string; description?: string; fields?: { name: string; description?: string }[] };
+
+// A record column's members are listed under it: "lot number" lives on vaccines[].lotNumber, and a
+// catalogue that showed only the column name made the classifier reject it as missing.
+const renderFields = (fields: CatalogField[], indent: string): string =>
   fields.length === 0
     ? `${indent}(none)`
-    : fields.map((f) => `${indent}- ${f.name}${f.description ? `: ${f.description}` : ''}`).join('\n');
+    : fields
+        .map((f) => {
+          const head = `${indent}- ${f.name}${f.description ? `: ${f.description}` : ''}`;
+          if (!f.fields?.length) return head;
+          const members = f.fields
+            .map((m) => `${indent}    ${f.name}[].${m.name}${m.description ? `: ${m.description}` : ''}`)
+            .join('\n');
+          return `${head}\n${members}`;
+        })
+        .join('\n');
 
 const renderCatalog = (datasets: CatalogDataset[], activeId: string): string =>
   datasets

--- a/packages/zambdas/src/shared/adhoc-datasets/billing.ts
+++ b/packages/zambdas/src/shared/adhoc-datasets/billing.ts
@@ -240,6 +240,15 @@ export async function fetchAdHocBillingRows(oystehr: Oystehr, params: AdHocBilli
       row.paymentMethods = methods;
       // RAW ISO instant of the latest payment (client-side becomes the viewer-local day).
       row.lastPaymentDate = dates.length ? dates[dates.length - 1] : null;
+      // Same raw ISO instants as lastPaymentDate — one format for every date in this layer.
+      row.payments = notices
+        .filter((n) => n.created)
+        .map((n) => ({
+          date: n.created!,
+          amount: round2(n.amount?.value ?? 0),
+          method: n.extension?.find((e) => e.url === PAYMENT_METHOD_EXTENSION_URL)?.valueString ?? '',
+        }))
+        .sort((a, b) => a.date.localeCompare(b.date));
     }
 
     if (includeCoverage) {

--- a/packages/zambdas/src/shared/adhoc-datasets/encounters.ts
+++ b/packages/zambdas/src/shared/adhoc-datasets/encounters.ts
@@ -32,10 +32,14 @@ import {
   mapGenderToLabel,
 } from 'utils/lib/fhir/patient';
 import { isInHouseLabServiceRequest } from 'utils/lib/helpers/in-house-labs';
+import { getVitalDTOCriticalityFromObservation } from 'utils/lib/helpers/vitals/utils';
+import { celsiusToFahrenheit, roundTemperatureValue } from 'utils/lib/helpers/vitals/vitals-temperature.helper';
 import { AdHocEncounterRow, AdHocEncountersInput } from 'utils/lib/types/adhoc/datasets/encounters';
+import { VitalAlertCriticality, VitalFieldNames } from 'utils/lib/types/api/chart-data/chart-data.constants';
 import {
   MEDICATION_ADMINISTRATION_IN_PERSON_RESOURCE_CODE,
   MEDICATION_DISPENSABLE_DRUG_ID,
+  VACCINE_ADMINISTRATION_VIS_DATE_EXTENSION_URL,
 } from 'utils/lib/types/api/medication-administration.constants';
 import { CREATED_BY_SYSTEM } from 'utils/lib/types/common';
 import { PATIENT_POINT_OF_DISCOVERY_URL } from 'utils/lib/types/constants';
@@ -49,9 +53,6 @@ import {
 } from '../adhoc-report';
 import { followUpTypeFromPerformerType } from '../chart-data';
 
-// Registrar full names, keyed by lowercase staff login email. Built once per warm container from the
-// IAM user list (email -> Practitioner profile -> name) — the same mapping the admin Employees page
-// uses. Cached because it's stable and the lookup (user.list + Practitioner names) is not free.
 let staffNameByEmail: Map<string, string> | undefined;
 
 async function getStaffNameByEmail(oystehr: Oystehr): Promise<Map<string, string>> {
@@ -88,13 +89,8 @@ async function getStaffNameByEmail(oystehr: Oystehr): Promise<Map<string, string
       const nm = nameById.get(pid);
       if (nm) map.set(email, nm);
     }
-    // Cache ONLY on success. A transient user.list/Practitioner failure must not poison every
-    // subsequent warm invocation with an empty map (which would silently fall registrar names back
-    // to raw emails until a cold start) — leaving it uncached lets the next call retry.
     staffNameByEmail = map;
   } catch (e) {
-    // Designed degradation (rows fall back to the raw registrar email), but the failure itself is
-    // still worth surfacing so a persistent IAM/Practitioner problem doesn't go unnoticed.
     console.warn('adhoc-encounters: registrar name resolution failed, falling back to email', e);
     captureException(e);
   }
@@ -107,9 +103,6 @@ const minutesBetween = (start?: string, end?: string): number | null => {
   return Number.isFinite(m) ? m : null;
 };
 
-// Normalize a prescribed-drug display to its base ingredient by dropping the strength/form tail
-// (everything from the first digit on): "Amoxicillin 500 mg tablet" -> "Amoxicillin". Lets a report
-// count "each drug" at ingredient grain instead of splitting one drug across strengths/forms.
 const normalizeDrugName = (display: string): string => {
   const base = display
     .split(/\s+\d/)[0]
@@ -119,24 +112,30 @@ const normalizeDrugName = (display: string): string => {
 };
 
 const round1 = (n: number): number => Math.round(n * 10) / 10;
-// Component codes used for blood-pressure (SNOMED + LOINC variants).
 const SYSTOLIC_CODES = ['271649006', '8480-6'];
 const DIASTOLIC_CODES = ['271650006', '8462-4'];
 
+const VITAL_ALERT_FIELDS: Record<string, string> = {
+  [VitalFieldNames.VitalTemperature]: 'temperatureF',
+  [VitalFieldNames.VitalHeartbeat]: 'heartRate',
+  [VitalFieldNames.VitalRespirationRate]: 'respirationRate',
+  [VitalFieldNames.VitalOxygenSaturation]: 'oxygenSaturation',
+  [VitalFieldNames.VitalBloodPressure]: 'bloodPressure',
+  [VitalFieldNames.VitalWeight]: 'weightKg',
+  [VitalFieldNames.VitalHeight]: 'heightCm',
+};
+
 const isActiveOrder = (sr: ServiceRequest): boolean => sr.status !== 'revoked' && sr.status !== 'entered-in-error';
-// A lab order: carries an Oystehr lab local code, an in-house lab test code, or a lab order-type tag.
+
 const isLabOrder = (sr: ServiceRequest): boolean =>
   Boolean(sr.code?.coding?.some((c) => c.system?.includes('oystehr-lab-local-codes'))) ||
   isInHouseLabServiceRequest(sr) ||
   Boolean(sr.meta?.tag?.some((t) => t.code === 'generic-lab-order' || t.code === 'in-house-lab' || t.code === 'lab'));
-// A radiology/imaging order: tagged radiology.
+
 const isImagingOrder = (sr: ServiceRequest): boolean => Boolean(sr.meta?.tag?.some((t) => t.code === 'radiology'));
 const orderDisplay = (sr: ServiceRequest): string =>
   sr.code?.text || sr.code?.coding?.find((c) => c.display)?.display || sr.code?.coding?.[0]?.code || '';
 
-// The full fetch+map pipeline, separated from auth/transport so fixture tests can run it against a
-// stubbed Oystehr client and assert the mapped rows parse with the endpoint's Zod schema — the same
-// schema the runtime output validation uses.
 export async function fetchAdHocEncounterRows(
   oystehr: Oystehr,
   params: AdHocEncountersInput
@@ -213,7 +212,7 @@ export async function fetchAdHocEncounterRows(
   // the encounter ids from the main pass, each as its own async-bulk job (no response-size cap).
   const encIds = Array.from(encounterById.keys());
   const encRefs = encIds.map((id) => `Encounter/${id}`);
-  // Per-encounter layer resources are fetched via the shared async-bulk scoped helper.
+
   const fetchScoped = <T extends FhirResource>(
     resourceType: T['resourceType'],
     paramName: string,
@@ -247,7 +246,6 @@ export async function fetchAdHocEncounterRows(
       );
     }
     if (includeAi || includeDocuments) {
-      // Trim the attachment payload — we only need type/description/tag/context, never the file bytes.
       indexByEncounter(
         await fetchScoped<DocumentReference>('DocumentReference', 'encounter', encRefs, [
           { name: '_elements', value: 'type,description,meta,context' },
@@ -278,10 +276,22 @@ export async function fetchAdHocEncounterRows(
       );
     }
     if (includeVitals || includeExamRos || includeIntake) {
-      indexByEncounter(
-        await fetchScoped<Observation>('Observation', 'encounter', encRefs),
-        (o) => stripEnc(o.encounter?.reference),
-        observationsByEncounterId
+      const fetchedObs = await fetchScoped<Observation>('Observation', 'encounter', encRefs);
+      const tagCounts: Record<string, number> = {};
+      let withEncounterRef = 0;
+      for (const o of fetchedObs) {
+        if (o.encounter?.reference) withEncounterRef += 1;
+        const tag = o.meta?.tag?.find((t) => t.code?.startsWith('vital-'))?.code ?? '(no vital- tag)';
+        tagCounts[tag] = (tagCounts[tag] ?? 0) + 1;
+      }
+      console.log(
+        `[adhoc-vitals] encountersRequested=${encIds.length} observationsReturned=${fetchedObs.length} ` +
+          `withEncounterRef=${withEncounterRef} tags=${JSON.stringify(tagCounts)}`
+      );
+      indexByEncounter(fetchedObs, (o) => stripEnc(o.encounter?.reference), observationsByEncounterId);
+      console.log(
+        `[adhoc-vitals] encountersWithObservations=${observationsByEncounterId.size} ` +
+          `sampleEncounterIds=${JSON.stringify(Array.from(observationsByEncounterId.keys()).slice(0, 3))}`
       );
     }
     if (includeLabs || includeImaging || includeDisposition || includeNursing) {
@@ -316,9 +326,8 @@ export async function fetchAdHocEncounterRows(
     resolveEncounterAppointment(encounter, appointmentMap, encounterById);
 
   const staffNames = await getStaffNameByEmail(oystehr);
-  // Memoized per location: getTimezone logs (and falls back) when a Location is missing its
-  // timezone extension, and we don't want that once per row.
   const tzByLocationId = new Map<string, string>();
+
   const timezoneForLocation = (loc: Location): string => {
     const key = loc.id ?? '';
     let tz = tzByLocationId.get(key);
@@ -329,9 +338,7 @@ export async function fetchAdHocEncounterRows(
     return tz;
   };
   const rows: AdHocEncounterRow[] = [];
-  // Iterate the id-deduped map, not the raw filter array: an encounter revincluded via both
-  // Encounter:appointment and Encounter:part-of appears twice in `encounters` and would emit
-  // duplicate rows.
+
   for (const encounter of encounterById.values()) {
     const appointment = resolveAppointment(encounter);
     if (!appointment) continue;
@@ -350,25 +357,22 @@ export async function fetchAdHocEncounterRows(
       start,
     } = buildEncounterRowContext(encounter, appointment, { encounterById, patientMap, locationMap, practitionerMap });
 
-    // Hours the clinic is open on this visit's weekday (Location.hoursOfOperation). The weekday is
-    // resolved in the LOCATION'S OWN timezone — hours-of-operation are clinic-local, so the clinic's
-    // zone (not the server's, and not any fixed practice zone) decides which day the visit fell on.
     let clinicOpenHours: number | null = null;
+
     const weekday =
       start && location
         ? DateTime.fromISO(start).setZone(timezoneForLocation(location)).toFormat('ccc').toLowerCase()
         : '';
+
     for (const h of location?.hoursOfOperation ?? []) {
       if (!weekday || !h.daysOfWeek?.includes(weekday as never) || !h.openingTime || !h.closingTime) continue;
       const hrs = DateTime.fromFormat(h.closingTime, 'HH:mm:ss').diff(
         DateTime.fromFormat(h.openingTime, 'HH:mm:ss'),
         'hours'
       ).hours;
-      // Skip malformed/overnight spans (close before open) so they don't corrupt the sum.
       if (Number.isFinite(hrs) && hrs > 0) clinicOpenHours = (clinicOpenHours ?? 0) + hrs;
     }
 
-    // Registration channel + registrar from the appointment's created-by tag.
     const createdBy = appointment.meta?.tag?.find((t) => t.system === CREATED_BY_SYSTEM)?.display ?? '';
     const registrationChannel = createdBy.startsWith('Staff')
       ? 'Staff'
@@ -399,6 +403,11 @@ export async function fetchAdHocEncounterRows(
       appointmentType: appointmentTypeForAppointment(appointment),
       serviceCategory,
       visitStatus,
+      statusHistory: getVisitStatusHistory(encounter).map((entry) => ({
+        status: entry.status,
+        start: entry.period.start ?? null,
+        end: entry.period.end ?? null,
+      })),
       encounterType,
       reason: encounter.reasonCode?.[0]?.text || appointment.appointmentType?.text || '',
       scheduledSlotMinutes: minutesBetween(appointment.start, appointment.end),
@@ -490,7 +499,7 @@ export async function fetchAdHocEncounterRows(
       row.intakeToProviderMinutes = minutesBetween(intake, provider);
       row.providerToDischargedMinutes = minutesBetween(provider, discharged);
       row.totalCycleMinutes = minutesBetween(arrived, discharged);
-      // On-time only meaningful for pre-booked visits: arrived at/ before the scheduled start.
+
       row.onTime =
         appointmentTypeForAppointment(appointment) === 'pre-booked' && arrived && appointment.start
           ? DateTime.fromISO(arrived) <= DateTime.fromISO(appointment.start)
@@ -523,8 +532,7 @@ export async function fetchAdHocEncounterRows(
         medicationSources.push(source);
         if (code) medicationCodes.push(code);
       };
-      // eRx prescriptions (MedicationRequest, drug on medicationCodeableConcept). All statuses except
-      // entered-in-error (FHIR's "this record was a mistake" tombstone).
+
       for (const req of encounter.id ? medRequestsByEncounterId.get(encounter.id) ?? [] : []) {
         if (req.status === 'entered-in-error') continue;
         const coding = (req.medicationCodeableConcept?.coding ?? []).find(
@@ -532,8 +540,7 @@ export async function fetchAdHocEncounterRows(
         );
         addMed(coding?.display || req.medicationCodeableConcept?.text || '', 'eRx', coding?.code);
       }
-      // In-house administered meds (MedicationAdministration / MAR; drug on a contained Medication).
-      // Only the in-house-medication tag — vaccines (immunization tag) belong to the immunizations layer.
+
       for (const ma of encounter.id ? medAdminsByEncounterId.get(encounter.id) ?? [] : []) {
         if (ma.status === 'entered-in-error') continue;
         if (!hasChartTag(ma, MEDICATION_ADMINISTRATION_IN_PERSON_RESOURCE_CODE)) continue;
@@ -553,38 +560,67 @@ export async function fetchAdHocEncounterRows(
 
     if (includeVitals) {
       const obs = encounter.id ? observationsByEncounterId.get(encounter.id) ?? [] : [];
-      // Last charted value wins per vital field. FHIR search order is not chronological, so sort by
-      // effectiveDateTime (set to the charting instant by makeObservationResource) before taking the last.
       const fieldCode = (o: Observation): string => o.meta?.tag?.find((t) => t.code?.startsWith('vital-'))?.code ?? '';
       const effectiveMillis = (o: Observation): number => {
         const ms = o.effectiveDateTime ? DateTime.fromISO(o.effectiveDateTime).toMillis() : NaN;
         return Number.isFinite(ms) ? ms : 0;
       };
-      const latest = (field: string): Observation | undefined =>
-        obs
-          .filter((o) => fieldCode(o) === field)
-          .sort((a, b) => effectiveMillis(a) - effectiveMillis(b))
-          .at(-1);
+
+      const chronological = (field: string): Observation[] =>
+        obs.filter((o) => fieldCode(o) === field).sort((a, b) => effectiveMillis(a) - effectiveMillis(b));
+
+      const latest = (field: string): Observation | undefined => chronological(field).at(-1);
+
       const qty = (o?: Observation): number | null =>
         typeof o?.valueQuantity?.value === 'number' ? o.valueQuantity.value : null;
 
-      const tempObs = latest('vital-temperature');
-      const tempVal = qty(tempObs);
-      const tempUnit = (tempObs?.valueQuantity?.unit || tempObs?.valueQuantity?.code || '').toUpperCase();
-      row.temperatureF =
-        tempVal == null ? null : tempUnit.startsWith('F') ? round1(tempVal) : round1((tempVal * 9) / 5 + 32);
+      const toF = (o?: Observation): number | null => {
+        const val = qty(o);
+        if (val == null) return null;
+        const unit = (o?.valueQuantity?.unit || o?.valueQuantity?.code || '').toUpperCase();
+        return roundTemperatureValue(unit.startsWith('F') ? val : celsiusToFahrenheit(val));
+      };
+
+      row.temperatureF = toF(latest('vital-temperature'));
 
       row.heartRate = qty(latest('vital-heartbeat'));
       row.respirationRate = qty(latest('vital-respiration-rate'));
       row.oxygenSaturation = qty(latest('vital-oxygen-sat'));
 
-      const bp = latest('vital-blood-pressure');
-      const bpComp = (codes: string[]): number | null => {
-        const c = bp?.component?.find((cm) => cm.code?.coding?.some((cd) => cd.code && codes.includes(cd.code)));
+      const bpComp = (bpObs: Observation | undefined, codes: string[]): number | null => {
+        const c = bpObs?.component?.find((cm) => cm.code?.coding?.some((cd) => cd.code && codes.includes(cd.code)));
         return typeof c?.valueQuantity?.value === 'number' ? c.valueQuantity.value : null;
       };
-      row.systolicBP = bpComp(SYSTOLIC_CODES);
-      row.diastolicBP = bpComp(DIASTOLIC_CODES);
+      const bp = latest('vital-blood-pressure');
+      row.systolicBP = bpComp(bp, SYSTOLIC_CODES);
+      row.diastolicBP = bpComp(bp, DIASTOLIC_CODES);
+
+      const numbers = (values: (number | null)[]): number[] => values.filter((v): v is number => v != null);
+      row.temperatureFReadings = numbers(chronological('vital-temperature').map(toF));
+      row.heartRateReadings = numbers(chronological('vital-heartbeat').map(qty));
+      row.respirationRateReadings = numbers(chronological('vital-respiration-rate').map(qty));
+      row.oxygenSaturationReadings = numbers(chronological('vital-oxygen-sat').map(qty));
+
+      const bpPairs = chronological('vital-blood-pressure')
+        .map((o) => ({ systolic: bpComp(o, SYSTOLIC_CODES), diastolic: bpComp(o, DIASTOLIC_CODES) }))
+        .filter((pair): pair is { systolic: number; diastolic: number } => {
+          return pair.systolic != null && pair.diastolic != null;
+        });
+
+      row.systolicBPReadings = bpPairs.map((pair) => pair.systolic);
+      row.diastolicBPReadings = bpPairs.map((pair) => pair.diastolic);
+
+      const abnormalVitals: string[] = [];
+      const criticalVitals: string[] = [];
+
+      for (const [field, name] of Object.entries(VITAL_ALERT_FIELDS)) {
+        const levels = chronological(field).map((o) => getVitalDTOCriticalityFromObservation(o));
+        if (levels.some((level) => level != null)) abnormalVitals.push(name);
+        if (levels.includes(VitalAlertCriticality.Critical)) criticalVitals.push(name);
+      }
+
+      row.abnormalVitals = abnormalVitals;
+      row.criticalVitals = criticalVitals;
 
       const weightObs = latest('vital-weight');
       const weightVal = qty(weightObs);
@@ -623,11 +659,6 @@ export async function fetchAdHocEncounterRows(
         row.nursingOrderCount = nursingOrders.length;
       }
       if (includeDisposition) {
-        // The 'disposition-follow-up' SR only carries the generic "Follow-up visit (procedure)" code.
-        // The actual follow-up items are separate SRs tagged 'sub-follow-up' whose type is encoded in
-        // performerType (see save-chart-data): a SNOMED coding for the coded types, text-only for
-        // 'other'/'lurie-ct'. Reverse-map via followUpTypeFromPerformerType, then render the same human
-        // label the disposition UI uses (dispositionCheckboxOptions).
         const followUpTypes = srs
           .filter((sr) => hasChartTag(sr, 'sub-follow-up'))
           .map((sr) => {
@@ -646,18 +677,35 @@ export async function fetchAdHocEncounterRows(
     }
 
     if (includeImmunizations) {
-      const immunizations: string[] = [];
+      type VaccineRecord = {
+        name: string;
+        status: 'administered' | 'partially-administered' | 'recorded';
+        visDate: string | null;
+      };
+
+      const vaccines: VaccineRecord[] = [];
+
       for (const ma of encounter.id ? medAdminsByEncounterId.get(encounter.id) ?? [] : []) {
-        // Only vaccines actually given. Per mapFhirToOrderStatus (utils/lib/fhir/medication-administration.ts):
-        // completed=administered, on-hold=partially administered (still given), while in-progress=pending order,
-        // not-done=refused/not administered, stopped=cancelled — none of those belong in "vaccines given".
-        if ((ma.status !== 'completed' && ma.status !== 'on-hold') || !hasChartTag(ma, 'immunization')) continue;
+        if (!hasChartTag(ma, 'immunization')) continue;
+
+        const status =
+          ma.status === 'completed' ? 'administered' : ma.status === 'on-hold' ? 'partially-administered' : undefined;
+
+        if (!status) continue;
+
+        const medication = getMedicationFromMA(ma);
+
         const name =
-          getMedicationName(getMedicationFromMA(ma)) ||
+          getMedicationName(medication) ||
           ma.medicationCodeableConcept?.coding?.[0]?.display ||
           ma.medicationCodeableConcept?.text ||
           '';
-        if (name) immunizations.push(name);
+        if (!name) continue;
+
+        const visDate = medication?.extension?.find((e) => e.url === VACCINE_ADMINISTRATION_VIS_DATE_EXTENSION_URL)
+          ?.valueDate;
+
+        vaccines.push({ name, status, visDate: visDate ?? null });
       }
       for (const ms of encounter.id ? medStatementsByEncounterId.get(encounter.id) ?? [] : []) {
         if (ms.status === 'entered-in-error' || !hasChartTag(ms, 'immunization')) continue;
@@ -667,10 +715,10 @@ export async function fetchAdHocEncounterRows(
           ms.medicationCodeableConcept?.text ||
           getMedicationName(containedMed) ||
           '';
-        if (name) immunizations.push(name);
+        // Charted history, not an administration on this visit, so it never carries a VIS.
+        if (name) vaccines.push({ name, status: 'recorded', visDate: null });
       }
-      row.immunizations = immunizations;
-      row.immunizationCount = immunizations.length;
+      row.vaccines = vaccines;
     }
 
     if (includeExamRos) {

--- a/packages/zambdas/src/shared/adhoc-datasets/encounters.ts
+++ b/packages/zambdas/src/shared/adhoc-datasets/encounters.ts
@@ -23,7 +23,12 @@ import { DateTime } from 'luxon';
 import { appointmentTypeForAppointment } from 'utils/lib/fhir/appointments';
 import { DOCUMENT_REFERENCE_SUMMARY_FROM_AUDIO, DOCUMENT_REFERENCE_SUMMARY_FROM_CHAT } from 'utils/lib/fhir/constants';
 import { dispositionCheckboxOptions } from 'utils/lib/fhir/disposition';
-import { getMedicationFromMA, getMedicationName } from 'utils/lib/fhir/medication-administration';
+import {
+  getDosageUnitsAndRouteOfMedication,
+  getMedicationFromMA,
+  getMedicationName,
+  getNdcCodeFromMedication,
+} from 'utils/lib/fhir/medication-administration';
 import {
   getEmailForIndividual,
   getPatientFirstName,
@@ -112,6 +117,11 @@ const normalizeDrugName = (display: string): string => {
 };
 
 const round1 = (n: number): number => Math.round(n * 10) / 10;
+
+// Medication.batch.expirationDate is a FHIR dateTime and the app writes a full instant with the
+// entry device's offset. An expiry is a calendar date, so take the date AS WRITTEN — converting the
+// zone would move "2026-07-29T00:00:00.000+04:00" back to the 28th and report a wrong expiry.
+const expiryDate = (value?: string): string | null => value?.slice(0, 10) ?? null;
 const SYSTOLIC_CODES = ['271649006', '8480-6'];
 const DIASTOLIC_CODES = ['271650006', '8462-4'];
 
@@ -276,22 +286,10 @@ export async function fetchAdHocEncounterRows(
       );
     }
     if (includeVitals || includeExamRos || includeIntake) {
-      const fetchedObs = await fetchScoped<Observation>('Observation', 'encounter', encRefs);
-      const tagCounts: Record<string, number> = {};
-      let withEncounterRef = 0;
-      for (const o of fetchedObs) {
-        if (o.encounter?.reference) withEncounterRef += 1;
-        const tag = o.meta?.tag?.find((t) => t.code?.startsWith('vital-'))?.code ?? '(no vital- tag)';
-        tagCounts[tag] = (tagCounts[tag] ?? 0) + 1;
-      }
-      console.log(
-        `[adhoc-vitals] encountersRequested=${encIds.length} observationsReturned=${fetchedObs.length} ` +
-          `withEncounterRef=${withEncounterRef} tags=${JSON.stringify(tagCounts)}`
-      );
-      indexByEncounter(fetchedObs, (o) => stripEnc(o.encounter?.reference), observationsByEncounterId);
-      console.log(
-        `[adhoc-vitals] encountersWithObservations=${observationsByEncounterId.size} ` +
-          `sampleEncounterIds=${JSON.stringify(Array.from(observationsByEncounterId.keys()).slice(0, 3))}`
+      indexByEncounter(
+        await fetchScoped<Observation>('Observation', 'encounter', encRefs),
+        (o) => stripEnc(o.encounter?.reference),
+        observationsByEncounterId
       );
     }
     if (includeLabs || includeImaging || includeDisposition || includeNursing) {
@@ -525,12 +523,30 @@ export async function fetchAdHocEncounterRows(
       const medicationIngredients: string[] = [];
       const medicationSources: ('eRx' | 'in-house')[] = [];
       const medicationCodes: string[] = [];
-      const addMed = (display: string, source: 'eRx' | 'in-house', code?: string): void => {
+      const drugs: NonNullable<AdHocEncounterRow['drugs']> = [];
+      const addMed = (
+        display: string,
+        source: 'eRx' | 'in-house',
+        code?: string,
+        detail?: Omit<NonNullable<AdHocEncounterRow['drugs']>[number], 'name' | 'source'>
+      ): void => {
         if (!display) return;
         medications.push(display);
         medicationIngredients.push(normalizeDrugName(display));
         medicationSources.push(source);
         if (code) medicationCodes.push(code);
+        drugs.push({
+          name: display,
+          source,
+          dose: detail?.dose ?? null,
+          units: detail?.units ?? null,
+          route: detail?.route ?? null,
+          ndc: detail?.ndc ?? null,
+          lotNumber: detail?.lotNumber ?? null,
+          expirationDate: detail?.expirationDate ?? null,
+          manufacturer: detail?.manufacturer ?? null,
+          administeredAt: detail?.administeredAt ?? null,
+        });
       };
 
       for (const req of encounter.id ? medRequestsByEncounterId.get(encounter.id) ?? [] : []) {
@@ -544,18 +560,30 @@ export async function fetchAdHocEncounterRows(
       for (const ma of encounter.id ? medAdminsByEncounterId.get(encounter.id) ?? [] : []) {
         if (ma.status === 'entered-in-error') continue;
         if (!hasChartTag(ma, MEDICATION_ADMINISTRATION_IN_PERSON_RESOURCE_CODE)) continue;
+        const medication = getMedicationFromMA(ma);
         const name =
-          getMedicationName(getMedicationFromMA(ma)) ||
+          getMedicationName(medication) ||
           ma.medicationCodeableConcept?.coding?.[0]?.display ||
           ma.medicationCodeableConcept?.text ||
           '';
-        addMed(name, 'in-house');
+        const dosage = getDosageUnitsAndRouteOfMedication(ma);
+        addMed(name, 'in-house', undefined, {
+          dose: dosage.dose ?? null,
+          units: dosage.units ?? null,
+          route: dosage.route ?? null,
+          ndc: (medication ? getNdcCodeFromMedication(medication) : undefined) ?? null,
+          lotNumber: medication?.batch?.lotNumber ?? null,
+          expirationDate: expiryDate(medication?.batch?.expirationDate),
+          manufacturer: medication?.manufacturer?.display ?? null,
+          administeredAt: ma.effectiveDateTime ?? null,
+        });
       }
       row.medications = medications;
       row.medicationIngredients = medicationIngredients;
       row.medicationSources = medicationSources;
       row.medicationCodes = medicationCodes;
       row.medicationCount = medications.length;
+      row.drugs = drugs;
     }
 
     if (includeVitals) {
@@ -681,6 +709,8 @@ export async function fetchAdHocEncounterRows(
         name: string;
         status: 'administered' | 'partially-administered' | 'recorded';
         visDate: string | null;
+        lotNumber: string | null;
+        expirationDate: string | null;
       };
 
       const vaccines: VaccineRecord[] = [];
@@ -705,7 +735,13 @@ export async function fetchAdHocEncounterRows(
         const visDate = medication?.extension?.find((e) => e.url === VACCINE_ADMINISTRATION_VIS_DATE_EXTENSION_URL)
           ?.valueDate;
 
-        vaccines.push({ name, status, visDate: visDate ?? null });
+        vaccines.push({
+          name,
+          status,
+          visDate: visDate ?? null,
+          lotNumber: medication?.batch?.lotNumber ?? null,
+          expirationDate: expiryDate(medication?.batch?.expirationDate),
+        });
       }
       for (const ms of encounter.id ? medStatementsByEncounterId.get(encounter.id) ?? [] : []) {
         if (ms.status === 'entered-in-error' || !hasChartTag(ms, 'immunization')) continue;
@@ -715,8 +751,8 @@ export async function fetchAdHocEncounterRows(
           ms.medicationCodeableConcept?.text ||
           getMedicationName(containedMed) ||
           '';
-        // Charted history, not an administration on this visit, so it never carries a VIS.
-        if (name) vaccines.push({ name, status: 'recorded', visDate: null });
+        // Charted history, not an administration on this visit: no VIS and no vial of ours.
+        if (name) vaccines.push({ name, status: 'recorded', visDate: null, lotNumber: null, expirationDate: null });
       }
       row.vaccines = vaccines;
     }

--- a/packages/zambdas/src/shared/adhoc-report.ts
+++ b/packages/zambdas/src/shared/adhoc-report.ts
@@ -38,25 +38,15 @@ export async function uploadAdHocReportDataToZ3(
   return createPresignedUrl(token, z3Url, 'download');
 }
 
-// Total time budget for one report's fetch, kept under the zambda's 900s (15 min) limit so the run
-// aborts with a clear error instead of being hard-killed mid-request. Headroom is left for the Z3
-// upload and the response.
 const REPORT_BUDGET_MS = 13 * 60 * 1000;
 
-// Per-job poll timeout used only when no budget was started (e.g. unit tests calling the fetch
-// directly). A real invocation uses the shared deadline below instead.
 const DEFAULT_JOB_TIMEOUT_MS = 10 * 60 * 1000;
 
-// Set at the start of each zambda invocation (module-level, like m2mToken) so every async job in the
-// run shares one deadline.
 let reportDeadlineMs = 0;
 export function beginReportBudget(): void {
   reportDeadlineMs = Date.now() + REPORT_BUDGET_MS;
 }
 
-// Poll settings for one async job, bounded by the time left in the report budget — so the sum of all
-// jobs (main + scoped searches, across pages) can never exceed it. Throws a clear error when the
-// budget is spent, rather than letting the zambda be hard-killed.
 function jobWait(): { pollIntervalMs: number; timeoutMs: number } {
   if (reportDeadlineMs === 0) return { pollIntervalMs: 2000, timeoutMs: DEFAULT_JOB_TIMEOUT_MS };
   const remaining = reportDeadlineMs - Date.now();
@@ -66,21 +56,26 @@ function jobWait(): { pollIntervalMs: number; timeoutMs: number } {
 
 const ASYNC_PAGE_SIZE = 1000;
 
-function readSearchsets<T extends FhirResource>(completion: Bundle): { resources: T[]; matchedIds: string[] } {
+function readSearchsets<T extends FhirResource>(
+  completion: Bundle
+): { resources: T[]; matchedIds: string[]; hasNext: boolean } {
   const resources: T[] = [];
   const matchedIds: string[] = [];
+  let hasNext = false;
   for (const outer of completion.entry ?? []) {
     const searchset = outer.resource as Bundle | undefined;
     if (!searchset || searchset.resourceType !== 'Bundle' || searchset.type !== 'searchset') continue;
+    if (searchset.link?.some((link) => link.relation === 'next')) hasNext = true;
     for (const entry of searchset.entry ?? []) {
       const resource = entry.resource;
       const mode = entry.search?.mode ?? 'match';
       if (!resource || mode === 'outcome') continue;
       resources.push(resource as T);
+      // Only matched resources advance the offset; _include ones ride along outside the page count.
       if (mode === 'match' && resource.id) matchedIds.push(resource.id);
     }
   }
-  return { resources, matchedIds };
+  return { resources, matchedIds, hasNext };
 }
 
 async function searchAllAsync<T extends FhirResource>(
@@ -97,18 +92,19 @@ async function searchAllAsync<T extends FhirResource>(
       ...params,
       { name: '_count', value: String(ASYNC_PAGE_SIZE) },
       { name: '_offset', value: String(offset) },
+      { name: '_sort', value: '_id' },
     ];
     const handle = await oystehr.fhir.search<T>({ resourceType, params: pageParams }, { mode: 'async-bundle' });
     const status = await oystehr.fhir.waitForAsyncJob<T>(handle.jobId, jobWait());
     if (status.status !== 200 || !('mode' in status) || status.mode !== 'bundle') {
       throw new Error(`Async search for ${resourceType} did not complete in bundle mode`);
     }
-    const { resources, matchedIds } = readSearchsets<T>(status.bundle as Bundle);
+    const { resources, matchedIds, hasNext } = readSearchsets<T>(status.bundle as Bundle);
     out.push(...resources);
     const newMatched = matchedIds.filter((id) => !seen.has(id));
     newMatched.forEach((id) => seen.add(id));
     offset += matchedIds.length;
-    progressed = newMatched.length > 0;
+    progressed = hasNext && newMatched.length > 0;
   }
   return out;
 }
@@ -135,9 +131,13 @@ export async function fetchAppointmentReportResources<T extends FhirResource>(
     { name: '_revinclude', value: 'Encounter:appointment' },
     { name: '_include:iterate', value: 'Encounter:participant:Practitioner' },
     ...(opts.extraParams ?? []),
-    { name: '_sort', value: 'date' },
   ]);
 }
+
+// One search per batch of scoping values. Measured: a single comma list of encounter references
+// comes back as an EMPTY searchset with no error, while batches of 100 return the data.
+const SCOPED_BATCH_SIZE = 100;
+const SCOPED_BATCH_CONCURRENCY = 4;
 
 export async function fetchScopedResources<T extends FhirResource>(
   oystehr: Oystehr,
@@ -147,23 +147,41 @@ export async function fetchScopedResources<T extends FhirResource>(
   extraParams: { name: string; value: string }[] = []
 ): Promise<T[]> {
   if (values.length === 0) return [];
-  try {
-    return await searchAllAsync<T>(oystehr, resourceType, [
-      { name: paramName, value: values.join(',') },
-      ...extraParams,
-    ]);
-  } catch (error) {
-    console.warn(
-      `fetchScopedResources: ${resourceType} async search failed; continuing with partial layer data`,
-      error
-    );
-    captureException(error, { extra: { resourceType, paramName, valueCount: values.length } });
-    return [];
+
+  const batches: string[][] = [];
+
+  for (let i = 0; i < values.length; i += SCOPED_BATCH_SIZE) {
+    batches.push(values.slice(i, i + SCOPED_BATCH_SIZE));
   }
+
+  const searchBatch = async (batch: string[]): Promise<T[]> => {
+    try {
+      return await searchAllAsync<T>(oystehr, resourceType, [
+        { name: paramName, value: batch.join(',') },
+        ...extraParams,
+      ]);
+    } catch (error) {
+      console.warn(
+        `fetchScopedResources: ${resourceType} async search failed; continuing with partial layer data`,
+        error
+      );
+      captureException(error, { extra: { resourceType, paramName, valueCount: batch.length } });
+      return [];
+    }
+  };
+
+  const out: T[] = [];
+  for (let i = 0; i < batches.length; i += SCOPED_BATCH_CONCURRENCY) {
+    const group = await Promise.all(batches.slice(i, i + SCOPED_BATCH_CONCURRENCY).map(searchBatch));
+    for (const resources of group) out.push(...resources);
+  }
+  console.log(
+    `[adhoc-scoped] ${resourceType} by ${paramName}: values=${values.length} batches=${batches.length} ` +
+      `returned=${out.length}`
+  );
+  return out;
 }
 
-// A follow-up encounter may carry no appointment reference of its own — resolve through its partOf
-// parent encounter in that case. Shared by the ad-hoc Encounters/Billing/incomplete-encounters reports.
 export function resolveEncounterAppointment(
   encounter: Encounter,
   appointmentMap: Map<string, Appointment>,
@@ -177,9 +195,6 @@ export function resolveEncounterAppointment(
   return parentRef ? appointmentMap.get(parentRef) : undefined;
 }
 
-// The per-encounter "visit row" prelude shared verbatim by the ad-hoc Encounters and Billing
-// datasets: follow-up/parent resolution, patient, location, attending provider name, visit
-// type/status, service category, patient address, and the row's start timestamp.
 export interface EncounterRowContext {
   encounterType: 'main' | 'follow-up' | 'scheduled-follow-up';
   isFollowUpRow: boolean;
@@ -209,10 +224,11 @@ export function buildEncounterRowContext(
 
   const encounterType = getEncounterVisitType(encounter) ?? 'main';
   const isFollowUpRow = encounterType === 'follow-up' || encounterType === 'scheduled-follow-up';
-  // Some follow-up encounters carry no subject of their own — fall back to the parent's.
+
   const parentEncounter = encounter.partOf?.reference
     ? encounterById.get(encounter.partOf.reference.replace('Encounter/', ''))
     : undefined;
+
   const patientRef = encounter.subject?.reference ?? parentEncounter?.subject?.reference;
   const patient = patientRef ? patientMap.get(patientRef) : undefined;
 
@@ -232,8 +248,6 @@ export function buildEncounterRowContext(
     ? 'In-Person'
     : 'Unknown';
 
-  // Follow-up rows report their own encounter status — the parent appointment's visit-status
-  // machinery doesn't apply to them.
   const visitStatus = isFollowUpRow
     ? encounter.status === 'finished'
       ? 'completed'
@@ -246,7 +260,6 @@ export function buildEncounterRowContext(
   const serviceCategory = svcCoding?.display || svcCoding?.code || '';
 
   const address = patient ? getAddressForIndividual(patient) : undefined;
-  // Follow-up rows carry their OWN dates (the follow-up happened later than the parent visit).
   const start = (isFollowUpRow ? encounter.period?.start : appointment.start) || '';
 
   return {

--- a/packages/zambdas/src/shared/adhoc-report.ts
+++ b/packages/zambdas/src/shared/adhoc-report.ts
@@ -1,7 +1,18 @@
 import Oystehr from '@oystehr/sdk';
 import { captureException } from '@sentry/aws-serverless';
 import { randomUUID } from 'crypto';
-import { Address, Appointment, Bundle, Encounter, FhirResource, Location, Patient, Practitioner } from 'fhir/r4b';
+import {
+  Address,
+  Appointment,
+  Bundle,
+  Encounter,
+  FhirResource,
+  Location,
+  OperationOutcome,
+  Patient,
+  Practitioner,
+} from 'fhir/r4b';
+import { DateTime } from 'luxon';
 import { BUCKET_NAMES, SERVICE_CATEGORY_SYSTEM } from 'utils/lib/fhir/constants';
 import { getEncounterVisitType } from 'utils/lib/fhir/encounter';
 import { isInPersonAppointment, isTelemedAppointment, OTTEHR_MODULE } from 'utils/lib/fhir/moduleIdentification';
@@ -63,6 +74,15 @@ function readSearchsets<T extends FhirResource>(
   const matchedIds: string[] = [];
   let hasNext = false;
   for (const outer of completion.entry ?? []) {
+    // A failed search arrives as an entry with a non-2xx status and NO searchset. Skipping it
+    // silently is how a search answering "400 Internal Error" became a successful empty report.
+    const status = outer.response?.status;
+    if (status && !status.startsWith('2')) {
+      const issues = (outer.response?.outcome as OperationOutcome | undefined)?.issue
+        ?.map((issue) => issue.details?.text || issue.diagnostics || issue.code)
+        .join('; ');
+      throw new Error(`FHIR search failed with ${status}${issues ? `: ${issues}` : ''}`);
+    }
     const searchset = outer.resource as Bundle | undefined;
     if (!searchset || searchset.resourceType !== 'Bundle' || searchset.type !== 'searchset') continue;
     if (searchset.link?.some((link) => link.relation === 'next')) hasNext = true;
@@ -113,6 +133,31 @@ const REPORT_APPOINTMENT_STATUSES = 'proposed,pending,booked,arrived,fulfilled,c
 
 export const REPORT_ATTENDED_APPOINTMENT_STATUSES = 'proposed,pending,booked,arrived,fulfilled,checked-in,waitlist';
 
+// The main search pulls a whole include graph per appointment, so its size follows the requested
+// date range, not a list we control. A five-month range came back empty; a one-month range over the
+// same data returned every row. Raise this only with a measurement to back it up.
+const REPORT_WINDOW_DAYS = 30;
+const REPORT_WINDOW_CONCURRENCY = 4;
+
+// Cuts a range into consecutive windows of at most REPORT_WINDOW_DAYS. A range that already fits,
+// or one whose bounds do not parse, is returned unchanged so the search behaves exactly as before.
+function reportWindows(dateRange: { start: string; end: string }): { start: string; end: string }[] {
+  const start = DateTime.fromISO(dateRange.start);
+  const end = DateTime.fromISO(dateRange.end);
+  if (!start.isValid || !end.isValid || end <= start) return [dateRange];
+
+  const windows: { start: string; end: string }[] = [];
+  let cursor = start;
+  while (cursor < end) {
+    const next = DateTime.min(cursor.plus({ days: REPORT_WINDOW_DAYS }), end);
+    windows.push({ start: cursor.toISO()!, end: next.toISO()! });
+    // The next window starts where this one ended; `date=ge`/`le` are inclusive on both sides, so
+    // step off the boundary by a millisecond to keep an appointment out of two windows.
+    cursor = next.plus({ milliseconds: 1 });
+  }
+  return windows;
+}
+
 export async function fetchAppointmentReportResources<T extends FhirResource>(
   oystehr: Oystehr,
   opts: {
@@ -121,21 +166,42 @@ export async function fetchAppointmentReportResources<T extends FhirResource>(
     statuses?: string;
   }
 ): Promise<T[]> {
-  return searchAllAsync<T>(oystehr, 'Appointment', [
-    { name: 'date', value: `ge${opts.dateRange.start}` },
-    { name: 'date', value: `le${opts.dateRange.end}` },
-    { name: 'status', value: opts.statuses ?? REPORT_APPOINTMENT_STATUSES },
-    { name: '_tag', value: `${OTTEHR_MODULE.TM},${OTTEHR_MODULE.IP}` },
-    { name: '_include', value: 'Appointment:patient' },
-    { name: '_include', value: 'Appointment:location' },
-    { name: '_revinclude', value: 'Encounter:appointment' },
-    { name: '_include:iterate', value: 'Encounter:participant:Practitioner' },
-    ...(opts.extraParams ?? []),
-  ]);
+  const searchWindow = (window: { start: string; end: string }): Promise<T[]> =>
+    searchAllAsync<T>(oystehr, 'Appointment', [
+      { name: 'date', value: `ge${window.start}` },
+      { name: 'date', value: `le${window.end}` },
+      { name: 'status', value: opts.statuses ?? REPORT_APPOINTMENT_STATUSES },
+      { name: '_tag', value: `${OTTEHR_MODULE.TM},${OTTEHR_MODULE.IP}` },
+      { name: '_include', value: 'Appointment:patient' },
+      { name: '_include', value: 'Appointment:location' },
+      { name: '_revinclude', value: 'Encounter:appointment' },
+      { name: '_include:iterate', value: 'Encounter:participant:Practitioner' },
+      ...(opts.extraParams ?? []),
+    ]);
+
+  const windows = reportWindows(opts.dateRange);
+  if (windows.length === 1) return searchWindow(windows[0]);
+
+  const out: T[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < windows.length; i += REPORT_WINDOW_CONCURRENCY) {
+    const group = await Promise.all(windows.slice(i, i + REPORT_WINDOW_CONCURRENCY).map(searchWindow));
+    for (const resources of group) {
+      for (const resource of resources) {
+        // An included Patient or Location is shared between appointments in different windows.
+        const key = `${resource.resourceType}/${resource.id}`;
+        if (resource.id && seen.has(key)) continue;
+        if (resource.id) seen.add(key);
+        out.push(resource);
+      }
+    }
+  }
+  return out;
 }
 
-// One search per batch of scoping values. Measured: a single comma list of encounter references
-// comes back as an EMPTY searchset with no error, while batches of 100 return the data.
+// One search per batch of scoping values. Measured: a comma list of 1249 encounter references
+// (63891 bytes) answers "400 Bad Request / Internal Error", while 100 references answer 200. The
+// limit between the two is not documented, so the batch size stays conservative.
 const SCOPED_BATCH_SIZE = 100;
 const SCOPED_BATCH_CONCURRENCY = 4;
 
@@ -154,6 +220,8 @@ export async function fetchScopedResources<T extends FhirResource>(
     batches.push(values.slice(i, i + SCOPED_BATCH_SIZE));
   }
 
+  // A failed batch used to return an empty list, so the layer came back partly filled and the
+  // report looked complete. A report on missing data is worse than a report that says it failed.
   const searchBatch = async (batch: string[]): Promise<T[]> => {
     try {
       return await searchAllAsync<T>(oystehr, resourceType, [
@@ -161,12 +229,11 @@ export async function fetchScopedResources<T extends FhirResource>(
         ...extraParams,
       ]);
     } catch (error) {
-      console.warn(
-        `fetchScopedResources: ${resourceType} async search failed; continuing with partial layer data`,
-        error
-      );
       captureException(error, { extra: { resourceType, paramName, valueCount: batch.length } });
-      return [];
+      throw new Error(
+        `Could not load ${resourceType} for the report (${batch.length} of ${values.length} by ${paramName}): ` +
+          `${error instanceof Error ? error.message : String(error)}`
+      );
     }
   };
 
@@ -176,7 +243,7 @@ export async function fetchScopedResources<T extends FhirResource>(
     for (const resources of group) out.push(...resources);
   }
   console.log(
-    `[adhoc-scoped] ${resourceType} by ${paramName}: values=${values.length} batches=${batches.length} ` +
+    `[adhoc] ${resourceType} by ${paramName}: values=${values.length} batches=${batches.length} ` +
       `returned=${out.length}`
   );
   return out;

--- a/packages/zambdas/test/adhoc-async-pagination.test.ts
+++ b/packages/zambdas/test/adhoc-async-pagination.test.ts
@@ -1,6 +1,6 @@
 import Oystehr from '@oystehr/sdk';
 import { Appointment, FhirResource } from 'fhir/r4b';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { fetchAppointmentReportResources } from '../src/shared/adhoc-report';
 
 const appt = (id: string): Appointment => ({ resourceType: 'Appointment', id, status: 'fulfilled', participant: [] });
@@ -12,15 +12,23 @@ function matchesForOffset(offset: number): Appointment[] {
   return [];
 }
 
+// Every window the code asks for, in request order — a window is identified by its `date=ge…` bound.
+const requestedWindows: string[] = [];
+
 // A completion bundle (batch-response) whose first entry is the searchset. Page 1000 also carries an
-// 'outcome'-mode entry and a non-searchset outer entry, both of which must be ignored.
+// 'outcome'-mode entry and a non-searchset outer entry, both of which must be ignored. A page with
+// results carries link[next], which is what tells the loop to ask for the following page.
 const fakeOystehr = {
   fhir: {
-    search: async ({ params }: { resourceType: string; params?: { name: string; value: string }[] }) => ({
-      jobId: params?.find((p) => p.name === '_offset')?.value ?? '0',
-      contentLocation: '',
-      mode: 'bundle',
-    }),
+    search: async ({ params }: { resourceType: string; params?: { name: string; value: string }[] }) => {
+      const from = params?.find((p) => p.name === 'date' && p.value.startsWith('ge'))?.value ?? '';
+      requestedWindows.push(from);
+      return {
+        jobId: params?.find((p) => p.name === '_offset')?.value ?? '0',
+        contentLocation: '',
+        mode: 'bundle',
+      };
+    },
     waitForAsyncJob: async (jobId: string) => {
       const offset = Number(jobId);
       const matches = matchesForOffset(offset);
@@ -38,7 +46,14 @@ const fakeOystehr = {
           resourceType: 'Bundle',
           type: 'batch-response',
           entry: [
-            { resource: { resourceType: 'Bundle', type: 'searchset', entry: searchsetEntries } },
+            {
+              resource: {
+                resourceType: 'Bundle',
+                type: 'searchset',
+                entry: searchsetEntries,
+                ...(matches.length ? { link: [{ relation: 'next', url: 'https://example.test/next' }] } : {}),
+              },
+            },
             ...(offset === 1000 ? [{ resource: { resourceType: 'OperationOutcome' } }] : []),
           ],
         },
@@ -47,19 +62,44 @@ const fakeOystehr = {
   },
 } as unknown as Oystehr;
 
-const dateRange = { start: '2026-07-01T00:00:00.000Z', end: '2026-07-31T23:59:59.999Z' };
+// Inside one 30-day window, so this range is searched in a single pass.
+const dateRange = { start: '2026-07-01T00:00:00.000Z', end: '2026-07-28T23:59:59.999Z' };
 
 describe('searchAllAsync pagination (via fetchAppointmentReportResources)', () => {
+  beforeEach(() => {
+    requestedWindows.length = 0;
+  });
+
   it('walks every page until an empty page and returns all matched resources', async () => {
     const resources = await fetchAppointmentReportResources<FhirResource>(fakeOystehr, { dateRange });
     const appointments = resources.filter((r) => r.resourceType === 'Appointment');
     // 1000 from page 0 + 2 from page 1000; the terminal empty page stops the loop.
     expect(appointments).toHaveLength(1002);
     expect(new Set(appointments.map((a) => a.id)).size).toBe(1002);
+    // A range this short is one window, so every request carried the same lower bound.
+    expect(new Set(requestedWindows).size).toBe(1);
   });
 
   it('ignores outcome-mode entries and non-searchset completion entries', async () => {
     const resources = await fetchAppointmentReportResources<FhirResource>(fakeOystehr, { dateRange });
     expect(resources.some((r) => r.resourceType === 'OperationOutcome')).toBe(false);
+  });
+
+  it('splits a long range into windows and returns each resource once', async () => {
+    // 100 days: the server answered a five-month range with 400 Internal Error, so the range is cut
+    // into windows and searched window by window.
+    const longRange = { start: '2026-01-01T00:00:00.000Z', end: '2026-04-11T00:00:00.000Z' };
+    const resources = await fetchAppointmentReportResources<FhirResource>(fakeOystehr, { dateRange: longRange });
+
+    const bounds = Array.from(new Set(requestedWindows)).sort();
+    expect(bounds).toHaveLength(4);
+    // Windows start where the previous one ended, and the last one stops at the requested end.
+    expect(bounds[0]).toContain('2026-01-01');
+    expect(requestedWindows.some((b) => b.includes('2026-04-11'))).toBe(false);
+
+    // The fake serves the same ids for every window; a resource must not be reported twice.
+    const appointments = resources.filter((r) => r.resourceType === 'Appointment');
+    expect(appointments).toHaveLength(1002);
+    expect(new Set(appointments.map((a) => a.id)).size).toBe(1002);
   });
 });

--- a/packages/zambdas/test/adhoc-datasets-fixture.test.ts
+++ b/packages/zambdas/test/adhoc-datasets-fixture.test.ts
@@ -8,14 +8,21 @@ import {
   MedicationAdministration,
   Observation,
   Patient,
+  PaymentNotice,
   Practitioner,
 } from 'fhir/r4b';
-import { FHIR_EXTENSION } from 'utils/lib/fhir/constants';
+import { FHIR_EXTENSION, PAYMENT_METHOD_EXTENSION_URL } from 'utils/lib/fhir/constants';
 import { OTTEHR_MODULE } from 'utils/lib/fhir/moduleIdentification';
+import { CODE_SYSTEM_NDC } from 'utils/lib/helpers/rcm/constants';
 import { AdHocBillingOutputSchema } from 'utils/lib/types/adhoc/datasets/billing';
 import { AdHocEncountersOutputSchema } from 'utils/lib/types/adhoc/datasets/encounters';
 import { AdHocPatientsOutputSchema } from 'utils/lib/types/adhoc/datasets/patients';
-import { VACCINE_ADMINISTRATION_VIS_DATE_EXTENSION_URL } from 'utils/lib/types/api/medication-administration.constants';
+import {
+  MEDICATION_ADMINISTRATION_IN_PERSON_RESOURCE_CODE,
+  MEDICATION_ADMINISTRATION_ROUTES_CODES_SYSTEM,
+  MEDICATION_IDENTIFIER_NAME_SYSTEM,
+  VACCINE_ADMINISTRATION_VIS_DATE_EXTENSION_URL,
+} from 'utils/lib/types/api/medication-administration.constants';
 import { CREATED_BY_SYSTEM } from 'utils/lib/types/common';
 import { PRACTITIONER_CODINGS } from 'utils/lib/types/data/appointments/appointments.types';
 import { describe, expect, it } from 'vitest';
@@ -184,12 +191,13 @@ const observations: Observation[] = [
   bpObs('obs-bp-2', '2026-07-01T14:20:00.000Z', 122, undefined, 'LX'),
 ];
 
-// One vaccine with a VIS date, one administered without it (the compliance gap).
+// One vaccine with a VIS date and a vial (lot + expiry), one administered without either.
 const vaccineAdmin = (
   id: string,
   name: string,
   status: 'completed' | 'on-hold',
-  visDate?: string
+  visDate?: string,
+  batch?: { lotNumber: string; expirationDate: string }
 ): MedicationAdministration => ({
   resourceType: 'MedicationAdministration' as const,
   id,
@@ -202,15 +210,79 @@ const vaccineAdmin = (
     {
       resourceType: 'Medication' as const,
       id: `med-${id}`,
-      identifier: [{ system: 'https://fhir.ottehr.com/Identifier/medication-name', value: name }],
+      identifier: [{ system: MEDICATION_IDENTIFIER_NAME_SYSTEM, value: name }],
+      ...(batch ? { batch } : {}),
       ...(visDate ? { extension: [{ url: VACCINE_ADMINISTRATION_VIS_DATE_EXTENSION_URL, valueDate: visDate }] } : {}),
     },
   ],
 });
 
+// In-house administration. The recall attributes live on the CONTAINED Medication copy, and an order
+// marked as not administered carries no batch at all — nothing was given, so no vial is tied to the
+// patient. `withVial: false` reproduces that.
+const inHouseAdmin = (
+  id: string,
+  name: string,
+  dose: number,
+  effectiveDateTime: string,
+  withVial: boolean
+): MedicationAdministration => ({
+  resourceType: 'MedicationAdministration' as const,
+  id,
+  status: withVial ? 'completed' : 'not-done',
+  meta: { tag: [{ code: MEDICATION_ADMINISTRATION_IN_PERSON_RESOURCE_CODE }] },
+  context: { reference: 'Encounter/enc-1' },
+  subject: { reference: 'Patient/pat-1' },
+  effectiveDateTime,
+  dosage: {
+    dose: { value: dose, unit: 'mg', system: 'http://unitsofmeasure.org' },
+    route: { coding: [{ system: MEDICATION_ADMINISTRATION_ROUTES_CODES_SYSTEM, code: 'IM' }] },
+  },
+  contained: [
+    {
+      resourceType: 'Medication' as const,
+      id: `med-${id}`,
+      identifier: [{ system: MEDICATION_IDENTIFIER_NAME_SYSTEM, value: name }],
+      code: { coding: [{ system: CODE_SYSTEM_NDC, code: '0409-7337-01' }] },
+      ...(withVial
+        ? {
+            manufacturer: { display: 'Acme Pharma' },
+            // batch.expirationDate is a FHIR dateTime; the app writes a full instant with an offset.
+            batch: { lotNumber: 'LOT-4472', expirationDate: '2027-03-31T00:00:00.000+04:00' },
+          }
+        : {}),
+    },
+  ],
+});
+
 const medicationAdministrations: FhirResource[] = [
-  vaccineAdmin('ma-1', 'Influenza', 'completed', '2026-07-01'),
+  vaccineAdmin('ma-1', 'Influenza', 'completed', '2026-07-01', {
+    lotNumber: 'FLU-2026-A',
+    expirationDate: '2027-01-31',
+  }),
   vaccineAdmin('ma-2', 'MMR', 'on-hold'),
+  inHouseAdmin('ma-3', 'Ceftriaxone 1 g', 1000, '2026-07-01T15:30:00.000Z', true),
+  inHouseAdmin('ma-4', 'Ceftriaxone 500 mg', 500, '2026-07-01T16:00:00.000Z', false),
+];
+
+// Two payments on one visit, out of order, with different methods; one has no method recorded.
+const paymentNotice = (id: string, amount: number, created: string, method?: string): PaymentNotice => ({
+  resourceType: 'PaymentNotice' as const,
+  id,
+  status: 'active',
+  created,
+  request: { reference: 'Encounter/enc-1' },
+  payment: {},
+  recipient: {},
+  amount: { value: amount, currency: 'USD' },
+  paymentStatus: { coding: [{ code: 'paid' }] },
+  ...(method ? { extension: [{ url: PAYMENT_METHOD_EXTENSION_URL, valueString: method }] } : {}),
+});
+
+const paymentNotices: FhirResource[] = [
+  paymentNotice('pay-2', 25.5, '2026-07-01T18:00:00.000Z', 'cash'),
+  paymentNotice('pay-1', 40, '2026-07-01T15:00:00.000Z', 'card'),
+  paymentNotice('pay-3', 10, '2026-07-01T19:00:00.000Z'),
 ];
 
 const rootResources: FhirResource[] = [appointment, encounter, patient, location, practitioner];
@@ -218,6 +290,7 @@ const scopedByType: Record<string, FhirResource[]> = {
   Condition: [condition],
   Observation: observations,
   MedicationAdministration: medicationAdministrations,
+  PaymentNotice: paymentNotices,
 };
 const resourcesFor = (resourceType: string): FhirResource[] =>
   resourceType === 'Appointment' ? rootResources : scopedByType[resourceType] ?? [];
@@ -331,9 +404,53 @@ describe('ad-hoc dataset zambdas: mapped rows parse against their Zod schema (fi
 
     expect(issuesOf(AdHocEncountersOutputSchema.safeParse({ encounters: rows }))).toEqual([]);
     expect(row.vaccines).toEqual([
-      { name: 'Influenza', status: 'administered', visDate: '2026-07-01' },
-      { name: 'MMR', status: 'partially-administered', visDate: null },
+      {
+        name: 'Influenza',
+        status: 'administered',
+        visDate: '2026-07-01',
+        lotNumber: 'FLU-2026-A',
+        expirationDate: '2027-01-31',
+      },
+      { name: 'MMR', status: 'partially-administered', visDate: null, lotNumber: null, expirationDate: null },
     ]);
+  });
+
+  it('encounters medications layer: one record per drug carrying the recall attributes', async () => {
+    const rows = await fetchAdHocEncounterRows(fakeOystehr, { dateRange, includeMedications: true });
+    const row = rows[0];
+
+    expect(issuesOf(AdHocEncountersOutputSchema.safeParse({ encounters: rows }))).toEqual([]);
+    // Immunization administrations belong to the vaccines field, not here.
+    expect(row.drugs?.map((d) => d.name)).toEqual(['Ceftriaxone 1 g', 'Ceftriaxone 500 mg']);
+
+    const given = row.drugs?.find((d) => d.name === 'Ceftriaxone 1 g');
+    expect(given).toEqual({
+      name: 'Ceftriaxone 1 g',
+      source: 'in-house',
+      dose: 1000,
+      units: 'mg',
+      route: 'IM',
+      ndc: '0409-7337-01',
+      lotNumber: 'LOT-4472',
+      // Kept as the calendar date that was entered — a zone conversion would report the 30th.
+      expirationDate: '2027-03-31',
+      manufacturer: 'Acme Pharma',
+      // The time the drug was given, NOT the visit date.
+      administeredAt: '2026-07-01T15:30:00.000Z',
+    });
+
+    // Marked as not administered: no vial is tied to the patient, so no lot, expiry or manufacturer.
+    const notGiven = row.drugs?.find((d) => d.name === 'Ceftriaxone 500 mg');
+    expect(notGiven?.lotNumber).toBeNull();
+    expect(notGiven?.expirationDate).toBeNull();
+    expect(notGiven?.manufacturer).toBeNull();
+    // The dose was still charted, and the NDC belongs to the catalogue entry rather than the vial.
+    expect(notGiven?.dose).toBe(500);
+    expect(notGiven?.ndc).toBe('0409-7337-01');
+
+    // The flat arrays stay in step with the records — they are what value sampling shows the model.
+    expect(row.medications).toEqual(['Ceftriaxone 1 g', 'Ceftriaxone 500 mg']);
+    expect(row.medicationCount).toBe(2);
   });
 
   it('billing: base rows match the schema; layer columns stay absent when not requested', async () => {
@@ -349,6 +466,24 @@ describe('ad-hoc dataset zambdas: mapped rows parse against their Zod schema (fi
     // Opt-in layer fields must be ABSENT (not null/garbage) when the layer wasn't requested.
     expect('paymentsCollected' in row).toBe(false);
     expect('payerType' in row).toBe(false);
+  });
+
+  it('billing payments layer: one record per payment, oldest first, aggregates in step', async () => {
+    const rows = await fetchAdHocBillingRows(fakeOystehr, { dateRange, includePayments: true });
+    const row = rows[0];
+
+    expect(issuesOf(AdHocBillingOutputSchema.safeParse({ rows }))).toEqual([]);
+    // Charted out of order in the fixture; the records come back oldest first.
+    expect(row.payments).toEqual([
+      { date: '2026-07-01T15:00:00.000Z', amount: 40, method: 'card' },
+      { date: '2026-07-01T18:00:00.000Z', amount: 25.5, method: 'cash' },
+      { date: '2026-07-01T19:00:00.000Z', amount: 10, method: '' },
+    ]);
+    // The aggregates must agree with the records, or a report mixing both contradicts itself.
+    expect(row.paymentsCollected).toBe(75.5);
+    expect(row.paymentCount).toBe(3);
+    expect(row.lastPaymentDate).toBe('2026-07-01T19:00:00.000Z');
+    expect(row.payments?.reduce((sum, p) => sum + p.amount, 0)).toBe(row.paymentsCollected);
   });
 
   it('patients: per-patient rollup rows match the schema', async () => {

--- a/packages/zambdas/test/adhoc-datasets-fixture.test.ts
+++ b/packages/zambdas/test/adhoc-datasets-fixture.test.ts
@@ -1,9 +1,21 @@
 import Oystehr from '@oystehr/sdk';
-import { Appointment, Condition, Encounter, FhirResource, Location, Patient, Practitioner } from 'fhir/r4b';
+import {
+  Appointment,
+  Condition,
+  Encounter,
+  FhirResource,
+  Location,
+  MedicationAdministration,
+  Observation,
+  Patient,
+  Practitioner,
+} from 'fhir/r4b';
+import { FHIR_EXTENSION } from 'utils/lib/fhir/constants';
 import { OTTEHR_MODULE } from 'utils/lib/fhir/moduleIdentification';
 import { AdHocBillingOutputSchema } from 'utils/lib/types/adhoc/datasets/billing';
 import { AdHocEncountersOutputSchema } from 'utils/lib/types/adhoc/datasets/encounters';
 import { AdHocPatientsOutputSchema } from 'utils/lib/types/adhoc/datasets/patients';
+import { VACCINE_ADMINISTRATION_VIS_DATE_EXTENSION_URL } from 'utils/lib/types/api/medication-administration.constants';
 import { CREATED_BY_SYSTEM } from 'utils/lib/types/common';
 import { PRACTITIONER_CODINGS } from 'utils/lib/types/data/appointments/appointments.types';
 import { describe, expect, it } from 'vitest';
@@ -34,6 +46,17 @@ const appointment: Appointment = {
   ],
 };
 
+// Ottehr's visit status is carried on statusHistory via an extension, not by the FHIR status itself.
+const visitStatusEntry = (
+  status: string,
+  start: string,
+  end?: string
+): NonNullable<Encounter['statusHistory']>[number] => ({
+  status: 'in-progress',
+  period: { start, ...(end ? { end } : {}) },
+  extension: [{ url: FHIR_EXTENSION.EncounterStatusHistory.ottehrVisitStatus.url, valueCode: status }],
+});
+
 const encounter: Encounter = {
   resourceType: 'Encounter',
   id: 'enc-1',
@@ -47,6 +70,14 @@ const encounter: Encounter = {
       individual: { reference: 'Practitioner/prac-1' },
       period: { start: '2026-07-01T14:05:00.000Z', end: '2026-07-01T14:25:00.000Z' },
     },
+  ],
+  // Deliberately includes a BACKWARD move (provider -> intake) so the ordered history is exercised.
+  statusHistory: [
+    visitStatusEntry('arrived', '2026-07-01T14:00:00.000Z', '2026-07-01T14:05:00.000Z'),
+    visitStatusEntry('intake', '2026-07-01T14:05:00.000Z', '2026-07-01T14:10:00.000Z'),
+    visitStatusEntry('provider', '2026-07-01T14:10:00.000Z', '2026-07-01T14:20:00.000Z'),
+    visitStatusEntry('intake', '2026-07-01T14:20:00.000Z', '2026-07-01T14:25:00.000Z'),
+    visitStatusEntry('completed', '2026-07-01T14:25:00.000Z'),
   ],
   diagnosis: [{ condition: { reference: 'Condition/cond-1' }, rank: 1 }],
 };
@@ -89,8 +120,105 @@ const condition: Condition = {
 
 // The Appointment search pulls its whole _include/_revinclude graph in one searchset; scoped layer
 // searches return that type's fixtures.
+// Vitals are charted in Celsius; the dataset converts to °F. The second BP reading has no diastolic
+// component, so pair filtering must drop it from BOTH arrays.
+// Alert level is written onto the Observation when the vital is charted, against the patient's age
+// on that day. The dataset reads it back; it never re-derives thresholds.
+const interpretationOf = (code: string): Observation['interpretation'] => [{ coding: [{ code }] }];
+
+const vitalObs = (
+  id: string,
+  tag: string,
+  effectiveDateTime: string,
+  value: number,
+  unit: string,
+  alertCode?: string
+): Observation => ({
+  resourceType: 'Observation',
+  id,
+  status: 'final',
+  code: { text: tag },
+  meta: { tag: [{ code: tag }] },
+  encounter: { reference: 'Encounter/enc-1' },
+  effectiveDateTime,
+  valueQuantity: { value, unit },
+  ...(alertCode ? { interpretation: interpretationOf(alertCode) } : {}),
+});
+
+// BP carries its alert level per component, not on the parent.
+const bpObs = (
+  id: string,
+  effectiveDateTime: string,
+  systolic: number,
+  diastolic?: number,
+  systolicAlertCode?: string
+): Observation => ({
+  resourceType: 'Observation',
+  id,
+  status: 'final',
+  code: { text: 'vital-blood-pressure' },
+  meta: { tag: [{ code: 'vital-blood-pressure' }] },
+  encounter: { reference: 'Encounter/enc-1' },
+  effectiveDateTime,
+  component: [
+    {
+      code: { coding: [{ code: '8480-6' }] },
+      valueQuantity: { value: systolic, unit: 'mmHg' },
+      ...(systolicAlertCode ? { interpretation: interpretationOf(systolicAlertCode) } : {}),
+    },
+    ...(diastolic == null
+      ? []
+      : [{ code: { coding: [{ code: '8462-4' }] }, valueQuantity: { value: diastolic, unit: 'mmHg' } }]),
+  ],
+});
+
+const observations: Observation[] = [
+  // Out of chronological order on purpose: the mapping must sort by effectiveDateTime.
+  vitalObs('obs-temp-2', 'vital-temperature', '2026-07-01T14:20:00.000Z', 37, 'C'),
+  vitalObs('obs-temp-1', 'vital-temperature', '2026-07-01T14:02:00.000Z', 39, 'C', 'HX'),
+  vitalObs('obs-hr-1', 'vital-heartbeat', '2026-07-01T14:02:00.000Z', 142, 'beats/min', 'HH'),
+  vitalObs('obs-hr-2', 'vital-heartbeat', '2026-07-01T14:20:00.000Z', 96, 'beats/min'),
+  // Charted before alert levels were persisted: no interpretation anywhere, so it reads as in range.
+  vitalObs('obs-o2-1', 'vital-oxygen-sat', '2026-07-01T14:02:00.000Z', 97, '%'),
+  bpObs('obs-bp-1', '2026-07-01T14:02:00.000Z', 118, 76),
+  bpObs('obs-bp-2', '2026-07-01T14:20:00.000Z', 122, undefined, 'LX'),
+];
+
+// One vaccine with a VIS date, one administered without it (the compliance gap).
+const vaccineAdmin = (
+  id: string,
+  name: string,
+  status: 'completed' | 'on-hold',
+  visDate?: string
+): MedicationAdministration => ({
+  resourceType: 'MedicationAdministration' as const,
+  id,
+  status,
+  meta: { tag: [{ code: 'immunization' }] },
+  context: { reference: 'Encounter/enc-1' },
+  subject: { reference: 'Patient/pat-1' },
+  effectiveDateTime: '2026-07-01T14:15:00.000Z',
+  contained: [
+    {
+      resourceType: 'Medication' as const,
+      id: `med-${id}`,
+      identifier: [{ system: 'https://fhir.ottehr.com/Identifier/medication-name', value: name }],
+      ...(visDate ? { extension: [{ url: VACCINE_ADMINISTRATION_VIS_DATE_EXTENSION_URL, valueDate: visDate }] } : {}),
+    },
+  ],
+});
+
+const medicationAdministrations: FhirResource[] = [
+  vaccineAdmin('ma-1', 'Influenza', 'completed', '2026-07-01'),
+  vaccineAdmin('ma-2', 'MMR', 'on-hold'),
+];
+
 const rootResources: FhirResource[] = [appointment, encounter, patient, location, practitioner];
-const scopedByType: Record<string, FhirResource[]> = { Condition: [condition] };
+const scopedByType: Record<string, FhirResource[]> = {
+  Condition: [condition],
+  Observation: observations,
+  MedicationAdministration: medicationAdministrations,
+};
 const resourcesFor = (resourceType: string): FhirResource[] =>
   resourceType === 'Appointment' ? rootResources : scopedByType[resourceType] ?? [];
 
@@ -159,6 +287,53 @@ describe('ad-hoc dataset zambdas: mapped rows parse against their Zod schema (fi
     expect(row.icdCodes).toEqual(['H66.90']);
     expect(row.primaryIcd).toBe('H66.90');
     expect(row.primaryIcdDisplay).toBe('Otitis media, unspecified');
+    // statusHistory is a BASE field: ordered oldest-first, so a backward move is detectable.
+    expect(row.statusHistory.map((e) => e.status)).toEqual(['arrived', 'intake', 'provider', 'intake', 'completed']);
+    expect(row.statusHistory[0].start).toBe('2026-07-01T14:00:00.000Z');
+    expect(row.statusHistory.at(-1)?.end).toBeNull();
+  });
+
+  it('encounters vitals layer: readings are chronological, °C converted to °F, BP pairs aligned', async () => {
+    const rows = await fetchAdHocEncounterRows(fakeOystehr, { dateRange, includeVitals: true });
+    const row = rows[0];
+
+    expect(issuesOf(AdHocEncountersOutputSchema.safeParse({ encounters: rows }))).toEqual([]);
+
+    // Charted 39 °C then 37 °C (out of order in the fixture) -> °F, oldest first.
+    expect(row.temperatureFReadings).toEqual([102.2, 98.6]);
+    expect(row.temperatureF).toBe(98.6); // scalar stays the MOST RECENT value
+    // [0] is the initial screening value, length is how many times it was taken.
+    expect(row.heartRateReadings).toEqual([142, 96]);
+    expect(row.heartRateReadings?.[0]).toBe(142);
+    expect(row.heartRateReadings).toHaveLength(2);
+    expect(row.heartRate).toBe(96);
+    // The second BP reading has no diastolic component, so it is dropped from BOTH arrays.
+    expect(row.systolicBPReadings).toEqual([118]);
+    expect(row.diastolicBPReadings).toEqual([76]);
+    expect(row.systolicBPReadings?.length).toBe(row.diastolicBPReadings?.length);
+  });
+
+  it('encounters vitals layer: alert levels come from the charted interpretation', async () => {
+    const rows = await fetchAdHocEncounterRows(fakeOystehr, { dateRange, includeVitals: true });
+    const row = rows[0];
+
+    // Temperature was abnormal on the FIRST reading only, heart rate was critical, BP was abnormal on
+    // a component. Oxygen saturation has no interpretation, so it counts as in range.
+    expect(row.abnormalVitals?.slice().sort()).toEqual(['bloodPressure', 'heartRate', 'temperatureF']);
+    expect(row.criticalVitals).toEqual(['heartRate']);
+    // A reading dropped from the paired arrays still counts towards the alert.
+    expect(row.abnormalVitals).toContain('bloodPressure');
+  });
+
+  it('encounters immunizations layer: one vaccine record each, VIS presence carried by the date', async () => {
+    const rows = await fetchAdHocEncounterRows(fakeOystehr, { dateRange, includeImmunizations: true });
+    const row = rows[0];
+
+    expect(issuesOf(AdHocEncountersOutputSchema.safeParse({ encounters: rows }))).toEqual([]);
+    expect(row.vaccines).toEqual([
+      { name: 'Influenza', status: 'administered', visDate: '2026-07-01' },
+      { name: 'MMR', status: 'partially-administered', visDate: null },
+    ]);
   });
 
   it('billing: base rows match the schema; layer columns stay absent when not requested', async () => {


### PR DESCRIPTION
Improvements:

Stronger request validation. A new step blocks report generation when the request asks for data that isn't in any schema. The user is told exactly which field wasn't found, gets hints (for example when the name is slightly off), and sees the full schema of all datasets including optional layers.

Better stability. Moving to async FHIR removed the batched requests, which could return incomplete data whenever one of the batches failed. The heavy work also moved out of the synchronous request into a background worker (15 min limit, 3 GB) that the client polls — large reports used to exceed the short synchronous timeout.

Status history added to the dataset. Reports like this are now possible: Ignoring cancelled encounters, how many went backward in status, and what was the out-of-order transition?

Vitals: first reading and recheck counts. Each vital now carries all of its readings in order, so "initial screening" means the first reading rather than the last, and "how many readings" is a real count.

Vaccines carry their VIS status. One record per vaccine with whether it was given and the VIS date, which supports requests like List vaccines administered without a VIS, with patient and date.

Billing no longer offers a dead claims layer. The claims data was never produced by a working feature, so the layer only invited wrong reports.

You can see what data exists. "Show fields" now also lists the optional layers, each expandable to the exact fields it would add, marked loaded or available. Schema version raised. Saved reports are regenerated automatically against the new schema.

Vitals: abnormal and critical values come ready-made. Two new fields list which vitals were out of range and which of those were critical, using the same age-banded thresholds the app applies on the Vitals page. The values are read from what was saved when the vital was charted, so the age band is the patient's age on the visit date. The LLM no longer works this out from the readings — it gets the answer.

Fixed layer data coming back empty. A report over 1249 visits asked for a layer's resources in one search, with every encounter reference in one parameter. The server returned an empty result and no error, so the report was built on missing data and still looked successful — a report on abnormal vitals found nothing while the chart showed a high temperature. The request is now split into batches of 100. This applies to every optional layer, not only vitals.

Table cells show nested values. A cell holding a list or a record used to render as "[object Object]", in the grid and in the CSV export. Lists are now joined and records show as "key: value". A column can also be computed from the row when it is not a plain field.

Medication recall data. One record per drug with lot number, NDC, manufacturer, expiration date, dose and the exact time given. No extra FHIR requests.

Vaccine recall data. Lot number and expiration date on vaccine records.
Individual payments. One record per payment (date, amount, method). Totals unchanged and consistent with the records.

Nested fields in the request check. The catalogue listed only top-level columns, so a lot number inside a vaccine record looked missing and the request was rejected. Members of record columns are now listed, in the prompt and in "Show fields".

Other improvements. Better prompts, more reliable data fetching, clearer error messages, and better schema descriptions. A spinner now shows while a report is being built, instead of an empty area.