### PR TITLE
fix(ai): ambient scribe stuck in "Loading" after a silent in-person recording

### DIFF
--- a/packages/zambdas/src/shared/ai.ts
+++ b/packages/zambdas/src/shared/ai.ts
@@ -287,10 +287,19 @@ export async function transcribeAndCreateResourcesFromZ3Audio(
     secrets
   );
 
-  if (transcript === NO_SPEECH_DETECTED) {
+  // Trim: Vertex commonly wraps the sentinel in trailing whitespace/newline, and an untrimmed compare would
+  // fall through and build chart resources out of the sentinel string itself.
+  if (transcript.trim() === NO_SPEECH_DETECTED) {
     console.log(
       `[transcribeAndCreateResourcesFromZ3Audio] No speech detected in recording z3URL=${args.z3URL}; skipping AI resource creation`
     );
+    // The in-person ambient scribe marks its recording with AMBIENT_SCRIBE_RECORDING_PENDING_CODING and the EHR
+    // keeps the scribe in "Loading" (and keeps polling) until something replaces that coding — normally
+    // createResourcesFromAiInterview, which we are skipping here. Clear the pending marker ourselves so the
+    // recording settles as a played-back-only document instead of loading forever.
+    if (args.existingDocumentReference) {
+      await clearPendingRecordingMarker(oystehr, args.existingDocumentReference);
+    }
     return 'no speech detected; skipped AI resource creation';
   }
 
@@ -305,6 +314,23 @@ export async function transcribeAndCreateResourcesFromZ3Audio(
     args.existingDocumentReference,
     secrets
   );
+}
+
+/**
+ * Swaps a pending ambient-scribe recording's type coding for the regular consult-note coding, without adding a
+ * transcript or AI observations. Used when the recording turns out to be silent: the audio stays listed and
+ * playable, but the EHR stops treating it as a recording still awaiting transcription.
+ */
+async function clearPendingRecordingMarker(
+  oystehr: Oystehr,
+  existingDocumentReference: DocumentReference
+): Promise<void> {
+  await oystehr.fhir.update<DocumentReference>({
+    ...existingDocumentReference,
+    type: {
+      coding: [VISIT_CONSULT_NOTE_DOC_REF_CODING_CODE],
+    },
+  });
 }
 
 export async function invokeChatbot(input: BaseMessageLike[], secrets: Secrets | null): Promise<AIMessageChunk> {

--- a/packages/zambdas/test/transcribe-no-speech.test.ts
+++ b/packages/zambdas/test/transcribe-no-speech.test.ts
@@ -1,0 +1,156 @@
+import { DocumentReference } from 'fhir/r4b';
+import { AMBIENT_SCRIBE_RECORDING_PENDING_CODING } from 'utils/lib/fhir/constants';
+import { VISIT_CONSULT_NOTE_DOC_REF_CODING_CODE } from 'utils/lib/types/api/appointment.types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The Z3 presign is the only network hop we can't express through the fetch stub below.
+vi.mock('../src/shared/z3Utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/shared/z3Utils')>();
+  return {
+    ...actual,
+    createPresignedUrl: vi.fn(async () => 'https://z3.example.com/presigned-download'),
+  };
+});
+
+import { NO_SPEECH_DETECTED, transcribeAndCreateResourcesFromZ3Audio } from '../src/shared/ai';
+
+const Z3_URL = 'https://project-api.zapehr.com/v1/z3/myproject-recordings/enc-1/audio.webm';
+
+const secrets = {
+  ENVIRONMENT: 'local',
+  GOOGLE_CLOUD_PROJECT_ID: 'gcp-project',
+  GOOGLE_CLOUD_API_KEY: 'gcp-key',
+} as any;
+
+const pendingDocumentReference = (): DocumentReference => ({
+  resourceType: 'DocumentReference',
+  id: 'doc-ref-1',
+  status: 'current',
+  type: { coding: [AMBIENT_SCRIBE_RECORDING_PENDING_CODING] },
+  subject: { reference: 'Patient/patient-1' },
+  content: [{ attachment: { url: Z3_URL, title: 'Audio recording (00:15)' } }],
+  context: { encounter: [{ reference: 'Encounter/enc-1' }] },
+});
+
+// Answers the Z3 download with a stub audio body and every Vertex call with `transcriptResponse`.
+const stubFetch = (transcriptResponse: string): void => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: any) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('aiplatform.googleapis.com')) {
+        return new Response(JSON.stringify({ candidates: [{ content: { parts: [{ text: transcriptResponse }] } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { 'Content-Type': 'audio/webm' },
+      });
+    })
+  );
+};
+
+const makeOystehr = (): any => ({
+  fhir: {
+    update: vi.fn(async (resource: DocumentReference) => resource),
+    transaction: vi.fn(async () => ({ entry: [] })),
+    search: vi.fn(async () => ({ unbundle: () => [] })),
+  },
+});
+
+describe('transcribeAndCreateResourcesFromZ3Audio - silent recordings', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('clears the pending marker on the in-person recording so the EHR stops showing it as loading', async () => {
+    stubFetch(NO_SPEECH_DETECTED);
+    const oystehr = makeOystehr();
+    const documentReference = pendingDocumentReference();
+
+    const result = await transcribeAndCreateResourcesFromZ3Audio(
+      oystehr,
+      'm2m-token',
+      {
+        encounterID: 'enc-1',
+        z3URL: Z3_URL,
+        providerUserProfile: 'Practitioner/practitioner-1',
+        existingDocumentReference: documentReference,
+      },
+      secrets
+    );
+
+    expect(result).toContain('no speech detected');
+    expect(oystehr.fhir.update).toHaveBeenCalledTimes(1);
+    const updated = oystehr.fhir.update.mock.calls[0][0] as DocumentReference;
+    expect(updated.id).toBe('doc-ref-1');
+    expect(updated.type?.coding?.[0].code).toBe(VISIT_CONSULT_NOTE_DOC_REF_CODING_CODE.code);
+    // The audio attachment survives, so the recording stays playable in the chart.
+    expect(updated.content?.[0].attachment.url).toBe(Z3_URL);
+    // No transcript document or AI observations get written for a silent recording.
+    expect(oystehr.fhir.transaction).not.toHaveBeenCalled();
+  });
+
+  it('recognizes the sentinel when the model pads it with whitespace', async () => {
+    stubFetch(`${NO_SPEECH_DETECTED}\n`);
+    const oystehr = makeOystehr();
+
+    await transcribeAndCreateResourcesFromZ3Audio(
+      oystehr,
+      'm2m-token',
+      {
+        encounterID: 'enc-1',
+        z3URL: Z3_URL,
+        providerUserProfile: 'Practitioner/practitioner-1',
+        existingDocumentReference: pendingDocumentReference(),
+      },
+      secrets
+    );
+
+    expect(oystehr.fhir.update).toHaveBeenCalledTimes(1);
+    expect(oystehr.fhir.transaction).not.toHaveBeenCalled();
+  });
+
+  it('has nothing to clear for a telemed recording, which has no pending DocumentReference', async () => {
+    stubFetch(NO_SPEECH_DETECTED);
+    const oystehr = makeOystehr();
+
+    const result = await transcribeAndCreateResourcesFromZ3Audio(
+      oystehr,
+      'm2m-token',
+      { encounterID: 'enc-1', z3URL: Z3_URL, providerUserProfile: 'Practitioner/practitioner-1' },
+      secrets
+    );
+
+    expect(result).toContain('no speech detected');
+    expect(oystehr.fhir.update).not.toHaveBeenCalled();
+    expect(oystehr.fhir.transaction).not.toHaveBeenCalled();
+  });
+
+  it('still runs the normal pipeline when the transcript merely mentions the sentinel', async () => {
+    stubFetch(`Provider: does the phrase ${NO_SPEECH_DETECTED} mean anything to you?`);
+    const oystehr = makeOystehr();
+
+    // Nothing downstream is stubbed (the chart-data call gets the same non-JSON body), so the pipeline throws —
+    // which is itself the proof that the silent-recording branch did not swallow this transcript.
+    await expect(
+      transcribeAndCreateResourcesFromZ3Audio(
+        oystehr,
+        'm2m-token',
+        {
+          encounterID: 'enc-1',
+          z3URL: Z3_URL,
+          providerUserProfile: 'Practitioner/practitioner-1',
+          existingDocumentReference: pendingDocumentReference(),
+        },
+        secrets
+      )
+    ).rejects.toThrow();
+
+    expect(oystehr.fhir.search).toHaveBeenCalled();
+    expect(oystehr.fhir.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to [#9217](https://github.com/masslight/ottehr/pull/9217). The no-speech short circuit added there is correct for telemed, but it breaks the in-person ambient scribe: recording silence leaves the scribe stuck in "Loading" forever, with a spinner in the Oystehr AI section.

The in-person flow tracks a recording with a DocumentReference tagged `AMBIENT_SCRIBE_RECORDING_PENDING_CODING` (`create-resources-from-audio-recording`). That coding is the pending flag — it sets `aiChat.hasPendingRecording`, which drives the `status="loading"` scribe card in `RecordAudioContainer`, and it's what `useAiResourcesPolling` searches for to keep polling. The only thing that ever clears it is `updateDocumentReference()` inside `createResourcesFromAiInterview`, which swaps the coding for `VISIT_CONSULT_NOTE_DOC_REF_CODING_CODE`.

`transcribeAndCreateResourcesFromZ3Audio` now returns before that call when the transcript comes back as `NO_SPEECH_DETECTED`, so the pending DocumentReference is never updated. The scribe card has no timeout, so it stays "Loading" across reloads; the Oystehr AI spinner keeps polling for the full 60 attempts (5 min) before falling back to "No AI data available".

### Changes

- In the no-speech branch, clear the pending marker when the caller passed an `existingDocumentReference` (in-person only — telemed passes none and is unaffected). The recording stays listed and playable in the chart; it just carries no transcript and no AI suggestions, which matches the expected behavior of "recording is Ready, nothing in Oystehr AI".
- Compare the sentinel against a trimmed transcript. Vertex commonly appends a newline, and the exact compare would fall through and build chart resources out of the sentinel string itself — the opposite failure mode.
- New offline unit test (`packages/zambdas/test/transcribe-no-speech.test.ts`) covering: pending marker cleared and no FHIR transaction for a silent in-person recording, whitespace-padded sentinel, telemed no-op, and a transcript that merely mentions the sentinel still running the normal pipeline.

Note: a recording whose transcription throws (Vertex outage, bad audio) hits the same stuck-loading state. That path predates #9217 and isn't addressed here.

## Test plan

- [x] `cd packages/zambdas && npx vitest run --project unit test/transcribe-no-speech.test.ts test/process-telemed-recording.test.ts test/unit/vertex-ai-error-handling.test.ts` (plus the extract-photo-id / extract-insurance-card suites that import `shared/ai`) — all passing
- [x] `npx tsc --noEmit` and eslint/prettier clean on the touched files
- [ ] In-person visit: start Ambient Scribe, stay silent, end the recording — recording shows as Ready and playable, Oystehr AI shows no suggestions and no spinner
- [ ] In-person visit with real dialogue still produces a transcript and AI suggestions
- [ ] Telemed silent call still produces no transcript and no AI notes (#9217 behavior unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtXi7d9nH5FkWswLiWFpzR)_