### PR TITLE
Billing app. Rules engine. Allow to derive service line's date of service

### DIFF
--- a/apps/billing/src/components/rules/RuleBuilder.tsx
+++ b/apps/billing/src/components/rules/RuleBuilder.tsx
@@ -18,6 +18,9 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import {
   ADD_SERVICE_LINE_FIELDS,
   addServiceLineFieldProblem,
+  DATE_SOURCE_CATALOG,
+  DateSourceSelectValue,
+  EXACT_DATE_SOURCE,
   getRuleFieldDef,
   getServiceLinePropertyDef,
   RULE_FIELD_CATALOG,
@@ -35,6 +38,7 @@ import {
   setFieldValueProblem,
 } from 'utils/lib/types/data/billing/rules-engine.field-catalog';
 import {
+  DateValue,
   operatorIsMultiValue,
   operatorIsRegex,
   operatorNeedsValue,
@@ -474,6 +478,67 @@ function ServiceLineValueInput({
   );
 }
 
+// Date-or-derived-source input for the serviceDate fields addServiceLine/updateServiceLines expose.
+// Deliberately separate from TypedValueInput/ServiceLineValueInput, which ServiceLineMatchEditor also
+// uses for its (literal-only) date comparisons — this selector must not leak into line matching.
+// "Exact date" (the default) keeps the plain-string form every rule saved before this option existed
+// already uses; picking one of the other two sources swaps the field's value to a tagged object.
+function DateOrSourceInput({
+  value,
+  onChange,
+  label,
+  required,
+  error,
+  helperText,
+  inputRef,
+}: {
+  value: DateValue | null | undefined;
+  onChange: (value: DateValue) => void;
+  label?: string;
+} & ValueInputValidationProps): ReactElement {
+  const source: DateSourceSelectValue = value && typeof value === 'object' ? value.source : EXACT_DATE_SOURCE;
+  return (
+    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+      <FormControl size="small" sx={{ minWidth: 220 }}>
+        <InputLabel>{label ? `${label} source` : 'Date source'}</InputLabel>
+        <Select
+          label={label ? `${label} source` : 'Date source'}
+          value={source}
+          inputRef={source !== EXACT_DATE_SOURCE ? inputRef : undefined}
+          onChange={(e) => {
+            const next = e.target.value as DateSourceSelectValue;
+            onChange(next === EXACT_DATE_SOURCE ? '' : { source: next });
+          }}
+        >
+          {DATE_SOURCE_CATALOG.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </Select>
+        {source !== EXACT_DATE_SOURCE && helperText != null && (
+          <FormHelperText error={error}>{helperText}</FormHelperText>
+        )}
+      </FormControl>
+      {source === EXACT_DATE_SOURCE && (
+        <TextField
+          size="small"
+          type="date"
+          label={label ?? 'Date'}
+          value={typeof value === 'string' ? value : ''}
+          onChange={(e) => onChange(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+          required={required}
+          error={error}
+          helperText={helperText}
+          inputRef={inputRef}
+          sx={{ minWidth: 200 }}
+        />
+      )}
+    </Box>
+  );
+}
+
 // --- Condition ---
 
 function ConditionEditor({ name }: { name: string }): ReactElement | null {
@@ -749,10 +814,26 @@ function AddServiceLineEditor({ name }: { name: string }): ReactElement {
           key={lineField.id}
           name={`${name}.line.${lineField.id}`}
           control={control}
-          rules={{ validate: (value: string | undefined) => addServiceLineFieldProblem(lineField.id, value) ?? true }}
+          rules={{
+            validate: (value: string | DateValue | undefined) =>
+              addServiceLineFieldProblem(lineField.id, value) ?? true,
+          }}
           render={({ field: { ref, value: fieldValue, onChange, onBlur }, fieldState: { error } }) => {
             const label = lineField.required ? lineField.label : `${lineField.label} (optional)`;
             const helperText = error?.message ?? (lineField.whenBlank ? `Blank: ${lineField.whenBlank}` : undefined);
+            if (lineField.id === 'serviceDate') {
+              return (
+                <DateOrSourceInput
+                  value={fieldValue}
+                  onChange={onChange}
+                  label={label}
+                  required={lineField.required}
+                  error={!!error}
+                  helperText={helperText}
+                  inputRef={ref}
+                />
+              );
+            }
             if (lineField.format === 'cpt') {
               return (
                 <ProcedureCodeAutocomplete
@@ -820,7 +901,7 @@ function AddServiceLineEditor({ name }: { name: string }): ReactElement {
 // properties: replace / add / remove), and the value.
 function ServiceLineSetEditor({ name }: { name: string }): ReactElement | null {
   const { control, clearErrors } = useFormContext();
-  const { value, replace } = useNode<{ property: string; value: string; operation?: ServiceLineSetOperation }>(name);
+  const { value, replace } = useNode<{ property: string; value: DateValue; operation?: ServiceLineSetOperation }>(name);
   if (!value) return null;
   const def = getServiceLinePropertyDef(value.property);
   const isList = def?.valueType === 'list';
@@ -879,24 +960,36 @@ function ServiceLineSetEditor({ name }: { name: string }): ReactElement | null {
         name={`${name}.value`}
         control={control}
         rules={{
-          validate: (v: string | null | undefined) =>
+          validate: (v: DateValue | null | undefined) =>
             def ? serviceLineSetValueProblem(def, value.operation, v) ?? true : true,
         }}
-        render={({ field: { ref, value: fieldValue, onChange }, fieldState: { error } }) => (
-          <ServiceLineValueInput
-            def={def}
-            multiple={false}
-            value={fieldValue}
-            onChange={(v) => onChange(typeof v === 'string' ? v : v[0] ?? '')}
-            label={valueLabel}
-            required={valueRequired}
-            error={!!error}
-            helperText={error?.message ?? formatHint(def)}
-            inputRef={ref}
-            // The only clearable scalar line property; an explicit empty entry means "clear it".
-            allowEmptyOption={def?.id === 'placeOfService'}
-          />
-        )}
+        render={({ field: { ref, value: fieldValue, onChange }, fieldState: { error } }) =>
+          def?.valueType === 'date' ? (
+            <DateOrSourceInput
+              value={fieldValue}
+              onChange={onChange}
+              label={valueLabel}
+              required={valueRequired}
+              error={!!error}
+              helperText={error?.message ?? formatHint(def)}
+              inputRef={ref}
+            />
+          ) : (
+            <ServiceLineValueInput
+              def={def}
+              multiple={false}
+              value={fieldValue as string | string[] | null | undefined}
+              onChange={(v) => onChange(typeof v === 'string' ? v : v[0] ?? '')}
+              label={valueLabel}
+              required={valueRequired}
+              error={!!error}
+              helperText={error?.message ?? formatHint(def)}
+              inputRef={ref}
+              // The only clearable scalar line property; an explicit empty entry means "clear it".
+              allowEmptyOption={def?.id === 'placeOfService'}
+            />
+          )
+        }
       />
     </Box>
   );

--- a/docs/billing-rules-engine.md
+++ b/docs/billing-rules-engine.md
@@ -275,7 +275,7 @@ touches.
 | Units | `units` | number | equals, does not equal, is greater than, is at least, is less than, is at most, is present, is empty | yes | The line's unit count. Setting it requires a positive number. |
 | Charges | `charges` | number | equals, does not equal, is greater than, is at least, is less than, is at most, is present, is empty | yes | The line's charge amount in dollars. Setting it requires a non-negative number; the claim's billed total is recomputed. |
 | Place of service code | `placeOfService` | one of the listed values | equals, does not equal, is one of, is not one of, matches pattern, does not match pattern, is present, is empty | yes | The line's CMS place-of-service code. Setting an empty value clears it. Allowed values: any CMS place-of-service code. |
-| Service date | `serviceDate` | date | equals, does not equal, is one of, is not one of, is after, is on or after, is before, is on or before, is present, is empty | yes | The line's date of service (YYYY-MM-DD). |
+| Service date | `serviceDate` | date | equals, does not equal, is one of, is not one of, is after, is on or after, is before, is on or before, is present, is empty | yes | The line's date of service (YYYY-MM-DD). When updating, the new value can be a literal date or derived from the claim (see Service date sources) — matching still compares against a literal date only. |
 | Rev Code | `revenueCode` | text | equals, does not equal, is one of, is not one of, contains, does not contain, starts with, does not start with, matches pattern, does not match pattern, is present, is empty | yes | Revenue code of the procedure. |
 
 ## Actions
@@ -286,8 +286,8 @@ A matched branch's outcome is a list of actions, applied in order:
 | --- | --- |
 | Set a property (`setField`) | Sets one of the settable claim properties above to a new value. Setting an empty value clears the property. The change is written to the claim's working-copy resources and recorded in the claim history, attributed to the specific rule that made it (linked from the history view). If the property cannot be set (unknown or read-only property, invalid value, or the target resource is missing from the claim), the rule fails and the claim is held. |
 | Apply a tag (`applyTag`) | Adds a tag to the claim (no-op if the claim already carries it). Applying the **Hold** tag holds the claim: the run stops and the on-success effect does not happen. |
-| Add a service line (`addServiceLine`) | Appends a new service line built from the fields below and recomputes the claim's billed total. Blank optional fields use the claim editor's defaults, and the new line is tied to the claim's rendering provider when one is set. An invalid field value fails the rule and holds the claim. |
-| Update service lines (`updateServiceLines`) | Applies one change (an updatable service line property + value; for modifiers, a set/add/remove operation) to every line matching the action's line predicate. Zero matching lines is a no-op, not a failure — pair the action with a condition when a match must exist. An invalid value or an operation that doesn't apply to the property fails the rule and holds the claim. Changing charges recomputes the claim's billed total. |
+| Add a service line (`addServiceLine`) | Appends a new service line built from the fields below and recomputes the claim's billed total. Blank optional fields use the claim editor's defaults, and the new line is tied to the claim's rendering provider when one is set. The service date can be a literal date or one of the derived sources below. An invalid field value fails the rule and holds the claim. |
+| Update service lines (`updateServiceLines`) | Applies one change (an updatable service line property + value; for modifiers, a set/add/remove operation) to every line matching the action's line predicate. When updating the service date, the value can be a literal date or one of the derived sources below. Zero matching lines is a no-op, not a failure — pair the action with a condition when a match must exist. An invalid value or an operation that doesn't apply to the property fails the rule and holds the claim. Changing charges recomputes the claim's billed total. |
 | Remove service lines (`removeServiceLines`) | Removes every line matching the action's line predicate (all lines when the predicate is "all service lines"). Surviving lines are re-sequenced and the claim's billed total is recomputed. Zero matching lines is a no-op. |
 | Apply charge master prices (`applyChargeMasterPrices`) | Re-prices every line matching the action's line predicate from the best applicable charge master: the active charge master designated as the default for the claim's billing type (insurance when the claim carries a real coverage, self-pay otherwise) whose effective date is the most recent on or before the claim's date of service. Each matched line's charges are set from the entry for its CPT code — an entry with a matching modifier for lines with modifiers, a modifier-less entry otherwise. A matched line the charge master has no entry for (or that has no CPT code) keeps its existing charges. The claim's billed total is recomputed when any line was re-priced. Zero matching lines is a no-op. This action never fails the rule or holds the claim — when no charge master applies (or the claim has no date of service to select one by), no lines are changed. Add a separate rule to hold claims whose lines are missing a price. |
 | Do nothing (`noop`) | Explicitly does nothing. Useful as an else branch that intentionally takes no action. |
@@ -304,5 +304,19 @@ A matched branch's outcome is a list of actions, applied in order:
 | Service date (`serviceDate`) | date | no | inherited from the claim's first service line; the action fails if the claim has no lines |
 | Diagnosis pointers (comma-separated) (`diagnosisPointers`) | text | no | points at the first diagnosis (1) |
 | Revenue code (`revenueCode`) | text | no | — |
+
+### Service date sources
+
+The service date on "Add a service line", and on "Update service lines" when updating the
+`serviceDate` property, can come from one of:
+
+| Source | Description |
+| --- | --- |
+| Exact date | A literal date entered on the rule. |
+| First service line's date | The claim's first service line's date of service — the same value a blank serviceDate has always inherited on "Add a service line". |
+
+"Exact date" is the default. On "Add a service line", leaving it blank is equivalent to "First
+service line's date" (kept for rules saved before this option existed). Service line **matching**
+always compares against a literal date.
 
 Actions after a failed action or after the **Hold** tag do not run.

--- a/packages/utils/lib/types/data/billing/rules-engine.docs.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.docs.ts
@@ -1,6 +1,7 @@
 import { RULES_ENGINE_TYPES, RULES_ENGINES } from './rules-engine.constants';
 import {
   ADD_SERVICE_LINE_FIELDS,
+  DATE_SOURCE_CATALOG,
   RULE_FIELD_CATALOG,
   RULE_FIELD_GROUP_LABELS,
   RULE_FIELD_GROUPS,
@@ -137,6 +138,12 @@ function renderAddServiceLineFieldTable(): string {
   return lines.join('\n');
 }
 
+function renderDateSourceTable(): string {
+  const lines = ['| Source | Description |', '| --- | --- |'];
+  for (const option of DATE_SOURCE_CATALOG) lines.push(`| ${cell(option.label)} | ${cell(option.description)} |`);
+  return lines.join('\n');
+}
+
 function renderEnginesTable(): string {
   const lines = ['| Rules | Run automatically | When every rule passes |', '| --- | --- | --- |'];
   for (const type of RULES_ENGINE_TYPES) {
@@ -225,8 +232,8 @@ A matched branch's outcome is a list of actions, applied in order:
 | --- | --- |
 | Set a property (\`setField\`) | Sets one of the settable claim properties above to a new value. Setting an empty value clears the property. The change is written to the claim's working-copy resources and recorded in the claim history, attributed to the specific rule that made it (linked from the history view). If the property cannot be set (unknown or read-only property, invalid value, or the target resource is missing from the claim), the rule fails and the claim is held. |
 | Apply a tag (\`applyTag\`) | Adds a tag to the claim (no-op if the claim already carries it). Applying the **${HOLD_TAG_NAME}** tag holds the claim: the run stops and the on-success effect does not happen. |
-| Add a service line (\`addServiceLine\`) | Appends a new service line built from the fields below and recomputes the claim's billed total. Blank optional fields use the claim editor's defaults, and the new line is tied to the claim's rendering provider when one is set. An invalid field value fails the rule and holds the claim. |
-| Update service lines (\`updateServiceLines\`) | Applies one change (an updatable service line property + value; for modifiers, a set/add/remove operation) to every line matching the action's line predicate. Zero matching lines is a no-op, not a failure — pair the action with a condition when a match must exist. An invalid value or an operation that doesn't apply to the property fails the rule and holds the claim. Changing charges recomputes the claim's billed total. |
+| Add a service line (\`addServiceLine\`) | Appends a new service line built from the fields below and recomputes the claim's billed total. Blank optional fields use the claim editor's defaults, and the new line is tied to the claim's rendering provider when one is set. The service date can be a literal date or one of the derived sources below. An invalid field value fails the rule and holds the claim. |
+| Update service lines (\`updateServiceLines\`) | Applies one change (an updatable service line property + value; for modifiers, a set/add/remove operation) to every line matching the action's line predicate. When updating the service date, the value can be a literal date or one of the derived sources below. Zero matching lines is a no-op, not a failure — pair the action with a condition when a match must exist. An invalid value or an operation that doesn't apply to the property fails the rule and holds the claim. Changing charges recomputes the claim's billed total. |
 | Remove service lines (\`removeServiceLines\`) | Removes every line matching the action's line predicate (all lines when the predicate is "all service lines"). Surviving lines are re-sequenced and the claim's billed total is recomputed. Zero matching lines is a no-op. |
 | Apply charge master prices (\`applyChargeMasterPrices\`) | Re-prices every line matching the action's line predicate from the best applicable charge master: the active charge master designated as the default for the claim's billing type (insurance when the claim carries a real coverage, self-pay otherwise) whose effective date is the most recent on or before the claim's date of service. Each matched line's charges are set from the entry for its CPT code — an entry with a matching modifier for lines with modifiers, a modifier-less entry otherwise. A matched line the charge master has no entry for (or that has no CPT code) keeps its existing charges. The claim's billed total is recomputed when any line was re-priced. Zero matching lines is a no-op. This action never fails the rule or holds the claim — when no charge master applies (or the claim has no date of service to select one by), no lines are changed. Add a separate rule to hold claims whose lines are missing a price. |
 | Do nothing (\`noop\`) | Explicitly does nothing. Useful as an else branch that intentionally takes no action. |
@@ -234,6 +241,17 @@ A matched branch's outcome is a list of actions, applied in order:
 ### "Add a service line" fields
 
 ${renderAddServiceLineFieldTable()}
+
+### Service date sources
+
+The service date on "Add a service line", and on "Update service lines" when updating the
+\`serviceDate\` property, can come from one of:
+
+${renderDateSourceTable()}
+
+"Exact date" is the default. On "Add a service line", leaving it blank is equivalent to "First
+service line's date" (kept for rules saved before this option existed). Service line **matching**
+always compares against a literal date.
 
 Actions after a failed action or after the **${HOLD_TAG_NAME}** tag do not run.`);
 

--- a/packages/utils/lib/types/data/billing/rules-engine.field-catalog.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.field-catalog.ts
@@ -9,6 +9,9 @@ import { BILLING_INSURANCE_TYPE_OPTIONS } from './billing.types';
 import { CLAIM_STATUS_FIELDS } from './claim-status';
 import {
   AddServiceLineInput,
+  DATE_SOURCE_KIND,
+  DateSourceKind,
+  DateValue,
   operatorIsMultiValue,
   operatorIsRegex,
   operatorNeedsValue,
@@ -894,7 +897,9 @@ export const SERVICE_LINE_PROPERTY_CATALOG: ServiceLinePropertyDef[] = [
     valueType: 'date',
     operators: DATE_OPS,
     settable: true,
-    description: "The line's date of service (YYYY-MM-DD).",
+    description:
+      "The line's date of service (YYYY-MM-DD). When updating, the new value can be a literal date or " +
+      'derived from the claim (see Service date sources) — matching still compares against a literal date only.',
   },
   {
     id: 'revenueCode',
@@ -966,14 +971,45 @@ export const ADD_SERVICE_LINE_FIELDS: AddServiceLineFieldDef[] = [
   { id: 'revenueCode', label: 'Revenue code', valueType: 'string', required: false },
 ];
 
+// The date-source options exposed by the addServiceLine/updateServiceLines serviceDate inputs and the
+// generated docs. "exact" is not part of DateSourceKind (it's the plain-string form, no tag) — it is
+// the UI/docs default.
+export const EXACT_DATE_SOURCE = 'exact' as const;
+export type DateSourceSelectValue = DateSourceKind | typeof EXACT_DATE_SOURCE;
+
+export const DATE_SOURCE_CATALOG: { value: DateSourceSelectValue; label: string; description: string }[] = [
+  { value: 'exact', label: 'Exact date', description: 'A literal date entered on the rule.' },
+  {
+    value: 'firstServiceLineDate',
+    label: "First service line's date",
+    description:
+      "The claim's first service line's date of service — the same value a blank serviceDate has always " +
+      'inherited on "Add a service line".',
+  },
+];
+
+// A date-typed rule value's problem when it may be a derived source instead of a literal date. A
+// literal is accepted as-is here (format is checked by each caller, since blank handling differs
+// between addServiceLine and updateServiceLines); a source object must name a known kind.
+export function derivedDateValueProblem(value: DateValue): string | undefined {
+  if (typeof value !== 'object') return undefined;
+  const known: string[] = Object.values(DATE_SOURCE_KIND);
+  return known.includes(value.source) ? undefined : 'Unknown date source';
+}
+
 // One add-line field's format problem, or undefined when the value is acceptable. Shared by the rule
 // builder (per-field validation messages) and save-time validation; claim-dependent checks (e.g. a
 // pointer beyond the claim's diagnosis count) happen at apply time in the engine.
 export function addServiceLineFieldProblem(
   fieldId: AddServiceLineFieldDef['id'],
-  value: string | undefined
+  value: string | DateValue | undefined
 ): string | undefined {
-  const trimmed = value?.trim() ?? '';
+  if (fieldId === 'serviceDate') {
+    if (value == null || value === '') return undefined; // inherited from the claim's first service line
+    if (typeof value === 'object') return derivedDateValueProblem(value);
+    return isoDateRegex.test(value.trim()) ? undefined : 'Service date must be an ISO date (YYYY-MM-DD)';
+  }
+  const trimmed = (value as string | undefined)?.trim() ?? '';
   switch (fieldId) {
     case 'cptCode':
       return trimmed ? undefined : 'CPT code is required';
@@ -997,9 +1033,6 @@ export function addServiceLineFieldProblem(
     case 'placeOfService':
       if (!trimmed) return undefined;
       return CMS_PLACE_OF_SERVICE_CODE_SET.has(trimmed) ? undefined : 'Unknown place of service code';
-    case 'serviceDate':
-      if (!trimmed) return undefined;
-      return isoDateRegex.test(trimmed) ? undefined : 'Service date must be an ISO date (YYYY-MM-DD)';
     default:
       return undefined;
   }
@@ -1118,12 +1151,17 @@ export function serviceLineMatchValueProblem(
 
 // An updateServiceLines set value's problem — mirrors the line writers exactly: units require a
 // positive number, charges a non-negative number, cptCode/serviceDate a value; placeOfService and
-// modifiers-with-"set" allow empty (clears).
+// modifiers-with-"set" allow empty (clears). A derived date-source object is only valid when the
+// target property is date-typed — there is no blank-fallback on update, unlike addServiceLine.
 export function serviceLineSetValueProblem(
   def: Pick<ServiceLinePropertyDef, 'id' | 'valueType' | 'options' | 'format'>,
   operation: ServiceLineSetOperation | undefined,
-  value: string | null | undefined
+  value: DateValue | null | undefined
 ): string | undefined {
+  if (typeof value === 'object' && value != null) {
+    if (def.valueType !== 'date') return 'This property does not accept a derived date value';
+    return derivedDateValueProblem(value);
+  }
   const trimmed = value?.trim() ?? '';
   if (def.valueType === 'list') {
     // modifiers: add/remove need the one modifier; "set" replaces the list (empty clears).

--- a/packages/utils/lib/types/data/billing/rules-engine.schemas.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.schemas.ts
@@ -189,6 +189,22 @@ export const ServiceLineMatchSchema: z.ZodType<ServiceLineMatch> = z.discriminat
 export const SERVICE_LINE_SET_OPERATIONS = ['set', 'add', 'remove'] as const;
 export type ServiceLineSetOperation = (typeof SERVICE_LINE_SET_OPERATIONS)[number];
 
+// A serviceDate value can be derived from the claim instead of typed literally. The plain-string form
+// (including blank/omitted) is what every rule saved before this option existed already stores, so it
+// must keep parsing unchanged; new rules can additionally pick one of these derived sources.
+export const DATE_SOURCE_KIND = {
+  firstServiceLineDate: 'firstServiceLineDate',
+} as const;
+export type DateSourceKind = (typeof DATE_SOURCE_KIND)[keyof typeof DATE_SOURCE_KIND];
+
+export const DerivedDateSourceSchema = z.object({ source: z.literal(DATE_SOURCE_KIND.firstServiceLineDate) });
+export type DerivedDateSource = z.output<typeof DerivedDateSourceSchema>;
+
+// A literal ISO date string (default; blank/omitted keeps addServiceLine's legacy implicit
+// fallback-to-first-line-date behavior) or a derived source.
+export const DateValueSchema = z.union([z.string(), DerivedDateSourceSchema]);
+export type DateValue = z.output<typeof DateValueSchema>;
+
 // The fields of a new service line added by the addServiceLine action. All values are strings (the
 // rule value model) and are validated at save time (format) and apply time (claim-dependent checks);
 // blank optional fields fall back to the same defaults the claim editor uses — see
@@ -200,7 +216,7 @@ export const AddServiceLineInputSchema = z.object({
   units: z.string().optional(),
   charges: z.string().min(1),
   placeOfService: z.string().optional(),
-  serviceDate: z.string().optional(),
+  serviceDate: DateValueSchema.optional(),
   // Comma-separated 1-based pointers into the claim's diagnosis list.
   diagnosisPointers: z.string().optional(),
   revenueCode: z.string().optional(),
@@ -215,7 +231,7 @@ export type RuleAction =
   | {
       type: 'updateServiceLines';
       match: ServiceLineMatch;
-      set: { property: string; value: string; operation?: ServiceLineSetOperation };
+      set: { property: string; value: DateValue; operation?: ServiceLineSetOperation };
     }
   | { type: 'removeServiceLines'; match: ServiceLineMatch }
   // Re-prices the matching lines from the best applicable charge master (resolved by the engine at
@@ -241,8 +257,10 @@ export const RuleActionSchema = z.discriminatedUnion('type', [
     set: z.object({
       property: z.string().min(1),
       // Empty is meaningful only for list-valued properties ("clear the modifiers"); scalar-property
-      // writers reject it at apply time and the engine holds the claim.
-      value: z.string(),
+      // writers reject it at apply time and the engine holds the claim. A derived-source object is
+      // only meaningful for the serviceDate property — save-time validation (field-catalog) rejects
+      // it for any other property, since the schema alone can't see the sibling `property` value.
+      value: DateValueSchema,
       operation: z.enum(SERVICE_LINE_SET_OPERATIONS).optional(),
     }),
   }),

--- a/packages/utils/lib/types/data/billing/rules-engine.test.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.test.ts
@@ -89,6 +89,30 @@ describe('service line action schemas', () => {
     ).toBe(false);
     expect(RuleActionSchema.safeParse({ type: 'removeServiceLines' }).success).toBe(false);
   });
+
+  it('parses updateServiceLines set values as a literal date or a derived date source', () => {
+    const literal = {
+      type: 'updateServiceLines',
+      match: { type: 'all' },
+      set: { property: 'serviceDate', value: '2026-02-02' },
+    };
+    expect(RuleActionSchema.parse(literal)).toEqual(literal);
+
+    const firstLine = {
+      type: 'updateServiceLines',
+      match: { type: 'all' },
+      set: { property: 'serviceDate', value: { source: 'firstServiceLineDate' } },
+    };
+    expect(RuleActionSchema.parse(firstLine)).toEqual(firstLine);
+
+    expect(
+      RuleActionSchema.safeParse({
+        type: 'updateServiceLines',
+        match: { type: 'all' },
+        set: { property: 'serviceDate', value: { source: 'bogus' } },
+      }).success
+    ).toBe(false);
+  });
 });
 
 describe('addServiceLine action schema', () => {
@@ -118,6 +142,21 @@ describe('addServiceLine action schema', () => {
 
     expect(RuleActionSchema.safeParse({ type: 'addServiceLine', line: { charges: '30' } }).success).toBe(false);
     expect(RuleActionSchema.safeParse({ type: 'addServiceLine', line: { cptCode: '99050' } }).success).toBe(false);
+  });
+
+  it('parses a derived date source for serviceDate, rejecting an unknown source', () => {
+    const firstLine = {
+      type: 'addServiceLine',
+      line: { cptCode: '99050', charges: '30', serviceDate: { source: 'firstServiceLineDate' } },
+    };
+    expect(RuleActionSchema.parse(firstLine)).toEqual(firstLine);
+
+    expect(
+      RuleActionSchema.safeParse({
+        type: 'addServiceLine',
+        line: { cptCode: '99050', charges: '30', serviceDate: { source: 'bogus' } },
+      }).success
+    ).toBe(false);
   });
 });
 
@@ -273,6 +312,13 @@ describe('rule value validation', () => {
     expect(serviceLineSetValueProblem(lineDate, undefined, '02/02/2026')).toContain('ISO');
     expect(serviceLineSetValueProblem(modifiers, 'add', '')).toBe('Value is required');
     expect(serviceLineSetValueProblem(modifiers, undefined, '')).toBeUndefined(); // "set" clears
+
+    // A derived date source is only accepted on date-typed properties.
+    expect(serviceLineSetValueProblem(lineDate, undefined, { source: 'firstServiceLineDate' })).toBeUndefined();
+    expect(serviceLineSetValueProblem(lineDate, undefined, { source: 'bogus' } as never)).toBe('Unknown date source');
+    expect(serviceLineSetValueProblem(units, undefined, { source: 'firstServiceLineDate' } as never)).toBe(
+      'This property does not accept a derived date value'
+    );
   });
 
   it('validates add-line place of service and service date formats', () => {
@@ -281,6 +327,10 @@ describe('rule value validation', () => {
     expect(addServiceLineFieldProblem('placeOfService', '')).toBeUndefined();
     expect(addServiceLineFieldProblem('serviceDate', '2026-02-02')).toBeUndefined();
     expect(addServiceLineFieldProblem('serviceDate', '02/02/2026')).toContain('ISO date');
+    expect(addServiceLineFieldProblem('serviceDate', undefined)).toBeUndefined(); // inherits first line's date
+    expect(addServiceLineFieldProblem('serviceDate', '')).toBeUndefined();
+    expect(addServiceLineFieldProblem('serviceDate', { source: 'firstServiceLineDate' })).toBeUndefined();
+    expect(addServiceLineFieldProblem('serviceDate', { source: 'bogus' } as never)).toBe('Unknown date source');
   });
 
   it('collects applyTag names across nested conditionals', () => {
@@ -633,6 +683,31 @@ describe('validateRuleFieldReferences', () => {
     expect(problems[1]).toContain('updates unknown service line property "alsoNotOne"');
     expect(problems[2]).toContain('matches service lines on "modifiers" with unsupported operator "gt"');
     expect(problems[3]).toContain('uses operation "add" on non-list service line property "units"');
+  });
+
+  it('rejects a derived date-source value on a non-date service line property', () => {
+    const problems = validateRuleFieldReferences(
+      ruleWith({
+        branches: [
+          {
+            condition: { type: 'all' },
+            outcome: {
+              type: 'actions',
+              actions: [
+                {
+                  type: 'updateServiceLines',
+                  match: { type: 'all' },
+                  set: { property: 'cptCode', value: { source: 'firstServiceLineDate' } as never },
+                },
+              ],
+            },
+          },
+        ],
+      })
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('updates service line property "cptCode" with an invalid value');
+    expect(problems[0]).toContain('does not accept a derived date value');
   });
 
   it('validates the applyChargeMasterPrices line match like the other service-line actions', () => {

--- a/packages/zambdas/src/billing/rules-engine/claim-model.ts
+++ b/packages/zambdas/src/billing/rules-engine/claim-model.ts
@@ -37,7 +37,7 @@ import {
   isValidClaimStatusValue,
 } from 'utils/lib/types/data/billing/claim-status';
 import { getServiceLinePropertyDef } from 'utils/lib/types/data/billing/rules-engine.field-catalog';
-import { ServiceLineSetOperation } from 'utils/lib/types/data/billing/rules-engine.schemas';
+import { DateValue, ServiceLineSetOperation } from 'utils/lib/types/data/billing/rules-engine.schemas';
 import { isoDateRegex, taxIdRegex, zipRegex } from 'utils/lib/validation/regex';
 import { updateExtension } from '../../shared/helpers';
 import { getCLIA, getPlaceOfServiceCode } from '../service-facility.helpers';
@@ -267,6 +267,27 @@ export const writeServiceLineProperty = (
   if (!writer) return false;
   if (operation !== 'set' && getServiceLinePropertyDef(propertyId)?.valueType !== 'list') return false;
   return writer(line, value, operation);
+};
+
+export type DateValueResolution = { value: string } | { error: string };
+
+const resolveFirstServiceLineDate = (model: RulesEngineClaimModel): DateValueResolution => {
+  const first = model.claim.item?.[0];
+  const date = first?.servicedPeriod?.start ?? first?.servicedDate;
+  return date
+    ? { value: date }
+    : { error: 'no service date could be resolved — the claim has no existing service lines to inherit one from' };
+};
+
+// Resolve a serviceDate-shaped rule value to a concrete date string. A literal string is returned
+// as-is (unvalidated — the writer's isoDateRegex check produces the usual "invalid service date"
+// error for a bad literal). Blank/omitted, and the explicit firstServiceLineDate source, both fall
+// back to the claim's first service line's date — addServiceLine's long-standing implicit behavior,
+// now this resolver's single definition of it.
+export const resolveDateValue = (value: DateValue | undefined, model: RulesEngineClaimModel): DateValueResolution => {
+  if (value != null && typeof value === 'object') return resolveFirstServiceLineDate(model);
+  const literal = value?.trim();
+  return literal ? { value: literal } : resolveFirstServiceLineDate(model);
 };
 
 // The claim's billed total is the sum of line charges (the invariant the claim editor maintains);

--- a/packages/zambdas/src/billing/rules-engine/claim-model.ts
+++ b/packages/zambdas/src/billing/rules-engine/claim-model.ts
@@ -285,7 +285,11 @@ const resolveFirstServiceLineDate = (model: RulesEngineClaimModel): DateValueRes
 // back to the claim's first service line's date — addServiceLine's long-standing implicit behavior,
 // now this resolver's single definition of it.
 export const resolveDateValue = (value: DateValue | undefined, model: RulesEngineClaimModel): DateValueResolution => {
-  if (value != null && typeof value === 'object') return resolveFirstServiceLineDate(model);
+  if (value != null && typeof value === 'object') {
+    return value.source === 'firstServiceLineDate'
+      ? resolveFirstServiceLineDate(model)
+      : { error: 'Unknown date source' };
+  }
   const literal = value?.trim();
   return literal ? { value: literal } : resolveFirstServiceLineDate(model);
 };

--- a/packages/zambdas/src/billing/rules-engine/evaluator.ts
+++ b/packages/zambdas/src/billing/rules-engine/evaluator.ts
@@ -24,6 +24,7 @@ import {
   readField,
   readServiceLineProperty,
   recomputeClaimTotal,
+  resolveDateValue,
   RulesEngineClaimModel,
   writeField,
   writeServiceLineProperty,
@@ -248,11 +249,9 @@ const applyAddServiceLine = (
   const input = action.line;
   const existing = claim.item ?? [];
 
-  const serviceDate =
-    input.serviceDate?.trim() || existing[0]?.servicedPeriod?.start || existing[0]?.servicedDate || '';
-  if (!serviceDate) {
-    return 'could not add service line — specify a service date (the claim has no existing lines to inherit one from)';
-  }
+  const dateResolution = resolveDateValue(input.serviceDate, model);
+  if ('error' in dateResolution) return `could not add service line — ${dateResolution.error}`;
+  const serviceDate = dateResolution.value;
 
   const resolved = resolveDiagnosisPointers(input.diagnosisPointers, claim.diagnosis?.length ?? 0);
   if (resolved.error) return `could not add service line — ${resolved.error}`;
@@ -295,11 +294,30 @@ const applyServiceLineUpdate = (
   action: Extract<RuleAction, { type: 'updateServiceLines' }>,
   model: RulesEngineClaimModel
 ): string | undefined => {
+  const def = getServiceLinePropertyDef(action.set.property);
+  let literalValue: string;
+  if (def?.valueType === 'date') {
+    // Resolve once, before mutating any line: a derived source reads claim-level state (billable
+    // period) or the first line's original date, which must not reflect a mutation this same action
+    // is about to make (e.g. when the first line is itself among the lines being updated).
+    const resolution = resolveDateValue(action.set.value, model);
+    if ('error' in resolution) {
+      return `could not update service line property "${action.set.property}" — ${resolution.error}`;
+    }
+    literalValue = resolution.value;
+  } else if (typeof action.set.value === 'string') {
+    literalValue = action.set.value;
+  } else {
+    // Save-time validation rejects a derived-source value on a non-date property; fail safe rather
+    // than crash if one reaches here anyway (e.g. a rule created directly through the API).
+    return `could not update service line property "${action.set.property}" — this property does not accept a derived date value`;
+  }
+
   const matching = (model.claim.item ?? []).filter((line) => serviceLineMatches(line, action.match));
   const operation = action.set.operation ?? 'set';
   let changed = false;
   for (const line of matching) {
-    if (!writeServiceLineProperty(line, action.set.property, action.set.value, operation)) {
+    if (!writeServiceLineProperty(line, action.set.property, literalValue, operation)) {
       // Keep the billed total consistent with any lines already updated before failing the rule.
       if (changed && action.set.property === 'charges') recomputeClaimTotal(model.claim);
       return (

--- a/packages/zambdas/src/billing/rules-engine/evaluator.ts
+++ b/packages/zambdas/src/billing/rules-engine/evaluator.ts
@@ -297,14 +297,22 @@ const applyServiceLineUpdate = (
   const def = getServiceLinePropertyDef(action.set.property);
   let literalValue: string;
   if (def?.valueType === 'date') {
-    // Resolve once, before mutating any line: a derived source reads claim-level state (billable
-    // period) or the first line's original date, which must not reflect a mutation this same action
-    // is about to make (e.g. when the first line is itself among the lines being updated).
-    const resolution = resolveDateValue(action.set.value, model);
-    if ('error' in resolution) {
-      return `could not update service line property "${action.set.property}" — ${resolution.error}`;
+    if (typeof action.set.value === 'string') {
+      const trimmed = action.set.value.trim();
+      if (!trimmed) {
+        return `could not update service line property "${action.set.property}" — value is required`;
+      }
+      literalValue = trimmed;
+    } else {
+      // Resolve once, before mutating any line: a derived source reads claim-level state (billable
+      // period) or the first line's original date, which must not reflect a mutation this same action
+      // is about to make (e.g. when the first line is itself among the lines being updated).
+      const resolution = resolveDateValue(action.set.value, model);
+      if ('error' in resolution) {
+        return `could not update service line property "${action.set.property}" — ${resolution.error}`;
+      }
+      literalValue = resolution.value;
     }
-    literalValue = resolution.value;
   } else if (typeof action.set.value === 'string') {
     literalValue = action.set.value;
   } else {

--- a/packages/zambdas/test/unit/billing/rules-engine.test.ts
+++ b/packages/zambdas/test/unit/billing/rules-engine.test.ts
@@ -26,6 +26,7 @@ import {
   READABLE_FIELD_IDS,
   readField,
   readServiceLineProperty,
+  resolveDateValue,
   RulesEngineClaimModel,
   SERVICE_LINE_READABLE_PROPERTY_IDS,
   SERVICE_LINE_WRITABLE_PROPERTY_IDS,
@@ -185,6 +186,36 @@ describe('field catalog / claim-model pairing', () => {
     expect([...SERVICE_LINE_READABLE_PROPERTY_IDS].sort()).toEqual([...propertyIds].sort());
     const settableIds = SERVICE_LINE_PROPERTY_CATALOG.filter((p) => p.settable).map((p) => p.id);
     expect([...SERVICE_LINE_WRITABLE_PROPERTY_IDS].sort()).toEqual([...settableIds].sort());
+  });
+});
+
+describe('resolveDateValue', () => {
+  it('returns a literal string as-is', () => {
+    const m = makeModel();
+    expect(resolveDateValue('2026-03-15', m)).toEqual({ value: '2026-03-15' });
+  });
+
+  it("falls back to the first service line's date when blank or omitted", () => {
+    const m = makeModel();
+    expect(resolveDateValue('', m)).toEqual({ value: '2026-01-05' });
+    expect(resolveDateValue(undefined, m)).toEqual({ value: '2026-01-05' });
+  });
+
+  it('errors on blank/omitted when the claim has no existing service lines', () => {
+    const m = makeModel();
+    m.claim.item = [];
+    expect(resolveDateValue(undefined, m)).toEqual({
+      error: 'no service date could be resolved — the claim has no existing service lines to inherit one from',
+    });
+  });
+
+  it('reads firstServiceLineDate explicitly, same as the blank fallback', () => {
+    const m = makeModel();
+    expect(resolveDateValue({ source: 'firstServiceLineDate' }, m)).toEqual({ value: '2026-01-05' });
+    m.claim.item = [];
+    expect(resolveDateValue({ source: 'firstServiceLineDate' }, m)).toEqual({
+      error: 'no service date could be resolved — the claim has no existing service lines to inherit one from',
+    });
   });
 });
 
@@ -734,6 +765,31 @@ describe('service line actions', () => {
     expect(m.claim.item).toHaveLength(1);
   });
 
+  it("adds a service line explicitly dated from the claim's first line's date", () => {
+    const m = makeModel();
+    expect(
+      applyAction(
+        {
+          type: 'addServiceLine',
+          line: { cptCode: '99050', charges: '30', serviceDate: { source: 'firstServiceLineDate' } },
+        },
+        m
+      )
+    ).toBeUndefined();
+    expect(readServiceLineProperty(m.claim.item![1], 'serviceDate')).toBe('2026-01-05');
+
+    m.claim.item = [];
+    expect(
+      applyAction(
+        {
+          type: 'addServiceLine',
+          line: { cptCode: '99051', charges: '30', serviceDate: { source: 'firstServiceLineDate' } },
+        },
+        m
+      )
+    ).toContain('service date');
+  });
+
   it('rejects invalid line place-of-service and service-date values instead of silently dropping them', () => {
     const m = makeModel();
     expect(
@@ -757,6 +813,41 @@ describe('service line actions', () => {
     // The failed actions must not have changed the claim's lines.
     expect(m.claim.item).toHaveLength(1);
     expect(readServiceLineProperty(m.claim.item![0], 'placeOfService')).toBe('20');
+  });
+
+  it('resolves firstServiceLineDate once, before mutating, even when the first line is among those updated', () => {
+    const m = makeModel();
+    addLine(m, '99214', 200);
+    m.claim.item![1].servicedPeriod = { start: '2026-05-05' }; // give line 2 a distinct date to update from
+    const error = applyAction(
+      {
+        type: 'updateServiceLines',
+        match: { type: 'all' }, // includes the first line itself
+        set: { property: 'serviceDate', value: { source: 'firstServiceLineDate' } },
+      },
+      m
+    );
+    expect(error).toBeUndefined();
+    // Both lines land on the *original* first line's date (2026-01-05), not a value from an
+    // already-mutated line earlier in the iteration.
+    expect(readServiceLineProperty(m.claim.item![0], 'serviceDate')).toBe('2026-01-05');
+    expect(readServiceLineProperty(m.claim.item![1], 'serviceDate')).toBe('2026-01-05');
+  });
+
+  it('fails the whole update when firstServiceLineDate cannot be resolved (no existing lines)', () => {
+    const m = makeModel();
+    m.claim.item = [];
+    const error = applyAction(
+      {
+        type: 'updateServiceLines',
+        match: { type: 'all' },
+        set: { property: 'serviceDate', value: { source: 'firstServiceLineDate' } },
+      },
+      m
+    );
+    expect(error).toContain('serviceDate');
+    expect(error).toContain('no service date could be resolved');
+    expect(m.claim.item).toEqual([]);
   });
 
   it('detects duplicate CPT codes and executes the canonical hold-on-duplicates rule', () => {


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-3258/billing-app-default-date-of-service-in-rules-should-provide-options

Add ability to set service line's date of service equal to date of service of the first service line.