### PR TITLE
fix(ai): stop create-resources-from-audio-recording from timing out (OTR-3304)

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/progress-note/RecordAudioContainer.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/progress-note/RecordAudioContainer.tsx
@@ -142,7 +142,7 @@ export function RecordAudioContainer(props: RecordAudioContainerProps): ReactEle
               const audioSource = getSource(item, oystehr, aiChat.providers);
               return <RecordedAudio duration={audioDuration} status="ready" source={audioSource} />;
             })}
-          {uploading && (
+          {(uploading || aiChat?.hasPendingRecording) && (
             <RecordedAudio
               duration={getFormatDuration(uploadedDuration)}
               status="loading"

--- a/apps/ehr/src/features/visits/shared/components/OttehrAi.tsx
+++ b/apps/ehr/src/features/visits/shared/components/OttehrAi.tsx
@@ -85,7 +85,7 @@ export const OttehrAi: React.FC<OttehrAiProps> = () => {
 
   const chartDataHasResources = (chartData?.aiChat?.documents?.length ?? 0) > 0;
 
-  const { isPolling, pollingExhausted, hasInterviewWithoutResources } = useAiResourcesPolling({
+  const { isPolling, pollingExhausted, hasPendingAiSource } = useAiResourcesPolling({
     appointment,
     encounter,
     oystehr,
@@ -118,7 +118,7 @@ export const OttehrAi: React.FC<OttehrAiProps> = () => {
   });
 
   const aiDocuments = chartData?.aiChat?.documents;
-  const shouldShowLoader = hasInterviewWithoutResources && (isLoading || isPolling);
+  const shouldShowLoader = hasPendingAiSource && (isLoading || isPolling);
 
   return (
     <Stack spacing={1}>

--- a/apps/ehr/src/features/visits/shared/components/OttehrAi.tsx
+++ b/apps/ehr/src/features/visits/shared/components/OttehrAi.tsx
@@ -90,6 +90,7 @@ export const OttehrAi: React.FC<OttehrAiProps> = () => {
     encounter,
     oystehr,
     chartDataHasResources,
+    hasPendingRecording: Boolean(chartData?.aiChat?.hasPendingRecording),
     onRefetch: refetchChartData,
   });
 

--- a/apps/ehr/src/features/visits/shared/components/Sidebar.tsx
+++ b/apps/ehr/src/features/visits/shared/components/Sidebar.tsx
@@ -328,7 +328,12 @@ export const Sidebar = (): JSX.Element => {
   const menuItems = generateMenuItems(
     Object.values(routesInPerson)
       .filter((route) => !route.isSkippedInNavigation)
-      .filter((route) => route.path !== ROUTER_PATH.OTTEHR_AI || chartData?.aiChat?.documents?.[0])
+      .filter(
+        (route) =>
+          route.path !== ROUTER_PATH.OTTEHR_AI ||
+          chartData?.aiChat?.documents?.[0] ||
+          chartData?.aiChat?.hasPendingRecording
+      )
   );
 
   return (

--- a/apps/ehr/src/features/visits/shared/components/useAiResourcesPolling.ts
+++ b/apps/ehr/src/features/visits/shared/components/useAiResourcesPolling.ts
@@ -1,6 +1,7 @@
 import Oystehr from '@oystehr/sdk';
-import { Appointment, Encounter, QuestionnaireResponse } from 'fhir/r4b';
+import { Appointment, DocumentReference, Encounter, QuestionnaireResponse } from 'fhir/r4b';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { AMBIENT_SCRIBE_RECORDING_PENDING_CODING } from 'utils/lib/fhir/constants';
 import { AI_QUESTIONNAIRE_ID } from 'utils/lib/types/constants';
 import { getInPersonVisitStatus } from 'utils/lib/utils/visitUtils';
 
@@ -14,7 +15,7 @@ interface UseAiResourcesPollingParams {
 
 interface UseAiResourcesPollingResult {
   isPolling: boolean;
-  hasInterviewWithoutResources: boolean;
+  hasPendingAiSource: boolean;
   pollingExhausted: boolean;
 }
 
@@ -30,7 +31,7 @@ export const useAiResourcesPolling = ({
   onRefetch,
 }: UseAiResourcesPollingParams): UseAiResourcesPollingResult => {
   const [isPolling, setIsPolling] = useState(false);
-  const [hasInterviewWithoutResources, setHasInterviewWithoutResources] = useState(false);
+  const [hasPendingAiSource, setHasPendingAiSource] = useState(false);
 
   const pollingAttemptsRef = useRef(0);
   const pollingIntervalRef = useRef<NodeJS.Timeout>();
@@ -67,6 +68,37 @@ export const useAiResourcesPolling = ({
     }
   }, [oystehr, encounter?.id, chartDataHasResources]);
 
+  // Check if an in-person recording was uploaded and is awaiting transcription
+  const checkForPendingAudioRecording = useCallback(async (): Promise<boolean> => {
+    if (!oystehr || !encounter?.id || chartDataHasResources) return false;
+
+    try {
+      const drResult = await oystehr.fhir.search<DocumentReference>({
+        resourceType: 'DocumentReference',
+        params: [
+          { name: 'encounter', value: `Encounter/${encounter.id}` },
+          {
+            name: 'type',
+            value: `${AMBIENT_SCRIBE_RECORDING_PENDING_CODING.system}|${AMBIENT_SCRIBE_RECORDING_PENDING_CODING.code}`,
+          },
+        ],
+      });
+
+      return drResult.unbundle().length > 0;
+    } catch (error) {
+      console.error('Error checking for pending audio recording:', error);
+      return false;
+    }
+  }, [oystehr, encounter?.id, chartDataHasResources]);
+
+  const checkForPendingAiSource = useCallback(async (): Promise<boolean> => {
+    const [interviewPending, audioRecordingPending] = await Promise.all([
+      checkForInterviewWithoutResources(),
+      checkForPendingAudioRecording(),
+    ]);
+    return interviewPending || audioRecordingPending;
+  }, [checkForInterviewWithoutResources, checkForPendingAudioRecording]);
+
   // Start polling when conditions are met
   useEffect(() => {
     const shouldPoll = async (): Promise<void> => {
@@ -76,7 +108,7 @@ export const useAiResourcesPolling = ({
       const isRelevantStatus = visitStatus === 'ready for provider' || visitStatus === 'provider';
 
       if (!isRelevantStatus) {
-        setHasInterviewWithoutResources(false);
+        setHasPendingAiSource(false);
         setIsPolling(false);
         pollingAttemptsRef.current = 0;
         pollingExhaustedRef.current = false;
@@ -87,8 +119,8 @@ export const useAiResourcesPolling = ({
       // Only check and start polling if we haven't done initial check yet
       // or if we know resources are missing
       if (!initialCheckDoneRef.current || !chartDataHasResources) {
-        const needsPolling = await checkForInterviewWithoutResources();
-        setHasInterviewWithoutResources(needsPolling);
+        const needsPolling = await checkForPendingAiSource();
+        setHasPendingAiSource(needsPolling);
         initialCheckDoneRef.current = true;
 
         if (needsPolling && !isPolling && pollingAttemptsRef.current < MAX_POLLING_ATTEMPTS) {
@@ -104,7 +136,7 @@ export const useAiResourcesPolling = ({
     };
 
     void shouldPoll();
-  }, [appointment, encounter, chartDataHasResources, isPolling, checkForInterviewWithoutResources]);
+  }, [appointment, encounter, chartDataHasResources, isPolling, checkForPendingAiSource]);
 
   // Handle polling interval
   useEffect(() => {
@@ -126,11 +158,11 @@ export const useAiResourcesPolling = ({
       await onRefetch();
 
       // Check if resources appeared
-      const stillNeedsPolling = await checkForInterviewWithoutResources();
+      const stillNeedsPolling = await checkForPendingAiSource();
 
       if (!stillNeedsPolling) {
         setIsPolling(false);
-        setHasInterviewWithoutResources(false);
+        setHasPendingAiSource(false);
         pollingAttemptsRef.current = 0;
         pollingExhaustedRef.current = false;
       } else if (pollingAttemptsRef.current >= MAX_POLLING_ATTEMPTS) {
@@ -144,11 +176,11 @@ export const useAiResourcesPolling = ({
         clearInterval(pollingIntervalRef.current);
       }
     };
-  }, [isPolling, onRefetch, checkForInterviewWithoutResources]);
+  }, [isPolling, onRefetch, checkForPendingAiSource]);
 
   return {
     isPolling,
-    hasInterviewWithoutResources,
+    hasPendingAiSource,
     pollingExhausted: pollingExhaustedRef.current,
   };
 };

--- a/apps/ehr/src/features/visits/shared/components/useAiResourcesPolling.ts
+++ b/apps/ehr/src/features/visits/shared/components/useAiResourcesPolling.ts
@@ -10,6 +10,7 @@ interface UseAiResourcesPollingParams {
   encounter: Encounter | undefined;
   oystehr: Oystehr | undefined;
   chartDataHasResources: boolean;
+  hasPendingRecording: boolean;
   onRefetch: () => Promise<void>;
 }
 
@@ -28,6 +29,7 @@ export const useAiResourcesPolling = ({
   encounter,
   oystehr,
   chartDataHasResources,
+  hasPendingRecording,
   onRefetch,
 }: UseAiResourcesPollingParams): UseAiResourcesPollingResult => {
   const [isPolling, setIsPolling] = useState(false);
@@ -107,7 +109,7 @@ export const useAiResourcesPolling = ({
       const visitStatus = getInPersonVisitStatus(appointment, encounter);
       const isRelevantStatus = visitStatus === 'ready for provider' || visitStatus === 'provider';
 
-      if (!isRelevantStatus) {
+      if (!hasPendingRecording && !isRelevantStatus) {
         setHasPendingAiSource(false);
         setIsPolling(false);
         pollingAttemptsRef.current = 0;
@@ -136,7 +138,7 @@ export const useAiResourcesPolling = ({
     };
 
     void shouldPoll();
-  }, [appointment, encounter, chartDataHasResources, isPolling, checkForPendingAiSource]);
+  }, [appointment, encounter, chartDataHasResources, hasPendingRecording, isPolling, checkForPendingAiSource]);
 
   // Handle polling interval
   useEffect(() => {

--- a/apps/ehr/src/features/visits/shared/components/useAiResourcesPolling.ts
+++ b/apps/ehr/src/features/visits/shared/components/useAiResourcesPolling.ts
@@ -21,7 +21,7 @@ interface UseAiResourcesPollingResult {
 }
 
 const MIN_ANSWERS_REQUIRED = 4;
-const MAX_POLLING_ATTEMPTS = 12;
+const MAX_POLLING_ATTEMPTS = 60;
 const POLLING_INTERVAL_MS = 5_000; // 5 seconds
 
 export const useAiResourcesPolling = ({

--- a/config/oystehr-core/zambdas.json
+++ b/config/oystehr-core/zambdas.json
@@ -362,6 +362,14 @@
       "src": "src/ehr/create-resources-from-audio-recording/index",
       "zip": ".dist/zips/create-resources-from-audio-recording.zip"
     },
+    "PROCESS-AUDIO-RECORDING": {
+      "name": "process-audio-recording",
+      "type": "subscription",
+      "runtime": "nodejs22.x",
+      "timeout": "300",
+      "src": "src/subscriptions/document-reference/process-audio-recording/index",
+      "zip": ".dist/zips/process-audio-recording.zip"
+    },
     "CREATE-UPLOAD-DOCUMENT-URL": {
       "name": "create-upload-document-url",
       "type": "http_auth",
@@ -2497,6 +2505,24 @@
         "channel": {
           "type": "rest-hook",
           "endpoint": "zapehr-lambda:#{ref/zambdas/PROCESS-TELEMED-RECORDING/id}"
+        },
+        "extension": [
+          {
+            "url": "http://zapehr.com/fhir/extension/SubscriptionTriggerEvent",
+            "valueString": "create"
+          }
+        ]
+      }
+    },
+    "PROCESS_AUDIO_RECORDING_SUBSCRIPTION": {
+      "resource": {
+        "resourceType": "Subscription",
+        "status": "active",
+        "reason": "In-person ambient scribe audio recording uploaded - generate AI chart recommendations",
+        "criteria": "DocumentReference?type=https://fhir.ottehr.com/CodeSystem/document-type|ambient-scribe-recording-pending",
+        "channel": {
+          "type": "rest-hook",
+          "endpoint": "zapehr-lambda:#{ref/zambdas/PROCESS-AUDIO-RECORDING/id}"
         },
         "extension": [
           {

--- a/packages/utils/lib/fhir/constants.ts
+++ b/packages/utils/lib/fhir/constants.ts
@@ -1125,6 +1125,12 @@ export const RcmTaskCodings: { [key: string]: CodeableConcept } = {
 export const DOCUMENT_REFERENCE_SUMMARY_FROM_AUDIO = 'Summary of visit from audio recording';
 export const DOCUMENT_REFERENCE_SUMMARY_FROM_CHAT = 'Summary of visit from chat';
 
+export const AMBIENT_SCRIBE_RECORDING_PENDING_CODING = {
+  system: `${OTTEHR_CODE_SYSTEM_BASE_URL}/document-type`,
+  code: 'ambient-scribe-recording-pending',
+  display: 'Ambient scribe recording pending transcription',
+};
+
 export const EMPLOYER_ORG_IDENTIFIER_SYSTEM = ottehrIdentifierSystem('organization-type');
 
 export const ATTORNEY_FIRM_EXTENSION_URL = `${PRIVATE_EXTENSION_BASE_URL}/attorney-firm`;

--- a/packages/utils/lib/types/api/chart-data/chart-data.types.ts
+++ b/packages/utils/lib/types/api/chart-data/chart-data.types.ts
@@ -35,6 +35,7 @@ import { GetChartDataResponse } from './get-chart-data.types';
 export interface AIChatDetails {
   documents: DocumentReference[];
   providers: Practitioner[];
+  hasPendingRecording?: boolean;
 }
 
 // todo: need to refactor and simplify types; there are different sets of fields for useChartData and useChartFields, but this types contains all possible values and not very useful

--- a/packages/zambdas/src/ehr/create-resources-from-audio-recording/index.ts
+++ b/packages/zambdas/src/ehr/create-resources-from-audio-recording/index.ts
@@ -1,10 +1,17 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
+import { DocumentReference, Encounter } from 'fhir/r4b';
+import { DateTime } from 'luxon';
 import { userMe } from 'utils/lib/auth/user-me.helper';
+import {
+  AMBIENT_SCRIBE_RECORDING_PENDING_CODING,
+  DOCUMENT_REFERENCE_SUMMARY_FROM_AUDIO,
+  PUBLIC_EXTENSION_BASE_URL,
+} from 'utils/lib/fhir/constants';
+import { getFormatDuration } from 'utils/lib/helpers/helpers';
 import { Secrets } from 'utils/lib/secrets';
 import { CreateResourcesFromAudioRecordingInput } from 'utils/lib/types/api/appointment.types';
-import { transcribeAndCreateResourcesFromZ3Audio } from '../../shared/ai';
 import { checkOrCreateM2MClientToken } from '../../shared/auth';
-import { createClinicalOystehrClient } from '../../shared/helpers';
+import { assertDefined, createClinicalOystehrClient } from '../../shared/helpers';
 import { wrapHandler } from '../../shared/sentry';
 import { ZambdaInput } from '../../shared/types/common';
 import { validateRequestParameters } from './validateRequestParameters';
@@ -27,15 +34,50 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
 
   const providerUserProfile = (await userMe(userToken, secrets)).profile;
 
-  const createdResources = await transcribeAndCreateResourcesFromZ3Audio(
-    oystehr,
-    m2mToken,
-    { encounterID: visitID, z3URL, duration, providerUserProfile },
-    secrets
-  );
+  const encounter = await oystehr.fhir.get<Encounter>({ resourceType: 'Encounter', id: visitID });
+  const patientId = assertDefined(encounter.subject?.reference?.split('/')[1], 'patientId');
+
+  const pendingDocumentReference: DocumentReference = {
+    resourceType: 'DocumentReference',
+    status: 'current',
+    type: { coding: [AMBIENT_SCRIBE_RECORDING_PENDING_CODING] },
+    category: [
+      {
+        coding: [
+          {
+            system: 'http://loinc.org',
+            code: '34133-9',
+            display: 'Summarization of episode note',
+          },
+        ],
+      },
+    ],
+    description: DOCUMENT_REFERENCE_SUMMARY_FROM_AUDIO,
+    subject: { reference: `Patient/${patientId}` },
+    date: DateTime.now().toISO(),
+    content: [
+      {
+        attachment: {
+          url: z3URL,
+          title: `Audio recording (${duration ? getFormatDuration(duration) : 'unknown'})`,
+        },
+      },
+    ],
+    context: {
+      encounter: [{ reference: `Encounter/${visitID}` }],
+    },
+    extension: [
+      {
+        url: `${PUBLIC_EXTENSION_BASE_URL}/provider`,
+        valueReference: { reference: providerUserProfile },
+      },
+    ],
+  };
+
+  const created = await oystehr.fhir.create<DocumentReference>(pendingDocumentReference);
 
   return {
     statusCode: 200,
-    body: JSON.stringify(`Successfully created ` + createdResources),
+    body: JSON.stringify(`Successfully created DocumentReference/${created.id}`),
   };
 });

--- a/packages/zambdas/src/shared/ai.ts
+++ b/packages/zambdas/src/shared/ai.ts
@@ -1,7 +1,7 @@
 import { AnthropicMessagesModelId, ChatAnthropic } from '@langchain/anthropic';
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { AIMessageChunk, BaseMessageLike, MessageContentComplex } from '@langchain/core/messages';
-import Oystehr, { BatchInputPostRequest } from '@oystehr/sdk';
+import Oystehr, { BatchInputPostRequest, BatchInputPutRequest, BatchInputRequest } from '@oystehr/sdk';
 import { captureException } from '@sentry/aws-serverless';
 import { Appointment, Condition, DocumentReference, Encounter, Observation, Patient } from 'fhir/r4b';
 import { DateTime } from 'luxon';
@@ -22,7 +22,7 @@ import { MIME_TYPES } from 'utils/lib/utils/file';
 import { fixAndParseJsonObjectFromString } from 'utils/lib/validation/json-fix';
 import { makeObservationResource } from './chart-data/index';
 import { assertDefined } from './helpers';
-import { parseCreatedResourcesBundle, saveResourceRequest } from './resources.helpers';
+import { parseCreatedResourcesBundle, saveResourceRequest, updateResourceRequest } from './resources.helpers';
 import { createPresignedUrl } from './z3Utils';
 
 export const TRANSCRIPT_PROMPT =
@@ -248,7 +248,13 @@ export async function invokeChatbotVertexAI(
 export async function transcribeAndCreateResourcesFromZ3Audio(
   oystehr: Oystehr,
   m2mToken: string,
-  args: { encounterID: string; z3URL: string; duration?: number; providerUserProfile: string | null },
+  args: {
+    encounterID: string;
+    z3URL: string;
+    duration?: number;
+    providerUserProfile: string | null;
+    existingDocumentReference?: DocumentReference;
+  },
   secrets: Secrets | null
 ): Promise<string> {
   const presignedFileDownloadUrl = await createPresignedUrl(m2mToken, args.z3URL, 'download');
@@ -285,6 +291,7 @@ export async function transcribeAndCreateResourcesFromZ3Audio(
     args.duration,
     mimeType,
     args.providerUserProfile,
+    args.existingDocumentReference,
     secrets
   );
 }
@@ -312,6 +319,7 @@ export async function createResourcesFromAiInterview(
   duration: number | undefined,
   mimeType: string | null,
   providerUserProfile: string | null,
+  existingDocumentReference: DocumentReference | undefined,
   secrets: Secrets | null
 ): Promise<string> {
   let fields =
@@ -392,19 +400,23 @@ export async function createResourcesFromAiInterview(
 
   const encounterId = assertDefined(encounter.id, 'encounter.id');
   const patientId = assertDefined(encounter.subject?.reference?.split('/')[1], 'patientId');
-  const requests: BatchInputPostRequest<DocumentReference | Observation | Condition>[] = [];
+  const requests: BatchInputRequest<DocumentReference | Observation | Condition>[] = [];
+  // Updating an existing DocumentReference in place needs no transaction-local urn:uuid — it already has a
+  // real id other entries in this same bundle (the Observations below) can reference directly.
   const documentReferenceCreateUrl = `urn:uuid:${uuid()}`;
   requests.push(
-    createDocumentReference(
-      encounterID,
-      patientId,
-      providerUserProfile,
-      documentReferenceCreateUrl,
-      z3URL,
-      chatTranscript,
-      duration,
-      mimeType
-    )
+    existingDocumentReference
+      ? updateDocumentReference(existingDocumentReference, chatTranscript)
+      : createDocumentReference(
+          encounterID,
+          patientId,
+          providerUserProfile,
+          documentReferenceCreateUrl,
+          z3URL,
+          chatTranscript,
+          duration,
+          mimeType
+        )
   );
   requests.push(...createObservations(aiResponse, documentReferenceCreateUrl, encounterId, patientId));
   console.log('Transaction requests: ' + JSON.stringify(requests, null, 2));
@@ -489,6 +501,32 @@ function createDocumentReference(
       : [],
   };
   return saveResourceRequest(documentReference, documentReferenceCreateUrl);
+}
+
+function updateDocumentReference(
+  existingDocumentReference: DocumentReference,
+  transcript: string
+): BatchInputPutRequest<DocumentReference> {
+  const existingAttachment = existingDocumentReference.content?.[0]?.attachment;
+  const documentReference: DocumentReference = {
+    ...existingDocumentReference,
+    type: {
+      coding: [VISIT_CONSULT_NOTE_DOC_REF_CODING_CODE],
+    },
+    content: [
+      ...(existingAttachment
+        ? [{ attachment: { ...existingAttachment, contentType: existingAttachment.contentType } }]
+        : []),
+      {
+        attachment: {
+          contentType: MIME_TYPES.TXT,
+          title: 'Transcript',
+          data: btoa(unescape(encodeURIComponent(transcript))),
+        },
+      },
+    ],
+  };
+  return updateResourceRequest(documentReference);
 }
 
 const FIELDS_WITH_ITEMS = new Set([

--- a/packages/zambdas/src/shared/ai.ts
+++ b/packages/zambdas/src/shared/ai.ts
@@ -401,9 +401,9 @@ export async function createResourcesFromAiInterview(
   const encounterId = assertDefined(encounter.id, 'encounter.id');
   const patientId = assertDefined(encounter.subject?.reference?.split('/')[1], 'patientId');
   const requests: BatchInputRequest<DocumentReference | Observation | Condition>[] = [];
-  // Updating an existing DocumentReference in place needs no transaction-local urn:uuid — it already has a
-  // real id other entries in this same bundle (the Observations below) can reference directly.
-  const documentReferenceCreateUrl = `urn:uuid:${uuid()}`;
+  const documentReferenceCreateUrl = existingDocumentReference?.id
+    ? `DocumentReference/${existingDocumentReference.id}`
+    : `urn:uuid:${uuid()}`;
   requests.push(
     existingDocumentReference
       ? updateDocumentReference(existingDocumentReference, chatTranscript)

--- a/packages/zambdas/src/shared/chart-data/index.ts
+++ b/packages/zambdas/src/shared/chart-data/index.ts
@@ -29,6 +29,7 @@ import { DateTime } from 'luxon';
 import {
   ACCIDENT_STATE_EXTENSION,
   ACCIDENT_TYPE_SYSTEM,
+  AMBIENT_SCRIBE_RECORDING_PENDING_CODING,
   BODY_SITE_SYSTEM,
   CPT_CODE_SYSTEM,
   ERX_MEDICATION_META_TAG_CODE,
@@ -1602,6 +1603,12 @@ const mapResourceToChartDataFields = (
     resource.type?.coding?.[0].code === VISIT_CONSULT_NOTE_DOC_REF_CODING_CODE.code
   ) {
     data.aiChat?.documents.push(resource);
+    resourceMapped = true;
+  } else if (
+    resource.resourceType === 'DocumentReference' &&
+    resource.type?.coding?.[0].code === AMBIENT_SCRIBE_RECORDING_PENDING_CODING.code
+  ) {
+    if (data.aiChat) data.aiChat.hasPendingRecording = true;
     resourceMapped = true;
   }
   return {

--- a/packages/zambdas/src/subscriptions/document-reference/process-audio-recording/index.ts
+++ b/packages/zambdas/src/subscriptions/document-reference/process-audio-recording/index.ts
@@ -1,0 +1,66 @@
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { DocumentReference } from 'fhir/r4b';
+import { PUBLIC_EXTENSION_BASE_URL } from 'utils/lib/fhir/constants';
+import { createOystehrClient } from 'utils/lib/helpers/helpers';
+import { getSecret, Secrets, SecretsKeys } from 'utils/lib/secrets';
+import { transcribeAndCreateResourcesFromZ3Audio } from '../../../shared/ai';
+import { getAuth0Token } from '../../../shared/getAuth0Token';
+import { wrapHandler } from '../../../shared/sentry';
+import { ZambdaInput } from '../../../shared/types/common';
+import { validateRequestParameters } from './validateRequestParameters';
+
+const ZAMBDA_NAME = 'process-audio-recording';
+
+export interface ProcessAudioRecordingSubscriptionInput {
+  documentReference: DocumentReference;
+  secrets: Secrets | null;
+}
+
+let oystehrToken: string;
+
+export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
+  const { documentReference, secrets } = validateRequestParameters(input);
+
+  const z3URL = documentReference.content?.[0]?.attachment?.url;
+  if (!z3URL) {
+    console.log(`DocumentReference/${documentReference.id} has no audio attachment URL; skipping.`);
+    return { statusCode: 200, body: JSON.stringify('No audio attachment; skipped') };
+  }
+
+  const encounterReference = documentReference.context?.encounter?.[0]?.reference;
+  const encounterID = encounterReference?.startsWith('Encounter/') ? encounterReference.split('/')[1] : undefined;
+  if (!encounterID) {
+    console.log(
+      `DocumentReference/${documentReference.id} has no Encounter context reference; cannot create AI resources. Skipping.`
+    );
+    return { statusCode: 200, body: JSON.stringify('No encounter context; skipped') };
+  }
+
+  const providerUserProfile =
+    documentReference.extension?.find((extension) => extension.url === `${PUBLIC_EXTENSION_BASE_URL}/provider`)
+      ?.valueReference?.reference ?? null;
+
+  if (!oystehrToken) {
+    console.log('getting token');
+    oystehrToken = await getAuth0Token(secrets);
+  } else {
+    console.log('already have token');
+  }
+  const oystehr = createOystehrClient(
+    oystehrToken,
+    getSecret(SecretsKeys.FHIR_API, secrets),
+    getSecret(SecretsKeys.PROJECT_API, secrets)
+  );
+
+  const createdResources = await transcribeAndCreateResourcesFromZ3Audio(
+    oystehr,
+    oystehrToken,
+    { encounterID, z3URL, providerUserProfile, existingDocumentReference: documentReference },
+    secrets
+  );
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(`Successfully created ` + createdResources),
+  };
+});

--- a/packages/zambdas/src/subscriptions/document-reference/process-audio-recording/validateRequestParameters.ts
+++ b/packages/zambdas/src/subscriptions/document-reference/process-audio-recording/validateRequestParameters.ts
@@ -1,0 +1,24 @@
+import { DocumentReference } from 'fhir/r4b';
+import { ZambdaInput } from '../../../shared/types/common';
+import { ProcessAudioRecordingSubscriptionInput } from '.';
+
+export function validateRequestParameters(input: ZambdaInput): ProcessAudioRecordingSubscriptionInput {
+  if (!input.body) {
+    throw new Error('No request body provided');
+  }
+
+  const documentReference = JSON.parse(input.body);
+
+  if (documentReference.resourceType !== 'DocumentReference') {
+    throw new Error(`resource parsed should be a DocumentReference but was a ${documentReference.resourceType}`);
+  }
+
+  if (!documentReference.id) {
+    throw new Error(`Triggering DocumentReference did not have an id. ${JSON.stringify(documentReference)}`);
+  }
+
+  return {
+    documentReference: documentReference as DocumentReference,
+    secrets: input.secrets,
+  };
+}

--- a/packages/zambdas/src/subscriptions/questionnaire-response/ai-interview-summary/index.ts
+++ b/packages/zambdas/src/subscriptions/questionnaire-response/ai-interview-summary/index.ts
@@ -36,6 +36,7 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
     undefined,
     null,
     null,
+    undefined,
     secrets
   );
 


### PR DESCRIPTION
## Summary
- `create-resources-from-audio-recording` (in-person ambient scribe) was timing out in production because it ran the full Vertex AI transcription + clinical-field extraction pipeline synchronously inside a single request/Lambda invocation, with no override on the platform's default timeout.
- The zambda now only writes a "pending" `DocumentReference` (audio attachment + patient/encounter context) and returns immediately.
- A new `process-audio-recording` subscription (timeout: 300s, matching the existing `ai-interview-summary` convention) picks up that pending doc asynchronously and does the actual transcription + FHIR writes, updating the same `DocumentReference` in place rather than creating a second one — mirroring how telemed recordings are already decoupled via `process-telemed-recording`.
- `chartData.aiChat.hasPendingRecording` surfaces the in-flight state through the existing chart-data fetch (no extra network calls) so the Sidebar's "Oystehr AI" tab and the Ambient Scribe recorder panel show a processing/pending state instead of going blank between upload and transcription completing.
- `useAiResourcesPolling` now also polls for a pending audio recording (previously only polled for the chat-based AI interview case).

Linear: OTR-3304

## Test plan
- [ ] Start an in-person visit, record a short clip, confirm the "Oystehr AI" tab appears and shows a processing indicator, then the transcript/notes once done
- [ ] Confirm the Ambient Scribe recorder panel shows a "loading" row for the recording between upload and transcription completing, not a gap
- [ ] Confirm a longer recording no longer causes a Lambda timeout
- [ ] Confirm telemed recording processing (`process-telemed-recording`) still works unaffected