### PR TITLE
OTR-3099: Extend consent-attestation save gate to per-section Save buttons

### DIFF
--- a/apps/ehr/src/features/visits/shared/components/patient/ActionBar.tsx
+++ b/apps/ehr/src/features/visits/shared/components/patient/ActionBar.tsx
@@ -2,6 +2,7 @@ import { LoadingButton } from '@mui/lab';
 import { Box, Button, Tooltip, useTheme } from '@mui/material';
 import { FC } from 'react';
 import { dataTestIds } from 'src/constants/data-test-ids';
+import { useSaveBlockedReason } from './SaveBlockedReasonContext';
 
 type ActionBarProps = {
   handleDiscard: () => void;
@@ -10,11 +11,6 @@ type ActionBarProps = {
   hidden?: boolean;
   submitDisabled?: boolean;
   backButtonHidden?: boolean;
-  /**
-   * When set, saving is blocked by something outside the form itself: the save button is disabled
-   * and this text explains why on hover.
-   */
-  submitBlockedReason?: string;
 };
 
 export const ActionBar: FC<ActionBarProps> = ({
@@ -24,9 +20,11 @@ export const ActionBar: FC<ActionBarProps> = ({
   hidden,
   submitDisabled,
   backButtonHidden,
-  submitBlockedReason,
 }) => {
   const theme = useTheme();
+  // Set by the visit page, which requires the consent attestation before any of the patient record
+  // can be written. Undefined everywhere else, so the standalone patient-info page is unaffected.
+  const submitBlockedReason = useSaveBlockedReason();
 
   const saveButton = (
     <LoadingButton

--- a/apps/ehr/src/features/visits/shared/components/patient/SaveBlockedReasonContext.tsx
+++ b/apps/ehr/src/features/visits/shared/components/patient/SaveBlockedReasonContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, FC, ReactNode, useContext } from 'react';
+
+/**
+ * Reason why saving patient-record data is blocked by something outside the form itself — e.g. the
+ * visit page requiring the consent attestation. `undefined` means saving is allowed.
+ *
+ * `PatientAccountComponent` provides it so every per-section Save button is gated the same way as
+ * the "Save All" button in the ActionBar. Both write the same patient-record data, so gating only
+ * "Save All" would leave a way around the block. The standalone patient-info page provides no
+ * reason, which leaves its Save buttons enabled.
+ */
+const SaveBlockedReasonContext = createContext<string | undefined>(undefined);
+
+export const SaveBlockedReasonProvider: FC<{ reason?: string; children: ReactNode }> = ({ reason, children }) => (
+  <SaveBlockedReasonContext.Provider value={reason}>{children}</SaveBlockedReasonContext.Provider>
+);
+
+export const useSaveBlockedReason = (): string | undefined => useContext(SaveBlockedReasonContext);

--- a/apps/ehr/src/features/visits/shared/components/patient/SectionSaveButton.tsx
+++ b/apps/ehr/src/features/visits/shared/components/patient/SectionSaveButton.tsx
@@ -1,5 +1,5 @@
 import { Save } from '@mui/icons-material';
-import { Button, CircularProgress } from '@mui/material';
+import { Button, CircularProgress, Tooltip } from '@mui/material';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Reference } from 'fhir/r4b';
 import { enqueueSnackbar } from 'notistack';
@@ -14,6 +14,7 @@ import { createQuestionnaireItemsMap } from 'utils/lib/types/data/paperwork/crea
 import { structureQuestionnaireResponse } from '../../../../../helpers/qr-structure';
 import { useUpdatePatientAccount } from '../../../../../hooks/useGetPatient';
 import { buildVisitEmployerUpdate, OCCUPATIONAL_MEDICINE_EMPLOYER_FIELD_KEY } from '../../visitEmployer';
+import { useSaveBlockedReason } from './SaveBlockedReasonContext';
 import { scrollToFirstInvalidField } from './scrollToFirstInvalidField';
 
 const questionnaire = PATIENT_RECORD_QUESTIONNAIRE();
@@ -70,6 +71,9 @@ export const SectionSaveButton: FC<SectionSaveButtonProps> = ({
   const { oystehrZambda } = useApiClients();
   const { watch, formState, resetField, getValues, trigger, getFieldState } = useFormContext();
   const { dirtyFields } = formState;
+  // Set by the visit page, which requires the consent attestation before any of the patient record
+  // can be written. Undefined everywhere else, so the standalone patient-info page is unaffected.
+  const saveBlockedReason = useSaveBlockedReason();
 
   const employerFieldDirty = Boolean(dirtyFields[OCCUPATIONAL_MEDICINE_EMPLOYER_FIELD_KEY]);
   const saveEmployerViaVisitDetails = useUpdateVisitDetailsForEmployer && Boolean(appointmentId) && employerFieldDirty;
@@ -205,16 +209,25 @@ export const SectionSaveButton: FC<SectionSaveButtonProps> = ({
 
   if (!isDirty) return null;
 
-  return (
+  const saveButton = (
     <Button
       variant="outlined"
       size="small"
       startIcon={isSaving ? <CircularProgress size={14} /> : <Save fontSize="small" />}
-      disabled={isSaving}
+      disabled={isSaving || Boolean(saveBlockedReason)}
       onClick={handleSave}
       sx={{ textTransform: 'none', fontSize: '13px', py: 0.25, px: 1.5 }}
     >
       Save
     </Button>
+  );
+
+  if (!saveBlockedReason) return saveButton;
+
+  return (
+    <Tooltip title={saveBlockedReason}>
+      {/* A disabled button emits no pointer events, so the tooltip needs an enabled wrapper. */}
+      <span>{saveButton}</span>
+    </Tooltip>
   );
 };

--- a/apps/ehr/src/pages/PatientInformationPage.tsx
+++ b/apps/ehr/src/pages/PatientInformationPage.tsx
@@ -34,6 +34,7 @@ import { createDynamicValidationResolver } from 'src/features/visits/shared/comp
 import { PharmacyContainer } from 'src/features/visits/shared/components/patient/PharmacyContainer';
 import { PrimaryCareContainer } from 'src/features/visits/shared/components/patient/PrimaryCareContainer';
 import { ResponsibleInformationContainer } from 'src/features/visits/shared/components/patient/ResponsibleInformationContainer';
+import { SaveBlockedReasonProvider } from 'src/features/visits/shared/components/patient/SaveBlockedReasonContext';
 import { scrollToFirstInvalidField } from 'src/features/visits/shared/components/patient/scrollToFirstInvalidField';
 import { WarningBanner } from 'src/features/visits/shared/components/patient/WarningBanner';
 import { useOystehrAPIClient } from 'src/features/visits/shared/hooks/useOystehrAPIClient';
@@ -397,8 +398,9 @@ interface PatientAccountComponentProps {
    */
   photoIdCardSlot?: ReactNode;
   /**
-   * When set, "Save All" is disabled and this text explains why on hover. Used by the visit page to
-   * require the consent attestation before any of the visit's details can be saved.
+   * When set, "Save All" and every per-section Save button are disabled and this text explains why
+   * on hover. Used by the visit page to require the consent attestation before any of the visit's
+   * details can be saved.
    */
   submitBlockedReason?: string;
 }
@@ -613,105 +615,108 @@ export const PatientAccountComponent: FC<PatientAccountComponentProps> = ({
   return (
     <div>
       {isFetching && <LoadingScreen />}
-      <FormProvider {...methods}>
-        <Box>
-          {renderHeader && <Header handleDiscard={handleBackClickWithConfirmation} id={id} />}
-          <Box sx={{ display: 'flex', flexDirection: 'column', ...containerSX, marginBottom: 2 }}>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-              {renderBreadCrumbs && <BreadCrumbs patient={patient} />}
-              {title && (
-                <Typography variant="h3" color="primary.main">
-                  {title}
-                </Typography>
-              )}
-              <PatientMergedBanner patient={patient} />
-              <WarningBanner
-                otherPatientsWithSameName={otherPatientsWithSameName}
-                onClose={() => setOtherPatientsWithSameName(false)}
-              />
-              <Box sx={{ display: 'flex', gap: 3 }}>
-                <Box sx={{ flex: '1 1', display: 'flex', flexDirection: 'column', gap: 2 }}>
-                  {aboutPatientSection}
-                  <ContactContainer
-                    isLoading={isFetching || submitQR.isPending}
-                    patientId={patient?.id}
-                    encounterId={appointmentContext?.encounterId}
-                  />
-                  <PatientDetailsContainer
-                    patient={patient}
-                    isLoading={isFetching || submitQR.isPending}
-                    patientId={patient?.id}
-                    encounterId={appointmentContext?.encounterId}
-                  />
-                  <PrimaryCareContainer
-                    isLoading={isFetching || submitQR.isPending}
-                    patientId={patient?.id}
-                    encounterId={appointmentContext?.encounterId}
-                  />
-                </Box>
-                <Box sx={{ flex: '1 1', display: 'flex', flexDirection: 'column', gap: 2 }}>
-                  {insuranceSection}
-                  <ResponsibleInformationContainer
-                    isLoading={isFetching || submitQR.isPending}
-                    patientId={patient?.id}
-                    encounterId={appointmentContext?.encounterId}
-                  />
-                  <EmployerInformationContainer
-                    isLoading={isFetching || submitQR.isPending}
-                    patientId={patient?.id}
-                    encounterId={appointmentContext?.encounterId}
-                  />
-                  <OccupationalMedicineEmployerInformationContainer
-                    isLoading={isFetching || submitQR.isPending}
-                    patientId={patient?.id}
-                    encounterId={appointmentContext?.encounterId}
-                    appointmentId={appointmentId}
-                    useUpdateVisitDetailsForEmployer={
-                      Boolean(appointmentId) && appointmentContext?.appointmentServiceCategory === 'pre-op'
-                    }
-                  />
-                  <AttorneyInformationContainer
-                    isLoading={isFetching || submitQR.isPending}
-                    patientId={patient?.id}
-                    encounterId={appointmentContext?.encounterId}
-                  />
-                  <EmergencyContactContainer
-                    isLoading={isFetching || submitQR.isPending}
-                    patientId={patient?.id}
-                    encounterId={appointmentContext?.encounterId}
-                  />
-                  <PharmacyContainer
-                    isLoading={isFetching || submitQR.isPending}
-                    patientId={patient?.id}
-                    encounterId={appointmentContext?.encounterId}
-                  />
+      {/* Gates the per-section Save buttons on the same condition as "Save All" below: both write
+          the same patient-record data, so gating only "Save All" would leave a way around it. */}
+      <SaveBlockedReasonProvider reason={submitBlockedReason}>
+        <FormProvider {...methods}>
+          <Box>
+            {renderHeader && <Header handleDiscard={handleBackClickWithConfirmation} id={id} />}
+            <Box sx={{ display: 'flex', flexDirection: 'column', ...containerSX, marginBottom: 2 }}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                {renderBreadCrumbs && <BreadCrumbs patient={patient} />}
+                {title && (
+                  <Typography variant="h3" color="primary.main">
+                    {title}
+                  </Typography>
+                )}
+                <PatientMergedBanner patient={patient} />
+                <WarningBanner
+                  otherPatientsWithSameName={otherPatientsWithSameName}
+                  onClose={() => setOtherPatientsWithSameName(false)}
+                />
+                <Box sx={{ display: 'flex', gap: 3 }}>
+                  <Box sx={{ flex: '1 1', display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    {aboutPatientSection}
+                    <ContactContainer
+                      isLoading={isFetching || submitQR.isPending}
+                      patientId={patient?.id}
+                      encounterId={appointmentContext?.encounterId}
+                    />
+                    <PatientDetailsContainer
+                      patient={patient}
+                      isLoading={isFetching || submitQR.isPending}
+                      patientId={patient?.id}
+                      encounterId={appointmentContext?.encounterId}
+                    />
+                    <PrimaryCareContainer
+                      isLoading={isFetching || submitQR.isPending}
+                      patientId={patient?.id}
+                      encounterId={appointmentContext?.encounterId}
+                    />
+                  </Box>
+                  <Box sx={{ flex: '1 1', display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    {insuranceSection}
+                    <ResponsibleInformationContainer
+                      isLoading={isFetching || submitQR.isPending}
+                      patientId={patient?.id}
+                      encounterId={appointmentContext?.encounterId}
+                    />
+                    <EmployerInformationContainer
+                      isLoading={isFetching || submitQR.isPending}
+                      patientId={patient?.id}
+                      encounterId={appointmentContext?.encounterId}
+                    />
+                    <OccupationalMedicineEmployerInformationContainer
+                      isLoading={isFetching || submitQR.isPending}
+                      patientId={patient?.id}
+                      encounterId={appointmentContext?.encounterId}
+                      appointmentId={appointmentId}
+                      useUpdateVisitDetailsForEmployer={
+                        Boolean(appointmentId) && appointmentContext?.appointmentServiceCategory === 'pre-op'
+                      }
+                    />
+                    <AttorneyInformationContainer
+                      isLoading={isFetching || submitQR.isPending}
+                      patientId={patient?.id}
+                      encounterId={appointmentContext?.encounterId}
+                    />
+                    <EmergencyContactContainer
+                      isLoading={isFetching || submitQR.isPending}
+                      patientId={patient?.id}
+                      encounterId={appointmentContext?.encounterId}
+                    />
+                    <PharmacyContainer
+                      isLoading={isFetching || submitQR.isPending}
+                      patientId={patient?.id}
+                      encounterId={appointmentContext?.encounterId}
+                    />
+                  </Box>
                 </Box>
               </Box>
             </Box>
+            <ActionBar
+              handleDiscard={handleBackClickWithConfirmation}
+              handleSave={handleSubmit(handleSaveForm, (validationErrors) => {
+                enqueueSnackbar('Please fix all field validation errors and try again', { variant: 'error' });
+                scrollToFirstInvalidField(Object.keys(validationErrors), (key) => Boolean(validationErrors[key]));
+              })}
+              loading={submitQR.isPending}
+              hidden={false}
+              submitDisabled={Object.keys(dirtyFields).length === 0}
+              backButtonHidden={renderBackButton === false}
+            />
           </Box>
-          <ActionBar
-            handleDiscard={handleBackClickWithConfirmation}
-            handleSave={handleSubmit(handleSaveForm, (validationErrors) => {
-              enqueueSnackbar('Please fix all field validation errors and try again', { variant: 'error' });
-              scrollToFirstInvalidField(Object.keys(validationErrors), (key) => Boolean(validationErrors[key]));
-            })}
-            loading={submitQR.isPending}
-            hidden={false}
-            submitDisabled={Object.keys(dirtyFields).length === 0}
-            submitBlockedReason={submitBlockedReason}
-            backButtonHidden={renderBackButton === false}
+          <CustomDialog
+            open={openConfirmationDialog}
+            handleClose={handleCloseConfirmationDialog}
+            title="Discard Changes?"
+            description="You have unsaved changes. Are you sure you want to discard them and go back?"
+            closeButtonText="Cancel"
+            handleConfirm={handleDiscardChanges}
+            confirmText="Discard Changes"
           />
-        </Box>
-        <CustomDialog
-          open={openConfirmationDialog}
-          handleClose={handleCloseConfirmationDialog}
-          title="Discard Changes?"
-          description="You have unsaved changes. Are you sure you want to discard them and go back?"
-          closeButtonText="Cancel"
-          handleConfirm={handleDiscardChanges}
-          confirmText="Discard Changes"
-        />
-      </FormProvider>
+        </FormProvider>
+      </SaveBlockedReasonProvider>
     </div>
   );
 };

--- a/apps/ehr/src/pages/VisitDetailsPage.tsx
+++ b/apps/ehr/src/pages/VisitDetailsPage.tsx
@@ -115,12 +115,14 @@ import { PatientAccountComponent } from './PatientInformationPage';
 
 const consentToTreatPatientDetailsKey = 'Consent Forms signed?';
 
-// The bottom "Save All" button and the "Completed consent forms" block's own Save button are gated on
-// the staff member attesting that consent was obtained. The inline pencil-icon dialogs (DOB, reason
-// for visit, service category, non-legal guardians) are intentionally not gated.
+// The "About this patient" saves - the bottom "Save All" button and each section's own Save button
+// alike - plus the "Completed consent forms" block's own Save button are gated on the staff member
+// attesting that consent was obtained. The "Booking details" pencil-icon dialogs (DOB, reason for
+// visit, service category, non-legal guardians) and the payments, notes and document blocks are
+// intentionally not gated.
 //
-// The Save All gate reads the *persisted* attestation, not the local checkbox, so it has to spell out
-// that the checkbox must be committed via the consent block's Save button first.
+// The "About this patient" gate reads the *persisted* attestation, not the local checkbox, so it has
+// to spell out that the checkbox must be committed via the consent block's Save button first.
 const CONSENT_ATTESTATION_NOT_SAVED_MESSAGE =
   'Please check "I verify that patient consent has been obtained." and click Save in the "Completed consent forms" block before saving.';
 const CONSENT_ATTESTATION_REQUIRED_MESSAGE =

--- a/apps/ehr/tests/component/ActionBar.test.tsx
+++ b/apps/ehr/tests/component/ActionBar.test.tsx
@@ -4,6 +4,7 @@ import { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { dataTestIds } from '../../src/constants/data-test-ids';
 import { ActionBar } from '../../src/features/visits/shared/components/patient/ActionBar';
+import { SaveBlockedReasonProvider } from '../../src/features/visits/shared/components/patient/SaveBlockedReasonContext';
 
 // ============================================================================
 // HARNESS
@@ -12,11 +13,20 @@ import { ActionBar } from '../../src/features/visits/shared/components/patient/A
 const BLOCKED_REASON = 'Please check "I verify that patient consent has been obtained." before saving.';
 
 const renderActionBar = (
-  overrides: Partial<ComponentProps<typeof ActionBar>> = {}
+  overrides: Partial<ComponentProps<typeof ActionBar>> = {},
+  blockedReason?: string
 ): { handleSave: ReturnType<typeof vi.fn> } => {
   const handleSave = vi.fn().mockResolvedValue(undefined);
   render(
-    <ActionBar handleDiscard={vi.fn()} handleSave={handleSave} loading={false} submitDisabled={false} {...overrides} />
+    <SaveBlockedReasonProvider reason={blockedReason}>
+      <ActionBar
+        handleDiscard={vi.fn()}
+        handleSave={handleSave}
+        loading={false}
+        submitDisabled={false}
+        {...overrides}
+      />
+    </SaveBlockedReasonProvider>
   );
   return { handleSave };
 };
@@ -37,7 +47,7 @@ describe('ActionBar', () => {
   });
 
   it('disables Save All while a blocking reason is present, even when the form is dirty', async () => {
-    const { handleSave } = renderActionBar({ submitBlockedReason: BLOCKED_REASON });
+    const { handleSave } = renderActionBar({}, BLOCKED_REASON);
 
     expect(saveButton()).toBeDisabled();
     // Click the wrapper: the disabled button itself swallows pointer events.
@@ -46,7 +56,7 @@ describe('ActionBar', () => {
   });
 
   it('explains the blocked submit on hover', async () => {
-    renderActionBar({ submitBlockedReason: BLOCKED_REASON });
+    renderActionBar({}, BLOCKED_REASON);
 
     await userEvent.hover(saveButton().parentElement!);
     expect(await screen.findByRole('tooltip')).toHaveTextContent(BLOCKED_REASON);

--- a/apps/ehr/tests/component/SectionSaveButton.test.tsx
+++ b/apps/ehr/tests/component/SectionSaveButton.test.tsx
@@ -45,6 +45,7 @@ vi.mock('../../src/hooks/useGetPatient', () => ({
 }));
 
 import { PATIENT_RECORD_QUESTIONNAIRE } from 'utils/lib/ottehr-config/patient-record';
+import { SaveBlockedReasonProvider } from '../../src/features/visits/shared/components/patient/SaveBlockedReasonContext';
 import { SectionSaveButton } from '../../src/features/visits/shared/components/patient/SectionSaveButton';
 
 // ============================================================================
@@ -92,9 +93,18 @@ interface HarnessProps {
   resolver?: Resolver<Record<string, unknown>>;
   patientId?: string;
   encounterId?: string;
+  blockedReason?: string;
 }
 
-const Harness: FC<HarnessProps> = ({ defaultValues, dirtyKeys = [], fieldKeys, resolver, patientId, encounterId }) => {
+const Harness: FC<HarnessProps> = ({
+  defaultValues,
+  dirtyKeys = [],
+  fieldKeys,
+  resolver,
+  patientId,
+  encounterId,
+  blockedReason,
+}) => {
   const methods = useForm<Record<string, unknown>>({ defaultValues, mode: 'onChange', resolver });
   useEffect(() => {
     dirtyKeys.forEach((key) => {
@@ -102,9 +112,11 @@ const Harness: FC<HarnessProps> = ({ defaultValues, dirtyKeys = [], fieldKeys, r
     });
   }, [dirtyKeys, defaultValues, methods]);
   return (
-    <FormProvider {...methods}>
-      <SectionSaveButton fieldKeys={fieldKeys} patientId={patientId} encounterId={encounterId} />
-    </FormProvider>
+    <SaveBlockedReasonProvider reason={blockedReason}>
+      <FormProvider {...methods}>
+        <SectionSaveButton fieldKeys={fieldKeys} patientId={patientId} encounterId={encounterId} />
+      </FormProvider>
+    </SaveBlockedReasonProvider>
   );
 };
 
@@ -149,6 +161,34 @@ describe('SectionSaveButton', () => {
       patientId: 'p1',
     });
     await waitFor(() => expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument());
+  });
+
+  it('disables Save and explains why when an outside condition blocks saving', async () => {
+    const user = userEvent.setup();
+    renderHarness({
+      defaultValues: { 'patient-email': 'a@b.co' },
+      dirtyKeys: ['patient-email'],
+      fieldKeys: ['patient-email'],
+      patientId: 'p1',
+      blockedReason: 'Consent has not been attested.',
+    });
+
+    const btn = await screen.findByRole('button', { name: /save/i });
+    expect(btn).toBeDisabled();
+
+    // The disabled button emits no pointer events, so the tooltip hangs off the wrapper span.
+    await user.hover(btn.parentElement as HTMLElement);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Consent has not been attested.');
+  });
+
+  it('leaves Save enabled when nothing outside the form blocks saving', async () => {
+    renderHarness({
+      defaultValues: { 'patient-email': 'a@b.co' },
+      dirtyKeys: ['patient-email'],
+      fieldKeys: ['patient-email'],
+      patientId: 'p1',
+    });
+    expect(await screen.findByRole('button', { name: /save/i })).toBeEnabled();
   });
 
   it('stays enabled even when a required field is empty (validation surfaces on click)', async () => {


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-3099/consent-checkbox-on-visit-detail#comment-6229b2d2

Previously only the "Save All" button on the visit's Patient Information page was disabled while consent attestation was outstanding — the per-section Save buttons wrote the same patient-record data but had no such gate, leaving a way to bypass the requirement. This adds a `SaveBlockedReasonContext`/`SaveBlockedReasonProvider` so every per-section `SectionSaveButton` is disabled (with an explanatory tooltip) under the same condition as `ActionBar's` "Save All", and refactors `ActionBar` to read the same context instead of a separately-drilled `submitBlockedReason` prop. The standalone patient-info page (no provider) is unaffected.

<img width="1147" height="566" alt="image" src="https://github.com/user-attachments/assets/5ecc8be6-a2d5-434a-a8da-90defa9a892f" />
