### PR TITLE
fixing the issue where error during invoice creation was not displayed

### DIFF
--- a/apps/ehr/src/pages/reports/InvoiceablePatients.tsx
+++ b/apps/ehr/src/pages/reports/InvoiceablePatients.tsx
@@ -37,7 +37,7 @@ import { getCoding } from 'utils/lib/fhir/helpers';
 import { getSMSNumberForIndividual } from 'utils/lib/fhir/patient';
 import { chooseJson } from 'utils/lib/helpers/oystehrApi';
 import {
-  getLatestTaskOutput,
+  getInvoiceTaskOutputs,
   mapDisplayToInvoiceTaskStatus,
   mapInvoiceTaskStatusToDisplay,
 } from 'utils/lib/helpers/tasks/invoices-tasks';
@@ -634,12 +634,7 @@ export default function InvoiceablePatients({ source }: InvoiceablePatientsProps
                   : isSending
                   ? 'sending'
                   : mapInvoiceTaskStatusToDisplay(report.task.status);
-                const lastTaskOutput = getLatestTaskOutput(report.task);
-                const statusTooltipMessage = lastTaskOutput
-                  ? lastTaskOutput.type === 'success'
-                    ? 'Invoice id: ' + lastTaskOutput.message
-                    : 'Error: ' + lastTaskOutput.message
-                  : displayStatus;
+                const { invoiceId, error } = getInvoiceTaskOutputs(report.task);
                 const maskedClaimId =
                   report.claimId.length > 12
                     ? `${report.claimId.slice(0, 6)}...${report.claimId.slice(-4)}`
@@ -714,20 +709,55 @@ export default function InvoiceablePatients({ source }: InvoiceablePatientsProps
                       <Typography variant="body1">${(report.amountInvoiceable / 100).toFixed(2)}</Typography>
                     </TableCell>
                     <TableCell>
-                      <Tooltip title={`${statusTooltipMessage} (click to copy)`}>
-                        <span
-                          onClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            void navigator.clipboard
-                              .writeText(statusTooltipMessage)
-                              .then(() => enqueueSnackbar('Status copied to clipboard', { variant: 'success' }));
-                          }}
-                          style={{ cursor: 'pointer' }}
+                      {invoiceId || (error && displayStatus === 'error') ? (
+                        <GenericToolTip
+                          customWidth={340}
+                          title={
+                            <Box sx={{ p: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+                              {invoiceId && (
+                                <Box>
+                                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                                    Last invoice ID
+                                  </Typography>
+                                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                                    <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                                      {invoiceId}
+                                    </Typography>
+                                    <IconButton
+                                      size="small"
+                                      onClick={(event) => {
+                                        event.preventDefault();
+                                        event.stopPropagation();
+                                        void navigator.clipboard
+                                          .writeText(invoiceId)
+                                          .then(() =>
+                                            enqueueSnackbar('Invoice ID copied to clipboard', { variant: 'success' })
+                                          );
+                                      }}
+                                    >
+                                      <ContentCopyIcon fontSize="small" />
+                                    </IconButton>
+                                  </Box>
+                                </Box>
+                              )}
+                              {error && displayStatus === 'error' && (
+                                <Box>
+                                  <Typography variant="subtitle2" sx={{ fontWeight: 600, color: '#BF360C' }}>
+                                    Error
+                                  </Typography>
+                                  <Typography variant="body2">{error}</Typography>
+                                </Box>
+                              )}
+                            </Box>
+                          }
                         >
-                          <MappedStatusChip status={displayStatus} mapper={INVOICEABLE_TASK_STATUS_COLORS_MAP} />
-                        </span>
-                      </Tooltip>
+                          <span>
+                            <MappedStatusChip status={displayStatus} mapper={INVOICEABLE_TASK_STATUS_COLORS_MAP} />
+                          </span>
+                        </GenericToolTip>
+                      ) : (
+                        <MappedStatusChip status={displayStatus} mapper={INVOICEABLE_TASK_STATUS_COLORS_MAP} />
+                      )}
                     </TableCell>
                     <TableCell sx={{ whiteSpace: 'nowrap', textAlign: 'right' }}>
                       <Tooltip title="Refresh invoice">

--- a/apps/ehr/tests/component/InvoiceablePatients.test.tsx
+++ b/apps/ehr/tests/component/InvoiceablePatients.test.tsx
@@ -1,8 +1,14 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Task } from 'fhir/r4b';
 import { ReactNode } from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { GET_INVOICES_TASKS_ZAMBDA_KEY, InvoiceTaskSource } from 'utils/lib/types/api/invoicing.types';
+import {
+  GET_INVOICES_TASKS_ZAMBDA_KEY,
+  InvoiceablePatientReport,
+  InvoiceTaskSource,
+} from 'utils/lib/types/api/invoicing.types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import InvoiceablePatients from '../../src/pages/reports/InvoiceablePatients';
 
@@ -44,6 +50,10 @@ vi.mock('../../src/constants/feature-flags', () => ({
   FEATURE_FLAGS: {
     OTTEHR_BILLING_INVOICING_ENABLED: true,
   },
+}));
+
+vi.mock('notistack', () => ({
+  enqueueSnackbar: vi.fn(),
 }));
 
 const createWrapper = () => {
@@ -151,5 +161,129 @@ describe('InvoiceablePatients source', () => {
 
     renderWithSource('candid');
     await waitFor(() => expect(lastGetInvoicesCall()?.patientId).toBe('pat-persisted'));
+  });
+});
+
+// ─── invoice status hover card ────────────────────────────────────────────────
+
+const INVOICE_ID_CODE = 'send-invoice-output-invoice-Id';
+const ERROR_CODE = 'send-invoice-output-error';
+
+const makeTask = (status: Task['status'], output?: Task['output']): Task => ({
+  resourceType: 'Task',
+  status,
+  intent: 'order',
+  output,
+});
+
+const makeReport = (task: Task): InvoiceablePatientReport => ({
+  claimId: 'claim-abc-123',
+  finalizationDateISO: '2025-01-15',
+  amountInvoiceable: 5000,
+  visitDate: 'Jan 1, 2025',
+  location: 'Test Clinic',
+  task,
+  patient: { patientId: 'patient-1', fullName: 'Jane Doe', phoneNumber: '555-1234' },
+  responsibleParty: {},
+});
+
+const mockOneReport = (report: InvoiceablePatientReport): void => {
+  mockExecute.mockResolvedValue({ output: { reports: [report], totalCount: 1 } });
+};
+
+describe('invoice status hover card', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    window.history.pushState({}, '', '/');
+  });
+
+  it('shows the invoice ID in the tooltip when hovering a sent-status chip', async () => {
+    const user = userEvent.setup();
+    mockOneReport(
+      makeReport(
+        makeTask('completed', [{ type: { coding: [{ code: INVOICE_ID_CODE }] }, valueString: 'in_test_invoice_123' }])
+      )
+    );
+    renderWithSource('candid');
+
+    const chip = await screen.findByTestId('telemed-appointment-status-chip');
+    await user.hover(chip);
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Last invoice ID');
+    expect(tooltip).toHaveTextContent('in_test_invoice_123');
+  });
+
+  it('copies the invoice ID to clipboard when the copy button is clicked', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, writable: true, configurable: true });
+
+    mockOneReport(
+      makeReport(
+        makeTask('completed', [{ type: { coding: [{ code: INVOICE_ID_CODE }] }, valueString: 'in_test_invoice_123' }])
+      )
+    );
+    renderWithSource('candid');
+
+    const chip = await screen.findByTestId('telemed-appointment-status-chip');
+    await user.hover(chip);
+
+    const copyIcon = await screen.findByTestId('ContentCopyIcon');
+    await user.click(copyIcon.closest('button')!);
+
+    expect(writeText).toHaveBeenCalledWith('in_test_invoice_123');
+  });
+
+  it('shows only the error message when the task is in error state with no prior invoice', async () => {
+    const user = userEvent.setup();
+    mockOneReport(
+      makeReport(
+        makeTask('failed', [{ type: { coding: [{ code: ERROR_CODE }] }, valueString: 'Stripe error: invalid email' }])
+      )
+    );
+    renderWithSource('candid');
+
+    const chip = await screen.findByTestId('telemed-appointment-status-chip');
+    await user.hover(chip);
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Error');
+    expect(tooltip).toHaveTextContent('Stripe error: invalid email');
+    expect(tooltip).not.toHaveTextContent('Invoice ID');
+  });
+
+  it('shows both invoice ID and error message when a task failed after a successful send', async () => {
+    const user = userEvent.setup();
+    mockOneReport(
+      makeReport(
+        makeTask('failed', [
+          { type: { coding: [{ code: INVOICE_ID_CODE }] }, valueString: 'in_prior_invoice_456' },
+          { type: { coding: [{ code: ERROR_CODE }] }, valueString: 'Retry failed: customer deleted' },
+        ])
+      )
+    );
+    renderWithSource('candid');
+
+    const chip = await screen.findByTestId('telemed-appointment-status-chip');
+    await user.hover(chip);
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Last invoice ID');
+    expect(tooltip).toHaveTextContent('in_prior_invoice_456');
+    expect(tooltip).toHaveTextContent('Error');
+    expect(tooltip).toHaveTextContent('Retry failed: customer deleted');
+  });
+
+  it('does not show a tooltip for a ready-status chip with no task output', async () => {
+    const user = userEvent.setup();
+    mockOneReport(makeReport(makeTask('ready')));
+    renderWithSource('candid');
+
+    const chip = await screen.findByTestId('telemed-appointment-status-chip');
+    await user.hover(chip);
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
   });
 });

