### PR TITLE
feat: configurable AI note-review warnings before signing (OTR-3079)

### DIFF
--- a/apps/ehr/src/constants/data-test-ids.ts
+++ b/apps/ehr/src/constants/data-test-ids.ts
@@ -317,7 +317,6 @@ export const dataTestIds = {
     sendFaxButton: 'send-fax-button',
     dischargeSummaryButton: 'discharge-summary-button',
     missingCard: 'missing-card',
-    missingCardText: 'missing-card-text',
     patientVerificationLink: 'patient-verification-link',
     primaryDiagnosisLink: 'primary-diagnosis-link',
     secondaryDiagnosisLink: 'secondary-diagnosis-link',

--- a/apps/ehr/src/features/admin/ProgressNoteAdminPage.tsx
+++ b/apps/ehr/src/features/admin/ProgressNoteAdminPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '@mui/material';
 import { ReactElement, useEffect } from 'react';
 import { Control, Controller, useForm } from 'react-hook-form';
+import useEvolveUser from 'src/hooks/useEvolveUser';
 import { useProgressNoteConfig, useUpdateProgressNoteConfig } from 'src/hooks/useProgressNoteConfig';
 import { mapDispositionTypeToLabel } from 'utils/lib/fhir/disposition';
 import {
@@ -26,6 +27,7 @@ import {
   VITALS_UNIT_INPUT_ORDER_LABELS,
   VITALS_UNIT_INPUT_ORDERS,
 } from 'utils/lib/types/api/progress-note-config/progress-note-config.types';
+import { RoleType } from 'utils/lib/types/api/user.types';
 import { DEFAULT_PROGRESS_NOTE_CONFIG } from 'utils/lib/utils/progress-note-config';
 
 type ProgressNoteTextFieldName = Exclude<keyof ProgressNoteConfig, 'mdmRequired' | 'vitalsUnitInputOrder'>;
@@ -58,6 +60,7 @@ const ConfigTextAreaField = ({ control, name, label, minRows = 2 }: ConfigTextAr
 export default function ProgressNoteAdminPage(): ReactElement {
   const { data, isPending, isError } = useProgressNoteConfig();
   const { mutate, isPending: isSubmitting } = useUpdateProgressNoteConfig();
+  const isCustomerSupport = useEvolveUser()?.hasRole([RoleType.CustomerSupport]) ?? false;
 
   const {
     control,
@@ -192,6 +195,22 @@ export default function ProgressNoteAdminPage(): ReactElement {
                 )}
               />
             </Box>
+
+            {/* Field is hidden for non-CustomerSupport users, but its value still round-trips unchanged:
+                react-hook-form submits values carried in defaultValues/reset even when the field is never rendered. */}
+            {isCustomerSupport && (
+              <>
+                <Divider />
+                <Box>
+                  <ConfigTextAreaField
+                    control={control}
+                    name="signReviewPrompt"
+                    label="Note review prompt (shown at signing)"
+                    minRows={4}
+                  />
+                </Box>
+              </>
+            )}
 
             <Divider />
 

--- a/apps/ehr/src/features/visits/shared/components/review-tab/MissingCard.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/MissingCard.tsx
@@ -35,7 +35,8 @@ import { extractObservationsFromExamComponents } from 'utils/lib/config-helpers/
 import { examConfig } from 'utils/lib/ottehr-config/examination';
 import { InPersonRosConfig, rosField, RosFindingState } from 'utils/lib/ottehr-config/review-of-systems';
 import { AISuggestionNotes } from 'utils/lib/types/api/ai-suggestions-notes';
-import { ExamObservationDTO } from 'utils/lib/types/api/chart-data/chart-data.types';
+import { ExamObservationDTO, VitalsObservationDTO } from 'utils/lib/types/api/chart-data/chart-data.types';
+import { GetVitalsResponseData } from 'utils/lib/types/api/chart-data/get-vitals.types';
 import { hashInput } from '../../hooks/useBillingSuggestions';
 import { useChartFields } from '../../hooks/useChartFields';
 import { useGetAppointmentAccessibility } from '../../hooks/useGetAppointmentAccessibility';
@@ -44,13 +45,26 @@ import { useAiSuggestionNotes } from '../../stores/appointment/appointment.queri
 import { useAppointmentData, useChartData } from '../../stores/appointment/appointment.store';
 import { useExamObservationsStore } from '../../stores/appointment/exam-observations.store';
 import { useRosObservationsStore } from '../../stores/appointment/ros-observations.store';
+import { useGetVitals } from '../vitals/hooks/useGetVitals';
 
 // Compact text serialization of the note sections the practice-level sign-review prompt may evaluate
+const serializeVitals = (vitals: GetVitalsResponseData | undefined): string[] => {
+  return Object.entries(vitals ?? {}).flatMap(([field, observations]) =>
+    (observations as VitalsObservationDTO[]).map((obs) => {
+      const label = field.replace(/^vital-/, '').replace(/-/g, ' ');
+      const value =
+        'systolicPressure' in obs ? `${obs.systolicPressure}/${obs.diastolicPressure}` : String(obs.value ?? '');
+      return `${label}: ${value}`;
+    })
+  );
+};
+
 const serializeNoteDetails = (
   rosState: Record<string, ExamObservationDTO>,
   examState: Record<string, ExamObservationDTO>,
   hpi: string | undefined,
-  mdm: string | undefined
+  mdm: string | undefined,
+  vitals: GetVitalsResponseData | undefined
 ): string => {
   const rosLines = Object.values(InPersonRosConfig).flatMap((system) => {
     const items = Object.entries(system.items).flatMap(([baseKey, item]) =>
@@ -67,7 +81,16 @@ const serializeNoteDetails = (
     ].map((item) => `${item.label}${item.abnormal ? ' (abnormal)' : ''} (checked)`);
     return items.length > 0 ? [`${section.label}: ${items.join(', ')}`] : [];
   });
-  return [`HPI: ${hpi ?? ''}`, `MDM: ${mdm ?? ''}`, 'ROS:', ...rosLines, 'EXAM:', ...examLines].join('\n');
+  return [
+    `HPI: ${hpi ?? ''}`,
+    `MDM: ${mdm ?? ''}`,
+    'VITALS:',
+    ...serializeVitals(vitals),
+    'ROS:',
+    ...rosLines,
+    'EXAM:',
+    ...examLines,
+  ].join('\n');
 };
 
 export const MissingCard: FC = () => {
@@ -139,14 +162,21 @@ export const MissingCard: FC = () => {
   const rosState = useRosObservationsStore();
   const examState = useExamObservationsStore();
   const signReviewPrompt = progressNoteConfig?.signReviewPrompt?.trim();
+  const { data: vitals, isLoading: isVitalsLoading } = useGetVitals(signReviewPrompt ? encounter.id : undefined);
   const noteDetails = useMemo(
-    () => (signReviewPrompt ? serializeNoteDetails(rosState, examState, hpi, medicalDecision) : ''),
-    [signReviewPrompt, rosState, examState, hpi, medicalDecision]
+    () => (signReviewPrompt ? serializeNoteDetails(rosState, examState, hpi, medicalDecision, vitals) : ''),
+    [signReviewPrompt, rosState, examState, hpi, medicalDecision, vitals]
   );
   const { data: noteReview, isLoading: isNoteReviewLoading } = useQuery<AISuggestionNotes>({
     queryKey: ['note-review-suggestions', encounter.id, hashInput(signReviewPrompt + noteDetails)],
     queryFn: () => apiClient!.aiSuggestionNotes({ type: 'note-review', reviewPrompt: signReviewPrompt!, noteDetails }),
-    enabled: !!apiClient && !!signReviewPrompt && !!encounter.id && !isAppointmentReadOnly && !isChartDataLoading,
+    enabled:
+      !!apiClient &&
+      !!signReviewPrompt &&
+      !!encounter.id &&
+      !isAppointmentReadOnly &&
+      !isChartDataLoading &&
+      !isVitalsLoading,
     staleTime: Infinity,
     retry: 0,
   });

--- a/apps/ehr/src/features/visits/shared/components/review-tab/MissingCard.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/MissingCard.tsx
@@ -1,7 +1,8 @@
 import { otherColors } from '@ehrTheme/colors';
 import { WarningAmber } from '@mui/icons-material';
-import { Avatar, Box, Link, Typography } from '@mui/material';
-import { FC, useEffect, useState } from 'react';
+import { Avatar, Box, CircularProgress, Link, Typography } from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AccordionCard } from 'src/components/AccordionCard';
 import { LoadingScreen } from 'src/components/LoadingScreen';
@@ -30,14 +31,49 @@ import {
   useProcedureStore,
   useVitalsDraftStore,
 } from 'src/state/draft-data.store';
+import { extractObservationsFromExamComponents } from 'utils/lib/config-helpers/exam-observations';
+import { examConfig } from 'utils/lib/ottehr-config/examination';
+import { InPersonRosConfig, rosField, RosFindingState } from 'utils/lib/ottehr-config/review-of-systems';
+import { AISuggestionNotes } from 'utils/lib/types/api/ai-suggestions-notes';
+import { ExamObservationDTO } from 'utils/lib/types/api/chart-data/chart-data.types';
+import { hashInput } from '../../hooks/useBillingSuggestions';
 import { useChartFields } from '../../hooks/useChartFields';
+import { useGetAppointmentAccessibility } from '../../hooks/useGetAppointmentAccessibility';
+import { useOystehrAPIClient } from '../../hooks/useOystehrAPIClient';
 import { useAiSuggestionNotes } from '../../stores/appointment/appointment.queries';
 import { useAppointmentData, useChartData } from '../../stores/appointment/appointment.store';
+import { useExamObservationsStore } from '../../stores/appointment/exam-observations.store';
+import { useRosObservationsStore } from '../../stores/appointment/ros-observations.store';
+
+// Compact text serialization of the note sections the practice-level sign-review prompt may evaluate
+const serializeNoteDetails = (
+  rosState: Record<string, ExamObservationDTO>,
+  examState: Record<string, ExamObservationDTO>,
+  hpi: string | undefined,
+  mdm: string | undefined
+): string => {
+  const rosLines = Object.values(InPersonRosConfig).flatMap((system) => {
+    const items = Object.entries(system.items).flatMap(([baseKey, item]) =>
+      [RosFindingState.Denies, RosFindingState.Reports]
+        .filter((state) => rosState[rosField(baseKey, state)]?.value === true)
+        .map((state) => `${state} ${item.label} (checked)`)
+    );
+    return items.length > 0 ? [`${system.label}: ${items.join(', ')}`] : [];
+  });
+  const examLines = Object.entries(examConfig.default.components).flatMap(([, section]) => {
+    const items = [
+      ...extractObservationsFromExamComponents(section.components.normal, 'normal', examState),
+      ...extractObservationsFromExamComponents(section.components.abnormal, 'abnormal', examState),
+    ].map((item) => `${item.label}${item.abnormal ? ' (abnormal)' : ''} (checked)`);
+    return items.length > 0 ? [`${section.label}: ${items.join(', ')}`] : [];
+  });
+  return [`HPI: ${hpi ?? ''}`, `MDM: ${mdm ?? ''}`, 'ROS:', ...rosLines, 'EXAM:', ...examLines].join('\n');
+};
 
 export const MissingCard: FC = () => {
   const { id: appointmentIdFromUrl } = useParams();
   const { encounter } = useAppointmentData();
-  const { chartData } = useChartData();
+  const { chartData, isLoading: isChartDataLoading } = useChartData();
   const { hasDraft: hasExternalLabDraft } = useCreateExternalLabStore();
   const { hasDraft: hasInHouseLabDraft } = useCreateInHouseLabStore();
   const { hasDraft: hasRadiologyDraft } = useCreateRadiologyOrderStore();
@@ -97,6 +133,25 @@ export const MissingCard: FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hpi]);
 
+  // Non-blocking, AI-generated note-review warnings driven by the practice-level sign-review prompt
+  const apiClient = useOystehrAPIClient();
+  const { isAppointmentReadOnly } = useGetAppointmentAccessibility();
+  const rosState = useRosObservationsStore();
+  const examState = useExamObservationsStore();
+  const signReviewPrompt = progressNoteConfig?.signReviewPrompt?.trim();
+  const noteDetails = useMemo(
+    () => (signReviewPrompt ? serializeNoteDetails(rosState, examState, hpi, medicalDecision) : ''),
+    [signReviewPrompt, rosState, examState, hpi, medicalDecision]
+  );
+  const { data: noteReview, isLoading: isNoteReviewLoading } = useQuery<AISuggestionNotes>({
+    queryKey: ['note-review-suggestions', encounter.id, hashInput(signReviewPrompt + noteDetails)],
+    queryFn: () => apiClient!.aiSuggestionNotes({ type: 'note-review', reviewPrompt: signReviewPrompt!, noteDetails }),
+    enabled: !!apiClient && !!signReviewPrompt && !!encounter.id && !isAppointmentReadOnly && !isChartDataLoading,
+    staleTime: Infinity,
+    retry: 0,
+  });
+  const noteReviewSuggestions = (signReviewPrompt && noteReview?.suggestions) || [];
+
   if (
     primaryDiagnosis &&
     (!mdmRequired || medicalDecision) &&
@@ -105,7 +160,9 @@ export const MissingCard: FC = () => {
     !suggestionNote &&
     !isPatientVerificationMissing &&
     !accidentMissingDate &&
-    !accidentMissingState
+    !accidentMissingState &&
+    noteReviewSuggestions.length === 0 &&
+    !isNoteReviewLoading
   ) {
     return null;
   }
@@ -148,10 +205,6 @@ export const MissingCard: FC = () => {
     <AccordionCard label="Missing & Warnings" dataTestId={dataTestIds.progressNotePage.missingCard}>
       <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1, alignItems: 'start', position: 'relative' }}>
         {isFetching && <LoadingScreen />}
-        <Typography data-testid={dataTestIds.progressNotePage.missingCardText}>
-          Click on the item to navigate to it.
-        </Typography>
-
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, alignItems: 'flex-start' }}>
           {isPatientVerificationMissing && (
             <Link
@@ -260,6 +313,13 @@ export const MissingCard: FC = () => {
               </Link>
             </div>
           )}
+          {isNoteReviewLoading && <CircularProgress size={14} />}
+          {noteReviewSuggestions.map((suggestion) => (
+            <Box key={suggestion} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <WarningAmber sx={{ fontSize: '18px', color: otherColors.orange700 }} />
+              <Typography>{suggestion}</Typography>
+            </Box>
+          ))}
           {encounter?.id && (
             <>
               {hasExternalLabDraft(encounter.id) && (

--- a/apps/ehr/src/features/visits/shared/hooks/useBillingSuggestions.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useBillingSuggestions.ts
@@ -158,7 +158,7 @@ export function buildBillingSuggestionInput(params: {
 
 // ── Stable hash of the input for use as a React Query cache key ─────────────
 
-function hashInput(input: BillingSuggestionInput): string {
+export function hashInput(input: unknown): string {
   return JSON.stringify(input);
 }
 

--- a/packages/utils/lib/types/api/ai-suggestions-notes.ts
+++ b/packages/utils/lib/types/api/ai-suggestions-notes.ts
@@ -6,6 +6,8 @@ export interface AISuggestionNotesInput {
   type: string;
   hpi?: string;
   details?: ProcedureDetails;
+  reviewPrompt?: string;
+  noteDetails?: string;
 }
 
 export interface AISuggestionNotes {

--- a/packages/utils/lib/types/api/progress-note-config/progress-note-config.types.ts
+++ b/packages/utils/lib/types/api/progress-note-config/progress-note-config.types.ts
@@ -20,6 +20,8 @@ export interface ProgressNoteConfig {
   anotherDispositionDefaultText: string;
   edDispositionDefaultText: string;
   vitalsUnitInputOrder: VitalsUnitInputOrder;
+  /** AI note-review prompt shown at signing; empty/absent disables the feature. Edited by customer support only. */
+  signReviewPrompt?: string;
 }
 
 export type GetProgressNoteConfigInput = Record<string, never>;
@@ -34,6 +36,7 @@ export const UpdateProgressNoteConfigInputSchema = z.object({
   // Optional with a default so older Admin clients/scripts that omit this field keep working;
   // the read path applies the same default for stored configs that predate this setting.
   vitalsUnitInputOrder: z.enum(VITALS_UNIT_INPUT_ORDERS).default(DEFAULT_VITALS_UNIT_INPUT_ORDER),
+  signReviewPrompt: z.string().optional(),
 });
 export type UpdateProgressNoteConfigInput = z.infer<typeof UpdateProgressNoteConfigInputSchema>;
 

--- a/packages/utils/lib/utils/progress-note-config.ts
+++ b/packages/utils/lib/utils/progress-note-config.ts
@@ -18,6 +18,7 @@ export const PROGRESS_NOTE_CONFIG_PCP_NO_TYPE_DISPOSITION_DEFAULT_TEXT_EXTENSION
 export const PROGRESS_NOTE_CONFIG_ANOTHER_DISPOSITION_DEFAULT_TEXT_EXTENSION_URL = `${PROGRESS_NOTE_CONFIG_EXTENSION_URL_PREFIX}-another-disposition-default-text`;
 export const PROGRESS_NOTE_CONFIG_ED_DISPOSITION_DEFAULT_TEXT_EXTENSION_URL = `${PROGRESS_NOTE_CONFIG_EXTENSION_URL_PREFIX}-ed-disposition-default-text`;
 export const PROGRESS_NOTE_CONFIG_VITALS_UNIT_INPUT_ORDER_EXTENSION_URL = `${PROGRESS_NOTE_CONFIG_EXTENSION_URL_PREFIX}-vitals-unit-input-order`;
+export const PROGRESS_NOTE_CONFIG_SIGN_REVIEW_PROMPT_EXTENSION_URL = `${PROGRESS_NOTE_CONFIG_EXTENSION_URL_PREFIX}-sign-review-prompt`;
 
 export const DEFAULT_PROGRESS_NOTE_CONFIG: ProgressNoteConfig = {
   mdmRequired: true,
@@ -26,6 +27,7 @@ export const DEFAULT_PROGRESS_NOTE_CONFIG: ProgressNoteConfig = {
   anotherDispositionDefaultText: getDefaultNote('another'),
   edDispositionDefaultText: getDefaultNote('ed'),
   vitalsUnitInputOrder: DEFAULT_VITALS_UNIT_INPUT_ORDER,
+  signReviewPrompt: '',
 };
 
 export const getDispositionDefaultTextFromProgressNoteConfig = (

--- a/packages/zambdas/src/ehr/ai-suggestion-notes/index.ts
+++ b/packages/zambdas/src/ehr/ai-suggestion-notes/index.ts
@@ -9,7 +9,7 @@ import { validateRequestParameters } from './validateRequestParameters';
 export const index = wrapHandler('ai-suggestion-notes', async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   console.group('validateRequestParameters');
   const validatedParameters = validateRequestParameters(input);
-  const { type, hpi, details, secrets } = validatedParameters;
+  const { type, hpi, details, reviewPrompt, noteDetails, secrets } = validatedParameters;
   console.groupEnd();
   console.debug('validateRequestParameters success');
 
@@ -30,6 +30,12 @@ export const index = wrapHandler('ai-suggestion-notes', async (input: ZambdaInpu
       ${procedureDetails}`;
   } else if (type === 'missing-hpi') {
     prompt = PROMPTS_CONFIG.HPI_SUGGESTION + `\nHPI: ${hpi}`;
+  } else if (type === 'note-review') {
+    prompt = `${reviewPrompt}
+
+      Return a JSON object with a single field "suggestions" that is an empty list if all requirements are met, otherwise a list of short warning strings. Do not return anything else.
+
+      ${noteDetails}`;
   }
 
   if (!prompt) {
@@ -56,7 +62,7 @@ export const index = wrapHandler('ai-suggestion-notes', async (input: ZambdaInpu
         'Please specify closure type (e.g. tissue adhesive or surgical staples or sutures); if surgical staples or sutures, specify the material and quantity',
       ],
     };
-  } else if (type === 'procedure' || type === 'missing-hpi') {
+  } else if (type === 'procedure' || type === 'missing-hpi' || type === 'note-review') {
     const aiResponseString = await invokeChatbotVertexAI([{ text: prompt }], secrets, suggestionSchema);
     console.log(aiResponseString);
 

--- a/packages/zambdas/src/ehr/ai-suggestion-notes/validateRequestParameters.ts
+++ b/packages/zambdas/src/ehr/ai-suggestion-notes/validateRequestParameters.ts
@@ -1,5 +1,5 @@
 import { AISuggestionNotesInput } from 'utils/lib/types/api/ai-suggestions-notes';
-import { MISSING_REQUIRED_PARAMETERS } from 'utils/lib/types/errors';
+import { INVALID_INPUT_ERROR, MISSING_REQUIRED_PARAMETERS } from 'utils/lib/types/errors';
 import { ZambdaInput } from '../../shared/types/common';
 import { safeJsonParse } from '../../shared/validation';
 
@@ -9,14 +9,14 @@ export function validateRequestParameters(input: ZambdaInput): AISuggestionNotes
   }
 
   // no complication
-  const { type, hpi, details } = safeJsonParse(input.body);
+  const { type, hpi, details, reviewPrompt, noteDetails } = safeJsonParse(input.body);
 
   if (!type) {
     throw MISSING_REQUIRED_PARAMETERS(['type']);
   }
 
-  if (!['procedure', 'missing-hpi'].includes(type)) {
-    throw new Error('Invalid type');
+  if (!['procedure', 'missing-hpi', 'note-review'].includes(type)) {
+    throw INVALID_INPUT_ERROR(`type must be one of: procedure, missing-hpi, note-review; received "${type}"`);
   }
 
   if (type === 'procedure' && details.procedureDetails == undefined) {
@@ -27,10 +27,16 @@ export function validateRequestParameters(input: ZambdaInput): AISuggestionNotes
     throw new Error('If type is missing-hpi, hpi is required');
   }
 
+  if (type === 'note-review' && (!reviewPrompt || !noteDetails)) {
+    throw MISSING_REQUIRED_PARAMETERS(['reviewPrompt', 'noteDetails']);
+  }
+
   return {
     type,
     hpi,
     details,
+    reviewPrompt,
+    noteDetails,
     secrets: input.secrets,
   };
 }

--- a/packages/zambdas/src/ehr/progress-note-config/admin-update-progress-note-config/index.ts
+++ b/packages/zambdas/src/ehr/progress-note-config/admin-update-progress-note-config/index.ts
@@ -6,7 +6,7 @@ import { RoleType } from 'utils/lib/types/api/user.types';
 import { checkOrCreateM2MClientToken, requireUserWithRole } from '../../../shared/auth';
 import { createClinicalOystehrClient } from '../../../shared/helpers';
 import { topLevelCatch } from '../../../shared/lambda';
-import { saveProgressNoteConfig } from '../../../shared/progress-note-config';
+import { getProgressNoteConfigPayload, saveProgressNoteConfig } from '../../../shared/progress-note-config';
 import { wrapHandler } from '../../../shared/sentry';
 import { ZambdaInput } from '../../../shared/types/common';
 import { validateRequestParameters } from './validateRequestParameters';
@@ -59,6 +59,7 @@ const performEffect = async (
     anotherDispositionDefaultText,
     edDispositionDefaultText,
     vitalsUnitInputOrder,
+    signReviewPrompt,
   } = validatedInput;
   await saveProgressNoteConfig(oystehr, {
     mdmRequired,
@@ -67,5 +68,8 @@ const performEffect = async (
     anotherDispositionDefaultText,
     edDispositionDefaultText,
     vitalsUnitInputOrder,
+    // Absent means "unchanged" so older clients that omit the field can't wipe the stored
+    // prompt; an explicit empty string is the deliberate clear.
+    signReviewPrompt: signReviewPrompt ?? (await getProgressNoteConfigPayload(oystehr)).signReviewPrompt,
   });
 };

--- a/packages/zambdas/src/shared/progress-note-config.ts
+++ b/packages/zambdas/src/shared/progress-note-config.ts
@@ -15,6 +15,7 @@ import {
   PROGRESS_NOTE_CONFIG_MDM_REQUIRED_EXTENSION_URL,
   PROGRESS_NOTE_CONFIG_MEDICAL_DECISION_DEFAULT_TEXT_EXTENSION_URL,
   PROGRESS_NOTE_CONFIG_PCP_NO_TYPE_DISPOSITION_DEFAULT_TEXT_EXTENSION_URL,
+  PROGRESS_NOTE_CONFIG_SIGN_REVIEW_PROMPT_EXTENSION_URL,
   PROGRESS_NOTE_CONFIG_VITALS_UNIT_INPUT_ORDER_EXTENSION_URL,
 } from 'utils/lib/utils/progress-note-config';
 
@@ -67,6 +68,11 @@ export async function getProgressNoteConfigPayload(oystehr: Oystehr): Promise<Ge
     PROGRESS_NOTE_CONFIG_ED_DISPOSITION_DEFAULT_TEXT_EXTENSION_URL,
     'valueString'
   );
+  const signReviewPrompt = getExtensionValue(
+    basic,
+    PROGRESS_NOTE_CONFIG_SIGN_REVIEW_PROMPT_EXTENSION_URL,
+    'valueString'
+  );
   const vitalsUnitInputOrderRaw = getExtensionValue(
     basic,
     PROGRESS_NOTE_CONFIG_VITALS_UNIT_INPUT_ORDER_EXTENSION_URL,
@@ -85,6 +91,7 @@ export async function getProgressNoteConfigPayload(oystehr: Oystehr): Promise<Ge
       anotherDispositionDefaultText ?? DEFAULT_PROGRESS_NOTE_CONFIG.anotherDispositionDefaultText,
     edDispositionDefaultText: edDispositionDefaultText ?? DEFAULT_PROGRESS_NOTE_CONFIG.edDispositionDefaultText,
     vitalsUnitInputOrder: vitalsUnitInputOrder ?? DEFAULT_PROGRESS_NOTE_CONFIG.vitalsUnitInputOrder,
+    signReviewPrompt: signReviewPrompt ?? DEFAULT_PROGRESS_NOTE_CONFIG.signReviewPrompt,
   };
 }
 
@@ -124,6 +131,10 @@ export async function saveProgressNoteConfig(oystehr: Oystehr, config: ProgressN
         url: PROGRESS_NOTE_CONFIG_VITALS_UNIT_INPUT_ORDER_EXTENSION_URL,
         valueString: config.vitalsUnitInputOrder,
       },
+      // FHIR forbids empty strings, so omit the extension entirely when the prompt is blank
+      ...(config.signReviewPrompt
+        ? [{ url: PROGRESS_NOTE_CONFIG_SIGN_REVIEW_PROMPT_EXTENSION_URL, valueString: config.signReviewPrompt }]
+        : []),
     ],
   };
 

--- a/packages/zambdas/test/unit/progress-note-config-roundtrip.test.ts
+++ b/packages/zambdas/test/unit/progress-note-config-roundtrip.test.ts
@@ -32,6 +32,7 @@ const customConfig: ProgressNoteConfig = {
   anotherDispositionDefaultText: 'Custom transfer text.',
   edDispositionDefaultText: 'Custom ED text.',
   vitalsUnitInputOrder: 'imperial-metric',
+  signReviewPrompt: 'ROS and Exam must each have at least 4 systems documented.',
 };
 
 describe('progress-note-config shared read/write', () => {


### PR DESCRIPTION
## What

A practice-configurable, AI-generated, **non-blocking** note review that runs before signing. A Customer Support-editable prompt (e.g. the "4x4" ROS/Exam completeness rule) is evaluated against the current note, and any warnings appear in the **Missing & Warnings** card on the Review & Sign page. Warnings are informational only — they never block signing.

## How it works

- **Config**: new optional `signReviewPrompt` on `ProgressNoteConfig` (FHIR Basic extension). Blank/absent disables the feature entirely. The field appears on the Progress Note admin page only for users with the Customer Support role; for everyone else it round-trips unchanged. The update zambda treats an absent field as "unchanged" so older clients can't wipe the stored prompt (empty string is the explicit clear).
- **AI**: reuses the existing `ai-suggestion-notes` zambda with a new `note-review` type — prompt + serialized note details (HPI, MDM, structured ROS and exam observations) → `{suggestions: string[]}` via the existing Vertex path.
- **Caching**: same pattern as the assessment screen's billing suggestions — React Query keyed on a hash of prompt + note content with `staleTime: Infinity`, so the AI fires only when the note (or prompt) actually changes.
- **UI**: warnings render as orange informational rows in the Missing & Warnings card (with a small spinner while loading), matching the card's existing items. The card now also shows when AI warnings exist even if nothing is missing.

## Size

130 insertions / 17 deletions across 12 files.

## Testing

- Zambda unit tests pass (`progress-note-config-roundtrip` extended for the new field).
- EHR typecheck + lint clean.
- Verified end-to-end on the synth environment: config round-trip, AI returns the exact configured warning strings on a failing note and an empty list on a passing note, and the warning renders in the card on a visit missing its ROS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9fX9o3x1nrMiKy8Xv67Cu