### PR TITLE
Billing report refresh framework

### DIFF
--- a/apps/billing/src/components/ReportStatusBar.tsx
+++ b/apps/billing/src/components/ReportStatusBar.tsx
@@ -4,8 +4,7 @@ import { DateTime } from 'luxon';
 import { ReactElement } from 'react';
 import { ReportRefreshStatus } from 'utils/lib/types/data/billing/billing.types';
 
-// Merges several report statuses into the "most active" one (running > error > idle), so pages
-// serving multiple kinds (e.g. Payments + Patient Payments) show a single coherent status line.
+// Merges several statuses into the "most active" one (running > error > idle).
 export function mergeReportStatuses(...statuses: (ReportRefreshStatus | undefined)[]): ReportRefreshStatus | undefined {
   const present = statuses.filter((status): status is ReportRefreshStatus => !!status);
   if (present.length === 0) return undefined;
@@ -19,10 +18,7 @@ export function mergeReportStatuses(...statuses: (ReportRefreshStatus | undefine
   );
 }
 
-// Uniform report-header status line + refresh button:
-// idle    → de-emphasized "Updated <relative time>" (absolute timestamp in the tooltip)
-// running → live worker phase text over a slim progress animation, refresh disabled
-// error   → warning + failure reason, refresh relabeled Retry
+// Report-header status line + refresh button: idle / running-with-live-progress / error+Retry.
 export function ReportStatusBar({
   status,
   loading,

--- a/apps/billing/src/components/ReportStatusBar.tsx
+++ b/apps/billing/src/components/ReportStatusBar.tsx
@@ -1,0 +1,74 @@
+import { Refresh as RefreshIcon, WarningAmberRounded as WarningIcon } from '@mui/icons-material';
+import { Box, Button, LinearProgress, Stack, Tooltip, Typography } from '@mui/material';
+import { DateTime } from 'luxon';
+import { ReactElement } from 'react';
+import { ReportRefreshStatus } from 'utils/lib/types/data/billing/billing.types';
+
+// Merges several report statuses into the "most active" one (running > error > idle), so pages
+// serving multiple kinds (e.g. Payments + Patient Payments) show a single coherent status line.
+export function mergeReportStatuses(...statuses: (ReportRefreshStatus | undefined)[]): ReportRefreshStatus | undefined {
+  const present = statuses.filter((status): status is ReportRefreshStatus => !!status);
+  if (present.length === 0) return undefined;
+  const running = present.find((status) => status.state === 'running');
+  if (running) return running;
+  const errored = present.find((status) => status.state === 'error');
+  if (errored) return errored;
+  // oldest completion is the honest "last updated" for the page as a whole
+  return present.reduce((oldest, status) =>
+    (status.lastCompletedAt ?? '') < (oldest.lastCompletedAt ?? '') ? status : oldest
+  );
+}
+
+// Uniform report-header status line + refresh button:
+// idle    → de-emphasized "Updated <relative time>" (absolute timestamp in the tooltip)
+// running → live worker phase text over a slim progress animation, refresh disabled
+// error   → warning + failure reason, refresh relabeled Retry
+export function ReportStatusBar({
+  status,
+  loading,
+  onRefresh,
+}: {
+  status: ReportRefreshStatus | undefined;
+  loading: boolean;
+  onRefresh: () => void;
+}): ReactElement {
+  const running = status?.state === 'running';
+  const lastCompleted = status?.lastCompletedAt ? DateTime.fromISO(status.lastCompletedAt) : undefined;
+
+  return (
+    <Stack direction="row" alignItems="center" gap={1.5}>
+      {running ? (
+        <Box sx={{ minWidth: 200, maxWidth: 360 }}>
+          <Typography variant="caption" color="text.secondary" noWrap component="div">
+            {`Refreshing — ${status?.progress ?? 'queued'}`}
+          </Typography>
+          <LinearProgress sx={{ mt: 0.5, height: 3, borderRadius: 1 }} />
+        </Box>
+      ) : status?.state === 'error' ? (
+        <Stack direction="row" alignItems="center" gap={0.75} sx={{ maxWidth: 360 }}>
+          <WarningIcon color="warning" sx={{ fontSize: 16 }} />
+          <Tooltip title={status.error ?? ''}>
+            <Typography variant="caption" color="warning.main" noWrap>
+              {`Last refresh failed${status.error ? `: ${status.error}` : ''}`}
+            </Typography>
+          </Tooltip>
+        </Stack>
+      ) : lastCompleted ? (
+        <Tooltip title={lastCompleted.toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS)}>
+          <Typography variant="caption" color="text.disabled" noWrap>
+            {`Updated ${lastCompleted.toRelative() ?? ''}`}
+          </Typography>
+        </Tooltip>
+      ) : null}
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={<RefreshIcon />}
+        disabled={loading || running}
+        onClick={onRefresh}
+      >
+        {status?.state === 'error' ? 'Retry' : 'Refresh'}
+      </Button>
+    </Stack>
+  );
+}

--- a/apps/billing/src/hooks/useBillingReport.ts
+++ b/apps/billing/src/hooks/useBillingReport.ts
@@ -22,9 +22,7 @@ export interface UseBillingReportResult<T extends ReportEnvelope> {
   refresh: () => void;
 }
 
-// Fetch-and-poll loop shared by all report pages: loads the cached report, and while the server
-// reports a running refresh, polls until the recomputed cache lands. `refresh()` queues a
-// server-side recompute and flips into the polling loop.
+// Shared fetch-and-poll loop: serves the cached report and polls while a server-side refresh runs.
 export function useBillingReport<T extends ReportEnvelope>(options: {
   fetch: (client: Oystehr, refresh?: boolean) => Promise<T>;
   errorMessage: string;

--- a/apps/billing/src/hooks/useBillingReport.ts
+++ b/apps/billing/src/hooks/useBillingReport.ts
@@ -1,0 +1,92 @@
+import Oystehr from '@oystehr/sdk';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getApiError } from 'utils/lib/helpers/oystehrApi';
+import { ReportRefreshStatus } from 'utils/lib/types/data/billing/billing.types';
+import { useApiClients } from './useAppClients';
+
+// polling cadence while a refresh runs server-side
+const POLL_INTERVAL_MS = 4000;
+const MAX_POLLS = 200;
+
+interface ReportEnvelope {
+  generatedAt: string;
+  status?: ReportRefreshStatus;
+}
+
+export interface UseBillingReportResult<T extends ReportEnvelope> {
+  report: T | null;
+  status: ReportRefreshStatus | undefined;
+  loading: boolean;
+  error: string | null;
+  clearError: () => void;
+  refresh: () => void;
+}
+
+// Fetch-and-poll loop shared by all report pages: loads the cached report, and while the server
+// reports a running refresh, polls until the recomputed cache lands. `refresh()` queues a
+// server-side recompute and flips into the polling loop.
+export function useBillingReport<T extends ReportEnvelope>(options: {
+  fetch: (client: Oystehr, refresh?: boolean) => Promise<T>;
+  errorMessage: string;
+  // when false, the initial load waits (e.g. until a date range resolves)
+  enabled?: boolean;
+}): UseBillingReportResult<T> {
+  const { fetch, errorMessage, enabled = true } = options;
+  const { oystehrZambda } = useApiClients();
+  const [report, setReport] = useState<T | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // invalidates in-flight loops when params change or the component unmounts
+  const generation = useRef(0);
+
+  const run = useCallback(
+    async (refresh?: boolean): Promise<void> => {
+      if (!oystehrZambda) return;
+      const myGeneration = ++generation.current;
+      setLoading(true);
+      setError(null);
+      try {
+        let current = await fetch(oystehrZambda, refresh);
+        if (generation.current !== myGeneration) return;
+        setReport(current);
+        setLoading(false);
+        let polls = 0;
+        while (current.status?.state === 'running' && polls < MAX_POLLS) {
+          await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+          if (generation.current !== myGeneration) return;
+          current = await fetch(oystehrZambda);
+          if (generation.current !== myGeneration) return;
+          setReport(current);
+          polls += 1;
+        }
+      } catch (err) {
+        if (generation.current !== myGeneration) return;
+        setError(getApiError({ error: err, defaultError: errorMessage }));
+      } finally {
+        if (generation.current === myGeneration) setLoading(false);
+      }
+    },
+    [oystehrZambda, fetch, errorMessage]
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    void run();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [oystehrZambda, run, enabled]);
+
+  useEffect(() => {
+    return () => {
+      generation.current += 1;
+    };
+  }, []);
+
+  return {
+    report,
+    status: report?.status,
+    loading,
+    error,
+    clearError: () => setError(null),
+    refresh: () => void run(true),
+  };
+}

--- a/config/billing-app-core/zambdas.json
+++ b/config/billing-app-core/zambdas.json
@@ -274,6 +274,13 @@
       "src": "src/billing/run-billing-rules-engine/index",
       "zip": ".dist/zips/run-billing-rules-engine.zip"
     },
+    "GET-BILLING-REPORT": {
+      "name": "get-billing-report",
+      "type": "http_auth",
+      "runtime": "nodejs22.x",
+      "src": "src/billing/reports/get-billing-report/index",
+      "zip": ".dist/zips/get-billing-report.zip"
+    },
     "TAG-BILLING-CLAIM": {
       "name": "tag-billing-claim",
       "type": "http_auth",
@@ -413,6 +420,14 @@
       "src": "src/subscriptions/task/sub-export-billing-claims-csv/index",
       "zip": ".dist/zips/sub-export-billing-claims-csv.zip"
     },
+    "SUB-REFRESH-BILLING-REPORT": {
+      "name": "sub-refresh-billing-report",
+      "type": "subscription",
+      "timeout": "870",
+      "runtime": "nodejs22.x",
+      "src": "src/subscriptions/task/sub-refresh-billing-report/index",
+      "zip": ".dist/zips/sub-refresh-billing-report.zip"
+    },
     "CLEANUP-BILLING-CLAIM-EXPORTS": {
       "name": "cleanup-billing-claim-exports",
       "type": "cron",
@@ -441,6 +456,24 @@
         "channel": {
           "type": "rest-hook",
           "endpoint": "zapehr-lambda:#{ref/zambdas/SUB-EXPORT-BILLING-CLAIMS-CSV/id}"
+        },
+        "extension": [
+          {
+            "url": "http://zapehr.com/fhir/extension/SubscriptionTriggerEvent",
+            "valueString": "create"
+          }
+        ]
+      }
+    },
+    "SUB_REFRESH_BILLING_REPORT_SUBSCRIPTION": {
+      "resource": {
+        "resourceType": "Subscription",
+        "status": "active",
+        "reason": "Recompute a heavy billing report cache asynchronously",
+        "criteria": "Task?code=https://fhir.ottehr.com/CodeSystem/export-task|refresh-billing-report&status=requested",
+        "channel": {
+          "type": "rest-hook",
+          "endpoint": "zapehr-lambda:#{ref/zambdas/SUB-REFRESH-BILLING-REPORT/id}"
         },
         "extension": [
           {

--- a/config/oystehr-core/roles.json
+++ b/config/oystehr-core/roles.json
@@ -301,6 +301,7 @@
             "Zambda:Function:update-billing-provider",
             "Zambda:Function:create-billing-claim",
             "Zambda:Function:search-billing-claims",
+            "Zambda:Function:get-billing-report",
             "Zambda:Function:get-patient-coverages",
             "Zambda:Function:search-billing-locations",
             "Zambda:Function:create-billing-patient",

--- a/docs/billing-report-refresh-framework.md
+++ b/docs/billing-report-refresh-framework.md
@@ -1,0 +1,281 @@
+# Billing Report Refresh Framework
+
+How the billing app's reports are computed, cached, refreshed, and drilled into. This document
+describes the **mechanism**; the individual reports built on it are documented in
+[billing-reports.md](./billing-reports.md).
+
+## 1. The model in one paragraph
+
+Every billing report follows the same task/subscribe pipeline: the HTTP zambda **never
+computes** — it serves a cached snapshot plus a refresh status, and queues an async refresh as
+a FHIR `Task`. A Subscription fires a worker zambda that routes the Task to the report's
+definition, runs its `compute()` with a long timeout, streams progress back onto the Task, and
+writes the result (and optionally a drilldown dataset) to gzip caches. The frontend polls the
+cheap HTTP endpoint while a refresh runs and renders one uniform status bar everywhere.
+
+There are exactly **two zambdas** for all reports:
+
+| Zambda | Role |
+|---|---|
+| `get-billing-report` | serve cache + status; queue refreshes; serve drilldown slices |
+| `sub-refresh-billing-report` | compute; write caches; report progress (Task-subscription worker) |
+
+Adding report kind #7 means writing one `ReportDefinition` and registering it — no new zambdas,
+no new config, no new frontend plumbing beyond a typed api wrapper and a page.
+
+## 2. Architecture
+
+```mermaid
+flowchart LR
+    subgraph Frontend["apps/billing"]
+        Page["Report page"] --> Hook["useBillingReport"]
+        Hook --> StatusBar["ReportStatusBar"]
+        Drawer["Drilldown drawer"]
+    end
+
+    subgraph HTTP["get-billing-report (HTTP, thin)"]
+        GetReport["{ kind, params, refresh?, drilldown? }"]
+    end
+
+    subgraph FHIR["FHIR store"]
+        TaskR["Task<br/>(queue + live status)"]
+        Cache["DocumentReference<br/>payload cache"]
+        Detail["DocumentReference<br/>detail cache (:detail)"]
+    end
+
+    subgraph Worker["sub-refresh-billing-report"]
+        Sub["route by kind"] --> Registry["reportRegistry"]
+        Registry --> Compute["definition.compute()"]
+    end
+
+    Hook -- "fetch / refresh" --> GetReport
+    Drawer -- "drilldown" --> GetReport
+    GetReport -- read --> Cache
+    GetReport -- "filter via drilldown.select" --> Detail
+    GetReport -- "read / conditional-create" --> TaskR
+    TaskR -- "Subscription: status=requested" --> Sub
+    Compute -- "progress → businessStatus" --> TaskR
+    Compute -- "payload" --> Cache
+    Compute -- "detail" --> Detail
+```
+
+Two invariants:
+
+1. The **Task is the single source of truth for refresh state**; the cache documents are the
+   single source of truth for report data.
+2. The HTTP zambda only ever reads/writes those resources — filtering a cached detail dataset
+   is the heaviest thing it does.
+
+## 3. Code layout
+
+```
+packages/zambdas/src/billing/reports/
+├── framework/
+│   ├── types.ts          # ReportDefinition contract, ReportContext, ReportPayload
+│   ├── registry.ts       # reportRegistry: RefreshReportKind → definition
+│   ├── refresh-task.ts   # Task queue: kickoff (race-free), find active/failed, progress writer
+│   └── report-cache.ts   # gzip DocumentReference load/save, cache keys, detail envelope
+├── definitions/
+│   └── *.report.ts       # one self-contained ReportDefinition per kind (see billing-reports.md)
+├── get-billing-report/   # the HTTP zambda
+└── shared.ts             # ERA/date helpers shared by report computes
+
+packages/zambdas/src/subscriptions/task/sub-refresh-billing-report/   # the worker
+
+apps/billing/src/
+├── hooks/useBillingReport.ts        # fetch + poll-while-running loop
+├── components/ReportStatusBar.tsx   # idle / running / error header widget
+└── api/api.ts                       # typed per-kind wrappers over get-billing-report
+
+packages/utils/lib/types/data/billing/
+├── billing.constants.ts  # REFRESH_REPORT_KINDS, Task codes
+├── billing.schemas.ts    # GetBillingReportInputSchema, per-kind params schemas
+└── billing.types.ts      # payload/detail/response types, ReportRefreshStatus
+```
+
+## 4. The `ReportDefinition` contract
+
+Defined in [framework/types.ts](../packages/zambdas/src/billing/reports/framework/types.ts):
+
+```ts
+interface ReportDefinition<Params, Payload extends ReportPayload, Detail, DrillParams> {
+  kind: RefreshReportKind;          // 'payments' | 'invoice' | …
+  cacheVersion: string;             // bump to invalidate stale-shape caches
+  paramsSchema: ZodType<Params>;    // validates HTTP input AND Task input
+  cacheKeyOf: (params) => string;   // params part of the cache key ('' if unparameterized)
+  emptyPayload: () => Payload;      // served while the first refresh runs
+
+  // full recomputation, worker-side; detail is the optional drilldown dataset
+  compute: (ctx, params, onProgress) => Promise<{ payload: Payload; detail?: Detail }>;
+
+  savesOwnCache?: boolean;          // compute persists intermediate state itself (worker skips save)
+  sanitizePayload?: (p) => Payload; // strip internal state before a payload leaves the server
+  shrink?: (p) => Payload | undefined;        // shed data until an oversized payload fits
+  shrinkDetail?: (d) => Detail | undefined;   // same, for the detail dataset
+  detailCacheKeyOf?: (params) => string;      // when detail keys differently than the report
+
+  drilldown?: {
+    paramsSchema: ZodType<DrillParams>;
+    select: (detail, drillParams) => Record<string, unknown>;  // pure filter, HTTP-side
+    empty: () => Record<string, unknown>;                      // served before first compute
+  };
+
+  summarize: (payload) => string;   // one-liner for the Task's completion statusReason
+}
+```
+
+`ReportContext` gives compute a billing-tagged client (`oystehr`), an untagged client for
+clinical resources (`untaggedClient`), and `secrets` for external systems (Stripe, etc.).
+
+## 5. Request/response protocol
+
+`POST get-billing-report` with `{ kind, params?, refresh?, drilldown? }`
+([GetBillingReportInputSchema](../packages/utils/lib/types/data/billing/billing.schemas.ts)):
+
+- **Fetch** (`{ kind, params }`): serve the cached payload (sanitized) + `status`. If the
+  report has never been computed, queue the first refresh and serve `emptyPayload()`.
+- **Refresh** (`refresh: true`): queue a refresh (idempotent, §6) and fall through to fetch.
+- **Drilldown** (`drilldown: {…}`): validate against the definition's drilldown schema, load
+  the detail cache, return `drilldown.select(detail, drillParams)` + `status`. Empty result
+  until the first refresh has written the detail document.
+
+Every response carries the uniform envelope:
+
+```ts
+interface ReportRefreshStatus {
+  state: 'idle' | 'running' | 'error';
+  lastCompletedAt?: string;  // ISO of the served snapshot
+  progress?: string;         // live worker phase text while running
+  error?: string;            // most recent failure's statusReason
+}
+// response = { ...payloadOrSlice, generatedAt, fromCache, status }
+```
+
+Error state is derived server-side: a `failed` refresh Task **newer than the served cache**
+means "your data is fine, the last attempt broke".
+
+## 6. The refresh Task
+
+Created by `kickOffRefreshTask` in
+[framework/refresh-task.ts](../packages/zambdas/src/billing/reports/framework/refresh-task.ts):
+
+- `code`: `EXPORT_TASK_SYSTEM|refresh-billing-report` — the Subscription in
+  [config/billing-app-core/zambdas.json](../config/billing-app-core/zambdas.json) matches this
+  with `status=requested`.
+- `identifier`: `ottehrIdentifierSystem('billing-report-refresh')|<cacheKey>` — the searchable
+  dedupe key.
+- `input[]`: report kind, JSON-serialized params (re-validated by the worker), and cacheKey.
+- `businessStatus.text`: live progress phrase, patched by the worker via `onProgress`.
+
+**Race-free idempotency.** Creation is a FHIR conditional create
+(`fhir.create(task, { ifNoneExist: identifier + status=requested,in-progress })`), so
+concurrent kickoffs — React StrictMode double-mounts, two users, parallel tabs — atomically
+resolve to one Task server-side. Stale tasks (untouched > 30 min, assumed hard-killed worker)
+are patched to `cancelled` before a replacement is created, so they can never wedge the
+condition.
+
+```mermaid
+stateDiagram-v2
+    [*] --> requested : kickoff (conditional create per cacheKey)
+    requested --> in_progress : worker picks up
+    in_progress --> in_progress : onProgress → businessStatus
+    in_progress --> completed : caches written (statusReason = summarize())
+    in_progress --> failed : compute threw (statusReason = error)
+    requested --> cancelled : stale (>30 min), superseded by new kickoff
+    in_progress --> cancelled : stale (>30 min), superseded by new kickoff
+```
+
+## 7. Caching
+
+All caches are **gzipped JSON in a `DocumentReference` attachment**, identified by
+`ottehrIdentifierSystem('billing-report')|<key>` and upserted by
+[framework/report-cache.ts](../packages/zambdas/src/billing/reports/framework/report-cache.ts):
+
+| Document | Key | Contents |
+|---|---|---|
+| payload cache | `<kind>:<cacheVersion>:<paramsKey>` | the report response payload (rows, totals, …) |
+| detail cache | `<kind>:<cacheVersion>:<detailParamsKey>:detail` | `{ generatedAt, detail }` drilldown dataset |
+
+- Parameterized reports get one payload document per params combination (e.g. per date window).
+- A 4 MB cap keeps documents under FHIR resource limits; oversized saves run through the
+  definition's `shrink`/`shrinkDetail` until they fit, or are skipped with a warning. A failed
+  cache write never fails the refresh.
+- `cacheVersion` bumps orphan old documents rather than migrating them.
+
+## 8. The worker
+
+[sub-refresh-billing-report](../packages/zambdas/src/subscriptions/task/sub-refresh-billing-report/index.ts)
+is a pure dispatcher: validate the Task inputs → look up the definition → `compute()` with an
+`onProgress` that patches `Task.businessStatus` → save payload (unless `savesOwnCache`) → save
+detail (when present) → complete the Task with `summarize()` as the statusReason. A thrown
+compute marks the Task `failed` with the error message, which the HTTP zambda surfaces as
+`status.state: 'error'`.
+
+```mermaid
+sequenceDiagram
+    participant UI as Report page
+    participant Z as get-billing-report
+    participant FHIR as FHIR (Task + caches)
+    participant W as worker
+
+    UI->>Z: { kind, params, refresh: true }
+    Z->>FHIR: conditional-create Task
+    Z-->>UI: stale payload + status{running}
+    FHIR-)W: Subscription fires
+    W->>W: registry[kind].compute()
+    loop phases
+        W->>FHIR: patch businessStatus ("checking cards 400/4,800…")
+    end
+    W->>FHIR: save payload + detail caches, Task → completed
+    loop poll every 4s
+        UI->>Z: { kind, params }
+        Z-->>UI: payload + live progress
+    end
+    UI->>Z: final poll → fresh payload + status{idle}
+    UI->>Z: { kind, params, drilldown } (row click)
+    Z->>FHIR: load detail cache
+    Z-->>UI: select(detail, drillParams) + status
+```
+
+Progress reporting conventions: each `onProgress` call is a FHIR patch, so computes throttle
+streaming counts (e.g. every 250–1,000 items). Totals are only shown when known up front
+("checking cards 400/4,800…"); cursor-paginated listings show running counts
+("listing customers… 12,000 so far").
+
+## 9. Frontend
+
+- [useBillingReport](../apps/billing/src/hooks/useBillingReport.ts): initial load, refetch on
+  params change (generation-counter guarded against races/unmount), `refresh()` action, and a
+  ~4 s polling loop while `status.state === 'running'`.
+- [ReportStatusBar](../apps/billing/src/components/ReportStatusBar.tsx): one widget for every
+  report header — de-emphasized "Updated 12 minutes ago" when idle (absolute time in tooltip),
+  phase text over a slim indeterminate bar when running, warning + Retry on error.
+  `mergeReportStatuses` collapses several statuses (running > error > oldest idle) for pages
+  hosting more than one kind.
+- [api.ts](../apps/billing/src/api/api.ts) keeps compile-time payload types via thin per-kind
+  wrappers that all call the same endpoint.
+
+## 10. Adding a new report
+
+1. Add the kind to `REFRESH_REPORT_KINDS` in
+   [billing.constants.ts](../packages/utils/lib/types/data/billing/billing.constants.ts).
+2. Define payload (and detail/drilldown, if any) types in `billing.types.ts`; pick or add a
+   params schema in `billing.schemas.ts`.
+3. Write `definitions/<kind>.report.ts` with `compute()` and register it in
+   [framework/registry.ts](../packages/zambdas/src/billing/reports/framework/registry.ts).
+4. Add a typed wrapper in `api.ts`, and a page using `useBillingReport` + `ReportStatusBar`.
+
+No zambda, config, or role changes.
+
+## 11. Design decisions & tradeoffs (recorded)
+
+- **Snapshot drilldowns.** Drilldowns are filtered views of the same snapshot the report was
+  built from — internally consistent with the rows the user clicked, at the cost of freshness
+  (e.g. patient-payment Stripe statuses are as-of-refresh, labeled "as of <time>" in the UI).
+- **Single grant RBAC.** Access is per-zambda in Oystehr; one `get-billing-report` grant covers
+  all kinds. Kind-level checks (via `callerHasRole`) are the escape hatch if ever needed.
+- **One worker profile.** All computes share one timeout/memory/bundle. If a report ever needs
+  a different profile, give its Task a distinct code and register a second worker over a
+  registry partition — the framework doesn't change.
+- **Polling, not push.** 4 s polling of a cheap cache read; SSE/websockets deliberately out of
+  scope.

--- a/docs/billing-report-refresh-framework.md
+++ b/docs/billing-report-refresh-framework.md
@@ -20,8 +20,8 @@ There are exactly **two zambdas** for all reports:
 | `get-billing-report` | serve cache + status; queue refreshes; serve drilldown slices |
 | `sub-refresh-billing-report` | compute; write caches; report progress (Task-subscription worker) |
 
-Adding report kind #7 means writing one `ReportDefinition` and registering it — no new zambdas,
-no new config, no new frontend plumbing beyond a typed api wrapper and a page.
+Adding a new report kind means writing one `ReportDefinition` and registering it — no new
+zambdas, no new config, no new frontend plumbing beyond a typed api wrapper and a page.
 
 ## 2. Architecture
 

--- a/packages/utils/lib/types/data/billing/billing.constants.ts
+++ b/packages/utils/lib/types/data/billing/billing.constants.ts
@@ -10,9 +10,8 @@ export const EXPORT_CLAIMS_CSV_TASK_CODE = 'export-billing-claims-csv';
 export const EXPORT_CLAIMS_FILTERS_CODE = 'export-claims-filters';
 export const EXPORT_CLAIMS_INCOMPLETE_CODE = 'export-claims-incomplete';
 
-// Task code (under EXPORT_TASK_SYSTEM) for an async billing-report refresh; the report kind,
-// JSON-serialized params, and the cache key travel as Task inputs. The Subscription that runs
-// the refresh matches on the code; idempotency is per cache key (kind + params).
+// Async billing-report refresh Task: kind/params/cacheKey travel as Task inputs; the
+// Subscription matches on the code.
 export const REFRESH_REPORT_TASK_CODE = 'refresh-billing-report';
 export const REFRESH_REPORT_KIND_CODE = 'refresh-report-kind';
 export const REFRESH_REPORT_PARAMS_CODE = 'refresh-report-params';

--- a/packages/utils/lib/types/data/billing/billing.constants.ts
+++ b/packages/utils/lib/types/data/billing/billing.constants.ts
@@ -10,6 +10,23 @@ export const EXPORT_CLAIMS_CSV_TASK_CODE = 'export-billing-claims-csv';
 export const EXPORT_CLAIMS_FILTERS_CODE = 'export-claims-filters';
 export const EXPORT_CLAIMS_INCOMPLETE_CODE = 'export-claims-incomplete';
 
+// Task code (under EXPORT_TASK_SYSTEM) for an async billing-report refresh; the report kind,
+// JSON-serialized params, and the cache key travel as Task inputs. The Subscription that runs
+// the refresh matches on the code; idempotency is per cache key (kind + params).
+export const REFRESH_REPORT_TASK_CODE = 'refresh-billing-report';
+export const REFRESH_REPORT_KIND_CODE = 'refresh-report-kind';
+export const REFRESH_REPORT_PARAMS_CODE = 'refresh-report-params';
+export const REFRESH_REPORT_CACHE_KEY_CODE = 'refresh-report-cache-key';
+export const REFRESH_REPORT_KINDS = [
+  'payments',
+  'patient-payments',
+  'invoice',
+  'cards-on-file',
+  'pipeline',
+  'productivity',
+] as const;
+export type RefreshReportKind = (typeof REFRESH_REPORT_KINDS)[number];
+
 // Max claims a single CSV export includes; matches beyond this are truncated and flagged incomplete.
 export const EXPORT_CLAIMS_MATCH_LIMIT = 10_000;
 

--- a/packages/utils/lib/types/data/billing/billing.schemas.ts
+++ b/packages/utils/lib/types/data/billing/billing.schemas.ts
@@ -5,7 +5,7 @@ import { isCLIAValid, isNPIValidWithChecksum } from '../../../helpers/helpers';
 import { CMS_PLACE_OF_SERVICE_CODE_SET, CODE_SYSTEM_CLAIM_TYPE_CODE_NAMES } from '../../../helpers/rcm/constants';
 import { fullZipRegex, stripeAccountIdRegex, taxIdRegex, zipRegex } from '../../../validation/regex';
 import { STATE_CODES } from '../../common';
-import { BILLING_MANUAL_PAYMENT_METHODS } from './billing.constants';
+import { BILLING_MANUAL_PAYMENT_METHODS, REFRESH_REPORT_KINDS } from './billing.constants';
 import { CLAIM_NOTE_MAX_LENGTH } from './claim-history';
 import {
   CLAIM_STATUS_FIELD_KEYS,
@@ -659,6 +659,36 @@ export const MatchClaimResponseToClaimInputSchema = z.object({
 export const UnmatchClaimResponseInputSchema = z.object({
   claimResponseId: nonEmptyString,
 });
+
+// report date-window fields: ISO date (YYYY-MM-DD), with from <= to when both are set
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected an ISO date (YYYY-MM-DD)');
+const dateWindowIsOrdered = (data: { dateFrom?: string; dateTo?: string }): boolean =>
+  !data.dateFrom || !data.dateTo || data.dateFrom <= data.dateTo;
+const DATE_WINDOW_MESSAGE = { message: 'dateFrom must not be after dateTo', path: ['dateFrom'] };
+
+export const GetBillingReportInputSchema = z.object({
+  kind: z.enum(REFRESH_REPORT_KINDS),
+  // per-kind params, validated against the report definition's paramsSchema server-side
+  params: z.record(z.unknown()).optional(),
+  // queue an async recompute (idempotent while one is already running for the same kind+params)
+  refresh: z.boolean().optional(),
+  // drilldown request: a filtered slice of the report's cached detail dataset, validated
+  // against the definition's drilldown paramsSchema server-side
+  drilldown: z.record(z.unknown()).optional(),
+});
+
+// date-window params shared by the parameterized report kinds (payments, patient-payments, …)
+export const ReportDateWindowParamsSchema = z
+  .object({
+    dateFrom: isoDate.optional(),
+    dateTo: isoDate.optional(),
+  })
+  .refine(dateWindowIsOrdered, DATE_WINDOW_MESSAGE);
+
+export const EmptyReportParamsSchema = z.object({});
+
+export type GetBillingReportInput = z.output<typeof GetBillingReportInputSchema>;
+export type ReportDateWindowParams = z.output<typeof ReportDateWindowParamsSchema>;
 
 export const RecordBillingManualPaymentInputSchema = z.object({
   encounterId: nonEmptyString.uuid(),

--- a/packages/utils/lib/types/data/billing/billing.schemas.ts
+++ b/packages/utils/lib/types/data/billing/billing.schemas.ts
@@ -668,16 +668,15 @@ const DATE_WINDOW_MESSAGE = { message: 'dateFrom must not be after dateTo', path
 
 export const GetBillingReportInputSchema = z.object({
   kind: z.enum(REFRESH_REPORT_KINDS),
-  // per-kind params, validated against the report definition's paramsSchema server-side
+  // validated against the definition's paramsSchema server-side
   params: z.record(z.unknown()).optional(),
-  // queue an async recompute (idempotent while one is already running for the same kind+params)
+  // queue an async recompute (idempotent per kind+params)
   refresh: z.boolean().optional(),
-  // drilldown request: a filtered slice of the report's cached detail dataset, validated
-  // against the definition's drilldown paramsSchema server-side
+  // filtered slice of the report's cached detail dataset
   drilldown: z.record(z.unknown()).optional(),
 });
 
-// date-window params shared by the parameterized report kinds (payments, patient-payments, …)
+// date window shared by the parameterized report kinds
 export const ReportDateWindowParamsSchema = z
   .object({
     dateFrom: isoDate.optional(),

--- a/packages/utils/lib/types/data/billing/billing.types.ts
+++ b/packages/utils/lib/types/data/billing/billing.types.ts
@@ -586,6 +586,17 @@ export interface SearchBillingTagsResponse {
   tags: BillingTag[];
 }
 
+// Refresh state of a cached billing report, derived from the refresh Task and the cache document.
+export interface ReportRefreshStatus {
+  state: 'idle' | 'running' | 'error';
+  // when the served cache was generated (absent when the report has never completed)
+  lastCompletedAt?: string;
+  // worker phase description while running (e.g. 'resolving cards 1500/3200…')
+  progress?: string;
+  // most recent failure's reason (state 'error')
+  error?: string;
+}
+
 export type GetBillingCoverageResponse = BillingCoverageOption;
 
 export interface GetPatientCoveragesResponse {

--- a/packages/utils/lib/types/data/billing/billing.types.ts
+++ b/packages/utils/lib/types/data/billing/billing.types.ts
@@ -586,14 +586,14 @@ export interface SearchBillingTagsResponse {
   tags: BillingTag[];
 }
 
-// Refresh state of a cached billing report, derived from the refresh Task and the cache document.
+// Refresh state of a cached billing report.
 export interface ReportRefreshStatus {
   state: 'idle' | 'running' | 'error';
-  // when the served cache was generated (absent when the report has never completed)
+  // when the served cache was generated
   lastCompletedAt?: string;
-  // worker phase description while running (e.g. 'resolving cards 1500/3200…')
+  // worker phase text while running
   progress?: string;
-  // most recent failure's reason (state 'error')
+  // most recent failure's reason
   error?: string;
 }
 

--- a/packages/zambdas/src/billing/reports/framework/refresh-task.ts
+++ b/packages/zambdas/src/billing/reports/framework/refresh-task.ts
@@ -1,0 +1,150 @@
+import Oystehr from '@oystehr/sdk';
+import { Task } from 'fhir/r4b';
+import { DateTime } from 'luxon';
+import { ottehrIdentifierSystem } from 'utils/lib/fhir/systemUrls';
+import { EXPORT_TASK_SYSTEM } from 'utils/lib/types/api/invoicing.types';
+import {
+  REFRESH_REPORT_CACHE_KEY_CODE,
+  REFRESH_REPORT_KIND_CODE,
+  REFRESH_REPORT_PARAMS_CODE,
+  REFRESH_REPORT_TASK_CODE,
+  RefreshReportKind,
+} from 'utils/lib/types/data/billing/billing.constants';
+
+// a refresh untouched for this long is assumed dead (hard-killed worker) and no longer blocks
+const STALE_REFRESH_MINUTES = 30;
+
+// the cache key doubles as a searchable Task identifier, making the conditional-create
+// dedupe (and all lookups) addressable server-side
+export const REFRESH_TASK_IDENTIFIER_SYSTEM = ottehrIdentifierSystem('billing-report-refresh');
+const identifierTokenOf = (cacheKey: string): string => `${REFRESH_TASK_IDENTIFIER_SYSTEM}|${cacheKey}`;
+
+const taskInputValue = (task: Task, code: string): string | undefined =>
+  task.input?.find((input) => input.type?.coding?.some((coding) => coding.code === code))?.valueString;
+
+export const refreshTaskKind = (task: Task): string | undefined => taskInputValue(task, REFRESH_REPORT_KIND_CODE);
+export const refreshTaskParamsJson = (task: Task): string | undefined =>
+  taskInputValue(task, REFRESH_REPORT_PARAMS_CODE);
+export const refreshTaskCacheKey = (task: Task): string | undefined =>
+  taskInputValue(task, REFRESH_REPORT_CACHE_KEY_CODE);
+
+async function searchRefreshTasksByCacheKey(
+  oystehr: Oystehr,
+  cacheKey: string,
+  statuses: string,
+  count: number
+): Promise<Task[]> {
+  const bundle = await oystehr.fhir.search<Task>({
+    resourceType: 'Task',
+    params: [
+      { name: 'identifier', value: identifierTokenOf(cacheKey) },
+      { name: 'status', value: statuses },
+      { name: '_sort', value: '-_lastUpdated' },
+      { name: '_count', value: String(count) },
+    ],
+  });
+  return bundle.unbundle();
+}
+
+const staleBeforeISO = (): string => DateTime.now().minus({ minutes: STALE_REFRESH_MINUTES }).toUTC().toISO() ?? '';
+
+// The running (or queued) refresh for one cache key, if any; stale tasks don't count.
+export async function findActiveRefreshTask(oystehr: Oystehr, cacheKey: string): Promise<Task | undefined> {
+  const tasks = await searchRefreshTasksByCacheKey(oystehr, cacheKey, 'requested,in-progress', 10);
+  const staleBefore = staleBeforeISO();
+  return tasks.find((task) => (task.meta?.lastUpdated ?? '') > staleBefore);
+}
+
+// The most recent failed refresh for the cache key that is newer than the served cache — the
+// signal that "your data is fine, but the last refresh attempt broke".
+export async function findRecentFailedRefreshTask(
+  oystehr: Oystehr,
+  cacheKey: string,
+  sinceISO: string
+): Promise<Task | undefined> {
+  const tasks = await searchRefreshTasksByCacheKey(oystehr, cacheKey, 'failed', 1);
+  return tasks.find((task) => (task.meta?.lastUpdated ?? '') > sinceISO);
+}
+
+// Queues an async report refresh; idempotent while one is already running for the same cache key.
+// Concurrent kickoffs are resolved atomically server-side: the Task carries the cache key as a
+// searchable identifier, and creation is a FHIR conditional create (If-None-Exist) on that
+// identifier + active statuses, so parallel requests all land on one Task.
+// Returns the already-active or newly created task so callers can report live progress.
+export async function kickOffRefreshTask(
+  oystehr: Oystehr,
+  input: { kind: RefreshReportKind; params: unknown; cacheKey: string }
+): Promise<Task> {
+  const activeStatusTasks = await searchRefreshTasksByCacheKey(oystehr, input.cacheKey, 'requested,in-progress', 10);
+  const staleBefore = staleBeforeISO();
+  const fresh = activeStatusTasks.find((task) => (task.meta?.lastUpdated ?? '') > staleBefore);
+  if (fresh) return fresh;
+
+  // stale leftovers (hard-killed worker) would satisfy the conditional create forever;
+  // cancel them so a new refresh can start
+  for (const stale of activeStatusTasks) {
+    try {
+      await oystehr.fhir.patch({
+        resourceType: 'Task',
+        id: stale.id ?? '',
+        operations: [
+          { op: 'replace', path: '/status', value: 'cancelled' },
+          { op: 'add', path: '/statusReason', value: { text: 'stale refresh superseded' } },
+        ],
+      });
+    } catch (err) {
+      console.warn(`Failed to cancel stale refresh Task/${stale.id}:`, (err as Error)?.message);
+    }
+  }
+
+  const task: Task = {
+    resourceType: 'Task',
+    status: 'requested',
+    intent: 'order',
+    businessStatus: { text: 'queued' },
+    identifier: [{ system: REFRESH_TASK_IDENTIFIER_SYSTEM, value: input.cacheKey }],
+    code: { coding: [{ system: EXPORT_TASK_SYSTEM, code: REFRESH_REPORT_TASK_CODE }] },
+    input: [
+      {
+        type: { coding: [{ system: EXPORT_TASK_SYSTEM, code: REFRESH_REPORT_KIND_CODE }] },
+        valueString: input.kind,
+      },
+      {
+        type: { coding: [{ system: EXPORT_TASK_SYSTEM, code: REFRESH_REPORT_PARAMS_CODE }] },
+        valueString: JSON.stringify(input.params ?? {}),
+      },
+      {
+        type: { coding: [{ system: EXPORT_TASK_SYSTEM, code: REFRESH_REPORT_CACHE_KEY_CODE }] },
+        valueString: input.cacheKey,
+      },
+    ],
+  };
+
+  try {
+    // returns the existing task instead of creating a second when the criteria match
+    return await oystehr.fhir.create<Task>(task, {
+      ifNoneExist: [
+        { name: 'identifier', value: identifierTokenOf(input.cacheKey) },
+        { name: 'status', value: 'requested,in-progress' },
+      ],
+    });
+  } catch (err) {
+    // e.g. HTTP 412 when the criteria matched multiple tasks — someone else already queued one
+    const existing = await findActiveRefreshTask(oystehr, input.cacheKey);
+    if (existing) return existing;
+    throw err;
+  }
+}
+
+// Worker-side phase reporting; failures are swallowed because progress is cosmetic.
+export async function updateRefreshTaskProgress(oystehr: Oystehr, taskId: string, progress: string): Promise<void> {
+  try {
+    await oystehr.fhir.patch({
+      resourceType: 'Task',
+      id: taskId,
+      operations: [{ op: 'add', path: '/businessStatus', value: { text: progress } }],
+    });
+  } catch (err) {
+    console.warn(`Failed to update refresh progress on Task/${taskId}:`, (err as Error)?.message);
+  }
+}

--- a/packages/zambdas/src/billing/reports/framework/refresh-task.ts
+++ b/packages/zambdas/src/billing/reports/framework/refresh-task.ts
@@ -11,11 +11,10 @@ import {
   RefreshReportKind,
 } from 'utils/lib/types/data/billing/billing.constants';
 
-// a refresh untouched for this long is assumed dead (hard-killed worker) and no longer blocks
+// a refresh untouched for this long is assumed dead and no longer blocks
 const STALE_REFRESH_MINUTES = 30;
 
-// the cache key doubles as a searchable Task identifier, making the conditional-create
-// dedupe (and all lookups) addressable server-side
+// the cache key doubles as a searchable Task identifier for dedupe and lookups
 export const REFRESH_TASK_IDENTIFIER_SYSTEM = ottehrIdentifierSystem('billing-report-refresh');
 const identifierTokenOf = (cacheKey: string): string => `${REFRESH_TASK_IDENTIFIER_SYSTEM}|${cacheKey}`;
 
@@ -48,15 +47,14 @@ async function searchRefreshTasksByCacheKey(
 
 const staleBeforeISO = (): string => DateTime.now().minus({ minutes: STALE_REFRESH_MINUTES }).toUTC().toISO() ?? '';
 
-// The running (or queued) refresh for one cache key, if any; stale tasks don't count.
+// the running (or queued) refresh for one cache key, if any; stale tasks don't count
 export async function findActiveRefreshTask(oystehr: Oystehr, cacheKey: string): Promise<Task | undefined> {
   const tasks = await searchRefreshTasksByCacheKey(oystehr, cacheKey, 'requested,in-progress', 10);
   const staleBefore = staleBeforeISO();
   return tasks.find((task) => (task.meta?.lastUpdated ?? '') > staleBefore);
 }
 
-// The most recent failed refresh for the cache key that is newer than the served cache — the
-// signal that "your data is fine, but the last refresh attempt broke".
+// most recent failed refresh newer than the served cache
 export async function findRecentFailedRefreshTask(
   oystehr: Oystehr,
   cacheKey: string,
@@ -66,11 +64,8 @@ export async function findRecentFailedRefreshTask(
   return tasks.find((task) => (task.meta?.lastUpdated ?? '') > sinceISO);
 }
 
-// Queues an async report refresh; idempotent while one is already running for the same cache key.
-// Concurrent kickoffs are resolved atomically server-side: the Task carries the cache key as a
-// searchable identifier, and creation is a FHIR conditional create (If-None-Exist) on that
-// identifier + active statuses, so parallel requests all land on one Task.
-// Returns the already-active or newly created task so callers can report live progress.
+// Queues a refresh; idempotent per cache key — concurrent kickoffs resolve to one Task via
+// FHIR conditional create on the identifier + active statuses.
 export async function kickOffRefreshTask(
   oystehr: Oystehr,
   input: { kind: RefreshReportKind; params: unknown; cacheKey: string }
@@ -80,8 +75,7 @@ export async function kickOffRefreshTask(
   const fresh = activeStatusTasks.find((task) => (task.meta?.lastUpdated ?? '') > staleBefore);
   if (fresh) return fresh;
 
-  // stale leftovers (hard-killed worker) would satisfy the conditional create forever;
-  // cancel them so a new refresh can start
+  // stale leftovers would satisfy the conditional create forever; cancel them first
   for (const stale of activeStatusTasks) {
     try {
       await oystehr.fhir.patch({
@@ -129,14 +123,14 @@ export async function kickOffRefreshTask(
       ],
     });
   } catch (err) {
-    // e.g. HTTP 412 when the criteria matched multiple tasks — someone else already queued one
+    // e.g. HTTP 412: multiple matches — someone else already queued one
     const existing = await findActiveRefreshTask(oystehr, input.cacheKey);
     if (existing) return existing;
     throw err;
   }
 }
 
-// Worker-side phase reporting; failures are swallowed because progress is cosmetic.
+// worker-side phase reporting; failures are swallowed because progress is cosmetic
 export async function updateRefreshTaskProgress(oystehr: Oystehr, taskId: string, progress: string): Promise<void> {
   try {
     await oystehr.fhir.patch({

--- a/packages/zambdas/src/billing/reports/framework/registry.ts
+++ b/packages/zambdas/src/billing/reports/framework/registry.ts
@@ -1,0 +1,6 @@
+import { RefreshReportKind } from 'utils/lib/types/data/billing/billing.constants';
+import { AnyReportDefinition } from './types';
+
+// One entry per report kind; the HTTP zambda and the refresh worker both route through this map.
+// Report definitions are added alongside the reports themselves (see docs/billing-reports.md).
+export const reportRegistry: Partial<Record<RefreshReportKind, AnyReportDefinition>> = {};

--- a/packages/zambdas/src/billing/reports/framework/report-cache.ts
+++ b/packages/zambdas/src/billing/reports/framework/report-cache.ts
@@ -63,9 +63,7 @@ export async function loadReportCache<Payload extends ReportPayload>(
   }
 }
 
-// gzipped JSON in a DocumentReference attachment; oversized payloads run through the definition's
-// shrink until they fit (or the save is skipped). The cache is an optimization; a failed write
-// must not fail the refresh.
+// gzipped JSON in a DocumentReference attachment; a failed write must not fail the refresh
 export async function saveReportCache<Payload extends ReportPayload>(
   oystehr: Oystehr,
   definition: { shrink?: (payload: Payload) => Payload | undefined },

--- a/packages/zambdas/src/billing/reports/framework/report-cache.ts
+++ b/packages/zambdas/src/billing/reports/framework/report-cache.ts
@@ -1,0 +1,112 @@
+import Oystehr from '@oystehr/sdk';
+import { DocumentReference } from 'fhir/r4b';
+import { ottehrIdentifierSystem } from 'utils/lib/fhir/systemUrls';
+import { gunzipSync, gzipSync } from 'zlib';
+import { ReportPayload } from './types';
+
+export const REPORT_IDENTIFIER_SYSTEM = ottehrIdentifierSystem('billing-report');
+// stay well under FHIR resource size limits
+const MAX_CACHE_BYTES = 4 * 1024 * 1024;
+
+// `<kind>:<cacheVersion>:<paramsKey>` — the DocumentReference identifier value for one cache entry
+export function fullCacheKey<Params>(
+  definition: { kind: string; cacheVersion: string; cacheKeyOf: (params: Params) => string },
+  params: Params
+): string {
+  return `${definition.kind}:${definition.cacheVersion}:${definition.cacheKeyOf(params) || 'all'}`;
+}
+
+// sibling cache entry holding a report's full drilldown dataset
+export function detailCacheKey<Params>(
+  definition: {
+    kind: string;
+    cacheVersion: string;
+    cacheKeyOf: (params: Params) => string;
+    detailCacheKeyOf?: (params: Params) => string;
+  },
+  params: Params
+): string {
+  const keyOf = definition.detailCacheKeyOf ?? definition.cacheKeyOf;
+  return `${definition.kind}:${definition.cacheVersion}:${keyOf(params) || 'all'}:detail`;
+}
+
+// wrapper persisted to the detail cache document
+export interface ReportDetailEnvelope<Detail> extends ReportPayload {
+  detail: Detail;
+}
+
+export async function findCacheDocument(oystehr: Oystehr, cacheKey: string): Promise<DocumentReference | undefined> {
+  const bundle = await oystehr.fhir.search<DocumentReference>({
+    resourceType: 'DocumentReference',
+    params: [
+      { name: 'identifier', value: `${REPORT_IDENTIFIER_SYSTEM}|${cacheKey}` },
+      { name: '_sort', value: '-_lastUpdated' },
+      { name: '_count', value: '1' },
+    ],
+  });
+  return bundle.unbundle()[0];
+}
+
+export async function loadReportCache<Payload extends ReportPayload>(
+  oystehr: Oystehr,
+  cacheKey: string
+): Promise<Payload | undefined> {
+  try {
+    const document = await findCacheDocument(oystehr, cacheKey);
+    const data = document?.content?.[0]?.attachment?.data;
+    if (!data) return undefined;
+    // plain Uint8Array keeps zlib typings happy across @types/node versions
+    return JSON.parse(gunzipSync(new Uint8Array(Buffer.from(data, 'base64'))).toString('utf8'));
+  } catch (err) {
+    console.warn(`Failed to load report cache ${cacheKey}:`, (err as Error)?.message);
+    return undefined;
+  }
+}
+
+// gzipped JSON in a DocumentReference attachment; oversized payloads run through the definition's
+// shrink until they fit (or the save is skipped). The cache is an optimization; a failed write
+// must not fail the refresh.
+export async function saveReportCache<Payload extends ReportPayload>(
+  oystehr: Oystehr,
+  definition: { shrink?: (payload: Payload) => Payload | undefined },
+  cacheKey: string,
+  payload: Payload
+): Promise<void> {
+  try {
+    const encode = (value: Payload): string =>
+      gzipSync(new Uint8Array(Buffer.from(JSON.stringify(value), 'utf8'))).toString('base64');
+    let toSave: Payload | undefined = payload;
+    let data = encode(toSave);
+    while (data.length > MAX_CACHE_BYTES) {
+      toSave = definition.shrink?.(toSave) as Payload | undefined;
+      if (!toSave) {
+        console.warn(`Report cache ${cacheKey} too large to save (${data.length} bytes); skipping save`);
+        return;
+      }
+      data = encode(toSave);
+    }
+    const document: DocumentReference = {
+      resourceType: 'DocumentReference',
+      status: 'current',
+      identifier: [{ system: REPORT_IDENTIFIER_SYSTEM, value: cacheKey }],
+      date: payload.generatedAt,
+      content: [
+        {
+          attachment: {
+            contentType: 'application/gzip',
+            title: `${cacheKey}.json.gz`,
+            data,
+          },
+        },
+      ],
+    };
+    const existing = await findCacheDocument(oystehr, cacheKey);
+    if (existing?.id) {
+      await oystehr.fhir.update<DocumentReference>({ ...document, id: existing.id });
+    } else {
+      await oystehr.fhir.create<DocumentReference>(document);
+    }
+  } catch (err) {
+    console.error(`Failed to save report cache ${cacheKey}:`, err);
+  }
+}

--- a/packages/zambdas/src/billing/reports/framework/types.ts
+++ b/packages/zambdas/src/billing/reports/framework/types.ts
@@ -8,57 +8,47 @@ export type ProgressFn = (message: string) => Promise<void>;
 export interface ReportContext {
   // billing-tagged client
   oystehr: Oystehr;
-  // clinical (untagged) resources living in the same store: patients, encounters, appointments, ERAs
+  // clinical (untagged) resources in the same store
   untaggedClient: Oystehr;
   secrets: ZambdaInput['secrets'];
 }
 
-// payload persisted to / served from the cache; generatedAt drives the status line
 export interface ReportPayload {
   generatedAt: string;
 }
 
-// Everything the framework needs to serve, refresh, and cache one report kind. The HTTP zambda
-// and the subscription worker are generic over this contract; adding a report means adding a
-// definition (and registering it) — no new zambdas.
+// One cached report kind: the HTTP zambda and the worker are generic over this contract.
 export interface ReportDefinition<Params, Payload extends ReportPayload, Detail = unknown, DrillParams = unknown> {
   kind: RefreshReportKind;
-  // bump when the cached payload shape changes, so stale-shape caches are never reused
+  // bump to invalidate stale-shape caches
   cacheVersion: string;
-  // validates params from both the HTTP request and the refresh Task input
   paramsSchema: ZodType<Params>;
   // params part of the cache key ('' for unparameterized kinds)
   cacheKeyOf: (params: Params) => string;
-  // served when the report has never been computed (while the first refresh runs)
   emptyPayload: () => Payload;
-  // full recomputation; runs inside the subscription worker's long timeout. `detail` is the
-  // full drilldown dataset, persisted separately and served as filtered slices by `drilldown`.
+  // full recomputation (worker-side); detail is the optional drilldown dataset
   compute: (
     ctx: ReportContext,
     params: Params,
     onProgress: ProgressFn
   ) => Promise<{ payload: Payload; detail?: Detail }>;
-  // compute manages its own cache writes (e.g. resumable drain state); the worker skips the central save
+  // compute persists its own cache (e.g. resumable drain state); worker skips the central save
   savesOwnCache?: boolean;
-  // strip internal state (e.g. pending lookup queues) before a cached payload leaves the server
+  // strip internal state before a cached payload leaves the server
   sanitizePayload?: (payload: Payload) => Payload;
-  // shed data until an oversized payload fits the cache cap; return undefined to give up on saving
+  // shed data until an oversized payload fits the cache cap; undefined = skip the save
   shrink?: (payload: Payload) => Payload | undefined;
-  // same, for an oversized detail dataset
   shrinkDetail?: (detail: Detail) => Detail | undefined;
-  // params part of the detail cache key, when it differs from the report's (e.g. payments detail
-  // spans all ERAs regardless of the report's date window)
+  // when the detail keys differently than the report (e.g. window-independent)
   detailCacheKeyOf?: (params: Params) => string;
-  // serves drilldown requests as pure filters over the cached detail; never computes
+  // drilldowns are pure filters over the cached detail
   drilldown?: {
     paramsSchema: ZodType<DrillParams>;
     select: (detail: Detail, params: DrillParams) => Record<string, unknown>;
-    // served while the detail has never been computed
     empty: () => Record<string, unknown>;
   };
-  // one-line completion summary for the refresh Task's statusReason
+  // one-liner for the Task's completion statusReason
   summarize: (payload: Payload) => string;
 }
 
-// registry entry type: params/payload are validated at the definition boundary
 export type AnyReportDefinition = ReportDefinition<any, any, any, any>;

--- a/packages/zambdas/src/billing/reports/framework/types.ts
+++ b/packages/zambdas/src/billing/reports/framework/types.ts
@@ -1,0 +1,64 @@
+import Oystehr from '@oystehr/sdk';
+import { RefreshReportKind } from 'utils/lib/types/data/billing/billing.constants';
+import { ZodType } from 'zod';
+import { ZambdaInput } from '../../../shared/types/common';
+
+export type ProgressFn = (message: string) => Promise<void>;
+
+export interface ReportContext {
+  // billing-tagged client
+  oystehr: Oystehr;
+  // clinical (untagged) resources living in the same store: patients, encounters, appointments, ERAs
+  untaggedClient: Oystehr;
+  secrets: ZambdaInput['secrets'];
+}
+
+// payload persisted to / served from the cache; generatedAt drives the status line
+export interface ReportPayload {
+  generatedAt: string;
+}
+
+// Everything the framework needs to serve, refresh, and cache one report kind. The HTTP zambda
+// and the subscription worker are generic over this contract; adding a report means adding a
+// definition (and registering it) — no new zambdas.
+export interface ReportDefinition<Params, Payload extends ReportPayload, Detail = unknown, DrillParams = unknown> {
+  kind: RefreshReportKind;
+  // bump when the cached payload shape changes, so stale-shape caches are never reused
+  cacheVersion: string;
+  // validates params from both the HTTP request and the refresh Task input
+  paramsSchema: ZodType<Params>;
+  // params part of the cache key ('' for unparameterized kinds)
+  cacheKeyOf: (params: Params) => string;
+  // served when the report has never been computed (while the first refresh runs)
+  emptyPayload: () => Payload;
+  // full recomputation; runs inside the subscription worker's long timeout. `detail` is the
+  // full drilldown dataset, persisted separately and served as filtered slices by `drilldown`.
+  compute: (
+    ctx: ReportContext,
+    params: Params,
+    onProgress: ProgressFn
+  ) => Promise<{ payload: Payload; detail?: Detail }>;
+  // compute manages its own cache writes (e.g. resumable drain state); the worker skips the central save
+  savesOwnCache?: boolean;
+  // strip internal state (e.g. pending lookup queues) before a cached payload leaves the server
+  sanitizePayload?: (payload: Payload) => Payload;
+  // shed data until an oversized payload fits the cache cap; return undefined to give up on saving
+  shrink?: (payload: Payload) => Payload | undefined;
+  // same, for an oversized detail dataset
+  shrinkDetail?: (detail: Detail) => Detail | undefined;
+  // params part of the detail cache key, when it differs from the report's (e.g. payments detail
+  // spans all ERAs regardless of the report's date window)
+  detailCacheKeyOf?: (params: Params) => string;
+  // serves drilldown requests as pure filters over the cached detail; never computes
+  drilldown?: {
+    paramsSchema: ZodType<DrillParams>;
+    select: (detail: Detail, params: DrillParams) => Record<string, unknown>;
+    // served while the detail has never been computed
+    empty: () => Record<string, unknown>;
+  };
+  // one-line completion summary for the refresh Task's statusReason
+  summarize: (payload: Payload) => string;
+}
+
+// registry entry type: params/payload are validated at the definition boundary
+export type AnyReportDefinition = ReportDefinition<any, any, any, any>;

--- a/packages/zambdas/src/billing/reports/get-billing-report/index.ts
+++ b/packages/zambdas/src/billing/reports/get-billing-report/index.ts
@@ -1,0 +1,91 @@
+import Oystehr from '@oystehr/sdk';
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { RefreshReportKind } from 'utils/lib/types/data/billing/billing.constants';
+import { ReportRefreshStatus } from 'utils/lib/types/data/billing/billing.types';
+import { checkOrCreateM2MClientToken } from '../../../shared/auth';
+import { wrapHandler } from '../../../shared/sentry';
+import { ZambdaInput } from '../../../shared/types/common';
+import { safeValidate } from '../../../shared/validation';
+import { createBillingClient } from '../../shared';
+import { findActiveRefreshTask, findRecentFailedRefreshTask, kickOffRefreshTask } from '../framework/refresh-task';
+import { reportRegistry } from '../framework/registry';
+import { detailCacheKey, fullCacheKey, loadReportCache, ReportDetailEnvelope } from '../framework/report-cache';
+import { ReportPayload } from '../framework/types';
+import { validateRequestParameters } from './validateRequestParameters';
+
+let m2mToken: string;
+const ZAMBDA_NAME = 'get-billing-report';
+
+export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
+  const { kind, params, refresh, drilldown, secrets } = validateRequestParameters(input);
+  m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
+  const oystehr = createBillingClient(m2mToken, secrets);
+
+  const response = await performEffect(oystehr, kind, params, refresh, drilldown);
+  return { statusCode: 200, body: JSON.stringify(response) };
+});
+
+// Serves the cache and queues async refreshes; the subscription worker computes. Never computes
+// a report in the HTTP request. A `drilldown` request is a pure filter over the report's cached
+// detail dataset.
+export async function performEffect(
+  oystehr: Oystehr,
+  kind: RefreshReportKind,
+  rawParams: unknown,
+  refresh: boolean | undefined,
+  rawDrilldown?: unknown
+): Promise<Record<string, unknown> & { fromCache: boolean; status: ReportRefreshStatus }> {
+  const definition = reportRegistry[kind];
+  if (!definition) throw new Error(`No report definition registered for kind '${kind}'`);
+  const params = safeValidate(definition.paramsSchema, rawParams ?? {});
+  const cacheKey = fullCacheKey(definition, params);
+
+  if (rawDrilldown !== undefined) {
+    if (!definition.drilldown) throw new Error(`Report kind '${kind}' does not support drilldown`);
+    const drillParams = safeValidate(definition.drilldown.paramsSchema, rawDrilldown);
+    const envelope = await loadReportCache<ReportDetailEnvelope<unknown>>(oystehr, detailCacheKey(definition, params));
+    const status = await statusOf(oystehr, kind, params, cacheKey, envelope?.generatedAt, undefined);
+    if (!envelope) {
+      return { ...definition.drilldown.empty(), generatedAt: '', fromCache: false, status };
+    }
+    return {
+      ...definition.drilldown.select(envelope.detail, drillParams),
+      generatedAt: envelope.generatedAt,
+      fromCache: true,
+      status,
+    };
+  }
+
+  let active = refresh
+    ? await kickOffRefreshTask(oystehr, { kind, params, cacheKey })
+    : await findActiveRefreshTask(oystehr, cacheKey);
+  const cached = await loadReportCache<ReportPayload>(oystehr, cacheKey);
+  // never computed: queue the first build instead of risking the request timeout
+  if (!cached && !active) {
+    active = await kickOffRefreshTask(oystehr, { kind, params, cacheKey });
+  }
+
+  const status = await statusOf(oystehr, kind, params, cacheKey, cached?.generatedAt, active);
+  const payload = cached ? definition.sanitizePayload?.(cached) ?? cached : definition.emptyPayload();
+  return { ...payload, fromCache: !!cached, status };
+}
+
+async function statusOf(
+  oystehr: Oystehr,
+  kind: RefreshReportKind,
+  params: unknown,
+  cacheKey: string,
+  generatedAt: string | undefined,
+  knownActive: Awaited<ReturnType<typeof findActiveRefreshTask>>
+): Promise<ReportRefreshStatus> {
+  const active = knownActive ?? (await findActiveRefreshTask(oystehr, cacheKey));
+  const lastCompletedAt = generatedAt ? { lastCompletedAt: generatedAt } : {};
+  if (active) {
+    return { state: 'running', ...lastCompletedAt, progress: active.businessStatus?.text ?? 'queued' };
+  }
+  // a failed refresh newer than the served cache means "your data is fine, the last attempt broke"
+  const failed = await findRecentFailedRefreshTask(oystehr, cacheKey, generatedAt ?? '');
+  return failed
+    ? { state: 'error', ...lastCompletedAt, error: failed.statusReason?.text ?? 'refresh failed' }
+    : { state: 'idle', ...lastCompletedAt };
+}

--- a/packages/zambdas/src/billing/reports/get-billing-report/index.ts
+++ b/packages/zambdas/src/billing/reports/get-billing-report/index.ts
@@ -25,9 +25,8 @@ export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promis
   return { statusCode: 200, body: JSON.stringify(response) };
 });
 
-// Serves the cache and queues async refreshes; the subscription worker computes. Never computes
-// a report in the HTTP request. A `drilldown` request is a pure filter over the report's cached
-// detail dataset.
+// Serves the cache and queues async refreshes; the worker computes. Drilldowns are pure
+// filters over the cached detail.
 export async function performEffect(
   oystehr: Oystehr,
   kind: RefreshReportKind,
@@ -83,7 +82,7 @@ async function statusOf(
   if (active) {
     return { state: 'running', ...lastCompletedAt, progress: active.businessStatus?.text ?? 'queued' };
   }
-  // a failed refresh newer than the served cache means "your data is fine, the last attempt broke"
+  // a failed refresh newer than the served cache surfaces as an error status
   const failed = await findRecentFailedRefreshTask(oystehr, cacheKey, generatedAt ?? '');
   return failed
     ? { state: 'error', ...lastCompletedAt, error: failed.statusReason?.text ?? 'refresh failed' }

--- a/packages/zambdas/src/billing/reports/get-billing-report/validateRequestParameters.ts
+++ b/packages/zambdas/src/billing/reports/get-billing-report/validateRequestParameters.ts
@@ -1,0 +1,20 @@
+import { GetBillingReportInput, GetBillingReportInputSchema } from 'utils/lib/types/data/billing/billing.schemas';
+import { MISSING_REQUEST_SECRETS } from 'utils/lib/types/errors';
+import { validateJsonBody } from '../../../shared/helpers';
+import { ZambdaInput } from '../../../shared/types/common';
+import { safeValidate } from '../../../shared/validation';
+
+export interface GetBillingReportParams extends GetBillingReportInput {
+  secrets: ZambdaInput['secrets'];
+}
+
+export function validateRequestParameters(input: ZambdaInput): GetBillingReportParams {
+  if (!input.secrets) throw MISSING_REQUEST_SECRETS;
+
+  const data = safeValidate(GetBillingReportInputSchema, validateJsonBody(input));
+
+  return {
+    ...data,
+    secrets: input.secrets,
+  };
+}

--- a/packages/zambdas/src/subscriptions/task/sub-refresh-billing-report/index.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-refresh-billing-report/index.ts
@@ -10,9 +10,8 @@ import { validateRequestParameters } from './validateRequestParameters';
 let m2mToken: string;
 const ZAMBDA_NAME = 'sub-refresh-billing-report';
 
-// Async worker for all billing-report refreshes; the http zambda only queues the Task and serves
-// the cache this worker writes. Routing and caching are generic — per-report logic lives in the
-// registry's ReportDefinitions.
+// Async worker for all billing-report refreshes: routes the Task to its ReportDefinition,
+// computes, and writes the payload + detail caches.
 export const index = wrapTaskHandler(ZAMBDA_NAME, async (input, _oystehr) => {
   const { kind, paramsJson, taskId, secrets } = validateRequestParameters(input);
   const definition = reportRegistry[kind];
@@ -30,7 +29,7 @@ export const index = wrapTaskHandler(ZAMBDA_NAME, async (input, _oystehr) => {
     await saveReportCache(oystehr, definition, fullCacheKey(definition, params), payload);
   }
   if (detail !== undefined && definition.drilldown) {
-    // detail rides in an envelope so the generic cache sees a generatedAt; shrink adapts through it
+    // envelope gives the generic cache a generatedAt; shrink adapts through it
     await saveReportCache(
       oystehr,
       {

--- a/packages/zambdas/src/subscriptions/task/sub-refresh-billing-report/index.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-refresh-billing-report/index.ts
@@ -1,0 +1,47 @@
+import { updateRefreshTaskProgress } from '../../../billing/reports/framework/refresh-task';
+import { reportRegistry } from '../../../billing/reports/framework/registry';
+import { detailCacheKey, fullCacheKey, saveReportCache } from '../../../billing/reports/framework/report-cache';
+import { createBillingClient, createEraReadClient } from '../../../billing/shared';
+import { checkOrCreateM2MClientToken } from '../../../shared/auth';
+import { safeValidate } from '../../../shared/validation';
+import { wrapTaskHandler } from '../helpers';
+import { validateRequestParameters } from './validateRequestParameters';
+
+let m2mToken: string;
+const ZAMBDA_NAME = 'sub-refresh-billing-report';
+
+// Async worker for all billing-report refreshes; the http zambda only queues the Task and serves
+// the cache this worker writes. Routing and caching are generic — per-report logic lives in the
+// registry's ReportDefinitions.
+export const index = wrapTaskHandler(ZAMBDA_NAME, async (input, _oystehr) => {
+  const { kind, paramsJson, taskId, secrets } = validateRequestParameters(input);
+  const definition = reportRegistry[kind];
+  if (!definition) throw new Error(`No report definition registered for kind '${kind}'`);
+  const params = safeValidate(definition.paramsSchema, JSON.parse(paramsJson));
+
+  m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
+  const oystehr = createBillingClient(m2mToken, secrets);
+  // patients/appointments/encounters are clinical (untagged) resources in the same store
+  const untaggedClient = createEraReadClient(m2mToken, secrets);
+  const onProgress = (message: string): Promise<void> => updateRefreshTaskProgress(oystehr, taskId, message);
+
+  const { payload, detail } = await definition.compute({ oystehr, untaggedClient, secrets }, params, onProgress);
+  if (!definition.savesOwnCache) {
+    await saveReportCache(oystehr, definition, fullCacheKey(definition, params), payload);
+  }
+  if (detail !== undefined && definition.drilldown) {
+    // detail rides in an envelope so the generic cache sees a generatedAt; shrink adapts through it
+    await saveReportCache(
+      oystehr,
+      {
+        shrink: (envelope: { generatedAt: string; detail: unknown }) => {
+          const shrunk = definition.shrinkDetail?.(envelope.detail);
+          return shrunk ? { ...envelope, detail: shrunk } : undefined;
+        },
+      },
+      detailCacheKey(definition, params),
+      { generatedAt: payload.generatedAt, detail }
+    );
+  }
+  return { taskStatus: 'completed', statusReason: definition.summarize(payload) };
+});

--- a/packages/zambdas/src/subscriptions/task/sub-refresh-billing-report/validateRequestParameters.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-refresh-billing-report/validateRequestParameters.ts
@@ -6,7 +6,7 @@ import { TaskSubscriptionInput } from '../validateRequestParameters';
 
 export interface RefreshBillingReportParams {
   kind: RefreshReportKind;
-  // JSON-serialized report params from the Task input; validated against the definition's schema
+  // JSON-serialized report params from the Task input
   paramsJson: string;
   taskId: string;
   secrets: ZambdaInput['secrets'];

--- a/packages/zambdas/src/subscriptions/task/sub-refresh-billing-report/validateRequestParameters.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-refresh-billing-report/validateRequestParameters.ts
@@ -1,0 +1,33 @@
+import { REFRESH_REPORT_KINDS, RefreshReportKind } from 'utils/lib/types/data/billing/billing.constants';
+import { MISSING_REQUEST_BODY, MISSING_REQUEST_SECRETS } from 'utils/lib/types/errors';
+import { refreshTaskKind, refreshTaskParamsJson } from '../../../billing/reports/framework/refresh-task';
+import { ZambdaInput } from '../../../shared/types/common';
+import { TaskSubscriptionInput } from '../validateRequestParameters';
+
+export interface RefreshBillingReportParams {
+  kind: RefreshReportKind;
+  // JSON-serialized report params from the Task input; validated against the definition's schema
+  paramsJson: string;
+  taskId: string;
+  secrets: ZambdaInput['secrets'];
+}
+
+export function validateRequestParameters(input: TaskSubscriptionInput): RefreshBillingReportParams {
+  if (!input.task) throw MISSING_REQUEST_BODY;
+  if (!input.secrets) throw MISSING_REQUEST_SECRETS;
+
+  const taskId = input.task.id;
+  if (!taskId) throw new Error('Task id is not found in the input task');
+
+  const kind = refreshTaskKind(input.task);
+  if (!kind || !REFRESH_REPORT_KINDS.includes(kind as RefreshReportKind)) {
+    throw new Error(`Unknown report kind '${kind ?? ''}' on Task/${taskId}`);
+  }
+
+  return {
+    kind: kind as RefreshReportKind,
+    paramsJson: refreshTaskParamsJson(input.task) ?? '{}',
+    taskId,
+    secrets: input.secrets,
+  };
+}


### PR DESCRIPTION
Task/subscribe infrastructure for cached billing reports. Stacked under #9244, which adds the reports themselves.
Framework documentation is [here](https://github.com/masslight/ottehr/blob/rzinger/billing-report-framework/docs/billing-report-refresh-framework.md)

- Reports are described by `ReportDefinition`s (params schema, compute, cache keys, optional drilldown) in a central registry — this PR ships the registry **empty**; definitions arrive with the reports in #9244.
- `get-billing-report` (the only report HTTP zambda) serves gzip `DocumentReference` caches + a uniform refresh status envelope, queues refreshes, and serves drilldowns as pure filters over cached detail datasets. It never computes.
- `sub-refresh-billing-report` (Task-subscription worker) computes with a long timeout, streams progress via `Task.businessStatus`, and writes payload + detail caches.
- Refresh Tasks are deduped race-free via identifier-based FHIR conditional create; stale tasks (>30 min) are cancelled and superseded.
- Frontend: `useBillingReport` (fetch + poll-while-running) and `ReportStatusBar` (idle / running-with-live-progress / error).

Full mechanism reference: `docs/billing-report-refresh-framework.md`.