--- a/packages/utils/lib/helpers/tasks/invoices-tasks.test.ts
+++ b/packages/utils/lib/helpers/tasks/invoices-tasks.test.ts
@@ -5,7 +5,12 @@ import {
   INVOICE_TASK_SOURCE_SYSTEM,
   invoiceTaskSourceTag,
 } from '../../types/api/invoicing.types';
-import { getInvoiceTaskClaimId, getInvoiceTaskSource, invoiceTaskSourceSearchParam } from './invoices-tasks';
+import {
+  getInvoiceTaskClaimId,
+  getInvoiceTaskOutputs,
+  getInvoiceTaskSource,
+  invoiceTaskSourceSearchParam,
+} from './invoices-tasks';
 
 const task = (overrides: Partial<Task> = {}): Task => ({
   resourceType: 'Task',
@@ -86,6 +91,90 @@ describe('source tag shape', () => {
       system: INVOICE_TASK_SOURCE_SYSTEM,
       code: 'ottehr-billing',
     });
+  });
+});
+
+const invoiceIdOutput = (valueString: string): NonNullable<Task['output']>[number] => ({
+  type: { coding: [{ code: 'send-invoice-output-invoice-Id' }] },
+  valueString,
+});
+
+const errorOutput = (valueString: string): NonNullable<Task['output']>[number] => ({
+  type: { coding: [{ code: 'send-invoice-output-error' }] },
+  valueString,
+});
+
+const unrelatedOutput = (): NonNullable<Task['output']>[number] => ({
+  type: { coding: [{ code: 'some-other-output-code' }] },
+  valueString: 'ignored',
+});
+
+describe('getInvoiceTaskOutputs', () => {
+  it('returns empty object when the task has no output array', () => {
+    expect(getInvoiceTaskOutputs(task())).toEqual({});
+  });
+
+  it('returns empty object when outputs carry unrecognised codes only', () => {
+    expect(getInvoiceTaskOutputs(task({ output: [unrelatedOutput(), unrelatedOutput()] }))).toEqual({});
+  });
+
+  it('extracts a single invoice ID', () => {
+    expect(getInvoiceTaskOutputs(task({ output: [invoiceIdOutput('in_abc')] }))).toEqual({ invoiceId: 'in_abc' });
+  });
+
+  it('extracts a single error', () => {
+    expect(getInvoiceTaskOutputs(task({ output: [errorOutput('Stripe error')] }))).toEqual({
+      error: 'Stripe error',
+    });
+  });
+
+  it('picks the latest invoice ID when multiple are present', () => {
+    const result = getInvoiceTaskOutputs(
+      task({ output: [invoiceIdOutput('in_first'), invoiceIdOutput('in_second'), invoiceIdOutput('in_latest')] })
+    );
+    expect(result.invoiceId).toBe('in_latest');
+  });
+
+  it('picks the latest error when multiple are present', () => {
+    const result = getInvoiceTaskOutputs(
+      task({ output: [errorOutput('err_first'), errorOutput('err_second'), errorOutput('err_latest')] })
+    );
+    expect(result.error).toBe('err_latest');
+  });
+
+  it('returns both when invoice ID output precedes an error output', () => {
+    // typical failed-after-send sequence
+    const result = getInvoiceTaskOutputs(task({ output: [invoiceIdOutput('in_sent'), errorOutput('retry failed')] }));
+    expect(result).toEqual({ invoiceId: 'in_sent', error: 'retry failed' });
+  });
+
+  it('returns both when outputs are interleaved with unrelated entries', () => {
+    const result = getInvoiceTaskOutputs(
+      task({
+        output: [
+          unrelatedOutput(),
+          invoiceIdOutput('in_early'),
+          unrelatedOutput(),
+          errorOutput('bad email'),
+          unrelatedOutput(),
+        ],
+      })
+    );
+    expect(result).toEqual({ invoiceId: 'in_early', error: 'bad email' });
+  });
+
+  it('picks the latest of each type independently when both appear multiple times', () => {
+    const result = getInvoiceTaskOutputs(
+      task({
+        output: [
+          invoiceIdOutput('in_first'),
+          errorOutput('err_first'),
+          invoiceIdOutput('in_second'),
+          errorOutput('err_second'),
+        ],
+      })
+    );
+    expect(result).toEqual({ invoiceId: 'in_second', error: 'err_second' });
   });
 });
 

