### PR TITLE
fix(ai): keep AI resources polling alive across tabs and recordings

### DIFF
--- a/apps/ehr/src/features/visits/in-person/layout/InPersonLayout.tsx
+++ b/apps/ehr/src/features/visits/in-person/layout/InPersonLayout.tsx
@@ -11,11 +11,13 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { CommandPaletteInPersonRegistrations } from 'src/components/CommandPaletteRegistrations';
 import { dataTestIds } from 'src/constants/data-test-ids';
+import { useApiClients } from 'src/hooks/useAppClients';
 import { ThemeProvider } from 'styled-components';
 import { isTelemedAppointment } from 'utils/lib/fhir/moduleIdentification';
 import { getSelectors } from 'utils/lib/store';
 import { isVisitFinished } from 'utils/lib/utils/visitUtils';
 import { Sidebar } from '../../shared/components/Sidebar';
+import { useAiResourcesPolling } from '../../shared/components/useAiResourcesPolling';
 import { useAiSuggestionsPolling } from '../../shared/hooks/useAiSuggestionsPolling';
 import { useAssignedProvider } from '../../shared/hooks/useAssignedProvider';
 import { useGetAppointmentAccessibility } from '../../shared/hooks/useGetAppointmentAccessibility';
@@ -63,7 +65,19 @@ export const InPersonLayout: React.FC = () => {
   useAiSuggestionsPolling();
   // Keep the Ambient Scribe recording alive across rotation; stop & save it on leaving the visit.
   useStopAmbientScribeOnLeave({ hostKey: encounter.id ?? '' });
-  const { chartData } = useChartData({ shouldUpdateExams: true });
+  const { chartData, refetch: refetchChartData } = useChartData({ shouldUpdateExams: true });
+  const { oystehr } = useApiClients();
+  // Mounted here (not in the OttehrAi route) so a pending recording or AI interview keeps getting
+  // refetched no matter which tab the provider is on — the Ambient Scribe panel above reads
+  // chartData.aiChat straight from the same query cache this refetch loop keeps warm.
+  useAiResourcesPolling({
+    appointment,
+    encounter,
+    oystehr,
+    chartDataHasResources: (chartData?.aiChat?.documents?.length ?? 0) > 0,
+    hasPendingRecording: Boolean(chartData?.aiChat?.hasPendingRecording),
+    onRefetch: refetchChartData,
+  });
   const { isAssignedProviderEligible, isAssignedProviderStale, assignedProviderName } = useAssignedProvider();
   // A finished visit is a record, not work in progress. The provider gate exists to stop new
   // charting and signing under an unassignable provider; applying it to finished visits too would

--- a/apps/ehr/src/features/visits/shared/components/OttehrAi.tsx
+++ b/apps/ehr/src/features/visits/shared/components/OttehrAi.tsx
@@ -5,19 +5,19 @@ import { DocumentReference, Practitioner } from 'fhir/r4b';
 import { DateTime } from 'luxon';
 import React from 'react';
 import { AccordionCard } from 'src/components/AccordionCard';
-import { useApiClients } from 'src/hooks/useAppClients';
 import {
   DOCUMENT_REFERENCE_SUMMARY_FROM_AUDIO,
   DOCUMENT_REFERENCE_SUMMARY_FROM_CHAT,
   PUBLIC_EXTENSION_BASE_URL,
 } from 'utils/lib/fhir/constants';
+import { getSelectors } from 'utils/lib/store';
 import { AiObservationField } from 'utils/lib/types/api/chart-data/chart-data.constants';
 import { ObservationTextFieldDTO } from 'utils/lib/types/data/screening-questions/types';
 import AiSuggestion from '../../in-person/components/AiSuggestion';
 import { PlayRecord } from '../../in-person/components/progress-note/PlayRecord';
+import { useAiResourcesPollingStore } from '../stores/aiResourcesPolling.store';
 import { useAppointmentData, useChartData } from '../stores/appointment/appointment.store';
 import { Loader } from './Loader';
-import { useAiResourcesPolling } from './useAiResourcesPolling';
 
 const AI_OBSERVATION_FIELDS = {
   [AiObservationField.HistoryOfPresentIllness]: 'History of Present Illness (HPI)',
@@ -77,22 +77,15 @@ export const OttehrAi: React.FC<OttehrAiProps> = () => {
     visitState: { appointment },
     isAppointmentLoading,
     appointmentError,
-    encounter,
   } = useAppointmentData();
 
-  const { isChartDataLoading, chartDataError, chartData, refetch: refetchChartData } = useChartData();
-  const { oystehr } = useApiClients();
+  const { isChartDataLoading, chartDataError, chartData } = useChartData();
 
-  const chartDataHasResources = (chartData?.aiChat?.documents?.length ?? 0) > 0;
-
-  const { isPolling, pollingExhausted, hasPendingAiSource } = useAiResourcesPolling({
-    appointment,
-    encounter,
-    oystehr,
-    chartDataHasResources,
-    hasPendingRecording: Boolean(chartData?.aiChat?.hasPendingRecording),
-    onRefetch: refetchChartData,
-  });
+  const { isPolling, hasPendingAiSource, pollingExhausted } = getSelectors(useAiResourcesPollingStore, [
+    'isPolling',
+    'hasPendingAiSource',
+    'pollingExhausted',
+  ]);
 
   const isLoading = isAppointmentLoading || isChartDataLoading;
   const error = chartDataError || appointmentError;

--- a/apps/ehr/src/features/visits/shared/components/useAiResourcesPolling.ts
+++ b/apps/ehr/src/features/visits/shared/components/useAiResourcesPolling.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { AMBIENT_SCRIBE_RECORDING_PENDING_CODING } from 'utils/lib/fhir/constants';
 import { AI_QUESTIONNAIRE_ID } from 'utils/lib/types/constants';
 import { getInPersonVisitStatus } from 'utils/lib/utils/visitUtils';
+import { useAiResourcesPollingStore } from '../stores/aiResourcesPolling.store';
 
 interface UseAiResourcesPollingParams {
   appointment: Appointment | undefined;
@@ -40,6 +41,17 @@ export const useAiResourcesPolling = ({
   const pollingExhaustedRef = useRef(false);
   const initialCheckDoneRef = useRef(false);
 
+  // Mirror this instance's state into the shared store so components that don't call this hook directly
+  // (e.g. OttehrAi, since this hook is only invoked from the persistently-mounted InPersonLayout) can still
+  // read live polling status without starting a second, competing poll loop of their own.
+  useEffect(() => {
+    useAiResourcesPollingStore.setState({
+      isPolling,
+      hasPendingAiSource,
+      pollingExhausted: pollingExhaustedRef.current,
+    });
+  }, [isPolling, hasPendingAiSource]);
+
   // Check if there's an AI interview with sufficient answers but no AI resources
   const checkForInterviewWithoutResources = useCallback(async (): Promise<boolean> => {
     if (!oystehr || !encounter?.id) return false;
@@ -72,7 +84,7 @@ export const useAiResourcesPolling = ({
 
   // Check if an in-person recording was uploaded and is awaiting transcription
   const checkForPendingAudioRecording = useCallback(async (): Promise<boolean> => {
-    if (!oystehr || !encounter?.id || chartDataHasResources) return false;
+    if (!oystehr || !encounter?.id) return false;
 
     try {
       const drResult = await oystehr.fhir.search<DocumentReference>({
@@ -91,7 +103,7 @@ export const useAiResourcesPolling = ({
       console.error('Error checking for pending audio recording:', error);
       return false;
     }
-  }, [oystehr, encounter?.id, chartDataHasResources]);
+  }, [oystehr, encounter?.id]);
 
   const checkForPendingAiSource = useCallback(async (): Promise<boolean> => {
     const [interviewPending, audioRecordingPending] = await Promise.all([
@@ -107,8 +119,13 @@ export const useAiResourcesPolling = ({
       if (!appointment || !encounter) return;
 
       const visitStatus = getInPersonVisitStatus(appointment, encounter);
-      const isRelevantStatus = visitStatus === 'ready for provider' || visitStatus === 'provider';
-
+      const isRelevantStatus =
+        visitStatus === 'pending' ||
+        visitStatus === 'arrived' ||
+        visitStatus === 'intake' ||
+        visitStatus === 'ready' ||
+        visitStatus === 'ready for provider' ||
+        visitStatus === 'provider';
       if (!hasPendingRecording && !isRelevantStatus) {
         setHasPendingAiSource(false);
         setIsPolling(false);
@@ -118,9 +135,9 @@ export const useAiResourcesPolling = ({
         return;
       }
 
-      // Only check and start polling if we haven't done initial check yet
-      // or if we know resources are missing
-      if (!initialCheckDoneRef.current || !chartDataHasResources) {
+      // Only check and start polling if we haven't done initial check yet, if we know resources are
+      // missing, or there is a pending recording
+      if (!initialCheckDoneRef.current || !chartDataHasResources || hasPendingRecording) {
         const needsPolling = await checkForPendingAiSource();
         setHasPendingAiSource(needsPolling);
         initialCheckDoneRef.current = true;

--- a/apps/ehr/src/features/visits/shared/components/useAiResourcesPolling.ts
+++ b/apps/ehr/src/features/visits/shared/components/useAiResourcesPolling.ts
@@ -40,6 +40,18 @@ export const useAiResourcesPolling = ({
   const pollingIntervalRef = useRef<NodeJS.Timeout>();
   const pollingExhaustedRef = useRef(false);
   const initialCheckDoneRef = useRef(false);
+  const previousEncounterIdRef = useRef(encounter?.id);
+
+  // Update polling state on encounter change
+  useEffect(() => {
+    if (previousEncounterIdRef.current === encounter?.id) return;
+    previousEncounterIdRef.current = encounter?.id;
+    setIsPolling(false);
+    setHasPendingAiSource(false);
+    pollingAttemptsRef.current = 0;
+    pollingExhaustedRef.current = false;
+    initialCheckDoneRef.current = false;
+  }, [encounter?.id]);
 
   // Mirror this instance's state into the shared store so components that don't call this hook directly
   // (e.g. OttehrAi, since this hook is only invoked from the persistently-mounted InPersonLayout) can still

--- a/apps/ehr/src/features/visits/shared/stores/aiResourcesPolling.store.ts
+++ b/apps/ehr/src/features/visits/shared/stores/aiResourcesPolling.store.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+
+interface AiResourcesPollingState {
+  isPolling: boolean;
+  hasPendingAiSource: boolean;
+  pollingExhausted: boolean;
+}
+
+// Written by the single, persistently-mounted useAiResourcesPolling instance in InPersonLayout (alive for
+// the whole visit, not just one tab), so OttehrAi can read polling status without running its own
+// competing poll loop.
+export const useAiResourcesPollingStore = create<AiResourcesPollingState>()(() => ({
+  isPolling: false,
+  hasPendingAiSource: false,
+  pollingExhausted: false,
+}));


### PR DESCRIPTION
## Summary
- Follow-up to #9231 / OTR-3304: QA found the Ambient Scribe "loading" chip still got stuck indefinitely (only fixed by a manual page reload) even with all of that PR's fixes in place.
- `useAiResourcesPolling` was only invoked from the `OttehrAi` route, so a provider who ended a recording and stayed on the progress note page (rather than opening the separate "Oystehr AI" tab) got exactly one one-shot chart-data refresh and then nothing — no polling ever ran. Moved the hook into `InPersonLayout` (mounted for the whole visit regardless of tab), writing into a small `aiResourcesPollingStore` that `OttehrAi` reads from instead of running a second, competing poll loop.
- Separately: `checkForPendingAudioRecording` (and its caller) short-circuited on `chartDataHasResources`, which goes permanently `true` after a visit's *first* completed recording — so a *second* recording on the same visit was never detected as pending. Dropped that gate from the search itself (which already scopes to the pending-only type code) and widened the outer re-check condition to also fire when `hasPendingRecording` is true.
- Widened `isRelevantStatus` to also cover `pending`/`arrived`/`intake`/`ready`, not just `ready for provider`/`provider`.

## Test plan
- [ ] Start and end an Ambient Scribe recording while staying on the progress note page (not the Oystehr AI tab) — confirm the loading chip clears once transcription finishes, without a manual reload.
- [ ] Record a second Ambient Scribe recording on the same visit after the first has completed — confirm it's also picked up and transcribed/polled correctly.
- [ ] Confirm telemed AI-interview polling still works (unaffected by these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)