### PR TITLE
fixed appearing delete button when medication is dispensed already

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/medication-administration/medication-editable-card/MedicationCardView.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/medication-administration/medication-editable-card/MedicationCardView.tsx
@@ -285,11 +285,15 @@ export const MedicationCardView: React.FC<MedicationCardViewProps> = ({
             onClick={onStatusSelect}
             status={selectedStatus}
           />
-          {!isReadOnly && onDelete && type !== 'completed-edit' && (
-            <ButtonRounded onClick={onDelete} variant="outlined" color="error" size="large">
-              Delete Order
-            </ButtonRounded>
-          )}
+          {!isReadOnly &&
+            onDelete &&
+            selectedStatus !== 'administered' &&
+            selectedStatus !== 'administered-partly' &&
+            selectedStatus !== 'administered-not' && (
+              <ButtonRounded onClick={onDelete} variant="outlined" color="error" size="large">
+                Delete Order
+              </ButtonRounded>
+            )}
         </Box>
         {isEditable && (
           <Box display="flex" flexDirection="row" gap={2}>


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2866/ehr-administeredpartly-administerednot-administered-buttons-disappear