--- a/packages/utils/lib/helpers/tasks/invoices-tasks.ts
+++ b/packages/utils/lib/helpers/tasks/invoices-tasks.ts
@@ -116,3 +116,16 @@ export function getLatestTaskOutput(task: Task): { type: 'error' | 'success'; me
   }
   return undefined;
 }
+
+export function getInvoiceTaskOutputs(task: Task): { invoiceId?: string; error?: string } {
+  const outputs = task.output ?? [];
+  const invoiceId = outputs
+    .slice()
+    .reverse()
+    .find((o) => o.type?.coding?.find((c) => c.code === RcmTaskCode.sendInvoiceOutputInvoiceId))?.valueString;
+  const error = outputs
+    .slice()
+    .reverse()
+    .find((o) => o.type?.coding?.find((c) => c.code === RcmTaskCode.sendInvoiceOutputError))?.valueString;
+  return { invoiceId, error };
+}

--- a/packages/zambdas/src/subscriptions/task/sub-send-invoice-to-patient/index.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-send-invoice-to-patient/index.ts
@@ -29,23 +29,25 @@ import { wrapHandler } from '../../../shared/sentry';
 import { ensureStripeCustomerId, getStripeClient, stripeEncounterMetadata } from '../../../shared/stripeIntegration';
 import { resolveTemplatePlaceholders } from '../../../shared/template-placeholders';
 import { ZambdaInput } from '../../../shared/types/common';
