### PR TITLE
Fix flows query bug

### DIFF
--- a/packages/zambdas/src/ehr/paperwork-flow/shared/index.ts
+++ b/packages/zambdas/src/ehr/paperwork-flow/shared/index.ts
@@ -22,6 +22,7 @@ import { CanonicalUrl, ServiceMode } from 'utils/lib/types/common';
 import { FlowForm, FlowService } from 'utils/lib/types/data/paperwork-flows/paperwork-flows.types';
 import { PAPERWORK_FLOW_ERROR } from 'utils/lib/types/errors';
 import { sendErrors } from '../../../shared/errors';
+import { compareVersions } from '../../../shared/fhir';
 
 export const healthcareServiceExtensionUrlMap = {
   [ServiceMode['in-person']]: PAPERWORK_FLOW_INPERSON_EXTENSION_URL,
@@ -98,9 +99,21 @@ const makeQuestionnaireSearchRequest = async (
     })
   ).unbundle();
 
+  // consent only questionnaires are all active - they are managed via tf and are bumped via our resource bump script
+  // which doesn't retire resources, so multiple active versions can be returned; take the highest version
+  if (url === CONSENT_ONLY_QUESTIONNAIRE_URL && qSearch.length > 1) {
+    const highest = qSearch.reduce((latest, q) =>
+      compareVersions(q.version ?? PAPERWORK_FLOW_BASE_VERSION, latest.version ?? PAPERWORK_FLOW_BASE_VERSION) > 0
+        ? q
+        : latest
+    );
+    console.log('returning the highest version of consent only: ', highest.version);
+    return highest;
+  }
+
   if (qSearch.length !== 1) {
     const returned = qSearch.map((q) => `Questionnaire/${q.id}`);
-    console.log('questionnaires returned', returned);
+    console.log('Unexpected number of questionnaires returned', returned);
     const errorMessage = `Unexpected number of questionnaires returned for ${url}|${version}: ${returned.length}`;
     const ENVIRONMENT = getSecret(SecretsKeys.ENVIRONMENT, secrets);
     // no need to error and fail the call but this would be odd so alerting

--- a/packages/zambdas/src/ehr/practice-managed-questionnaire/helpers/index.ts
+++ b/packages/zambdas/src/ehr/practice-managed-questionnaire/helpers/index.ts
@@ -3,6 +3,7 @@ import { Questionnaire } from 'fhir/r4b';
 import { PAPERWORK_FLOW_TAG, PRACTICE_MANAGED_QUESTIONNAIRE_TAG } from 'utils/lib/fhir/constants';
 import { PRACTICE_MANAGED_QUESTIONNAIRE_BASE_VERSION } from 'utils/lib/helpers/practice-managed-questionnaires';
 import { MANAGED_QUESTIONNAIRE_ERROR } from 'utils/lib/types/errors';
+import { compareVersions } from '../../../shared/fhir';
 import {
   getCanonicalUrlFromQ,
   PAPERWORK_FLOW_BASE_VERSION,
@@ -27,18 +28,6 @@ export function isLatestVersion(candidate: FhirQuestionnaireSubset, current: Fhi
   const currentLastUpdated = current.meta?.lastUpdated;
 
   return new Date(candidateLastUpdated ?? '') >= new Date(currentLastUpdated ?? '');
-}
-
-function compareVersions(versionA: string, versionB: string): number {
-  const a = versionA.split('.').map(Number);
-  const b = versionB.split('.').map(Number);
-
-  for (let i = 0; i < 3; i++) {
-    if (a[i] > b[i]) return 1;
-    if (a[i] < b[i]) return -1;
-  }
-
-  return 0;
 }
 
 export const patchQuestionnaireVersion = (version: string): string => {

--- a/packages/zambdas/src/shared/fhir.ts
+++ b/packages/zambdas/src/shared/fhir.ts
@@ -620,3 +620,18 @@ export async function fetchAllPages(
     }
   } while (hasMorePages);
 }
+
+/**
+ * compares semver strings; returns 1 if versionA > versionB, -1 if versionA < versionB, 0 if equal
+ */
+export function compareVersions(versionA: string, versionB: string): number {
+  const a = versionA.split('.').map(Number);
+  const b = versionB.split('.').map(Number);
+
+  for (let i = 0; i < 3; i++) {
+    if (a[i] > b[i]) return 1;
+    if (a[i] < b[i]) return -1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Consent only questionnaires are all active, they are managed via tf and are bumped via our resource bump script which doesn't retire resources, so multiple active versions can be returned. When searching for them to display in flows selection, we should take the highest version. 

Related https://masslight.slack.com/archives/C090W5LNP0C/p1787681914775219 