-import { validateRequestParameters } from './validateRequestParameters';
+import { getTaskAndSecretsFromInput, validateRequestParameters } from './validateRequestParameters';
 
 let m2mToken: string;
 
 const ZAMBDA_NAME = 'sub-send-invoice-to-patient';
 
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
-  const validatedParams = validateRequestParameters(input);
-  const { secrets, encounterId, invoiceTaskInput, task } = validatedParams;
-  const { amountCents, dueDate, memo, smsTextMessage } = invoiceTaskInput;
-  console.log('Input task id: ', task.id);
-
+  const { task, secrets } = getTaskAndSecretsFromInput(input);
   m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
-  const oystehr = createClinicalOystehrClient(m2mToken, secrets);
-  const stripe = getStripeClient(secrets);
 
   try {
+    const validatedParams = validateRequestParameters(task);
+    const { encounterId, invoiceTaskInput } = validatedParams;
+    const { amountCents, dueDate, memo, smsTextMessage } = invoiceTaskInput;
+    console.log('Input task id: ', task.id);
+
+    const oystehr = createClinicalOystehrClient(m2mToken, secrets);
+    const stripe = getStripeClient(secrets);
+
     console.log('Fetching fhir resources');
     const fhirResources = await getFhirResources(oystehr, encounterId);
     const { patient, encounter, account, appointment, location, schedule, stripeAccountId } = fhirResources;

--- a/packages/zambdas/src/subscriptions/task/sub-send-invoice-to-patient/validateRequestParameters.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-send-invoice-to-patient/validateRequestParameters.ts
@@ -9,22 +9,10 @@ import { MISSING_REQUEST_BODY } from 'utils/lib/types/errors';
 import { ZambdaInput } from '../../../shared/types/common';
 import { safeJsonParse } from '../../../shared/validation';
 
-export function validateRequestParameters(
-  input: ZambdaInput
-): { task: Task; encounterId: string; invoiceTaskInput: SubSendInvoiceToPatientTaskInput } & Pick<
-  ZambdaInput,
-  'secrets'
-> {
-  if (!input.body) throw MISSING_REQUEST_BODY;
-
-  const inputRes = safeJsonParse(input.body);
-
-  if (inputRes.resourceType !== 'Task') {
-    throw new Error(`resource parsed should be a Task but was a ${inputRes.resourceType}`);
-  }
-
-  const task = inputRes as Task;
-
+export function validateRequestParameters(task: Task): {
+  encounterId: string;
+  invoiceTaskInput: SubSendInvoiceToPatientTaskInput;
+} {
   const encounterId = task.encounter?.reference?.split('/')[1];
   if (!encounterId) throw new Error('Encounter id is not found');
 
@@ -36,9 +24,23 @@ export function validateRequestParameters(
     throw new Error('Due date should be in the future');
 
   return {
-    task: task as Task,
     encounterId,
     invoiceTaskInput: invoiceTaskInputParsed,
+  };
+}
+
+export function getTaskAndSecretsFromInput(input: ZambdaInput): { task: Task } & Pick<ZambdaInput, 'secrets'> {
+  if (!input.body) throw MISSING_REQUEST_BODY;
+
+  const inputRes = safeJsonParse(input.body);
+
+  if (inputRes.resourceType !== 'Task') {
+    throw new Error(`resource parsed should be a Task but was a ${inputRes.resourceType}`);
+  }
+
+  const task = inputRes as Task;
+  return {
+    task,
     secrets: input.secrets,
   };
 }

--- a/packages/zambdas/test/unit/sub-send-invoice-to-patient.test.ts
+++ b/packages/zambdas/test/unit/sub-send-invoice-to-patient.test.ts
@@ -292,6 +292,26 @@ describe('sub-send-invoice-to-patient source guard', () => {
 
     await expect(runHandler(pastTask)).rejects.toThrow('Due date should be in the future');
     expect(mockStripe.invoices.create).not.toHaveBeenCalled();
+
+    const patchArg = mockClinicalClient.fhir.patch.mock.calls[0][0] as {
+      operations: { op: string; path: string; value: unknown }[];
+    };
+    expect(patchArg.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: '/status', value: 'failed' }),
+        expect.objectContaining({
+          path: '/output',
+          value: expect.arrayContaining([
+            expect.objectContaining({
+              type: expect.objectContaining({
+                coding: expect.arrayContaining([expect.objectContaining({ code: 'send-invoice-output-error' })]),
+              }),
+              valueString: 'Due date should be in the future',
+            }),
+          ]),
+        }),
+      ])
+    );
   });
 
   it('rejects a task whose dueDate has an invalid format without calling Stripe', async () => {
@@ -305,5 +325,24 @@ describe('sub-send-invoice-to-patient source guard', () => {
 
     await expect(runHandler(badFormatTask)).rejects.toThrow();
     expect(mockStripe.invoices.create).not.toHaveBeenCalled();
+
+    const patchArg = mockClinicalClient.fhir.patch.mock.calls[0][0] as {
+      operations: { op: string; path: string; value: unknown }[];
+    };
+    expect(patchArg.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: '/status', value: 'failed' }),
+        expect.objectContaining({
+          path: '/output',
+          value: expect.arrayContaining([
+            expect.objectContaining({
+              type: expect.objectContaining({
+                coding: expect.arrayContaining([expect.objectContaining({ code: 'send-invoice-output-error' })]),
+              }),
+            }),
+          ]),
+        }),
+      ])
+    );
   });
 });


### PR DESCRIPTION
This pr is a fix for https://linear.app/zapehr/issue/OTR-3139/error-in-sub-send-invoice-to-patient-when-due-date-is-in-the-past ticket and also a little change how info is displayed when hovering over status of invoicing task. New Layout:
<img width="331" height="144" alt="image" src="https://github.com/user-attachments/assets/3cae7669-6de5-42e9-8998-3fa2d8597bec" />
