### PR TITLE
feat(billing): non-insurance organizations — CRUD zambdas, directory, and management UI

### DIFF
--- a/apps/billing/src/App.tsx
+++ b/apps/billing/src/App.tsx
@@ -4,6 +4,7 @@ import { LicenseInfo } from '@mui/x-data-grid-pro';
 import { SnackbarProvider } from 'notistack';
 import { ReactElement } from 'react';
 import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router-dom';
+import { FEATURE_FLAGS_CONFIG } from 'utils/lib/ottehr-config/feature-flags';
 import { RoleType } from 'utils/lib/types/api/user.types';
 import { DEFAULT_RULES_ENGINE } from 'utils/lib/types/data/billing/rules-engine.constants';
 import { Layout } from './components/Layout';
@@ -21,6 +22,7 @@ import CreateClaim from './pages/CreateClaim';
 import EraClaimDetail from './pages/EraClaimDetail';
 import ERADetail from './pages/ERADetail';
 import ERAList from './pages/ERAList';
+import { NonInsuranceOrganizationDetail, NonInsuranceOrganizationsList } from './pages/NonInsuranceOrganizations';
 import PatientDetail from './pages/PatientDetail';
 import PatientsList from './pages/PatientsList';
 import { RenderingProviderDetail, RenderingProvidersList } from './pages/RenderingProviders';
@@ -81,6 +83,12 @@ export default function App(): ReactElement {
               <Route path="/rendering-providers/:id" element={<RenderingProviderDetail />} />
               <Route path="/service-facilities" element={<ServiceFacilitiesList />} />
               <Route path="/service-facilities/:id" element={<ServiceFacilityDetail />} />
+              {FEATURE_FLAGS_CONFIG.nonInsuranceOrganizationsEnabled && (
+                <>
+                  <Route path="/non-insurance-organizations" element={<NonInsuranceOrganizationsList />} />
+                  <Route path="/non-insurance-organizations/:id" element={<NonInsuranceOrganizationDetail />} />
+                </>
+              )}
               <Route
                 path={`/${ChargeItemDefinitionLabels['charge-master'].pathComponent}`}
                 element={<ChargeItemDefinitionList type="charge-master" />}

--- a/apps/billing/src/App.tsx
+++ b/apps/billing/src/App.tsx
@@ -4,7 +4,6 @@ import { LicenseInfo } from '@mui/x-data-grid-pro';
 import { SnackbarProvider } from 'notistack';
 import { ReactElement } from 'react';
 import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router-dom';
-import { FEATURE_FLAGS_CONFIG } from 'utils/lib/ottehr-config/feature-flags';
 import { RoleType } from 'utils/lib/types/api/user.types';
 import { DEFAULT_RULES_ENGINE } from 'utils/lib/types/data/billing/rules-engine.constants';
 import { Layout } from './components/Layout';
@@ -83,12 +82,8 @@ export default function App(): ReactElement {
               <Route path="/rendering-providers/:id" element={<RenderingProviderDetail />} />
               <Route path="/service-facilities" element={<ServiceFacilitiesList />} />
               <Route path="/service-facilities/:id" element={<ServiceFacilityDetail />} />
-              {FEATURE_FLAGS_CONFIG.nonInsuranceOrganizationsEnabled && (
-                <>
-                  <Route path="/non-insurance-organizations" element={<NonInsuranceOrganizationsList />} />
-                  <Route path="/non-insurance-organizations/:id" element={<NonInsuranceOrganizationDetail />} />
-                </>
-              )}
+              <Route path="/non-insurance-organizations" element={<NonInsuranceOrganizationsList />} />
+              <Route path="/non-insurance-organizations/:id" element={<NonInsuranceOrganizationDetail />} />
               <Route
                 path={`/${ChargeItemDefinitionLabels['charge-master'].pathComponent}`}
                 element={<ChargeItemDefinitionList type="charge-master" />}

--- a/apps/billing/src/api/api.ts
+++ b/apps/billing/src/api/api.ts
@@ -84,6 +84,13 @@ import {
 } from 'utils/lib/types/data/billing/billing.types';
 import { GetClaimHistoryResponse } from 'utils/lib/types/data/billing/claim-history';
 import {
+  CreateNonInsuranceOrgInputSchema,
+  DeleteNonInsuranceOrgInputSchema,
+  SearchNonInsuranceOrgsInputSchema,
+  UpdateNonInsuranceOrgInputSchema,
+} from 'utils/lib/types/data/billing/non-insurance-org.schemas';
+import { SearchNonInsuranceOrgsResponse } from 'utils/lib/types/data/billing/non-insurance-org.types';
+import {
   BillingRulesResponse,
   GetBillingRulesInputSchema,
   RunBillingRulesEngineInputSchema,
@@ -298,6 +305,29 @@ export const deleteBillingServiceFacility = (
   oystehr: Oystehr,
   parameters: z.input<typeof DeleteServiceFacilityInputSchema>
 ): Promise<DeletedResponse> => executeBillingZambda(oystehr, 'delete-billing-service-facility', parameters);
+
+// --- Non-Insurance Organizations ---
+
+export const createBillingNonInsuranceOrg = (
+  oystehr: Oystehr,
+  parameters: z.input<typeof CreateNonInsuranceOrgInputSchema>
+): Promise<CreatedResourceResponse> => executeBillingZambda(oystehr, 'create-billing-non-insurance-org', parameters);
+
+export const updateBillingNonInsuranceOrg = (
+  oystehr: Oystehr,
+  parameters: z.input<typeof UpdateNonInsuranceOrgInputSchema>
+): Promise<SavedResourceResponse> => executeBillingZambda(oystehr, 'update-billing-non-insurance-org', parameters);
+
+export const searchBillingNonInsuranceOrgs = (
+  oystehr: Oystehr,
+  parameters: z.input<typeof SearchNonInsuranceOrgsInputSchema>
+): Promise<SearchNonInsuranceOrgsResponse> =>
+  executeBillingZambda(oystehr, 'search-billing-non-insurance-orgs', parameters);
+
+export const deleteBillingNonInsuranceOrg = (
+  oystehr: Oystehr,
+  parameters: z.input<typeof DeleteNonInsuranceOrgInputSchema>
+): Promise<DeletedResponse> => executeBillingZambda(oystehr, 'delete-billing-non-insurance-org', parameters);
 
 // --- Terminology ---
 

--- a/apps/billing/src/components/Sidebar.tsx
+++ b/apps/billing/src/components/Sidebar.tsx
@@ -15,7 +15,6 @@ import {
 import { Box, Divider, Drawer, List, ListItemButton, ListItemIcon, ListItemText, Typography } from '@mui/material';
 import { FC, ReactElement } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { FEATURE_FLAGS_CONFIG } from 'utils/lib/ottehr-config/feature-flags';
 import { RULES_ENGINE_TYPES, RULES_ENGINES } from 'utils/lib/types/data/billing/rules-engine.constants';
 import { ChargeItemDefinitionLabels } from '../constants/chargeItemDefinition';
 import { otherColors } from '../themes/ottehr/colors';
@@ -29,15 +28,11 @@ const navItems = [
   { label: 'Billing Providers', path: '/billing-providers', icon: <BusinessIcon sx={{ fontSize: 18 }} /> },
   { label: 'Rendering Providers', path: '/rendering-providers', icon: <MedicalServicesIcon sx={{ fontSize: 18 }} /> },
   { label: 'Service Facilities', path: '/service-facilities', icon: <ApartmentIcon sx={{ fontSize: 18 }} /> },
-  ...(FEATURE_FLAGS_CONFIG.nonInsuranceOrganizationsEnabled
-    ? [
-        {
-          label: 'Non-Insurance Orgs',
-          path: '/non-insurance-organizations',
-          icon: <BusinessCenterIcon sx={{ fontSize: 18 }} />,
-        },
-      ]
-    : []),
+  {
+    label: 'Non-Insurance Orgs',
+    path: '/non-insurance-organizations',
+    icon: <BusinessCenterIcon sx={{ fontSize: 18 }} />,
+  },
   {
     label: ChargeItemDefinitionLabels['charge-master'].listTitle,
     path: `/${ChargeItemDefinitionLabels['charge-master'].pathComponent}`,

--- a/apps/billing/src/components/Sidebar.tsx
+++ b/apps/billing/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useAuth0 } from '@auth0/auth0-react';
 import {
   Apartment as ApartmentIcon,
   Business as BusinessIcon,
+  BusinessCenterOutlined as BusinessCenterIcon,
   Description as DescriptionIcon,
   Label as LabelIcon,
   List as ListIcon,
@@ -14,6 +15,7 @@ import {
 import { Box, Divider, Drawer, List, ListItemButton, ListItemIcon, ListItemText, Typography } from '@mui/material';
 import { FC, ReactElement } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { FEATURE_FLAGS_CONFIG } from 'utils/lib/ottehr-config/feature-flags';
 import { RULES_ENGINE_TYPES, RULES_ENGINES } from 'utils/lib/types/data/billing/rules-engine.constants';
 import { ChargeItemDefinitionLabels } from '../constants/chargeItemDefinition';
 import { otherColors } from '../themes/ottehr/colors';
@@ -27,6 +29,15 @@ const navItems = [
   { label: 'Billing Providers', path: '/billing-providers', icon: <BusinessIcon sx={{ fontSize: 18 }} /> },
   { label: 'Rendering Providers', path: '/rendering-providers', icon: <MedicalServicesIcon sx={{ fontSize: 18 }} /> },
   { label: 'Service Facilities', path: '/service-facilities', icon: <ApartmentIcon sx={{ fontSize: 18 }} /> },
+  ...(FEATURE_FLAGS_CONFIG.nonInsuranceOrganizationsEnabled
+    ? [
+        {
+          label: 'Non-Insurance Orgs',
+          path: '/non-insurance-organizations',
+          icon: <BusinessCenterIcon sx={{ fontSize: 18 }} />,
+        },
+      ]
+    : []),
   {
     label: ChargeItemDefinitionLabels['charge-master'].listTitle,
     path: `/${ChargeItemDefinitionLabels['charge-master'].pathComponent}`,

--- a/apps/billing/src/components/claim/EditableSection.tsx
+++ b/apps/billing/src/components/claim/EditableSection.tsx
@@ -12,6 +12,9 @@ interface EditableSectionProps<T> {
   defaultValues?: DefaultValues<T>;
   onSave: (data: T) => Promise<string | null> | Promise<void>;
   onCancel?: () => void;
+  // Swap between read and edit mode instantly. For tall edit forms the height animation reads as
+  // the form sliding in from the bottom.
+  disableTransition?: boolean;
 }
 
 export const EditableSection = <T extends FieldValues>({
@@ -21,6 +24,7 @@ export const EditableSection = <T extends FieldValues>({
   defaultValues,
   onSave,
   onCancel,
+  disableTransition,
 }: EditableSectionProps<T>): ReactElement => {
   const methods = useForm<T, unknown, T>({
     defaultValues,
@@ -91,8 +95,10 @@ export const EditableSection = <T extends FieldValues>({
             {error}
           </Alert>
         )}
-        <Collapse in={!editing}>{children}</Collapse>
-        <Collapse in={editing}>
+        <Collapse in={!editing} timeout={disableTransition ? 0 : undefined}>
+          {children}
+        </Collapse>
+        <Collapse in={editing} timeout={disableTransition ? 0 : undefined}>
           {/* {defaultValues ? ( */}
           <FormProvider {...methods}>
             <Box sx={{ mt: 2 }}>{editForm}</Box>

--- a/apps/billing/src/components/claim/EditableSection.tsx
+++ b/apps/billing/src/components/claim/EditableSection.tsx
@@ -12,9 +12,6 @@ interface EditableSectionProps<T> {
   defaultValues?: DefaultValues<T>;
   onSave: (data: T) => Promise<string | null> | Promise<void>;
   onCancel?: () => void;
-  // Swap between read and edit mode instantly. For tall edit forms the height animation reads as
-  // the form sliding in from the bottom.
-  disableTransition?: boolean;
 }
 
 export const EditableSection = <T extends FieldValues>({
@@ -24,7 +21,6 @@ export const EditableSection = <T extends FieldValues>({
   defaultValues,
   onSave,
   onCancel,
-  disableTransition,
 }: EditableSectionProps<T>): ReactElement => {
   const methods = useForm<T, unknown, T>({
     defaultValues,
@@ -95,10 +91,8 @@ export const EditableSection = <T extends FieldValues>({
             {error}
           </Alert>
         )}
-        <Collapse in={!editing} timeout={disableTransition ? 0 : undefined}>
-          {children}
-        </Collapse>
-        <Collapse in={editing} timeout={disableTransition ? 0 : undefined}>
+        <Collapse in={!editing}>{children}</Collapse>
+        <Collapse in={editing}>
           {/* {defaultValues ? ( */}
           <FormProvider {...methods}>
             <Box sx={{ mt: 2 }}>{editForm}</Box>

--- a/apps/billing/src/components/nio/ContactsPanel.tsx
+++ b/apps/billing/src/components/nio/ContactsPanel.tsx
@@ -1,0 +1,104 @@
+import { Add as AddIcon, DeleteOutline as DeleteIcon } from '@mui/icons-material';
+import { Box, Button, IconButton, Paper, TextField, Typography } from '@mui/material';
+import { ReactElement } from 'react';
+import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
+import { REQUIRED_FIELD_ERROR_MESSAGE } from 'utils/lib/validation/constants';
+import { emptyNioContactForm } from '../../constants/nonInsuranceOrg';
+
+// Contacts are embedded in the NIO (Organization.contact) and saved with it — this panel only
+// edits form state.
+export function ContactsPanel(): ReactElement {
+  const { control } = useFormContext();
+  const { fields, append, remove } = useFieldArray({ control, name: 'contacts' });
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="h6" color="primary.dark" fontWeight={600} fontSize={16}>
+          Contacts
+        </Typography>
+        <Button size="small" startIcon={<AddIcon />} onClick={() => append(emptyNioContactForm())}>
+          Add Contact
+        </Button>
+      </Box>
+      {fields.length === 0 && (
+        <Typography variant="body2" color="text.secondary">
+          No contacts added yet.
+        </Typography>
+      )}
+      {fields.map((field, index) => (
+        <Paper key={field.id} variant="outlined" sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Typography variant="subtitle2" fontWeight={600}>
+              Contact {index + 1}
+            </Typography>
+            <IconButton size="small" aria-label={`Remove contact ${index + 1}`} onClick={() => remove(index)}>
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Box>
+          <Controller
+            name={`contacts.${index}.name`}
+            control={control}
+            rules={{ required: REQUIRED_FIELD_ERROR_MESSAGE }}
+            render={({ field: nameField, fieldState: { error } }) => (
+              <TextField
+                label="Name *"
+                size="small"
+                fullWidth
+                value={nameField.value}
+                onChange={(e) => nameField.onChange(e.target.value)}
+                error={!!error}
+                helperText={error?.message}
+              />
+            )}
+          />
+          <Controller
+            name={`contacts.${index}.title`}
+            control={control}
+            render={({ field: titleField }) => (
+              <TextField
+                label="Title"
+                size="small"
+                fullWidth
+                value={titleField.value}
+                onChange={(e) => titleField.onChange(e.target.value)}
+              />
+            )}
+          />
+          <Controller
+            name={`contacts.${index}.phone`}
+            control={control}
+            render={({ field: phoneField }) => (
+              <TextField
+                label="Phone"
+                size="small"
+                fullWidth
+                value={phoneField.value}
+                onChange={(e) => phoneField.onChange(e.target.value)}
+              />
+            )}
+          />
+          <Controller
+            name={`contacts.${index}.email`}
+            control={control}
+            rules={{
+              validate: (value: string) =>
+                !value || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim()) || 'Invalid email address',
+            }}
+            render={({ field: emailField, fieldState: { error } }) => (
+              <TextField
+                label="Email"
+                size="small"
+                fullWidth
+                value={emailField.value}
+                onChange={(e) => emailField.onChange(e.target.value)}
+                error={!!error}
+                helperText={error?.message}
+              />
+            )}
+          />
+        </Paper>
+      ))}
+    </Box>
+  );
+}

--- a/apps/billing/src/components/nio/ContactsPanel.tsx
+++ b/apps/billing/src/components/nio/ContactsPanel.tsx
@@ -5,8 +5,6 @@ import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 import { REQUIRED_FIELD_ERROR_MESSAGE } from 'utils/lib/validation/constants';
 import { emptyNioContactForm } from '../../constants/nonInsuranceOrg';
 
-// Contacts are embedded in the NIO (Organization.contact) and saved with it — this panel only
-// edits form state.
 export function ContactsPanel(): ReactElement {
   const { control } = useFormContext();
   const { fields, append, remove } = useFieldArray({ control, name: 'contacts' });

--- a/apps/billing/src/components/nio/CoversSection.tsx
+++ b/apps/billing/src/components/nio/CoversSection.tsx
@@ -1,0 +1,145 @@
+import {
+  Box,
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
+  FormLabel,
+  Paper,
+  Radio,
+  RadioGroup,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { ReactElement } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { NIO_COVERAGE_CATEGORIES, NioCoverageCategory } from 'utils/lib/types/data/billing/non-insurance-org.schemas';
+import { NIO_COVERAGE_CATEGORY_LABELS } from 'utils/lib/types/data/billing/non-insurance-org.types';
+import { PayerSelect } from '../PayerSelect';
+import { SubmissionMechanismFields } from './SubmissionMechanismFields';
+
+// The "Covers" checkboxes; checking a category expands its detail card. Workers comp is special:
+// bill a WC insurance payer (payer picker) or bill the organization directly (submission block).
+export function CoversSection(): ReactElement {
+  const { control, watch } = useFormContext();
+  const enabled = Object.fromEntries(
+    NIO_COVERAGE_CATEGORIES.map((category) => [category, watch(`covers.${category}.enabled`) as boolean])
+  );
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box>
+        <FormLabel sx={{ fontSize: 14, color: 'primary.main' }}>Covers</FormLabel>
+        <FormGroup row>
+          {NIO_COVERAGE_CATEGORIES.map((category) => (
+            <Controller
+              key={category}
+              name={`covers.${category}.enabled`}
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  control={
+                    <Checkbox size="small" checked={!!field.value} onChange={(e) => field.onChange(e.target.checked)} />
+                  }
+                  label={NIO_COVERAGE_CATEGORY_LABELS[category]}
+                />
+              )}
+            />
+          ))}
+        </FormGroup>
+      </Box>
+      {NIO_COVERAGE_CATEGORIES.filter((category) => enabled[category]).map((category) => (
+        <CoverageCard key={category} category={category} />
+      ))}
+    </Box>
+  );
+}
+
+function CoverageCard({ category }: { category: NioCoverageCategory }): ReactElement {
+  const { control, watch } = useFormContext();
+  const billingMode = watch('covers.workers-comp.billingMode') as string;
+  const sameAsOrgAddress = watch('covers.workers-comp.sameAsOrgAddress') as boolean;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+      <Typography variant="subtitle1" color="primary.dark" fontWeight={600}>
+        {NIO_COVERAGE_CATEGORY_LABELS[category]}
+      </Typography>
+
+      {category === 'workers-comp' && (
+        <>
+          <FormLabel sx={{ fontSize: 14 }}>Billing</FormLabel>
+          <Controller
+            name="covers.workers-comp.billingMode"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup row value={field.value} onChange={(e) => field.onChange(e.target.value)}>
+                <FormControlLabel value="insurance" control={<Radio size="small" />} label="Bill Insurance" />
+                <FormControlLabel value="direct" control={<Radio size="small" />} label="Bill Directly" />
+              </RadioGroup>
+            )}
+          />
+          {billingMode === 'insurance' ? (
+            <Controller
+              name="covers.workers-comp.payerId"
+              control={control}
+              render={({ field }) => (
+                <PayerSelect
+                  multiple={false}
+                  value={field.value}
+                  onChange={field.onChange}
+                  label="Workers Comp Insurance Payer"
+                  initialOptions={
+                    watch('covers.workers-comp.payerOption') ? [watch('covers.workers-comp.payerOption')] : undefined
+                  }
+                />
+              )}
+            />
+          ) : (
+            <>
+              <Controller
+                name="covers.workers-comp.sameAsOrgAddress"
+                control={control}
+                render={({ field }) => (
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        size="small"
+                        checked={!!field.value}
+                        onChange={(e) => field.onChange(e.target.checked)}
+                      />
+                    }
+                    label="Same as organization address"
+                  />
+                )}
+              />
+              <SubmissionMechanismFields prefix="covers.workers-comp.submission" hideMailAddress={sameAsOrgAddress} />
+            </>
+          )}
+        </>
+      )}
+
+      {category === 'occupational-medicine' && (
+        <SubmissionMechanismFields prefix="covers.occupational-medicine.submission" />
+      )}
+
+      {category === 'other' && (
+        <>
+          <Controller
+            name="covers.other.name"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                label="Name"
+                size="small"
+                fullWidth
+                value={field.value}
+                onChange={(e) => field.onChange(e.target.value)}
+              />
+            )}
+          />
+          <SubmissionMechanismFields prefix="covers.other.submission" />
+        </>
+      )}
+    </Paper>
+  );
+}

--- a/apps/billing/src/components/nio/NioAddressFields.tsx
+++ b/apps/billing/src/components/nio/NioAddressFields.tsx
@@ -1,0 +1,100 @@
+import { Box, FormControl, InputLabel, MenuItem, Select, TextField } from '@mui/material';
+import { ReactElement } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { InputMask } from 'ui-components/lib/components/InputMask';
+import { AllStates, stateCodeToFullName } from 'utils/lib/types/common';
+
+// Optional address block for NIO forms. Unlike AddressFields, every field is optional (partial
+// addresses are allowed by design) and the field names are prefixed, so multiple address groups —
+// the organization address plus per-coverage mail addresses — can coexist in one form.
+export function NioAddressFields({ prefix }: { prefix: string }): ReactElement {
+  const { control } = useFormContext();
+  return (
+    <>
+      <Controller
+        name={`${prefix}.line1`}
+        control={control}
+        render={({ field }) => (
+          <TextField
+            label="Address Line 1"
+            size="small"
+            fullWidth
+            value={field.value}
+            onChange={(e) => field.onChange(e.target.value)}
+          />
+        )}
+      />
+      <Controller
+        name={`${prefix}.line2`}
+        control={control}
+        render={({ field }) => (
+          <TextField
+            label="Address Line 2"
+            size="small"
+            fullWidth
+            value={field.value}
+            onChange={(e) => field.onChange(e.target.value)}
+          />
+        )}
+      />
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        <Controller
+          name={`${prefix}.city`}
+          control={control}
+          render={({ field }) => (
+            <TextField
+              label="City"
+              size="small"
+              fullWidth
+              value={field.value}
+              onChange={(e) => field.onChange(e.target.value)}
+            />
+          )}
+        />
+        <Controller
+          name={`${prefix}.state`}
+          control={control}
+          render={({ field }) => (
+            <FormControl size="small" fullWidth>
+              <InputLabel id={`${prefix}-state-label`}>State</InputLabel>
+              <Select
+                label="State"
+                labelId={`${prefix}-state-label`}
+                size="small"
+                fullWidth
+                value={field.value}
+                onChange={(e) => field.onChange(e.target.value)}
+              >
+                <MenuItem value="">
+                  <em>None</em>
+                </MenuItem>
+                {AllStates.map((state) => (
+                  <MenuItem value={state.value} key={state.value}>
+                    {stateCodeToFullName[state.value]}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+        />
+        <Controller
+          name={`${prefix}.zip`}
+          control={control}
+          render={({ field }) => (
+            <TextField
+              label="ZIP"
+              size="small"
+              fullWidth
+              value={field.value}
+              onChange={(e) => field.onChange(e.target.value)}
+              InputProps={{
+                inputComponent: InputMask as any,
+                inputProps: { mask: '00000-0000' },
+              }}
+            />
+          )}
+        />
+      </Box>
+    </>
+  );
+}

--- a/apps/billing/src/components/nio/NonInsuranceOrgDetailSection.tsx
+++ b/apps/billing/src/components/nio/NonInsuranceOrgDetailSection.tsx
@@ -48,6 +48,7 @@ export function NonInsuranceOrgDetailSection({
       defaultValues={defaultValues}
       onSave={handleSave}
       editForm={<NonInsuranceOrgFormFields />}
+      disableTransition
     >
       <Row label="Name" value={item.name} />
       <Row label="Employer" value={item.employer ? 'Yes' : 'No'} />

--- a/apps/billing/src/components/nio/NonInsuranceOrgDetailSection.tsx
+++ b/apps/billing/src/components/nio/NonInsuranceOrgDetailSection.tsx
@@ -48,7 +48,6 @@ export function NonInsuranceOrgDetailSection({
       defaultValues={defaultValues}
       onSave={handleSave}
       editForm={<NonInsuranceOrgFormFields />}
-      disableTransition
     >
       <Row label="Name" value={item.name} />
       <Row label="Employer" value={item.employer ? 'Yes' : 'No'} />

--- a/apps/billing/src/components/nio/NonInsuranceOrgDetailSection.tsx
+++ b/apps/billing/src/components/nio/NonInsuranceOrgDetailSection.tsx
@@ -1,0 +1,66 @@
+import { ReactElement, useMemo } from 'react';
+import { getApiError } from 'utils/lib/helpers/oystehrApi';
+import {
+  NIO_COVERAGE_CATEGORY_LABELS,
+  NonInsuranceOrganizationItem,
+} from 'utils/lib/types/data/billing/non-insurance-org.types';
+import { updateBillingNonInsuranceOrg } from '../../api/api';
+import {
+  formatNioAddress,
+  nioCoverageSummary,
+  nioFormToInput,
+  nioItemToFormValues,
+  NonInsuranceOrgForm,
+} from '../../constants/nonInsuranceOrg';
+import { useApiClients } from '../../hooks/useAppClients';
+import { EditableSection } from '../claim/EditableSection';
+import { Row } from '../Row';
+import { NonInsuranceOrgFormFields } from './NonInsuranceOrgFormFields';
+
+export function NonInsuranceOrgDetailSection({
+  item,
+  onSaved,
+}: {
+  item: NonInsuranceOrganizationItem;
+  onSaved: () => Promise<void>;
+}): ReactElement {
+  const { oystehrZambda } = useApiClients();
+  const defaultValues = useMemo(() => nioItemToFormValues(item), [item]);
+
+  const handleSave = async (data: NonInsuranceOrgForm): Promise<string | null> => {
+    if (!oystehrZambda) return 'Client not ready';
+    try {
+      await updateBillingNonInsuranceOrg(oystehrZambda, { ...nioFormToInput(data), nioId: item.id });
+    } catch (err) {
+      return getApiError({ error: err, defaultError: 'Failed to save changes' });
+    }
+    await onSaved();
+    return null;
+  };
+
+  const contactsSummary = item.contacts
+    .map((contact) => [contact.name, contact.title].filter(Boolean).join(' — '))
+    .join('; ');
+
+  return (
+    <EditableSection
+      title="Organization Details"
+      defaultValues={defaultValues}
+      onSave={handleSave}
+      editForm={<NonInsuranceOrgFormFields />}
+    >
+      <Row label="Name" value={item.name} />
+      <Row label="Employer" value={item.employer ? 'Yes' : 'No'} />
+      <Row label="Address" value={formatNioAddress(item.address)} />
+      <Row label="Contacts" value={contactsSummary} hideBorder={item.covers.length === 0} />
+      {item.covers.map((coverage, index) => (
+        <Row
+          key={coverage.category}
+          label={`Covers · ${NIO_COVERAGE_CATEGORY_LABELS[coverage.category]}`}
+          value={nioCoverageSummary(coverage)}
+          hideBorder={index === item.covers.length - 1}
+        />
+      ))}
+    </EditableSection>
+  );
+}

--- a/apps/billing/src/components/nio/NonInsuranceOrgDialog.tsx
+++ b/apps/billing/src/components/nio/NonInsuranceOrgDialog.tsx
@@ -69,8 +69,6 @@ export function NonInsuranceOrgDialog({ open, onClose, onCreated }: NonInsurance
           </Alert>
         )}
         <FormProvider {...methods}>
-          {/* Top margin keeps the first field's floated label from being clipped by the
-              DialogContent scroll edge (same treatment as AddServiceFacilityDialog). */}
           <Box sx={{ mt: 1 }}>
             <NonInsuranceOrgFormFields />
           </Box>

--- a/apps/billing/src/components/nio/NonInsuranceOrgDialog.tsx
+++ b/apps/billing/src/components/nio/NonInsuranceOrgDialog.tsx
@@ -1,6 +1,7 @@
 import { Close as CloseIcon } from '@mui/icons-material';
 import {
   Alert,
+  Box,
   Button,
   Dialog,
   DialogActions,
@@ -68,7 +69,11 @@ export function NonInsuranceOrgDialog({ open, onClose, onCreated }: NonInsurance
           </Alert>
         )}
         <FormProvider {...methods}>
-          <NonInsuranceOrgFormFields />
+          {/* Top margin keeps the first field's floated label from being clipped by the
+              DialogContent scroll edge (same treatment as AddServiceFacilityDialog). */}
+          <Box sx={{ mt: 1 }}>
+            <NonInsuranceOrgFormFields />
+          </Box>
         </FormProvider>
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2 }}>

--- a/apps/billing/src/components/nio/NonInsuranceOrgDialog.tsx
+++ b/apps/billing/src/components/nio/NonInsuranceOrgDialog.tsx
@@ -1,0 +1,82 @@
+import { Close as CloseIcon } from '@mui/icons-material';
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from '@mui/material';
+import { ReactElement, useEffect, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { getApiError } from 'utils/lib/helpers/oystehrApi';
+import { createBillingNonInsuranceOrg } from '../../api/api';
+import { emptyNonInsuranceOrgForm, nioFormToInput, NonInsuranceOrgForm } from '../../constants/nonInsuranceOrg';
+import { useApiClients } from '../../hooks/useAppClients';
+import { NonInsuranceOrgFormFields } from './NonInsuranceOrgFormFields';
+
+interface NonInsuranceOrgDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export function NonInsuranceOrgDialog({ open, onClose, onCreated }: NonInsuranceOrgDialogProps): ReactElement {
+  const { oystehrZambda } = useApiClients();
+  const methods = useForm<NonInsuranceOrgForm>({ defaultValues: emptyNonInsuranceOrgForm() });
+  const {
+    handleSubmit,
+    reset,
+    formState: { isSubmitting },
+  } = methods;
+
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    reset(emptyNonInsuranceOrgForm());
+  }, [open, reset]);
+
+  const handleSave = async (data: NonInsuranceOrgForm): Promise<void> => {
+    if (!oystehrZambda) return;
+    setError(null);
+    try {
+      const result = await createBillingNonInsuranceOrg(oystehrZambda, nioFormToInput(data));
+      if (!result.id) throw new Error('Non-insurance organization was not created');
+      onCreated();
+      onClose();
+    } catch (err) {
+      setError(getApiError({ error: err, defaultError: 'Failed to create non-insurance organization' }));
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth={false} PaperProps={{ sx: { width: 1080, maxWidth: '95vw' } }}>
+      <DialogTitle sx={{ px: 3, pt: 3, pb: 2, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="h5">Add Non-Insurance Organization</Typography>
+        <IconButton size="small" onClick={onClose} aria-label="Close">
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        <FormProvider {...methods}>
+          <NonInsuranceOrgFormFields />
+        </FormProvider>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" onClick={handleSubmit(handleSave)} disabled={isSubmitting}>
+          {isSubmitting ? 'Saving...' : 'Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/billing/src/components/nio/NonInsuranceOrgFormFields.tsx
+++ b/apps/billing/src/components/nio/NonInsuranceOrgFormFields.tsx
@@ -1,0 +1,62 @@
+import { Box, FormControlLabel, Switch, TextField, Typography } from '@mui/material';
+import { ReactElement } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { REQUIRED_FIELD_ERROR_MESSAGE } from 'utils/lib/validation/constants';
+import { ContactsPanel } from './ContactsPanel';
+import { CoversSection } from './CoversSection';
+import { NioAddressFields } from './NioAddressFields';
+
+// The whole NIO form body — org fields + covers on the left, contacts on the right — shared by
+// the create dialog and the detail page's edit mode. Must render inside a FormProvider whose
+// values are a NonInsuranceOrgForm.
+export function NonInsuranceOrgFormFields(): ReactElement {
+  const { control } = useFormContext();
+  return (
+    <Box sx={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
+      <Box sx={{ flex: 2, minWidth: 420, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Controller
+          name="name"
+          control={control}
+          rules={{ required: REQUIRED_FIELD_ERROR_MESSAGE }}
+          render={({ field, fieldState: { error } }) => (
+            <TextField
+              label="Organization Name *"
+              size="small"
+              fullWidth
+              value={field.value}
+              onChange={(e) => field.onChange(e.target.value)}
+              error={!!error}
+              helperText={error?.message}
+            />
+          )}
+        />
+        <Controller
+          name="employer"
+          control={control}
+          render={({ field }) => (
+            <FormControlLabel
+              control={<Switch checked={!!field.value} onChange={(e) => field.onChange(e.target.checked)} />}
+              label="Employer"
+            />
+          )}
+        />
+        <Typography variant="subtitle1" color="primary.dark" fontWeight={600}>
+          Organization Address
+        </Typography>
+        <NioAddressFields prefix="address" />
+        <CoversSection />
+      </Box>
+      <Box
+        sx={{
+          flex: 1,
+          minWidth: 280,
+          borderLeft: { md: 1 },
+          borderColor: { md: 'divider' },
+          pl: { md: 5 },
+        }}
+      >
+        <ContactsPanel />
+      </Box>
+    </Box>
+  );
+}

--- a/apps/billing/src/components/nio/SubmissionMechanismFields.tsx
+++ b/apps/billing/src/components/nio/SubmissionMechanismFields.tsx
@@ -16,7 +16,7 @@ import { NioAddressFields } from './NioAddressFields';
 
 // Manual bill/invoice submission block shared by workers-comp (direct billing), occupational
 // medicine, and other coverage: a preferred-mechanism radio plus one accordion of details per
-// mechanism. Everything is optional — the radio is a preference, not a requirement.
+// mechanism.
 export function SubmissionMechanismFields({
   prefix,
   hideMailAddress,

--- a/apps/billing/src/components/nio/SubmissionMechanismFields.tsx
+++ b/apps/billing/src/components/nio/SubmissionMechanismFields.tsx
@@ -1,0 +1,122 @@
+import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  FormControlLabel,
+  FormLabel,
+  Radio,
+  RadioGroup,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { ReactElement } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { NioAddressFields } from './NioAddressFields';
+
+// Manual bill/invoice submission block shared by workers-comp (direct billing), occupational
+// medicine, and other coverage: a preferred-mechanism radio plus one accordion of details per
+// mechanism. Everything is optional — the radio is a preference, not a requirement.
+export function SubmissionMechanismFields({
+  prefix,
+  hideMailAddress,
+}: {
+  // Form path of the NioSubmissionForm this block edits, e.g. 'covers.workers-comp.submission'.
+  prefix: string;
+  // When the coverage reuses the organization address, the mail accordion shows a note instead of
+  // address fields.
+  hideMailAddress?: boolean;
+}): ReactElement {
+  const { control } = useFormContext();
+  return (
+    <>
+      <FormLabel sx={{ fontSize: 14 }}>Preferred Submission Mechanism</FormLabel>
+      <Controller
+        name={`${prefix}.preferredMechanism`}
+        control={control}
+        render={({ field }) => (
+          <RadioGroup row value={field.value} onChange={(e) => field.onChange(e.target.value)}>
+            <FormControlLabel value="email" control={<Radio size="small" />} label="Email" />
+            <FormControlLabel value="portal" control={<Radio size="small" />} label="Portal" />
+            <FormControlLabel value="fax" control={<Radio size="small" />} label="Fax" />
+            <FormControlLabel value="mail" control={<Radio size="small" />} label="Mail" />
+          </RadioGroup>
+        )}
+      />
+      <Accordion disableGutters variant="outlined">
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>Mail</AccordionSummary>
+        <AccordionDetails sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {hideMailAddress ? (
+            <Typography variant="body2" color="text.secondary">
+              Uses the organization address.
+            </Typography>
+          ) : (
+            <NioAddressFields prefix={`${prefix}.mailAddress`} />
+          )}
+        </AccordionDetails>
+      </Accordion>
+      <Accordion disableGutters variant="outlined">
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>Fax</AccordionSummary>
+        <AccordionDetails>
+          <Controller
+            name={`${prefix}.fax`}
+            control={control}
+            render={({ field }) => (
+              <TextField
+                label="Fax Number"
+                size="small"
+                fullWidth
+                value={field.value}
+                onChange={(e) => field.onChange(e.target.value)}
+              />
+            )}
+          />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion disableGutters variant="outlined">
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>Online Portal</AccordionSummary>
+        <AccordionDetails>
+          <Controller
+            name={`${prefix}.portalNotes`}
+            control={control}
+            render={({ field }) => (
+              <TextField
+                label="Portal Notes"
+                size="small"
+                fullWidth
+                multiline
+                minRows={2}
+                value={field.value}
+                onChange={(e) => field.onChange(e.target.value)}
+              />
+            )}
+          />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion disableGutters variant="outlined">
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>Email</AccordionSummary>
+        <AccordionDetails>
+          <Controller
+            name={`${prefix}.email`}
+            control={control}
+            rules={{
+              validate: (value: string) =>
+                !value || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim()) || 'Invalid email address',
+            }}
+            render={({ field, fieldState: { error } }) => (
+              <TextField
+                label="Email Address"
+                size="small"
+                fullWidth
+                value={field.value}
+                onChange={(e) => field.onChange(e.target.value)}
+                error={!!error}
+                helperText={error?.message}
+              />
+            )}
+          />
+        </AccordionDetails>
+      </Accordion>
+    </>
+  );
+}

--- a/apps/billing/src/constants/nonInsuranceOrg.ts
+++ b/apps/billing/src/constants/nonInsuranceOrg.ts
@@ -1,0 +1,240 @@
+import { BillingPayerOption } from 'utils/lib/types/data/billing/billing.types';
+import {
+  CreateNonInsuranceOrgInput,
+  NIO_COVERAGE_CATEGORIES,
+  NioAddress,
+  NioContact,
+  NioCoverageCategory,
+  NioCoverageInput,
+  NioSubmission,
+  NioSubmissionMechanism,
+  NioWcBillingMode,
+} from 'utils/lib/types/data/billing/non-insurance-org.schemas';
+import { NioCoverageDetail, NonInsuranceOrganizationItem } from 'utils/lib/types/data/billing/non-insurance-org.types';
+
+export interface NioAddressForm {
+  line1: string;
+  line2: string;
+  city: string;
+  state: string;
+  zip: string;
+}
+
+export interface NioSubmissionForm {
+  preferredMechanism: '' | NioSubmissionMechanism;
+  email: string;
+  fax: string;
+  portalNotes: string;
+  mailAddress: NioAddressForm;
+}
+
+export interface NioContactForm {
+  name: string;
+  title: string;
+  phone: string;
+  email: string;
+}
+
+// One entry per category; `enabled` mirrors the category's checkbox. The mode-specific fields
+// (billingMode/payerId for workers comp, name for other) are simply unused by the other categories.
+export interface NioCoverageForm {
+  enabled: boolean;
+  billingMode: NioWcBillingMode;
+  payerId: string;
+  // Seeds PayerSelect's initialOptions on edit so a stored payer renders its label pre-search.
+  payerOption: BillingPayerOption | null;
+  sameAsOrgAddress: boolean;
+  name: string;
+  submission: NioSubmissionForm;
+}
+
+export interface NonInsuranceOrgForm {
+  name: string;
+  employer: boolean;
+  address: NioAddressForm;
+  contacts: NioContactForm[];
+  covers: Record<NioCoverageCategory, NioCoverageForm>;
+}
+
+export function emptyNioAddressForm(): NioAddressForm {
+  return { line1: '', line2: '', city: '', state: '', zip: '' };
+}
+
+function emptySubmissionForm(): NioSubmissionForm {
+  return { preferredMechanism: '', email: '', fax: '', portalNotes: '', mailAddress: emptyNioAddressForm() };
+}
+
+export function emptyNioContactForm(): NioContactForm {
+  return { name: '', title: '', phone: '', email: '' };
+}
+
+function emptyCoverageForm(): NioCoverageForm {
+  return {
+    enabled: false,
+    billingMode: 'direct',
+    payerId: '',
+    payerOption: null,
+    sameAsOrgAddress: false,
+    name: '',
+    submission: emptySubmissionForm(),
+  };
+}
+
+export function emptyNonInsuranceOrgForm(): NonInsuranceOrgForm {
+  return {
+    name: '',
+    employer: false,
+    address: emptyNioAddressForm(),
+    contacts: [],
+    covers: {
+      'workers-comp': emptyCoverageForm(),
+      'occupational-medicine': emptyCoverageForm(),
+      other: emptyCoverageForm(),
+    },
+  };
+}
+
+function addressToForm(address?: NioAddress): NioAddressForm {
+  return {
+    line1: address?.line1 ?? '',
+    line2: address?.line2 ?? '',
+    city: address?.city ?? '',
+    state: address?.state ?? '',
+    zip: address?.zip ?? '',
+  };
+}
+
+function addressToInput(address: NioAddressForm): NioAddress | undefined {
+  const result: NioAddress = {
+    ...(address.line1.trim() ? { line1: address.line1.trim() } : {}),
+    ...(address.line2.trim() ? { line2: address.line2.trim() } : {}),
+    ...(address.city.trim() ? { city: address.city.trim() } : {}),
+    ...(address.state ? { state: address.state } : {}),
+    ...(address.zip.trim() ? { zip: address.zip.trim() } : {}),
+  };
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function submissionToForm(submission?: NioSubmission): NioSubmissionForm {
+  return {
+    preferredMechanism: submission?.preferredMechanism ?? '',
+    email: submission?.email ?? '',
+    fax: submission?.fax ?? '',
+    portalNotes: submission?.portalNotes ?? '',
+    mailAddress: addressToForm(submission?.mailAddress),
+  };
+}
+
+function submissionToInput(submission: NioSubmissionForm, mailOverride?: NioAddress): NioSubmission | undefined {
+  const mailAddress = mailOverride ?? addressToInput(submission.mailAddress);
+  const result: NioSubmission = {
+    ...(submission.preferredMechanism ? { preferredMechanism: submission.preferredMechanism } : {}),
+    ...(submission.email.trim() ? { email: submission.email.trim() } : {}),
+    ...(submission.fax.trim() ? { fax: submission.fax.trim() } : {}),
+    ...(submission.portalNotes.trim() ? { portalNotes: submission.portalNotes.trim() } : {}),
+    ...(mailAddress ? { mailAddress } : {}),
+  };
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+export function nioItemToFormValues(item?: NonInsuranceOrganizationItem | null): NonInsuranceOrgForm {
+  const form = emptyNonInsuranceOrgForm();
+  if (!item) return form;
+  form.name = item.name;
+  form.employer = item.employer;
+  form.address = addressToForm(item.address);
+  form.contacts = item.contacts.map((contact) => ({
+    name: contact.name,
+    title: contact.title ?? '',
+    phone: contact.phone ?? '',
+    email: contact.email ?? '',
+  }));
+  for (const coverage of item.covers) {
+    const entry = form.covers[coverage.category];
+    entry.enabled = true;
+    entry.submission = submissionToForm(coverage.submission);
+    if (coverage.category === 'workers-comp') {
+      entry.billingMode = coverage.billingMode;
+      entry.payerId = coverage.payer?.id ?? '';
+      entry.payerOption = coverage.payer ?? null;
+    } else if (coverage.category === 'other') {
+      entry.name = coverage.name ?? '';
+    }
+  }
+  return form;
+}
+
+export function nioFormToInput(form: NonInsuranceOrgForm): CreateNonInsuranceOrgInput {
+  const orgAddress = addressToInput(form.address);
+
+  const contacts: NioContact[] = form.contacts
+    .filter((contact) => contact.name.trim())
+    .map((contact) => ({
+      name: contact.name.trim(),
+      ...(contact.title.trim() ? { title: contact.title.trim() } : {}),
+      ...(contact.phone.trim() ? { phone: contact.phone.trim() } : {}),
+      ...(contact.email.trim() ? { email: contact.email.trim() } : {}),
+    }));
+
+  const covers: NioCoverageInput[] = [];
+  for (const category of NIO_COVERAGE_CATEGORIES) {
+    const entry = form.covers[category];
+    if (!entry.enabled) continue;
+    if (category === 'workers-comp') {
+      if (entry.billingMode === 'insurance') {
+        covers.push({ category, billingMode: 'insurance', ...(entry.payerId ? { payerId: entry.payerId } : {}) });
+      } else {
+        const submission = submissionToInput(entry.submission, entry.sameAsOrgAddress ? orgAddress : undefined);
+        covers.push({ category, billingMode: 'direct', ...(submission ? { submission } : {}) });
+      }
+    } else {
+      const submission = submissionToInput(entry.submission);
+      covers.push({
+        category,
+        ...(category === 'other' && entry.name.trim() ? { name: entry.name.trim() } : {}),
+        ...(submission ? { submission } : {}),
+      });
+    }
+  }
+
+  return {
+    name: form.name.trim(),
+    employer: form.employer,
+    ...(orgAddress ? { address: orgAddress } : {}),
+    ...(contacts.length ? { contacts } : {}),
+    ...(covers.length ? { covers } : {}),
+  };
+}
+
+export function formatNioAddress(address?: NioAddress): string {
+  if (!address) return '';
+  const cityStateZip = [address.city, [address.state, address.zip].filter(Boolean).join(' ')]
+    .filter(Boolean)
+    .join(', ');
+  return [address.line1, address.line2, cityStateZip].filter(Boolean).join(', ');
+}
+
+const MECHANISM_LABELS: Record<NioSubmissionMechanism, string> = {
+  email: 'Email',
+  portal: 'Portal',
+  fax: 'Fax',
+  mail: 'Mail',
+};
+
+export function nioCoverageSummary(coverage: NioCoverageDetail): string {
+  const parts: string[] = [];
+  if (coverage.category === 'workers-comp') {
+    if (coverage.billingMode === 'insurance') {
+      parts.push('Bill Insurance');
+      const payerLabel = coverage.payer?.name || coverage.payer?.payerId;
+      if (payerLabel) parts.push(payerLabel);
+    } else {
+      parts.push('Bill Directly');
+    }
+  } else if (coverage.category === 'other' && coverage.name) {
+    parts.push(coverage.name);
+  }
+  const mechanism = coverage.submission?.preferredMechanism;
+  if (mechanism) parts.push(`prefers ${MECHANISM_LABELS[mechanism]}`);
+  return parts.join(' · ') || 'Covered';
+}

--- a/apps/billing/src/pages/NonInsuranceOrganizations.tsx
+++ b/apps/billing/src/pages/NonInsuranceOrganizations.tsx
@@ -1,0 +1,265 @@
+import { Add as AddIcon, ArrowBack as ArrowBackIcon, Search as SearchIcon } from '@mui/icons-material';
+import { Alert, Box, Button, CircularProgress, IconButton, InputAdornment, TextField, Typography } from '@mui/material';
+import { DataGridPro, GridColDef, GridPaginationModel } from '@mui/x-data-grid-pro';
+import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { getApiError } from 'utils/lib/helpers/oystehrApi';
+import {
+  NIO_COVERAGE_CATEGORY_LABELS,
+  NonInsuranceOrganizationItem,
+} from 'utils/lib/types/data/billing/non-insurance-org.types';
+import { deleteBillingNonInsuranceOrg, searchBillingNonInsuranceOrgs } from '../api/api';
+import { dataGridSlots, dataGridSx } from '../components/BillingDataGrid';
+import { NonInsuranceOrgDetailSection } from '../components/nio/NonInsuranceOrgDetailSection';
+import { NonInsuranceOrgDialog } from '../components/nio/NonInsuranceOrgDialog';
+import { formatNioAddress } from '../constants/nonInsuranceOrg';
+import { useApiClients } from '../hooks/useAppClients';
+import { useDebounce } from '../hooks/useDebounce';
+
+interface NioRow extends NonInsuranceOrganizationItem {
+  employerDisplay: string;
+  coversDisplay: string;
+  addressDisplay: string;
+}
+
+function toRow(item: NonInsuranceOrganizationItem): NioRow {
+  return {
+    ...item,
+    employerDisplay: item.employer ? 'Yes' : '—',
+    coversDisplay: item.covers.map((coverage) => NIO_COVERAGE_CATEGORY_LABELS[coverage.category]).join(', '),
+    addressDisplay: formatNioAddress(item.address),
+  };
+}
+
+const columns: GridColDef[] = [
+  {
+    field: 'name',
+    headerName: 'Name',
+    flex: 1,
+    minWidth: 220,
+  },
+  {
+    field: 'employerDisplay',
+    headerName: 'Employer',
+    width: 110,
+  },
+  {
+    field: 'coversDisplay',
+    headerName: 'Covers',
+    flex: 1,
+    minWidth: 240,
+  },
+  {
+    field: 'addressDisplay',
+    headerName: 'Address',
+    flex: 1,
+    minWidth: 240,
+  },
+];
+
+export function NonInsuranceOrganizationsList(): ReactElement {
+  const navigate = useNavigate();
+  const { oystehrZambda } = useApiClients();
+
+  const [rows, setRows] = useState<NioRow[]>([]);
+  const [totalRows, setTotalRows] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({ page: 0, pageSize: 25 });
+  const [searchName, setSearchName] = useState('');
+  const [addOpen, setAddOpen] = useState(false);
+  const { debounce } = useDebounce();
+
+  const fetchOrganizations = useCallback(
+    async (pagination: GridPaginationModel, name?: string): Promise<void> => {
+      if (!oystehrZambda) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await searchBillingNonInsuranceOrgs(oystehrZambda, {
+          pageSize: pagination.pageSize,
+          offset: pagination.page * pagination.pageSize,
+          ...(name ? { name } : {}),
+        });
+        setRows((data.organizations ?? []).map(toRow));
+        setTotalRows(data.total ?? 0);
+      } catch (err) {
+        setError(getApiError({ error: err, defaultError: 'Failed to load non-insurance organizations' }));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [oystehrZambda]
+  );
+
+  const initialLoadDone = useRef(false);
+  useEffect(() => {
+    if (!oystehrZambda || initialLoadDone.current) return;
+    initialLoadDone.current = true;
+    void fetchOrganizations(paginationModel);
+  }, [oystehrZambda, fetchOrganizations, paginationModel]);
+
+  const handleSearchChange = (value: string): void => {
+    setSearchName(value);
+    debounce(() => {
+      setPaginationModel((prev) => {
+        const next = {
+          ...prev,
+          page: 0,
+        };
+        void fetchOrganizations(next, value || undefined);
+        return next;
+      });
+    }, 'search');
+  };
+
+  const handlePaginationChange = (model: GridPaginationModel): void => {
+    setPaginationModel(model);
+    void fetchOrganizations(model, searchName || undefined);
+  };
+
+  return (
+    <Box sx={{ p: 0 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 3 }}>
+        <Typography variant="h4" color="primary.dark" fontWeight={600}>
+          Non-Insurance Organizations
+        </Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button variant="contained" startIcon={<AddIcon />} onClick={() => setAddOpen(true)}>
+          Add Organization
+        </Button>
+      </Box>
+
+      <TextField
+        fullWidth
+        size="small"
+        placeholder="Search by name..."
+        value={searchName}
+        onChange={(e) => handleSearchChange(e.target.value)}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon fontSize="small" color="action" />
+            </InputAdornment>
+          ),
+        }}
+        sx={{ mb: 2 }}
+      />
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <DataGridPro
+        rows={rows}
+        columns={columns}
+        loading={loading}
+        rowCount={totalRows}
+        paginationMode="server"
+        paginationModel={paginationModel}
+        onPaginationModelChange={handlePaginationChange}
+        pageSizeOptions={[25, 50, 100]}
+        onRowClick={(params) => navigate(`/non-insurance-organizations/${params.id}`)}
+        disableRowSelectionOnClick
+        disableColumnMenu
+        slots={dataGridSlots()}
+        pagination={true}
+        sx={{
+          ...dataGridSx,
+          height: 'calc(100vh - 310px)',
+        }}
+      />
+
+      <NonInsuranceOrgDialog
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        onCreated={() => void fetchOrganizations(paginationModel, searchName || undefined)}
+      />
+    </Box>
+  );
+}
+
+export function NonInsuranceOrganizationDetail(): ReactElement {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { oystehrZambda } = useApiClients();
+
+  const [item, setItem] = useState<NonInsuranceOrganizationItem | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDetail = useCallback(async () => {
+    if (!oystehrZambda || !id) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await searchBillingNonInsuranceOrgs(oystehrZambda, { nioId: id });
+      setItem((data.organizations ?? [])[0] ?? null);
+    } catch (err) {
+      setError(getApiError({ error: err, defaultError: 'Failed to load non-insurance organization' }));
+    } finally {
+      setLoading(false);
+    }
+  }, [oystehrZambda, id]);
+
+  useEffect(() => {
+    void fetchDetail();
+  }, [fetchDetail]);
+
+  const handleDelete = async (): Promise<void> => {
+    if (!oystehrZambda || !item) return;
+    if (!window.confirm(`Delete non-insurance organization "${item.name}"?`)) return;
+    try {
+      await deleteBillingNonInsuranceOrg(oystehrZambda, { nioId: item.id });
+      navigate('/non-insurance-organizations');
+    } catch (err) {
+      setError(getApiError({ error: err, defaultError: 'Failed to delete non-insurance organization' }));
+    }
+  };
+
+  if (loading && !item) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '50vh',
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error || !item) {
+    return (
+      <Box sx={{ p: 0 }}>
+        <Alert severity="error">{error ?? 'Non-insurance organization not found'}</Alert>
+        <Button sx={{ mt: 2 }} onClick={() => navigate('/non-insurance-organizations')}>
+          Back to Non-Insurance Organizations
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 0 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+        <IconButton onClick={() => navigate('/non-insurance-organizations')} size="small">
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography variant="h5" color="primary.dark" fontWeight={600}>
+          {item.name}
+        </Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button color="error" onClick={() => void handleDelete()}>
+          Delete
+        </Button>
+      </Box>
+      <NonInsuranceOrgDetailSection item={item} onSaved={fetchDetail} />
+    </Box>
+  );
+}

--- a/apps/billing/tests/component/NonInsuranceOrganizations.test.tsx
+++ b/apps/billing/tests/component/NonInsuranceOrganizations.test.tsx
@@ -1,0 +1,237 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { NonInsuranceOrganizationItem } from 'utils/lib/types/data/billing/non-insurance-org.types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  NonInsuranceOrganizationDetail,
+  NonInsuranceOrganizationsList,
+} from '../../src/pages/NonInsuranceOrganizations';
+
+const {
+  searchBillingNonInsuranceOrgsMock,
+  createBillingNonInsuranceOrgMock,
+  updateBillingNonInsuranceOrgMock,
+  deleteBillingNonInsuranceOrgMock,
+  searchBillingPayersMock,
+} = vi.hoisted(() => ({
+  searchBillingNonInsuranceOrgsMock: vi.fn(),
+  createBillingNonInsuranceOrgMock: vi.fn(),
+  updateBillingNonInsuranceOrgMock: vi.fn(),
+  deleteBillingNonInsuranceOrgMock: vi.fn(),
+  searchBillingPayersMock: vi.fn(),
+}));
+
+vi.mock('../../src/api/api', () => ({
+  searchBillingNonInsuranceOrgs: searchBillingNonInsuranceOrgsMock,
+  createBillingNonInsuranceOrg: createBillingNonInsuranceOrgMock,
+  updateBillingNonInsuranceOrg: updateBillingNonInsuranceOrgMock,
+  deleteBillingNonInsuranceOrg: deleteBillingNonInsuranceOrgMock,
+  searchBillingPayers: searchBillingPayersMock,
+}));
+
+// A stable client object: the pages' fetch callbacks depend on oystehrZambda's identity, so a
+// fresh object per render would refire their effects forever.
+vi.mock('../../src/hooks/useAppClients', () => {
+  const clients = { oystehrZambda: {} };
+  return { useApiClients: () => clients };
+});
+
+const fedEx: NonInsuranceOrganizationItem = {
+  id: 'nio-1',
+  name: 'FedEx',
+  employer: true,
+  active: true,
+  address: { line1: '1 Main St', city: 'Springfield', state: 'CA', zip: '90210' },
+  contacts: [{ name: 'Jane Smith', title: 'Billing Manager' }],
+  covers: [
+    {
+      category: 'workers-comp',
+      billingMode: 'insurance',
+      payer: { id: 'payer-1', name: 'Acme Insurance', payerId: 'PAYER123' },
+    },
+    { category: 'other', name: 'Medical Clearance', submission: { preferredMechanism: 'portal' } },
+  ],
+};
+
+function renderList(): void {
+  render(
+    <MemoryRouter initialEntries={['/non-insurance-organizations']}>
+      <NonInsuranceOrganizationsList />
+    </MemoryRouter>
+  );
+}
+
+describe('NonInsuranceOrganizationsList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchBillingNonInsuranceOrgsMock.mockResolvedValue({
+      organizations: [fedEx],
+      total: 1,
+      offset: 0,
+      pageSize: 25,
+    });
+    searchBillingPayersMock.mockResolvedValue({ payers: [] });
+  });
+
+  it('lists organizations with employer, covers, and address columns', async () => {
+    renderList();
+
+    // Generous timeout: the first grid render in a fresh jsdom is slow enough to flake at 1s.
+    expect(await screen.findByText('FedEx', {}, { timeout: 5000 })).toBeInTheDocument();
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    // The address column sits far enough right that jsdom's viewport virtualizes it away, so the
+    // formatted address is asserted on the detail view instead.
+    expect(screen.getByText('Workers Comp, Other')).toBeInTheDocument();
+  });
+
+  it('expands a covers card when its checkbox is checked and swaps WC billing modes', async () => {
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText('FedEx');
+
+    await user.click(screen.getByRole('button', { name: /add organization/i }));
+    const dialog = within(screen.getByRole('dialog'));
+
+    // No detail card until the category is checked.
+    expect(dialog.queryByText('Billing')).not.toBeInTheDocument();
+    await user.click(dialog.getByRole('checkbox', { name: 'Workers Comp' }));
+
+    // Bill Directly is the default: convenience checkbox + submission block, no payer picker.
+    expect(dialog.getByText('Billing')).toBeInTheDocument();
+    expect(dialog.getByRole('radio', { name: 'Bill Directly' })).toBeChecked();
+    expect(dialog.getByRole('checkbox', { name: 'Same as organization address' })).toBeInTheDocument();
+    expect(dialog.getAllByText('Preferred Submission Mechanism').length).toBeGreaterThan(0);
+    expect(dialog.queryByLabelText(/workers comp insurance payer/i)).not.toBeInTheDocument();
+
+    // Bill Insurance swaps in the payer picker and drops the submission block.
+    await user.click(dialog.getByRole('radio', { name: 'Bill Insurance' }));
+    expect(dialog.getByLabelText(/workers comp insurance payer/i)).toBeInTheDocument();
+    expect(dialog.queryByText('Preferred Submission Mechanism')).not.toBeInTheDocument();
+    expect(dialog.queryByRole('checkbox', { name: 'Same as organization address' })).not.toBeInTheDocument();
+  });
+
+  it('adds and removes contacts in the dialog', async () => {
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText('FedEx');
+
+    await user.click(screen.getByRole('button', { name: /add organization/i }));
+    const dialog = within(screen.getByRole('dialog'));
+
+    expect(dialog.getByText('No contacts added yet.')).toBeInTheDocument();
+    await user.click(dialog.getByRole('button', { name: /add contact/i }));
+    await user.click(dialog.getByRole('button', { name: /add contact/i }));
+    expect(dialog.getByText('Contact 1')).toBeInTheDocument();
+    expect(dialog.getByText('Contact 2')).toBeInTheDocument();
+
+    await user.click(dialog.getByRole('button', { name: 'Remove contact 2' }));
+    expect(dialog.queryByText('Contact 2')).not.toBeInTheDocument();
+  });
+
+  it('saves the mapped input and refreshes the list', async () => {
+    const user = userEvent.setup();
+    createBillingNonInsuranceOrgMock.mockResolvedValue({ id: 'nio-new' });
+    renderList();
+    await screen.findByText('FedEx');
+
+    await user.click(screen.getByRole('button', { name: /add organization/i }));
+    const dialog = within(screen.getByRole('dialog'));
+
+    await user.type(dialog.getByLabelText('Organization Name *'), 'UPS');
+    await user.click(dialog.getByRole('checkbox', { name: 'Employer' }));
+
+    await user.click(dialog.getByRole('checkbox', { name: 'Other' }));
+    await user.type(dialog.getByLabelText('Name'), 'Medical Clearance');
+    await user.click(dialog.getByRole('radio', { name: 'Portal' }));
+
+    await user.click(dialog.getByRole('button', { name: /add contact/i }));
+    await user.type(dialog.getByLabelText('Name *'), 'Jane Smith');
+    await user.type(dialog.getByLabelText('Title'), 'Billing Manager');
+
+    await user.click(dialog.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(createBillingNonInsuranceOrgMock).toHaveBeenCalledTimes(1));
+    expect(createBillingNonInsuranceOrgMock).toHaveBeenCalledWith(expect.anything(), {
+      name: 'UPS',
+      employer: true,
+      contacts: [{ name: 'Jane Smith', title: 'Billing Manager' }],
+      covers: [{ category: 'other', name: 'Medical Clearance', submission: { preferredMechanism: 'portal' } }],
+    });
+    // Initial load + refresh after create.
+    await waitFor(() => expect(searchBillingNonInsuranceOrgsMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not save without the required organization name', async () => {
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText('FedEx');
+
+    await user.click(screen.getByRole('button', { name: /add organization/i }));
+    await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(screen.getByLabelText('Organization Name *')).toBeInvalid());
+    expect(createBillingNonInsuranceOrgMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('NonInsuranceOrganizationDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchBillingNonInsuranceOrgsMock.mockResolvedValue({
+      organizations: [fedEx],
+      total: 1,
+      offset: 0,
+      pageSize: 50,
+    });
+    searchBillingPayersMock.mockResolvedValue({ payers: [] });
+  });
+
+  function renderDetail(): void {
+    render(
+      <MemoryRouter initialEntries={['/non-insurance-organizations/nio-1']}>
+        <Routes>
+          <Route path="/non-insurance-organizations/:id" element={<NonInsuranceOrganizationDetail />} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it('renders the read-only summary including covers rows', async () => {
+    renderDetail();
+
+    expect(await screen.findByText('Organization Details')).toBeInTheDocument();
+    expect(screen.getByText('1 Main St, Springfield, CA 90210')).toBeInTheDocument();
+    expect(screen.getByText('Covers · Workers Comp')).toBeInTheDocument();
+    expect(screen.getByText('Bill Insurance · Acme Insurance')).toBeInTheDocument();
+    expect(screen.getByText('Covers · Other')).toBeInTheDocument();
+    expect(screen.getByText('Medical Clearance · prefers Portal')).toBeInTheDocument();
+    expect(screen.getByText('Jane Smith — Billing Manager')).toBeInTheDocument();
+  });
+
+  it('edits and saves with the stored nioId, then refetches', async () => {
+    const user = userEvent.setup();
+    updateBillingNonInsuranceOrgMock.mockResolvedValue({ id: 'nio-1' });
+    renderDetail();
+    await screen.findByText('Organization Details');
+
+    await user.click(screen.getByRole('button', { name: /edit/i }));
+    const nameField = await screen.findByLabelText('Organization Name *');
+    await user.clear(nameField);
+    await user.type(nameField, 'FedEx Ground');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateBillingNonInsuranceOrgMock).toHaveBeenCalledTimes(1));
+    const [, payload] = updateBillingNonInsuranceOrgMock.mock.calls[0];
+    expect(payload.nioId).toBe('nio-1');
+    expect(payload.name).toBe('FedEx Ground');
+    expect(payload.employer).toBe(true);
+    // The stored covers round-trip through the form: WC keeps its payer id.
+    expect(payload.covers).toEqual([
+      { category: 'workers-comp', billingMode: 'insurance', payerId: 'payer-1' },
+      { category: 'other', name: 'Medical Clearance', submission: { preferredMechanism: 'portal' } },
+    ]);
+    // Initial fetch + refetch after save.
+    await waitFor(() => expect(searchBillingNonInsuranceOrgsMock).toHaveBeenCalledTimes(2));
+  });
+});

--- a/config/billing-app-core/zambdas.json
+++ b/config/billing-app-core/zambdas.json
@@ -390,6 +390,41 @@
       "src": "src/billing/record-billing-manual-payment/index",
       "zip": ".dist/zips/record-billing-manual-payment.zip"
     },
+    "CREATE-BILLING-NON-INSURANCE-ORG": {
+      "name": "create-billing-non-insurance-org",
+      "type": "http_auth",
+      "runtime": "nodejs22.x",
+      "src": "src/billing/create-billing-non-insurance-org/index",
+      "zip": ".dist/zips/create-billing-non-insurance-org.zip"
+    },
+    "UPDATE-BILLING-NON-INSURANCE-ORG": {
+      "name": "update-billing-non-insurance-org",
+      "type": "http_auth",
+      "runtime": "nodejs22.x",
+      "src": "src/billing/update-billing-non-insurance-org/index",
+      "zip": ".dist/zips/update-billing-non-insurance-org.zip"
+    },
+    "SEARCH-BILLING-NON-INSURANCE-ORGS": {
+      "name": "search-billing-non-insurance-orgs",
+      "type": "http_auth",
+      "runtime": "nodejs22.x",
+      "src": "src/billing/search-billing-non-insurance-orgs/index",
+      "zip": ".dist/zips/search-billing-non-insurance-orgs.zip"
+    },
+    "DELETE-BILLING-NON-INSURANCE-ORG": {
+      "name": "delete-billing-non-insurance-org",
+      "type": "http_auth",
+      "runtime": "nodejs22.x",
+      "src": "src/billing/delete-billing-non-insurance-org/index",
+      "zip": ".dist/zips/delete-billing-non-insurance-org.zip"
+    },
+    "LIST-NON-INSURANCE-ORGANIZATIONS": {
+      "name": "list-non-insurance-organizations",
+      "type": "http_auth",
+      "runtime": "nodejs22.x",
+      "src": "src/billing/list-non-insurance-organizations/index",
+      "zip": ".dist/zips/list-non-insurance-organizations.zip"
+    },
     "SUB-RULES-ENGINE": {
       "name": "sub-rules-engine",
       "type": "subscription",

--- a/config/oystehr-core/roles.json
+++ b/config/oystehr-core/roles.json
@@ -322,7 +322,11 @@
             "Zambda:Function:record-billing-manual-payment",
             "Zambda:Function:search-billing-patient-ar-claims",
             "Zambda:Function:get-billing-patient-balance",
-            "Zambda:Function:export-billing-claims"
+            "Zambda:Function:export-billing-claims",
+            "Zambda:Function:create-billing-non-insurance-org",
+            "Zambda:Function:update-billing-non-insurance-org",
+            "Zambda:Function:search-billing-non-insurance-orgs",
+            "Zambda:Function:delete-billing-non-insurance-org"
           ]
         }
       ]

--- a/packages/config-types/config/feature-flags.ts
+++ b/packages/config-types/config/feature-flags.ts
@@ -25,6 +25,12 @@ export const FeatureFlagsConfigSchema = z.object({
   // The admin UI is unaffected (it queries `admin-list-service-categories`,
   // not the patient-facing `get-service-categories`).
   dynamicServiceCategoriesEnabled: z.boolean().optional(),
+  // When true, this deployment runs in NIO mode: the billing app manages
+  // non-insurance organizations (and clinical employer pickers will source from
+  // them). When false/omitted, the legacy clinical Employers feature — with its
+  // Candid non-insurance payer sync — stays active. Per-deployment so customers
+  // can migrate at different times.
+  nonInsuranceOrganizationsEnabled: z.boolean().optional(),
 });
 
 export type FeatureFlagsConfig = z.infer<typeof FeatureFlagsConfigSchema>;

--- a/packages/utils/lib/helpers/helpers.ts
+++ b/packages/utils/lib/helpers/helpers.ts
@@ -1730,13 +1730,16 @@ export function getNioReferenceUrl(nioId: string): string {
   return `${BILLING_NIO_REFERENCE_BASE}/${nioId}`;
 }
 
-export function isNioReferenceUrl(maybeUrl?: string): boolean {
-  return !!maybeUrl && maybeUrl.startsWith(`${BILLING_NIO_REFERENCE_BASE}/`);
+export function extractNioIdFromReferenceUrl(maybeUrl?: string): string | undefined {
+  if (!maybeUrl || !maybeUrl.startsWith(`${BILLING_NIO_REFERENCE_BASE}/`)) return undefined;
+  const nioId = maybeUrl.slice(BILLING_NIO_REFERENCE_BASE.length + 1);
+  // A token carries exactly one non-empty id segment; anything else is not an NIO reference.
+  if (nioId === '' || nioId.includes('/')) return undefined;
+  return nioId;
 }
 
-export function extractNioIdFromReferenceUrl(maybeUrl?: string): string | undefined {
-  if (!maybeUrl || !isNioReferenceUrl(maybeUrl)) return undefined;
-  return maybeUrl.slice(BILLING_NIO_REFERENCE_BASE.length + 1);
+export function isNioReferenceUrl(maybeUrl?: string): boolean {
+  return extractNioIdFromReferenceUrl(maybeUrl) !== undefined;
 }
 
 export const getNameFromScheduleResource = (scheduleResource: ScheduleOwnerFhirResource): string | undefined => {

--- a/packages/utils/lib/helpers/helpers.ts
+++ b/packages/utils/lib/helpers/helpers.ts
@@ -1720,6 +1720,25 @@ export function extractPayerIdFromUrl(maybeUrl?: string): string | undefined {
   return maybeUrl.replace('https://rcm-api.zapehr.com/v1/payer/', '');
 }
 
+// Non-insurance organizations (NIOs) are billing-app-owned FHIR resources. The clinical app never
+// stores or reads them as FHIR — a stored NIO reference uses this URL token so readers know to
+// resolve it through the billing app's zambda interface (list-non-insurance-organizations), the
+// same way payer URLs above mark payers as living in the Oystehr RCM payer list.
+export const BILLING_NIO_REFERENCE_BASE = 'https://fhir.ottehr.com/billing/non-insurance-organization';
+
+export function getNioReferenceUrl(nioId: string): string {
+  return `${BILLING_NIO_REFERENCE_BASE}/${nioId}`;
+}
+
+export function isNioReferenceUrl(maybeUrl?: string): boolean {
+  return !!maybeUrl && maybeUrl.startsWith(`${BILLING_NIO_REFERENCE_BASE}/`);
+}
+
+export function extractNioIdFromReferenceUrl(maybeUrl?: string): string | undefined {
+  if (!maybeUrl || !isNioReferenceUrl(maybeUrl)) return undefined;
+  return maybeUrl.slice(BILLING_NIO_REFERENCE_BASE.length + 1);
+}
+
 export const getNameFromScheduleResource = (scheduleResource: ScheduleOwnerFhirResource): string | undefined => {
   let location: string | undefined;
   if (scheduleResource.resourceType === 'Location') {

--- a/packages/utils/lib/ottehr-config/feature-flags/index.ts
+++ b/packages/utils/lib/ottehr-config/feature-flags/index.ts
@@ -21,6 +21,10 @@ const FEATURE_FLAGS_DATA: FeatureFlagsConfig = {
   // and land at undefined (falsy → FHIR categories suppressed) — customers
   // opt in explicitly by setting `dynamicServiceCategoriesEnabled: true`.
   dynamicServiceCategoriesEnabled: true,
+  // ON in core so dev/e2e exercise the billing app's non-insurance organizations.
+  // Customer forks omit this field (undefined → falsy → legacy Employers mode with
+  // Candid sync) and opt in at their migration time.
+  nonInsuranceOrganizationsEnabled: true,
 };
 
 export const FEATURE_FLAGS_CONFIG = Object.freeze(FeatureFlagsConfigSchema.parse(FEATURE_FLAGS_DATA));

--- a/packages/utils/lib/types/data/billing/non-insurance-org.schemas.test.ts
+++ b/packages/utils/lib/types/data/billing/non-insurance-org.schemas.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BILLING_NIO_REFERENCE_BASE,
+  extractNioIdFromReferenceUrl,
+  getNioReferenceUrl,
+  isNioReferenceUrl,
+} from '../../../helpers/helpers';
+import {
+  CreateNonInsuranceOrgInputSchema,
+  ListNonInsuranceOrganizationsInputSchema,
+  SearchNonInsuranceOrgsInputSchema,
+  UpdateNonInsuranceOrgInputSchema,
+} from './non-insurance-org.schemas';
+
+const NIO_ID = '11111111-1111-4111-8111-111111111111';
+
+const fullInput = {
+  name: 'FedEx',
+  employer: true,
+  address: { line1: '1 Main St', city: 'Springfield', state: 'CA', zip: '90210' },
+  contacts: [{ name: 'Jane Smith', title: 'Billing Manager', phone: '555-123-4567', email: 'jane@fedex.com' }],
+  covers: [
+    { category: 'workers-comp', billingMode: 'insurance', payerId: 'payer-org-id' },
+    {
+      category: 'occupational-medicine',
+      submission: {
+        preferredMechanism: 'fax',
+        fax: '555-999-0000',
+        email: 'occmed@fedex.com',
+        portalNotes: 'portal.fedex.com, login in vault',
+        mailAddress: { line1: 'PO Box 5' },
+      },
+    },
+    { category: 'other', name: 'Medical Clearance', submission: { preferredMechanism: 'portal' } },
+  ],
+};
+
+describe('non-insurance-org input schemas', () => {
+  it('accepts a minimal create (name + employer only)', () => {
+    expect(CreateNonInsuranceOrgInputSchema.safeParse({ name: 'FedEx', employer: false }).success).toBe(true);
+  });
+
+  it('accepts a fully-populated create', () => {
+    expect(CreateNonInsuranceOrgInputSchema.safeParse(fullInput).success).toBe(true);
+  });
+
+  it.each([
+    ['missing name', { employer: false }],
+    ['empty name', { name: '   ', employer: false }],
+    ['missing employer', { name: 'FedEx' }],
+  ])('rejects create with %s', (_label, input) => {
+    expect(CreateNonInsuranceOrgInputSchema.safeParse(input).success).toBe(false);
+  });
+
+  it('accepts a partial address — no completeness rule', () => {
+    const result = CreateNonInsuranceOrgInputSchema.safeParse({
+      name: 'FedEx',
+      employer: false,
+      address: { zip: '90210' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects duplicate coverage categories', () => {
+    const result = CreateNonInsuranceOrgInputSchema.safeParse({
+      name: 'FedEx',
+      employer: false,
+      covers: [
+        { category: 'other', name: 'A' },
+        { category: 'other', name: 'B' },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unknown coverage category', () => {
+    const result = CreateNonInsuranceOrgInputSchema.safeParse({
+      name: 'FedEx',
+      employer: false,
+      covers: [{ category: 'medical-clearance' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('requires billingMode on workers-comp coverage', () => {
+    const result = CreateNonInsuranceOrgInputSchema.safeParse({
+      name: 'FedEx',
+      employer: false,
+      covers: [{ category: 'workers-comp' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('requires a name on each contact but nothing else', () => {
+    const base = { name: 'FedEx', employer: false };
+    expect(CreateNonInsuranceOrgInputSchema.safeParse({ ...base, contacts: [{ name: 'Jane' }] }).success).toBe(true);
+    expect(CreateNonInsuranceOrgInputSchema.safeParse({ ...base, contacts: [{ title: 'Manager' }] }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects a malformed contact email', () => {
+    const result = CreateNonInsuranceOrgInputSchema.safeParse({
+      name: 'FedEx',
+      employer: false,
+      contacts: [{ name: 'Jane', email: 'not-an-email' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('requires nioId on update', () => {
+    expect(UpdateNonInsuranceOrgInputSchema.safeParse({ name: 'FedEx', employer: false }).success).toBe(false);
+    expect(UpdateNonInsuranceOrgInputSchema.safeParse({ nioId: NIO_ID, name: 'FedEx', employer: false }).success).toBe(
+      true
+    );
+  });
+
+  it('search accepts only the employers-only filter value', () => {
+    expect(SearchNonInsuranceOrgsInputSchema.safeParse({ employer: true }).success).toBe(true);
+    expect(SearchNonInsuranceOrgsInputSchema.safeParse({ employer: false }).success).toBe(false);
+    expect(SearchNonInsuranceOrgsInputSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('directory input accepts nioId / employerOnly / search', () => {
+    expect(
+      ListNonInsuranceOrganizationsInputSchema.safeParse({ nioId: NIO_ID, employerOnly: true, search: 'fed' }).success
+    ).toBe(true);
+    expect(ListNonInsuranceOrganizationsInputSchema.safeParse({ employerOnly: false }).success).toBe(false);
+  });
+});
+
+describe('NIO reference tokens', () => {
+  it('round-trips an id through the token', () => {
+    const token = getNioReferenceUrl(NIO_ID);
+    expect(token).toBe(`${BILLING_NIO_REFERENCE_BASE}/${NIO_ID}`);
+    expect(isNioReferenceUrl(token)).toBe(true);
+    expect(extractNioIdFromReferenceUrl(token)).toBe(NIO_ID);
+  });
+
+  it.each([
+    ['a plain FHIR reference', `Organization/${NIO_ID}`],
+    ['a payer URL', 'https://rcm-api.zapehr.com/v1/payer/abc123'],
+    ['the bare base with no id', BILLING_NIO_REFERENCE_BASE],
+    ['undefined', undefined],
+  ])('does not treat %s as an NIO reference', (_label, value) => {
+    expect(isNioReferenceUrl(value)).toBe(false);
+    expect(extractNioIdFromReferenceUrl(value)).toBeUndefined();
+  });
+});

--- a/packages/utils/lib/types/data/billing/non-insurance-org.schemas.test.ts
+++ b/packages/utils/lib/types/data/billing/non-insurance-org.schemas.test.ts
@@ -91,6 +91,42 @@ describe('non-insurance-org input schemas', () => {
     expect(result.success).toBe(false);
   });
 
+  it('rejects a workers-comp payer when billing direct', () => {
+    const result = CreateNonInsuranceOrgInputSchema.safeParse({
+      name: 'FedEx',
+      employer: false,
+      covers: [{ category: 'workers-comp', billingMode: 'direct', payerId: 'payer-org-id' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects workers-comp submission details when billing through insurance', () => {
+    const result = CreateNonInsuranceOrgInputSchema.safeParse({
+      name: 'FedEx',
+      employer: false,
+      covers: [
+        { category: 'workers-comp', billingMode: 'insurance', payerId: 'payer-org-id', submission: { fax: '555' } },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts the consistent workers-comp combinations', () => {
+    const base = { name: 'FedEx', employer: false };
+    expect(
+      CreateNonInsuranceOrgInputSchema.safeParse({
+        ...base,
+        covers: [{ category: 'workers-comp', billingMode: 'insurance', payerId: 'payer-org-id' }],
+      }).success
+    ).toBe(true);
+    expect(
+      CreateNonInsuranceOrgInputSchema.safeParse({
+        ...base,
+        covers: [{ category: 'workers-comp', billingMode: 'direct', submission: { fax: '555' } }],
+      }).success
+    ).toBe(true);
+  });
+
   it('requires a name on each contact but nothing else', () => {
     const base = { name: 'FedEx', employer: false };
     expect(CreateNonInsuranceOrgInputSchema.safeParse({ ...base, contacts: [{ name: 'Jane' }] }).success).toBe(true);
@@ -141,6 +177,8 @@ describe('NIO reference tokens', () => {
     ['a plain FHIR reference', `Organization/${NIO_ID}`],
     ['a payer URL', 'https://rcm-api.zapehr.com/v1/payer/abc123'],
     ['the bare base with no id', BILLING_NIO_REFERENCE_BASE],
+    ['a trailing slash with an empty id', `${BILLING_NIO_REFERENCE_BASE}/`],
+    ['extra path segments after the id', `${BILLING_NIO_REFERENCE_BASE}/${NIO_ID}/extra`],
     ['undefined', undefined],
   ])('does not treat %s as an NIO reference', (_label, value) => {
     expect(isNioReferenceUrl(value)).toBe(false);

--- a/packages/utils/lib/types/data/billing/non-insurance-org.schemas.ts
+++ b/packages/utils/lib/types/data/billing/non-insurance-org.schemas.ts
@@ -77,6 +77,22 @@ const coversSchema = z.array(NioCoverageSchema).superRefine((covers, ctx) => {
       });
     }
     seen.add(coverage.category);
+    if (coverage.category === 'workers-comp') {
+      if (coverage.billingMode === 'direct' && coverage.payerId !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'payerId is only allowed when workers-comp bills through insurance',
+          path: [index, 'payerId'],
+        });
+      }
+      if (coverage.billingMode === 'insurance' && coverage.submission !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'submission details are only allowed when workers-comp bills direct',
+          path: [index, 'submission'],
+        });
+      }
+    }
   });
 });
 

--- a/packages/utils/lib/types/data/billing/non-insurance-org.schemas.ts
+++ b/packages/utils/lib/types/data/billing/non-insurance-org.schemas.ts
@@ -89,8 +89,6 @@ export const CreateNonInsuranceOrgInputSchema = z.object({
 });
 export type CreateNonInsuranceOrgInput = z.output<typeof CreateNonInsuranceOrgInputSchema>;
 
-// Full-replace semantics: the edit form submits the whole entity. Omitted optional fields clear,
-// and the covers set is reconciled server-side (an unchecked category deactivates its pair).
 export const UpdateNonInsuranceOrgInputSchema = CreateNonInsuranceOrgInputSchema.extend({
   nioId: nonEmptyString,
 });

--- a/packages/utils/lib/types/data/billing/non-insurance-org.schemas.ts
+++ b/packages/utils/lib/types/data/billing/non-insurance-org.schemas.ts
@@ -1,0 +1,124 @@
+import { z } from 'zod';
+
+const nonEmptyString = z.string().trim().min(1);
+const nonNegativeInt = z.number().int().nonnegative();
+const optionalTrimmedString = z.string().trim().optional();
+
+export const NIO_COVERAGE_CATEGORIES = ['workers-comp', 'occupational-medicine', 'other'] as const;
+export type NioCoverageCategory = (typeof NIO_COVERAGE_CATEGORIES)[number];
+
+export const NIO_SUBMISSION_MECHANISMS = ['email', 'portal', 'fax', 'mail'] as const;
+export type NioSubmissionMechanism = (typeof NIO_SUBMISSION_MECHANISMS)[number];
+
+export const NIO_WC_BILLING_MODES = ['insurance', 'direct'] as const;
+export type NioWcBillingMode = (typeof NIO_WC_BILLING_MODES)[number];
+
+// Addresses are deliberately loose: partial addresses are allowed, with no completeness rule.
+export const NioAddressSchema = z.object({
+  line1: optionalTrimmedString,
+  line2: optionalTrimmedString,
+  city: optionalTrimmedString,
+  state: optionalTrimmedString,
+  zip: optionalTrimmedString,
+});
+export type NioAddress = z.output<typeof NioAddressSchema>;
+
+export const NioContactSchema = z.object({
+  name: nonEmptyString,
+  title: optionalTrimmedString,
+  phone: optionalTrimmedString,
+  email: z.string().trim().email('Invalid contact email').optional(),
+});
+export type NioContact = z.output<typeof NioContactSchema>;
+
+// How a bill/invoice is submitted manually for a coverage. Everything is optional — the
+// preferred mechanism is a hint and does not require its detail fields to be filled in.
+export const NioSubmissionSchema = z.object({
+  preferredMechanism: z.enum(NIO_SUBMISSION_MECHANISMS).optional(),
+  email: z.string().trim().email('Invalid submission email').optional(),
+  fax: optionalTrimmedString,
+  portalNotes: optionalTrimmedString,
+  mailAddress: NioAddressSchema.optional(),
+});
+export type NioSubmission = z.output<typeof NioSubmissionSchema>;
+
+const workersCompCoverageSchema = z.object({
+  category: z.literal('workers-comp'),
+  billingMode: z.enum(NIO_WC_BILLING_MODES),
+  // RCM payer Organization id, the token PayerSelect stores (BillingPayerOption.id); insurance mode only.
+  payerId: nonEmptyString.optional(),
+  // Manual submission details; direct mode only.
+  submission: NioSubmissionSchema.optional(),
+});
+
+const occupationalMedicineCoverageSchema = z.object({
+  category: z.literal('occupational-medicine'),
+  submission: NioSubmissionSchema.optional(),
+});
+
+// 'other' also absorbs categories without their own code yet (e.g. Medical Clearance) via its name.
+const otherCoverageSchema = z.object({
+  category: z.literal('other'),
+  name: optionalTrimmedString,
+  submission: NioSubmissionSchema.optional(),
+});
+
+export const NioCoverageSchema = z.discriminatedUnion('category', [
+  workersCompCoverageSchema,
+  occupationalMedicineCoverageSchema,
+  otherCoverageSchema,
+]);
+export type NioCoverageInput = z.output<typeof NioCoverageSchema>;
+
+const coversSchema = z.array(NioCoverageSchema).superRefine((covers, ctx) => {
+  const seen = new Set<string>();
+  covers.forEach((coverage, index) => {
+    if (seen.has(coverage.category)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate coverage category "${coverage.category}"`,
+        path: [index, 'category'],
+      });
+    }
+    seen.add(coverage.category);
+  });
+});
+
+export const CreateNonInsuranceOrgInputSchema = z.object({
+  name: nonEmptyString,
+  employer: z.boolean(),
+  address: NioAddressSchema.optional(),
+  contacts: z.array(NioContactSchema).optional(),
+  covers: coversSchema.optional(),
+});
+export type CreateNonInsuranceOrgInput = z.output<typeof CreateNonInsuranceOrgInputSchema>;
+
+// Full-replace semantics: the edit form submits the whole entity. Omitted optional fields clear,
+// and the covers set is reconciled server-side (an unchecked category deactivates its pair).
+export const UpdateNonInsuranceOrgInputSchema = CreateNonInsuranceOrgInputSchema.extend({
+  nioId: nonEmptyString,
+});
+export type UpdateNonInsuranceOrgInput = z.output<typeof UpdateNonInsuranceOrgInputSchema>;
+
+export const SearchNonInsuranceOrgsInputSchema = z.object({
+  nioId: nonEmptyString.optional(),
+  name: nonEmptyString.optional(),
+  // The only supported filter is employers-only; omit for all NIOs.
+  employer: z.literal(true).optional(),
+  offset: nonNegativeInt.optional(),
+  pageSize: nonNegativeInt.optional(),
+});
+export type SearchNonInsuranceOrgsInput = z.output<typeof SearchNonInsuranceOrgsInputSchema>;
+
+export const DeleteNonInsuranceOrgInputSchema = z.object({
+  nioId: nonEmptyString,
+});
+export type DeleteNonInsuranceOrgInput = z.output<typeof DeleteNonInsuranceOrgInputSchema>;
+
+// Clinical directory (list-non-insurance-organizations) — the stable clinical-facing contract.
+export const ListNonInsuranceOrganizationsInputSchema = z.object({
+  nioId: nonEmptyString.optional(),
+  employerOnly: z.literal(true).optional(),
+  search: nonEmptyString.optional(),
+});
+export type ListNonInsuranceOrganizationsInput = z.output<typeof ListNonInsuranceOrganizationsInputSchema>;

--- a/packages/utils/lib/types/data/billing/non-insurance-org.schemas.ts
+++ b/packages/utils/lib/types/data/billing/non-insurance-org.schemas.ts
@@ -97,7 +97,6 @@ export type UpdateNonInsuranceOrgInput = z.output<typeof UpdateNonInsuranceOrgIn
 export const SearchNonInsuranceOrgsInputSchema = z.object({
   nioId: nonEmptyString.optional(),
   name: nonEmptyString.optional(),
-  // The only supported filter is employers-only; omit for all NIOs.
   employer: z.literal(true).optional(),
   offset: nonNegativeInt.optional(),
   pageSize: nonNegativeInt.optional(),

--- a/packages/utils/lib/types/data/billing/non-insurance-org.schemas.ts
+++ b/packages/utils/lib/types/data/billing/non-insurance-org.schemas.ts
@@ -13,7 +13,6 @@ export type NioSubmissionMechanism = (typeof NIO_SUBMISSION_MECHANISMS)[number];
 export const NIO_WC_BILLING_MODES = ['insurance', 'direct'] as const;
 export type NioWcBillingMode = (typeof NIO_WC_BILLING_MODES)[number];
 
-// Addresses are deliberately loose: partial addresses are allowed, with no completeness rule.
 export const NioAddressSchema = z.object({
   line1: optionalTrimmedString,
   line2: optionalTrimmedString,

--- a/packages/utils/lib/types/data/billing/non-insurance-org.schemas.ts
+++ b/packages/utils/lib/types/data/billing/non-insurance-org.schemas.ts
@@ -30,8 +30,6 @@ export const NioContactSchema = z.object({
 });
 export type NioContact = z.output<typeof NioContactSchema>;
 
-// How a bill/invoice is submitted manually for a coverage. Everything is optional — the
-// preferred mechanism is a hint and does not require its detail fields to be filled in.
 export const NioSubmissionSchema = z.object({
   preferredMechanism: z.enum(NIO_SUBMISSION_MECHANISMS).optional(),
   email: z.string().trim().email('Invalid submission email').optional(),
@@ -55,7 +53,6 @@ const occupationalMedicineCoverageSchema = z.object({
   submission: NioSubmissionSchema.optional(),
 });
 
-// 'other' also absorbs categories without their own code yet (e.g. Medical Clearance) via its name.
 const otherCoverageSchema = z.object({
   category: z.literal('other'),
   name: optionalTrimmedString,

--- a/packages/utils/lib/types/data/billing/non-insurance-org.types.ts
+++ b/packages/utils/lib/types/data/billing/non-insurance-org.types.ts
@@ -1,0 +1,87 @@
+import { BillingPayerOption } from './billing.types';
+import {
+  NioAddress,
+  NioContact,
+  NioCoverageCategory,
+  NioSubmission,
+  NioWcBillingMode,
+} from './non-insurance-org.schemas';
+
+// --- FHIR systems & extensions (billing workspace) ---
+
+// Organization.type coding marking the role an Organization plays in the billing workspace.
+export const NIO_ORGANIZATION_KIND_SYSTEM = 'https://fhir.ottehr.com/billing/organization-kind';
+export const NIO_KIND_CODE = 'non-insurance-organization';
+export const NIO_COVERAGE_KIND_CODE = 'nio-coverage';
+export const NIO_EMPLOYER_KIND_CODE = 'employer';
+
+// Coverage category, carried on both the coverage Organization's type and the
+// OrganizationAffiliation.code, so list/directory reads never need the coverage org.
+export const NIO_COVERAGE_CATEGORY_SYSTEM = 'https://fhir.ottehr.com/billing/nio-coverage-category';
+
+export const NIO_PREFERRED_SUBMISSION_EXTENSION_URL = 'https://fhir.ottehr.com/billing/preferred-submission-mechanism';
+export const NIO_PORTAL_NOTES_EXTENSION_URL = 'https://fhir.ottehr.com/billing/portal-submission-notes';
+export const NIO_WC_BILLING_MODE_EXTENSION_URL = 'https://fhir.ottehr.com/billing/wc-billing-mode';
+export const NIO_WC_PAYER_EXTENSION_URL = 'https://fhir.ottehr.com/billing/wc-insurance-payer';
+
+export const NIO_COVERAGE_CATEGORY_LABELS: Record<NioCoverageCategory, string> = {
+  'workers-comp': 'Workers Comp',
+  'occupational-medicine': 'Occupational Medicine',
+  other: 'Other',
+};
+
+// --- Billing app DTOs ---
+
+export interface NioWorkersCompCoverage {
+  category: 'workers-comp';
+  billingMode: NioWcBillingMode;
+  payer?: BillingPayerOption;
+  submission?: NioSubmission;
+}
+
+export interface NioStandardCoverage {
+  category: Exclude<NioCoverageCategory, 'workers-comp'>;
+  // User-entered name; 'other' only.
+  name?: string;
+  submission?: NioSubmission;
+}
+
+export type NioCoverageDetail = NioWorkersCompCoverage | NioStandardCoverage;
+
+export interface NonInsuranceOrganizationItem {
+  id: string;
+  name: string;
+  employer: boolean;
+  active: boolean;
+  address?: NioAddress;
+  contacts: NioContact[];
+  covers: NioCoverageDetail[];
+}
+
+export interface SearchNonInsuranceOrgsResponse {
+  organizations: NonInsuranceOrganizationItem[];
+  total: number;
+  offset: number;
+  pageSize: number;
+}
+
+// --- Clinical interface DTOs ---
+// The stable contract the clinical app consumes; deliberately minimal (no payer refs, no
+// submission details, no contacts) so billing internals can evolve freely.
+
+export interface ClinicalNioOption {
+  id: string;
+  // NIO reference token (see getNioReferenceUrl) — what clinical code stores in Reference.reference.
+  reference: string;
+  name: string;
+  employer: boolean;
+  // A stored reference can point at a since-deleted NIO; lookups by nioId still resolve it, with
+  // active=false, so clinical validation and display both work.
+  active: boolean;
+  address?: NioAddress;
+  coversCategories: NioCoverageCategory[];
+}
+
+export interface ListNonInsuranceOrganizationsResponse {
+  organizations: ClinicalNioOption[];
+}

--- a/packages/zambdas/src/billing/create-billing-non-insurance-org/index.ts
+++ b/packages/zambdas/src/billing/create-billing-non-insurance-org/index.ts
@@ -1,0 +1,93 @@
+import Oystehr, { BatchInputRequest } from '@oystehr/sdk';
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { randomUUID } from 'crypto';
+import { FhirResource, Organization } from 'fhir/r4b';
+import { InternalError } from 'utils/lib/helpers/oystehrApi';
+import { CreatedResourceResponse } from 'utils/lib/types/data/billing/billing.types';
+import { checkOrCreateM2MClientToken } from '../../shared/auth';
+import { wrapHandler } from '../../shared/sentry';
+import { ZambdaInput } from '../../shared/types/common';
+import {
+  buildCoverageOrganization,
+  buildNioAffiliation,
+  buildNioOrganization,
+  isNonInsuranceOrganization,
+  NioPayerReference,
+  resolveWcPayerReference,
+} from '../non-insurance-org.helpers';
+import { createBillingClient } from '../shared';
+import { CreateNonInsuranceOrgParams, validateRequestParameters } from './validateRequestParameters';
+
+let m2mToken: string;
+const ZAMBDA_NAME = 'create-billing-non-insurance-org';
+
+export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
+  console.group('validateRequestParameters');
+  const params = validateRequestParameters(input);
+  const { secrets, ...restOfParams } = params;
+  console.groupEnd();
+  console.debug('validateRequestParameters success', restOfParams);
+
+  m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
+  const oystehr = createBillingClient(m2mToken, secrets);
+
+  console.group('complexValidation');
+  const payerRef = await resolveWcPayerReference(oystehr, params.covers);
+  console.groupEnd();
+  console.debug('complexValidation success');
+
+  console.group('performEffect');
+  const response = await performEffect(oystehr, params, payerRef);
+  console.groupEnd();
+  console.debug('performEffect success', response);
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(response),
+  };
+});
+
+// The NIO org, one coverage org per checked category, and the affiliations linking them are
+// written in one transaction so they all succeed or fail together.
+export async function performEffect(
+  oystehr: Oystehr,
+  params: CreateNonInsuranceOrgParams,
+  payerRef?: NioPayerReference
+): Promise<CreatedResourceResponse> {
+  const nioUrn = `urn:uuid:${randomUUID()}`;
+  const requests: BatchInputRequest<FhirResource>[] = [
+    { method: 'POST', url: '/Organization', resource: buildNioOrganization(params), fullUrl: nioUrn },
+  ];
+
+  for (const coverage of params.covers ?? []) {
+    const coverageUrn = `urn:uuid:${randomUUID()}`;
+    requests.push({
+      method: 'POST',
+      url: '/Organization',
+      resource: buildCoverageOrganization({
+        nioName: params.name,
+        coverage,
+        payerRef: coverage.category === 'workers-comp' ? payerRef : undefined,
+      }),
+      fullUrl: coverageUrn,
+    });
+    requests.push({
+      method: 'POST',
+      url: '/OrganizationAffiliation',
+      resource: buildNioAffiliation({
+        nioReference: nioUrn,
+        coverageReference: coverageUrn,
+        category: coverage.category,
+      }),
+    });
+  }
+
+  const tx = await oystehr.fhir.transaction<FhirResource>({ requests });
+  const created = (tx.entry ?? [])
+    .map((entry) => entry.resource)
+    .find((resource): resource is Organization => {
+      return resource?.resourceType === 'Organization' && isNonInsuranceOrganization(resource);
+    });
+  if (!created?.id) throw InternalError;
+  return { id: created.id };
+}

--- a/packages/zambdas/src/billing/create-billing-non-insurance-org/validateRequestParameters.ts
+++ b/packages/zambdas/src/billing/create-billing-non-insurance-org/validateRequestParameters.ts
@@ -1,0 +1,23 @@
+import {
+  CreateNonInsuranceOrgInput,
+  CreateNonInsuranceOrgInputSchema,
+} from 'utils/lib/types/data/billing/non-insurance-org.schemas';
+import { MISSING_REQUEST_BODY, MISSING_REQUEST_SECRETS } from 'utils/lib/types/errors';
+import { validateJsonBody } from '../../shared/helpers';
+import { ZambdaInput } from '../../shared/types/common';
+import { safeValidate } from '../../shared/validation';
+
+export interface CreateNonInsuranceOrgParams extends CreateNonInsuranceOrgInput {
+  secrets: ZambdaInput['secrets'];
+}
+
+export function validateRequestParameters(input: ZambdaInput): CreateNonInsuranceOrgParams {
+  if (!input.body) throw MISSING_REQUEST_BODY;
+  if (!input.secrets) throw MISSING_REQUEST_SECRETS;
+
+  const data = safeValidate(CreateNonInsuranceOrgInputSchema, validateJsonBody(input));
+  return {
+    ...data,
+    secrets: input.secrets,
+  };
+}

--- a/packages/zambdas/src/billing/delete-billing-non-insurance-org/index.ts
+++ b/packages/zambdas/src/billing/delete-billing-non-insurance-org/index.ts
@@ -1,0 +1,91 @@
+import Oystehr, { BatchInputRequest } from '@oystehr/sdk';
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { FhirResource, Organization } from 'fhir/r4b';
+import { makeOptimisticLockIfMatchHeader } from 'utils/lib/fhir/helpers';
+import { DeletedResponse } from 'utils/lib/types/data/billing/billing.types';
+import { INVALID_INPUT_ERROR } from 'utils/lib/types/errors';
+import { checkOrCreateM2MClientToken } from '../../shared/auth';
+import { wrapHandler } from '../../shared/sentry';
+import { ZambdaInput } from '../../shared/types/common';
+import { fetchNioCoveragePairs, isNonInsuranceOrganization, NioCoveragePair } from '../non-insurance-org.helpers';
+import { createBillingClient, fetchById } from '../shared';
+import { DeleteNonInsuranceOrgParams, validateRequestParameters } from './validateRequestParameters';
+
+let m2mToken: string;
+const ZAMBDA_NAME = 'delete-billing-non-insurance-org';
+
+export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
+  console.group('validateRequestParameters');
+  const params = validateRequestParameters(input);
+  const { secrets, ...restOfParams } = params;
+  console.groupEnd();
+  console.debug('validateRequestParameters success', restOfParams);
+
+  m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
+  const oystehr = createBillingClient(m2mToken, secrets);
+
+  console.group('complexValidation');
+  const { existing, pairs } = await complexValidation(oystehr, params);
+  console.groupEnd();
+  console.debug('complexValidation success');
+
+  console.group('performEffect');
+  const response = await performEffect(oystehr, existing, pairs);
+  console.groupEnd();
+  console.debug('performEffect success', response);
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(response),
+  };
+});
+
+async function complexValidation(
+  oystehr: Oystehr,
+  params: DeleteNonInsuranceOrgParams
+): Promise<{ existing: Organization; pairs: NioCoveragePair[] }> {
+  const existing = await fetchById<Organization>(oystehr, 'Organization', params.nioId);
+  if (!isNonInsuranceOrganization(existing)) {
+    throw INVALID_INPUT_ERROR(`Organization ${params.nioId} is not a non-insurance organization`);
+  }
+  const pairs = await fetchNioCoveragePairs(oystehr, params.nioId);
+  return { existing, pairs };
+}
+
+// Soft delete: active=false on the NIO org and every still-active affiliation + coverage org, in
+// one transaction. Stored references to the NIO stay resolvable.
+export async function performEffect(
+  oystehr: Oystehr,
+  existing: Organization,
+  pairs: NioCoveragePair[]
+): Promise<DeletedResponse> {
+  const requests: BatchInputRequest<FhirResource>[] = [
+    {
+      method: 'PUT',
+      url: `Organization/${existing.id}`,
+      resource: { ...existing, active: false },
+      ifMatch: makeOptimisticLockIfMatchHeader(existing),
+    },
+  ];
+  for (const pair of pairs) {
+    if (pair.affiliation.active !== false) {
+      requests.push({
+        method: 'PUT',
+        url: `OrganizationAffiliation/${pair.affiliation.id}`,
+        resource: { ...pair.affiliation, active: false },
+        ifMatch: makeOptimisticLockIfMatchHeader(pair.affiliation),
+      });
+    }
+    if (pair.coverageOrg && pair.coverageOrg.active !== false) {
+      requests.push({
+        method: 'PUT',
+        url: `Organization/${pair.coverageOrg.id}`,
+        resource: { ...pair.coverageOrg, active: false },
+        ifMatch: makeOptimisticLockIfMatchHeader(pair.coverageOrg),
+      });
+    }
+  }
+
+  await oystehr.fhir.transaction<FhirResource>({ requests });
+  return { deleted: true };
+}

--- a/packages/zambdas/src/billing/delete-billing-non-insurance-org/validateRequestParameters.ts
+++ b/packages/zambdas/src/billing/delete-billing-non-insurance-org/validateRequestParameters.ts
@@ -1,0 +1,23 @@
+import {
+  DeleteNonInsuranceOrgInput,
+  DeleteNonInsuranceOrgInputSchema,
+} from 'utils/lib/types/data/billing/non-insurance-org.schemas';
+import { MISSING_REQUEST_BODY, MISSING_REQUEST_SECRETS } from 'utils/lib/types/errors';
+import { validateJsonBody } from '../../shared/helpers';
+import { ZambdaInput } from '../../shared/types/common';
+import { safeValidate } from '../../shared/validation';
+
+export interface DeleteNonInsuranceOrgParams extends DeleteNonInsuranceOrgInput {
+  secrets: ZambdaInput['secrets'];
+}
+
+export function validateRequestParameters(input: ZambdaInput): DeleteNonInsuranceOrgParams {
+  if (!input.body) throw MISSING_REQUEST_BODY;
+  if (!input.secrets) throw MISSING_REQUEST_SECRETS;
+
+  const data = safeValidate(DeleteNonInsuranceOrgInputSchema, validateJsonBody(input));
+  return {
+    ...data,
+    secrets: input.secrets,
+  };
+}

--- a/packages/zambdas/src/billing/list-non-insurance-organizations/index.ts
+++ b/packages/zambdas/src/billing/list-non-insurance-organizations/index.ts
@@ -77,7 +77,7 @@ export async function performEffect(
       await oystehr.fhir.search<OrganizationAffiliation>({
         resourceType: 'OrganizationAffiliation',
         params: [
-          { name: 'organization', value: orgs.map((org) => `Organization/${org.id}`).join(',') },
+          { name: 'primary-organization', value: orgs.map((org) => `Organization/${org.id}`).join(',') },
           { name: 'active', value: 'true' },
           { name: '_count', value: '1000' },
         ],

--- a/packages/zambdas/src/billing/list-non-insurance-organizations/index.ts
+++ b/packages/zambdas/src/billing/list-non-insurance-organizations/index.ts
@@ -20,8 +20,6 @@ let m2mToken: string;
 const ZAMBDA_NAME = 'list-non-insurance-organizations';
 
 const PAGE_SIZE = 1000;
-// primary-organization takes a comma-joined id list; chunking keeps the query string bounded.
-const AFFILIATION_ORG_CHUNK = 100;
 
 // The clinical app's one door to billing-owned NIO data. Clinical code never reads billing FHIR:
 // EHR frontends execute this zambda with user tokens, and clinical zambdas invoke it over the
@@ -69,43 +67,33 @@ export async function performEffect(
     searchParams.push({ name: 'name', value: params.search });
   }
 
+  // One round trip per page: affiliations ride along via _revinclude (their coverage orgs are
+  // never needed here — categories live on affiliation.code). _revinclude can't filter, so
+  // inactive pairs are dropped in code below.
+  searchParams.push({ name: '_revinclude', value: 'OrganizationAffiliation:primary-organization' });
+
   const orgs: Organization[] = [];
+  const categoriesByNioId = new Map<string, Set<NioCoverageCategory>>();
   await fetchAllPages(async (offset, count) => {
-    const bundle = await oystehr.fhir.search<Organization>({
+    const bundle = await oystehr.fhir.search<Organization | OrganizationAffiliation>({
       resourceType: 'Organization',
       params: [...searchParams, { name: '_offset', value: String(offset) }, { name: '_count', value: String(count) }],
     });
-    orgs.push(...bundle.unbundle());
+    for (const resource of bundle.unbundle()) {
+      if (resource.resourceType === 'Organization') {
+        orgs.push(resource);
+        continue;
+      }
+      if (resource.active === false) continue;
+      const nioId = referencedId(resource.organization);
+      const category = getNioCoverageCategory(resource.code);
+      if (!nioId || !category) continue;
+      const set = categoriesByNioId.get(nioId) ?? new Set<NioCoverageCategory>();
+      set.add(category);
+      categoriesByNioId.set(nioId, set);
+    }
     return bundle;
   }, PAGE_SIZE);
-
-  // Coverage categories live on OrganizationAffiliation.code, so this never touches coverage orgs.
-  const categoriesByNioId = new Map<string, Set<NioCoverageCategory>>();
-  const affiliations: OrganizationAffiliation[] = [];
-  for (let i = 0; i < orgs.length; i += AFFILIATION_ORG_CHUNK) {
-    const chunk = orgs.slice(i, i + AFFILIATION_ORG_CHUNK);
-    await fetchAllPages(async (offset, count) => {
-      const bundle = await oystehr.fhir.search<OrganizationAffiliation>({
-        resourceType: 'OrganizationAffiliation',
-        params: [
-          { name: 'primary-organization', value: chunk.map((org) => `Organization/${org.id}`).join(',') },
-          { name: 'active', value: 'true' },
-          { name: '_offset', value: String(offset) },
-          { name: '_count', value: String(count) },
-        ],
-      });
-      affiliations.push(...bundle.unbundle());
-      return bundle;
-    }, PAGE_SIZE);
-  }
-  for (const affiliation of affiliations) {
-    const nioId = referencedId(affiliation.organization);
-    const category = getNioCoverageCategory(affiliation.code);
-    if (!nioId || !category) continue;
-    const set = categoriesByNioId.get(nioId) ?? new Set<NioCoverageCategory>();
-    set.add(category);
-    categoriesByNioId.set(nioId, set);
-  }
 
   const organizations = orgs.map((org) => {
     const categories = [...(categoriesByNioId.get(org.id ?? '') ?? [])].sort(

--- a/packages/zambdas/src/billing/list-non-insurance-organizations/index.ts
+++ b/packages/zambdas/src/billing/list-non-insurance-organizations/index.ts
@@ -20,8 +20,7 @@ const ZAMBDA_NAME = 'list-non-insurance-organizations';
 
 // The clinical app's one door to billing-owned NIO data. Clinical code never reads billing FHIR:
 // EHR frontends execute this zambda with user tokens, and clinical zambdas invoke it over the
-// wire. The response is the deliberately minimal ClinicalNioOption — no payer refs, no submission
-// details, no contacts — whose `reference` field is the NIO token clinical code stores verbatim.
+// wire.
 export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
   console.group('validateRequestParameters');
   const params = validateRequestParameters(input);

--- a/packages/zambdas/src/billing/list-non-insurance-organizations/index.ts
+++ b/packages/zambdas/src/billing/list-non-insurance-organizations/index.ts
@@ -9,6 +9,7 @@ import {
   NIO_ORGANIZATION_KIND_SYSTEM,
 } from 'utils/lib/types/data/billing/non-insurance-org.types';
 import { checkOrCreateM2MClientToken } from '../../shared/auth';
+import { fetchAllPages } from '../../shared/fhir';
 import { wrapHandler } from '../../shared/sentry';
 import { ZambdaInput } from '../../shared/types/common';
 import { getNioCoverageCategory, mapClinicalNioOption, referencedId } from '../non-insurance-org.helpers';
@@ -17,6 +18,10 @@ import { ListNonInsuranceOrganizationsParams, validateRequestParameters } from '
 
 let m2mToken: string;
 const ZAMBDA_NAME = 'list-non-insurance-organizations';
+
+const PAGE_SIZE = 1000;
+// primary-organization takes a comma-joined id list; chunking keeps the query string bounded.
+const AFFILIATION_ORG_CHUNK = 100;
 
 // The clinical app's one door to billing-owned NIO data. Clinical code never reads billing FHIR:
 // EHR frontends execute this zambda with user tokens, and clinical zambdas invoke it over the
@@ -49,7 +54,6 @@ export async function performEffect(
   const searchParams: { name: string; value: string }[] = [
     { name: 'type', value: `${NIO_ORGANIZATION_KIND_SYSTEM}|${NIO_KIND_CODE}` },
     { name: '_sort', value: 'name' },
-    { name: '_count', value: '1000' },
   ];
   if (params.nioId) {
     // Lookups by id resolve deleted NIOs too (active=false in the response), so stored references
@@ -65,31 +69,42 @@ export async function performEffect(
     searchParams.push({ name: 'name', value: params.search });
   }
 
-  const orgs = (
-    await oystehr.fhir.search<Organization>({ resourceType: 'Organization', params: searchParams })
-  ).unbundle();
+  const orgs: Organization[] = [];
+  await fetchAllPages(async (offset, count) => {
+    const bundle = await oystehr.fhir.search<Organization>({
+      resourceType: 'Organization',
+      params: [...searchParams, { name: '_offset', value: String(offset) }, { name: '_count', value: String(count) }],
+    });
+    orgs.push(...bundle.unbundle());
+    return bundle;
+  }, PAGE_SIZE);
 
   // Coverage categories live on OrganizationAffiliation.code, so this never touches coverage orgs.
   const categoriesByNioId = new Map<string, Set<NioCoverageCategory>>();
-  if (orgs.length > 0) {
-    const affiliations = (
-      await oystehr.fhir.search<OrganizationAffiliation>({
+  const affiliations: OrganizationAffiliation[] = [];
+  for (let i = 0; i < orgs.length; i += AFFILIATION_ORG_CHUNK) {
+    const chunk = orgs.slice(i, i + AFFILIATION_ORG_CHUNK);
+    await fetchAllPages(async (offset, count) => {
+      const bundle = await oystehr.fhir.search<OrganizationAffiliation>({
         resourceType: 'OrganizationAffiliation',
         params: [
-          { name: 'primary-organization', value: orgs.map((org) => `Organization/${org.id}`).join(',') },
+          { name: 'primary-organization', value: chunk.map((org) => `Organization/${org.id}`).join(',') },
           { name: 'active', value: 'true' },
-          { name: '_count', value: '1000' },
+          { name: '_offset', value: String(offset) },
+          { name: '_count', value: String(count) },
         ],
-      })
-    ).unbundle();
-    for (const affiliation of affiliations) {
-      const nioId = referencedId(affiliation.organization);
-      const category = getNioCoverageCategory(affiliation.code);
-      if (!nioId || !category) continue;
-      const set = categoriesByNioId.get(nioId) ?? new Set<NioCoverageCategory>();
-      set.add(category);
-      categoriesByNioId.set(nioId, set);
-    }
+      });
+      affiliations.push(...bundle.unbundle());
+      return bundle;
+    }, PAGE_SIZE);
+  }
+  for (const affiliation of affiliations) {
+    const nioId = referencedId(affiliation.organization);
+    const category = getNioCoverageCategory(affiliation.code);
+    if (!nioId || !category) continue;
+    const set = categoriesByNioId.get(nioId) ?? new Set<NioCoverageCategory>();
+    set.add(category);
+    categoriesByNioId.set(nioId, set);
   }
 
   const organizations = orgs.map((org) => {

--- a/packages/zambdas/src/billing/list-non-insurance-organizations/index.ts
+++ b/packages/zambdas/src/billing/list-non-insurance-organizations/index.ts
@@ -1,0 +1,104 @@
+import Oystehr from '@oystehr/sdk';
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { Organization, OrganizationAffiliation } from 'fhir/r4b';
+import { NIO_COVERAGE_CATEGORIES, NioCoverageCategory } from 'utils/lib/types/data/billing/non-insurance-org.schemas';
+import {
+  ListNonInsuranceOrganizationsResponse,
+  NIO_EMPLOYER_KIND_CODE,
+  NIO_KIND_CODE,
+  NIO_ORGANIZATION_KIND_SYSTEM,
+} from 'utils/lib/types/data/billing/non-insurance-org.types';
+import { checkOrCreateM2MClientToken } from '../../shared/auth';
+import { wrapHandler } from '../../shared/sentry';
+import { ZambdaInput } from '../../shared/types/common';
+import { getNioCoverageCategory, mapClinicalNioOption, referencedId } from '../non-insurance-org.helpers';
+import { createBillingClient } from '../shared';
+import { ListNonInsuranceOrganizationsParams, validateRequestParameters } from './validateRequestParameters';
+
+let m2mToken: string;
+const ZAMBDA_NAME = 'list-non-insurance-organizations';
+
+// The clinical app's one door to billing-owned NIO data. Clinical code never reads billing FHIR:
+// EHR frontends execute this zambda with user tokens, and clinical zambdas invoke it over the
+// wire. The response is the deliberately minimal ClinicalNioOption — no payer refs, no submission
+// details, no contacts — whose `reference` field is the NIO token clinical code stores verbatim.
+export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
+  console.group('validateRequestParameters');
+  const params = validateRequestParameters(input);
+  const { secrets, ...restOfParams } = params;
+  console.groupEnd();
+  console.debug('validateRequestParameters success', restOfParams);
+
+  m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
+  const oystehr = createBillingClient(m2mToken, secrets);
+
+  console.group('performEffect');
+  const response = await performEffect(oystehr, params);
+  console.groupEnd();
+  console.debug('performEffect success', response);
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(response),
+  };
+});
+
+export async function performEffect(
+  oystehr: Oystehr,
+  params: ListNonInsuranceOrganizationsParams
+): Promise<ListNonInsuranceOrganizationsResponse> {
+  const searchParams: { name: string; value: string }[] = [
+    { name: 'type', value: `${NIO_ORGANIZATION_KIND_SYSTEM}|${NIO_KIND_CODE}` },
+    { name: '_sort', value: 'name' },
+    { name: '_count', value: '1000' },
+  ];
+  if (params.nioId) {
+    // Lookups by id resolve deleted NIOs too (active=false in the response), so stored references
+    // stay displayable and clinical validation can tell active from retired.
+    searchParams.push({ name: '_id', value: params.nioId });
+  } else {
+    searchParams.push({ name: 'active', value: 'true' });
+  }
+  if (params.employerOnly) {
+    searchParams.push({ name: 'type', value: `${NIO_ORGANIZATION_KIND_SYSTEM}|${NIO_EMPLOYER_KIND_CODE}` });
+  }
+  if (params.search) {
+    searchParams.push({ name: 'name', value: params.search });
+  }
+
+  const orgs = (
+    await oystehr.fhir.search<Organization>({ resourceType: 'Organization', params: searchParams })
+  ).unbundle();
+
+  // Coverage categories live on OrganizationAffiliation.code, so this never touches coverage orgs.
+  const categoriesByNioId = new Map<string, Set<NioCoverageCategory>>();
+  if (orgs.length > 0) {
+    const affiliations = (
+      await oystehr.fhir.search<OrganizationAffiliation>({
+        resourceType: 'OrganizationAffiliation',
+        params: [
+          { name: 'organization', value: orgs.map((org) => `Organization/${org.id}`).join(',') },
+          { name: 'active', value: 'true' },
+          { name: '_count', value: '1000' },
+        ],
+      })
+    ).unbundle();
+    for (const affiliation of affiliations) {
+      const nioId = referencedId(affiliation.organization);
+      const category = getNioCoverageCategory(affiliation.code);
+      if (!nioId || !category) continue;
+      const set = categoriesByNioId.get(nioId) ?? new Set<NioCoverageCategory>();
+      set.add(category);
+      categoriesByNioId.set(nioId, set);
+    }
+  }
+
+  const organizations = orgs.map((org) => {
+    const categories = [...(categoriesByNioId.get(org.id ?? '') ?? [])].sort(
+      (a, b) => NIO_COVERAGE_CATEGORIES.indexOf(a) - NIO_COVERAGE_CATEGORIES.indexOf(b)
+    );
+    return mapClinicalNioOption(org, categories);
+  });
+
+  return { organizations };
+}

--- a/packages/zambdas/src/billing/list-non-insurance-organizations/validateRequestParameters.ts
+++ b/packages/zambdas/src/billing/list-non-insurance-organizations/validateRequestParameters.ts
@@ -1,0 +1,23 @@
+import {
+  ListNonInsuranceOrganizationsInput,
+  ListNonInsuranceOrganizationsInputSchema,
+} from 'utils/lib/types/data/billing/non-insurance-org.schemas';
+import { MISSING_REQUEST_BODY, MISSING_REQUEST_SECRETS } from 'utils/lib/types/errors';
+import { validateJsonBody } from '../../shared/helpers';
+import { ZambdaInput } from '../../shared/types/common';
+import { safeValidate } from '../../shared/validation';
+
+export interface ListNonInsuranceOrganizationsParams extends ListNonInsuranceOrganizationsInput {
+  secrets: ZambdaInput['secrets'];
+}
+
+export function validateRequestParameters(input: ZambdaInput): ListNonInsuranceOrganizationsParams {
+  if (!input.body) throw MISSING_REQUEST_BODY;
+  if (!input.secrets) throw MISSING_REQUEST_SECRETS;
+
+  const data = safeValidate(ListNonInsuranceOrganizationsInputSchema, validateJsonBody(input));
+  return {
+    ...data,
+    secrets: input.secrets,
+  };
+}

--- a/packages/zambdas/src/billing/non-insurance-org.helpers.ts
+++ b/packages/zambdas/src/billing/non-insurance-org.helpers.ts
@@ -205,6 +205,10 @@ export function buildCoverageOrganization(params: {
     ...(existing?.id ? { id: existing.id } : {}),
     active: true,
     ...(name ? { name } : {}),
+    // FHIR org-1 requires a name or an identifier on every Organization, and an unnamed 'other'
+    // coverage has no name — carry a constant kind identifier so the invariant always holds
+    // (the same trick the WC-employer harvest uses for nameless employer orgs).
+    identifier: [{ system: NIO_ORGANIZATION_KIND_SYSTEM, value: NIO_COVERAGE_KIND_CODE }],
     type: [
       { coding: [{ system: NIO_ORGANIZATION_KIND_SYSTEM, code: NIO_COVERAGE_KIND_CODE }] },
       { coding: [{ system: NIO_COVERAGE_CATEGORY_SYSTEM, code: coverage.category }] },

--- a/packages/zambdas/src/billing/non-insurance-org.helpers.ts
+++ b/packages/zambdas/src/billing/non-insurance-org.helpers.ts
@@ -1,0 +1,439 @@
+import Oystehr from '@oystehr/sdk';
+import { Address, ContactPoint, Extension, Organization, OrganizationAffiliation, Reference } from 'fhir/r4b';
+import { extractPayerIdFromUrl, getNioReferenceUrl, getPayerId, isPayerUrl } from 'utils/lib/helpers/helpers';
+import { BillingPayerOption } from 'utils/lib/types/data/billing/billing.types';
+import {
+  CreateNonInsuranceOrgInput,
+  NIO_COVERAGE_CATEGORIES,
+  NIO_SUBMISSION_MECHANISMS,
+  NIO_WC_BILLING_MODES,
+  NioAddress,
+  NioContact,
+  NioCoverageCategory,
+  NioCoverageInput,
+  NioSubmission,
+} from 'utils/lib/types/data/billing/non-insurance-org.schemas';
+import {
+  ClinicalNioOption,
+  NIO_COVERAGE_CATEGORY_LABELS,
+  NIO_COVERAGE_CATEGORY_SYSTEM,
+  NIO_COVERAGE_KIND_CODE,
+  NIO_EMPLOYER_KIND_CODE,
+  NIO_KIND_CODE,
+  NIO_ORGANIZATION_KIND_SYSTEM,
+  NIO_PORTAL_NOTES_EXTENSION_URL,
+  NIO_PREFERRED_SUBMISSION_EXTENSION_URL,
+  NIO_WC_BILLING_MODE_EXTENSION_URL,
+  NIO_WC_PAYER_EXTENSION_URL,
+  NioCoverageDetail,
+  NonInsuranceOrganizationItem,
+} from 'utils/lib/types/data/billing/non-insurance-org.types';
+import { INVALID_INPUT_ERROR } from 'utils/lib/types/errors';
+import { buildPayorReference, payerDisplay } from './shared';
+
+type OrganizationContact = NonNullable<Organization['contact']>[number];
+
+// --- Type guards & readers ---
+
+function hasKindCoding(org: Organization, code: string): boolean {
+  return !!org.type?.some(
+    (concept) =>
+      concept.coding?.some((coding) => coding.system === NIO_ORGANIZATION_KIND_SYSTEM && coding.code === code)
+  );
+}
+
+export function isNonInsuranceOrganization(org: Organization): boolean {
+  return hasKindCoding(org, NIO_KIND_CODE);
+}
+
+export function isNioEmployer(org: Organization): boolean {
+  return hasKindCoding(org, NIO_EMPLOYER_KIND_CODE);
+}
+
+export function getNioCoverageCategory(
+  concepts: OrganizationAffiliation['code'] | Organization['type']
+): NioCoverageCategory | undefined {
+  for (const concept of concepts ?? []) {
+    for (const coding of concept.coding ?? []) {
+      if (
+        coding.system === NIO_COVERAGE_CATEGORY_SYSTEM &&
+        (NIO_COVERAGE_CATEGORIES as readonly string[]).includes(coding.code ?? '')
+      ) {
+        return coding.code as NioCoverageCategory;
+      }
+    }
+  }
+  return undefined;
+}
+
+function getExtension(org: Organization, url: string): Extension | undefined {
+  return org.extension?.find((ext) => ext.url === url);
+}
+
+// --- Input ⇄ FHIR field conversions ---
+
+function toFhirAddress(address: NioAddress | undefined): Address | undefined {
+  if (!address) return undefined;
+  const line = [address.line1, address.line2].filter((part): part is string => !!part);
+  const result: Address = {
+    ...(line.length ? { line } : {}),
+    ...(address.city ? { city: address.city } : {}),
+    ...(address.state ? { state: address.state } : {}),
+    ...(address.zip ? { postalCode: address.zip } : {}),
+  };
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function toNioAddress(address: Address | undefined): NioAddress | undefined {
+  if (!address) return undefined;
+  const result: NioAddress = {
+    ...(address.line?.[0] ? { line1: address.line[0] } : {}),
+    ...(address.line?.[1] ? { line2: address.line[1] } : {}),
+    ...(address.city ? { city: address.city } : {}),
+    ...(address.state ? { state: address.state } : {}),
+    ...(address.postalCode ? { zip: address.postalCode } : {}),
+  };
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+// Contact title lives in purpose.text — the same mapping the WC-employer paperwork harvest writes.
+function toFhirContact(contact: NioContact): OrganizationContact {
+  const telecom: ContactPoint[] = [];
+  if (contact.phone) telecom.push({ system: 'phone', value: contact.phone });
+  if (contact.email) telecom.push({ system: 'email', value: contact.email });
+  return {
+    name: { text: contact.name },
+    ...(contact.title ? { purpose: { text: contact.title } } : {}),
+    ...(telecom.length ? { telecom } : {}),
+  };
+}
+
+function toNioContact(contact: OrganizationContact): NioContact | undefined {
+  const name = contact.name?.text;
+  if (!name) return undefined;
+  const phone = contact.telecom?.find((point) => point.system === 'phone')?.value;
+  const email = contact.telecom?.find((point) => point.system === 'email')?.value;
+  return {
+    name,
+    ...(contact.purpose?.text ? { title: contact.purpose.text } : {}),
+    ...(phone ? { phone } : {}),
+    ...(email ? { email } : {}),
+  };
+}
+
+function mapSubmission(org: Organization): NioSubmission | undefined {
+  const preferredCode = getExtension(org, NIO_PREFERRED_SUBMISSION_EXTENSION_URL)?.valueCode;
+  const preferredMechanism = (NIO_SUBMISSION_MECHANISMS as readonly string[]).includes(preferredCode ?? '')
+    ? (preferredCode as NioSubmission['preferredMechanism'])
+    : undefined;
+  const email = org.telecom?.find((point) => point.system === 'email')?.value;
+  const fax = org.telecom?.find((point) => point.system === 'fax')?.value;
+  const portalNotes = getExtension(org, NIO_PORTAL_NOTES_EXTENSION_URL)?.valueString;
+  const mailAddress = toNioAddress(org.address?.[0]);
+  const submission: NioSubmission = {
+    ...(preferredMechanism ? { preferredMechanism } : {}),
+    ...(email ? { email } : {}),
+    ...(fax ? { fax } : {}),
+    ...(portalNotes ? { portalNotes } : {}),
+    ...(mailAddress ? { mailAddress } : {}),
+  };
+  return Object.keys(submission).length > 0 ? submission : undefined;
+}
+
+// --- Resource builders (full replace: these own every field they write) ---
+
+export function buildNioOrganization(input: CreateNonInsuranceOrgInput, existing?: Organization): Organization {
+  const address = toFhirAddress(input.address);
+  const contacts = (input.contacts ?? []).map(toFhirContact);
+  return {
+    resourceType: 'Organization',
+    ...(existing?.id ? { id: existing.id } : {}),
+    active: true,
+    name: input.name,
+    type: [
+      { coding: [{ system: NIO_ORGANIZATION_KIND_SYSTEM, code: NIO_KIND_CODE }] },
+      ...(input.employer ? [{ coding: [{ system: NIO_ORGANIZATION_KIND_SYSTEM, code: NIO_EMPLOYER_KIND_CODE }] }] : []),
+    ],
+    ...(address ? { address: [address] } : {}),
+    ...(contacts.length ? { contact: contacts } : {}),
+  };
+}
+
+export interface NioPayerReference {
+  reference: string;
+  display?: string;
+}
+
+export function buildCoverageOrganization(params: {
+  nioName: string;
+  coverage: NioCoverageInput;
+  payerRef?: NioPayerReference;
+  existing?: Organization;
+}): Organization {
+  const { nioName, coverage, payerRef, existing } = params;
+
+  const extension: Extension[] = [];
+  if (coverage.category === 'workers-comp') {
+    extension.push({ url: NIO_WC_BILLING_MODE_EXTENSION_URL, valueCode: coverage.billingMode });
+    if (payerRef) {
+      extension.push({
+        url: NIO_WC_PAYER_EXTENSION_URL,
+        valueReference: { reference: payerRef.reference, ...(payerRef.display ? { display: payerRef.display } : {}) },
+      });
+    }
+  }
+  const submission = coverage.submission;
+  if (submission?.preferredMechanism) {
+    extension.push({ url: NIO_PREFERRED_SUBMISSION_EXTENSION_URL, valueCode: submission.preferredMechanism });
+  }
+  if (submission?.portalNotes) {
+    extension.push({ url: NIO_PORTAL_NOTES_EXTENSION_URL, valueString: submission.portalNotes });
+  }
+
+  const telecom: ContactPoint[] = [];
+  if (submission?.email) telecom.push({ system: 'email', value: submission.email });
+  if (submission?.fax) telecom.push({ system: 'fax', value: submission.fax });
+  const mailAddress = toFhirAddress(submission?.mailAddress);
+
+  // 'other' keeps exactly the user-entered name (possibly none) so it round-trips into the edit
+  // form; the coded categories get a derived name for admin/debugging legibility.
+  const name =
+    coverage.category === 'other' ? coverage.name : `${nioName} — ${NIO_COVERAGE_CATEGORY_LABELS[coverage.category]}`;
+
+  return {
+    resourceType: 'Organization',
+    ...(existing?.id ? { id: existing.id } : {}),
+    active: true,
+    ...(name ? { name } : {}),
+    type: [
+      { coding: [{ system: NIO_ORGANIZATION_KIND_SYSTEM, code: NIO_COVERAGE_KIND_CODE }] },
+      { coding: [{ system: NIO_COVERAGE_CATEGORY_SYSTEM, code: coverage.category }] },
+    ],
+    ...(extension.length ? { extension } : {}),
+    ...(telecom.length ? { telecom } : {}),
+    ...(mailAddress ? { address: [mailAddress] } : {}),
+  };
+}
+
+export function buildNioAffiliation(params: {
+  nioReference: string;
+  coverageReference: string;
+  category: NioCoverageCategory;
+  existing?: OrganizationAffiliation;
+}): OrganizationAffiliation {
+  return {
+    resourceType: 'OrganizationAffiliation',
+    ...(params.existing?.id ? { id: params.existing.id } : {}),
+    active: true,
+    organization: { reference: params.nioReference },
+    participatingOrganization: { reference: params.coverageReference },
+    code: [{ coding: [{ system: NIO_COVERAGE_CATEGORY_SYSTEM, code: params.category }] }],
+  };
+}
+
+// --- FHIR → DTO mapping ---
+
+function fallbackPayerOption(ref: Reference): BillingPayerOption {
+  const reference = ref.reference ?? '';
+  return {
+    id: reference.startsWith('Organization/') ? reference.slice('Organization/'.length) : '',
+    name: ref.display ?? '',
+    payerId: extractPayerIdFromUrl(reference) ?? '',
+  };
+}
+
+function mapCoverageDetail(
+  category: NioCoverageCategory,
+  coverageOrg: Organization | undefined,
+  payerOptionsByRef: Map<string, BillingPayerOption> | undefined
+): NioCoverageDetail {
+  const submission = coverageOrg ? mapSubmission(coverageOrg) : undefined;
+  if (category === 'workers-comp') {
+    const modeCode = coverageOrg ? getExtension(coverageOrg, NIO_WC_BILLING_MODE_EXTENSION_URL)?.valueCode : undefined;
+    const billingMode = (NIO_WC_BILLING_MODES as readonly string[]).includes(modeCode ?? '')
+      ? (modeCode as (typeof NIO_WC_BILLING_MODES)[number])
+      : 'direct';
+    const payerRef = coverageOrg ? getExtension(coverageOrg, NIO_WC_PAYER_EXTENSION_URL)?.valueReference : undefined;
+    const payer = payerRef?.reference
+      ? payerOptionsByRef?.get(payerRef.reference) ?? fallbackPayerOption(payerRef)
+      : undefined;
+    return { category, billingMode, ...(payer ? { payer } : {}), ...(submission ? { submission } : {}) };
+  }
+  if (category === 'other') {
+    return {
+      category,
+      ...(coverageOrg?.name ? { name: coverageOrg.name } : {}),
+      ...(submission ? { submission } : {}),
+    };
+  }
+  return { category, ...(submission ? { submission } : {}) };
+}
+
+export function mapNonInsuranceOrganization(params: {
+  org: Organization;
+  affiliations: OrganizationAffiliation[];
+  coverageOrgsById: Map<string, Organization>;
+  payerOptionsByRef?: Map<string, BillingPayerOption>;
+}): NonInsuranceOrganizationItem {
+  const { org, affiliations, coverageOrgsById, payerOptionsByRef } = params;
+
+  const covers: NioCoverageDetail[] = [];
+  for (const affiliation of affiliations) {
+    if (affiliation.active === false) continue;
+    const category = getNioCoverageCategory(affiliation.code);
+    if (!category || covers.some((detail) => detail.category === category)) continue;
+    const coverageOrgId = referencedId(affiliation.participatingOrganization);
+    const coverageOrg = coverageOrgId ? coverageOrgsById.get(coverageOrgId) : undefined;
+    covers.push(mapCoverageDetail(category, coverageOrg, payerOptionsByRef));
+  }
+  covers.sort((a, b) => NIO_COVERAGE_CATEGORIES.indexOf(a.category) - NIO_COVERAGE_CATEGORIES.indexOf(b.category));
+
+  const contacts = (org.contact ?? [])
+    .map(toNioContact)
+    .filter((contact): contact is NioContact => contact !== undefined);
+  const address = toNioAddress(org.address?.[0]);
+
+  return {
+    id: org.id ?? '',
+    name: org.name ?? '',
+    employer: isNioEmployer(org),
+    active: org.active !== false,
+    ...(address ? { address } : {}),
+    contacts,
+    covers,
+  };
+}
+
+export function referencedId(reference: Reference | undefined): string | undefined {
+  return reference?.reference?.split('/')[1];
+}
+
+// The minimal clinical-facing shape; `reference` is the NIO token clinical code stores verbatim.
+export function mapClinicalNioOption(org: Organization, coversCategories: NioCoverageCategory[]): ClinicalNioOption {
+  const address = toNioAddress(org.address?.[0]);
+  return {
+    id: org.id ?? '',
+    reference: getNioReferenceUrl(org.id ?? ''),
+    name: org.name ?? '',
+    employer: isNioEmployer(org),
+    active: org.active !== false,
+    ...(address ? { address } : {}),
+    coversCategories,
+  };
+}
+
+// --- Coverage pair fetching & reconciliation ---
+
+export interface NioCoveragePair {
+  affiliation: OrganizationAffiliation;
+  coverageOrg?: Organization;
+}
+
+// All affiliation/coverage-org pairs for one NIO, inactive included (an unchecked category's pair
+// is kept around inactive so re-checking it later reactivates instead of duplicating).
+export async function fetchNioCoveragePairs(oystehr: Oystehr, nioId: string): Promise<NioCoveragePair[]> {
+  const bundle = await oystehr.fhir.search<Organization | OrganizationAffiliation>({
+    resourceType: 'OrganizationAffiliation',
+    params: [
+      { name: 'organization', value: `Organization/${nioId}` },
+      { name: '_include', value: 'OrganizationAffiliation:participating-organization' },
+      { name: '_count', value: '1000' },
+    ],
+  });
+  const resources = bundle.unbundle();
+  const orgsById = new Map<string, Organization>();
+  resources.forEach((resource) => {
+    if (resource.resourceType === 'Organization' && resource.id) orgsById.set(resource.id, resource);
+  });
+  return resources
+    .filter((resource): resource is OrganizationAffiliation => resource.resourceType === 'OrganizationAffiliation')
+    .map((affiliation) => {
+      const coverageOrgId = referencedId(affiliation.participatingOrganization);
+      return { affiliation, coverageOrg: coverageOrgId ? orgsById.get(coverageOrgId) : undefined };
+    });
+}
+
+export interface CoverageChanges {
+  creates: NioCoverageInput[];
+  // Category present in the input and already paired: rebuild the coverage org; reactivate the
+  // affiliation when it was inactive.
+  updates: { coverage: NioCoverageInput; pair: NioCoveragePair }[];
+  deactivates: NioCoveragePair[];
+}
+
+export function computeCoverageChanges(covers: NioCoverageInput[], pairs: NioCoveragePair[]): CoverageChanges {
+  const chosen = new Set<NioCoveragePair>();
+  const creates: NioCoverageInput[] = [];
+  const updates: CoverageChanges['updates'] = [];
+
+  for (const coverage of covers) {
+    // A pair whose coverage org went missing (data drift) is not reusable — it gets deactivated
+    // below and the category recreated fresh.
+    const candidates = pairs.filter(
+      (pair) => pair.coverageOrg && getNioCoverageCategory(pair.affiliation.code) === coverage.category
+    );
+    const pair = candidates.find((candidate) => candidate.affiliation.active !== false) ?? candidates[0];
+    if (pair) {
+      chosen.add(pair);
+      updates.push({ coverage, pair });
+    } else {
+      creates.push(coverage);
+    }
+  }
+
+  const deactivates = pairs.filter((pair) => !chosen.has(pair) && pair.affiliation.active !== false);
+  return { creates, updates, deactivates };
+}
+
+// --- Payer resolution (Oystehr RCM) ---
+
+// The workers-comp payer selection arrives as the RCM payer Organization id (what PayerSelect
+// stores); persist it in the same canonical reference form Coverage.payor uses.
+export async function resolveWcPayerReference(
+  oystehr: Oystehr,
+  covers: NioCoverageInput[] | undefined
+): Promise<NioPayerReference | undefined> {
+  const workersComp = covers?.find((coverage) => coverage.category === 'workers-comp');
+  if (!workersComp || workersComp.category !== 'workers-comp' || !workersComp.payerId) return undefined;
+  let payerOrg: Organization | undefined;
+  try {
+    payerOrg = await oystehr.rcm.getPayer({ id: workersComp.payerId });
+  } catch (error) {
+    console.error(`Failed to look up payer ${workersComp.payerId}:`, error);
+  }
+  if (!payerOrg) throw INVALID_INPUT_ERROR(`Unknown payer id ${workersComp.payerId}`);
+  return { reference: buildPayorReference(payerOrg), display: payerDisplay(payerOrg) };
+}
+
+// Resolve stored WC payer references back to live BillingPayerOptions so the edit form's
+// PayerSelect round-trips; mapCoverageDetail falls back to the stored reference + display for
+// anything that fails to resolve.
+export async function resolvePayerOptionsByRef(
+  oystehr: Oystehr,
+  coverageOrgs: Organization[]
+): Promise<Map<string, BillingPayerOption>> {
+  const refs = new Set<string>();
+  coverageOrgs.forEach((org) => {
+    const reference = getExtension(org, NIO_WC_PAYER_EXTENSION_URL)?.valueReference?.reference;
+    if (reference) refs.add(reference);
+  });
+  const byRef = new Map<string, BillingPayerOption>();
+  await Promise.all(
+    [...refs].map(async (ref) => {
+      try {
+        let payerOrg: Organization | undefined;
+        if (isPayerUrl(ref)) {
+          payerOrg = await oystehr.rcm.getPayerByUrl({ url: ref });
+        } else if (ref.startsWith('Organization/')) {
+          payerOrg = await oystehr.rcm.getPayer({ id: ref.slice('Organization/'.length) });
+        }
+        if (payerOrg) {
+          byRef.set(ref, { id: payerOrg.id ?? '', name: payerOrg.name ?? '', payerId: getPayerId(payerOrg) ?? '' });
+        }
+      } catch (error) {
+        console.error(`Failed to resolve NIO payer ${ref}:`, error);
+      }
+    })
+  );
+  return byRef;
+}

--- a/packages/zambdas/src/billing/non-insurance-org.helpers.ts
+++ b/packages/zambdas/src/billing/non-insurance-org.helpers.ts
@@ -335,7 +335,9 @@ export async function fetchNioCoveragePairs(oystehr: Oystehr, nioId: string): Pr
   const bundle = await oystehr.fhir.search<Organization | OrganizationAffiliation>({
     resourceType: 'OrganizationAffiliation',
     params: [
-      { name: 'organization', value: `Organization/${nioId}` },
+      // The element is OrganizationAffiliation.organization, but its R4 search parameter is
+      // primary-organization (participatingOrganization's is participating-organization).
+      { name: 'primary-organization', value: `Organization/${nioId}` },
       { name: '_include', value: 'OrganizationAffiliation:participating-organization' },
       { name: '_count', value: '1000' },
     ],

--- a/packages/zambdas/src/billing/search-billing-non-insurance-orgs/index.ts
+++ b/packages/zambdas/src/billing/search-billing-non-insurance-orgs/index.ts
@@ -1,0 +1,117 @@
+import Oystehr from '@oystehr/sdk';
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { Organization, OrganizationAffiliation } from 'fhir/r4b';
+import { SearchNonInsuranceOrgsResponse } from 'utils/lib/types/data/billing/non-insurance-org.types';
+import {
+  NIO_EMPLOYER_KIND_CODE,
+  NIO_KIND_CODE,
+  NIO_ORGANIZATION_KIND_SYSTEM,
+} from 'utils/lib/types/data/billing/non-insurance-org.types';
+import { checkOrCreateM2MClientToken } from '../../shared/auth';
+import { wrapHandler } from '../../shared/sentry';
+import { ZambdaInput } from '../../shared/types/common';
+import { mapNonInsuranceOrganization, referencedId, resolvePayerOptionsByRef } from '../non-insurance-org.helpers';
+import { createBillingClient } from '../shared';
+import { SearchNonInsuranceOrgsParams, validateRequestParameters } from './validateRequestParameters';
+
+let m2mToken: string;
+const ZAMBDA_NAME = 'search-billing-non-insurance-orgs';
+
+export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
+  console.group('validateRequestParameters');
+  const params = validateRequestParameters(input);
+  const { secrets, ...restOfParams } = params;
+  console.groupEnd();
+  console.debug('validateRequestParameters success', restOfParams);
+
+  m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
+  const oystehr = createBillingClient(m2mToken, secrets);
+
+  console.group('performEffect');
+  const response = await performEffect(oystehr, params);
+  console.groupEnd();
+  console.debug('performEffect success', response);
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(response),
+  };
+});
+
+// Serves both the list page (paginated) and the detail page (nioId filter); rows come back as
+// full DTOs — contacts and covers included — so both views share one shape.
+export async function performEffect(
+  oystehr: Oystehr,
+  params: SearchNonInsuranceOrgsParams
+): Promise<SearchNonInsuranceOrgsResponse> {
+  const pageSize = params.pageSize ?? 50;
+  const offset = params.offset ?? 0;
+
+  const searchParams: { name: string; value: string }[] = [
+    { name: 'type', value: `${NIO_ORGANIZATION_KIND_SYSTEM}|${NIO_KIND_CODE}` },
+    { name: '_sort', value: 'name' },
+    { name: '_count', value: String(pageSize) },
+    { name: '_offset', value: String(offset) },
+    { name: '_total', value: 'accurate' },
+  ];
+  if (params.nioId) {
+    searchParams.push({ name: '_id', value: params.nioId });
+  } else {
+    searchParams.push({ name: 'active', value: 'true' });
+  }
+  if (params.employer) {
+    searchParams.push({ name: 'type', value: `${NIO_ORGANIZATION_KIND_SYSTEM}|${NIO_EMPLOYER_KIND_CODE}` });
+  }
+  if (params.name) {
+    searchParams.push({ name: 'name', value: params.name });
+  }
+
+  const orgBundle = await oystehr.fhir.search<Organization>({
+    resourceType: 'Organization',
+    params: searchParams,
+  });
+  const orgs = orgBundle.unbundle();
+
+  // One affiliation search covers the whole page; categories live on affiliation.code and the
+  // coverage orgs ride along via _include.
+  const affiliationsByNioId = new Map<string, OrganizationAffiliation[]>();
+  const coverageOrgsById = new Map<string, Organization>();
+  if (orgs.length > 0) {
+    const affiliationBundle = await oystehr.fhir.search<Organization | OrganizationAffiliation>({
+      resourceType: 'OrganizationAffiliation',
+      params: [
+        { name: 'organization', value: orgs.map((org) => `Organization/${org.id}`).join(',') },
+        { name: 'active', value: 'true' },
+        { name: '_include', value: 'OrganizationAffiliation:participating-organization' },
+        { name: '_count', value: '1000' },
+      ],
+    });
+    for (const resource of affiliationBundle.unbundle()) {
+      if (resource.resourceType === 'Organization') {
+        if (resource.id) coverageOrgsById.set(resource.id, resource);
+        continue;
+      }
+      const nioId = referencedId(resource.organization);
+      if (!nioId) continue;
+      affiliationsByNioId.set(nioId, [...(affiliationsByNioId.get(nioId) ?? []), resource]);
+    }
+  }
+
+  const payerOptionsByRef = await resolvePayerOptionsByRef(oystehr, [...coverageOrgsById.values()]);
+
+  const organizations = orgs.map((org) =>
+    mapNonInsuranceOrganization({
+      org,
+      affiliations: affiliationsByNioId.get(org.id ?? '') ?? [],
+      coverageOrgsById,
+      payerOptionsByRef,
+    })
+  );
+
+  return {
+    organizations,
+    total: orgBundle.total ?? 0,
+    offset,
+    pageSize,
+  };
+}

--- a/packages/zambdas/src/billing/search-billing-non-insurance-orgs/index.ts
+++ b/packages/zambdas/src/billing/search-billing-non-insurance-orgs/index.ts
@@ -80,7 +80,7 @@ export async function performEffect(
     const affiliationBundle = await oystehr.fhir.search<Organization | OrganizationAffiliation>({
       resourceType: 'OrganizationAffiliation',
       params: [
-        { name: 'organization', value: orgs.map((org) => `Organization/${org.id}`).join(',') },
+        { name: 'primary-organization', value: orgs.map((org) => `Organization/${org.id}`).join(',') },
         { name: 'active', value: 'true' },
         { name: '_include', value: 'OrganizationAffiliation:participating-organization' },
         { name: '_count', value: '1000' },

--- a/packages/zambdas/src/billing/search-billing-non-insurance-orgs/index.ts
+++ b/packages/zambdas/src/billing/search-billing-non-insurance-orgs/index.ts
@@ -10,7 +10,12 @@ import {
 import { checkOrCreateM2MClientToken } from '../../shared/auth';
 import { wrapHandler } from '../../shared/sentry';
 import { ZambdaInput } from '../../shared/types/common';
-import { mapNonInsuranceOrganization, referencedId, resolvePayerOptionsByRef } from '../non-insurance-org.helpers';
+import {
+  isNonInsuranceOrganization,
+  mapNonInsuranceOrganization,
+  referencedId,
+  resolvePayerOptionsByRef,
+} from '../non-insurance-org.helpers';
 import { createBillingClient } from '../shared';
 import { SearchNonInsuranceOrgsParams, validateRequestParameters } from './validateRequestParameters';
 
@@ -53,6 +58,10 @@ export async function performEffect(
     { name: '_count', value: String(pageSize) },
     { name: '_offset', value: String(offset) },
     { name: '_total', value: 'accurate' },
+    // One round trip: affiliations ride along via _revinclude and their coverage orgs via
+    // _include:iterate. _revinclude can't filter, so inactive pairs are dropped in code below.
+    { name: '_revinclude', value: 'OrganizationAffiliation:primary-organization' },
+    { name: '_include:iterate', value: 'OrganizationAffiliation:participating-organization' },
   ];
   if (params.nioId) {
     searchParams.push({ name: '_id', value: params.nioId });
@@ -66,34 +75,27 @@ export async function performEffect(
     searchParams.push({ name: 'name', value: params.name });
   }
 
-  const orgBundle = await oystehr.fhir.search<Organization>({
+  const orgBundle = await oystehr.fhir.search<Organization | OrganizationAffiliation>({
     resourceType: 'Organization',
     params: searchParams,
   });
-  const orgs = orgBundle.unbundle();
 
-  // One affiliation search covers the whole page; categories live on affiliation.code and the
-  // coverage orgs ride along via _include.
+  const orgs: Organization[] = [];
   const affiliationsByNioId = new Map<string, OrganizationAffiliation[]>();
   const coverageOrgsById = new Map<string, Organization>();
-  if (orgs.length > 0) {
-    const affiliationBundle = await oystehr.fhir.search<Organization | OrganizationAffiliation>({
-      resourceType: 'OrganizationAffiliation',
-      params: [
-        { name: 'primary-organization', value: orgs.map((org) => `Organization/${org.id}`).join(',') },
-        { name: 'active', value: 'true' },
-        { name: '_include', value: 'OrganizationAffiliation:participating-organization' },
-        { name: '_count', value: '1000' },
-      ],
-    });
-    for (const resource of affiliationBundle.unbundle()) {
-      if (resource.resourceType === 'Organization') {
-        if (resource.id) coverageOrgsById.set(resource.id, resource);
-        continue;
-      }
+  for (const resource of orgBundle.unbundle()) {
+    if (resource.resourceType === 'OrganizationAffiliation') {
+      if (resource.active === false) continue;
       const nioId = referencedId(resource.organization);
       if (!nioId) continue;
       affiliationsByNioId.set(nioId, [...(affiliationsByNioId.get(nioId) ?? []), resource]);
+      continue;
+    }
+    // NIO rows and included coverage orgs are both Organizations; the kind coding tells them apart.
+    if (isNonInsuranceOrganization(resource)) {
+      orgs.push(resource);
+    } else if (resource.id) {
+      coverageOrgsById.set(resource.id, resource);
     }
   }
 

--- a/packages/zambdas/src/billing/search-billing-non-insurance-orgs/validateRequestParameters.ts
+++ b/packages/zambdas/src/billing/search-billing-non-insurance-orgs/validateRequestParameters.ts
@@ -1,0 +1,23 @@
+import {
+  SearchNonInsuranceOrgsInput,
+  SearchNonInsuranceOrgsInputSchema,
+} from 'utils/lib/types/data/billing/non-insurance-org.schemas';
+import { MISSING_REQUEST_BODY, MISSING_REQUEST_SECRETS } from 'utils/lib/types/errors';
+import { validateJsonBody } from '../../shared/helpers';
+import { ZambdaInput } from '../../shared/types/common';
+import { safeValidate } from '../../shared/validation';
+
+export interface SearchNonInsuranceOrgsParams extends SearchNonInsuranceOrgsInput {
+  secrets: ZambdaInput['secrets'];
+}
+
+export function validateRequestParameters(input: ZambdaInput): SearchNonInsuranceOrgsParams {
+  if (!input.body) throw MISSING_REQUEST_BODY;
+  if (!input.secrets) throw MISSING_REQUEST_SECRETS;
+
+  const data = safeValidate(SearchNonInsuranceOrgsInputSchema, validateJsonBody(input));
+  return {
+    ...data,
+    secrets: input.secrets,
+  };
+}

--- a/packages/zambdas/src/billing/shared.ts
+++ b/packages/zambdas/src/billing/shared.ts
@@ -1146,7 +1146,7 @@ export function getClaimService(claim: Claim): string | undefined {
 // aligned. The one intentional difference: the subscriber RelatedPerson is persisted standalone here
 // (so it can be searched), whereas harvest contains it on the Coverage.
 
-function buildPayorReference(payerOrg: Organization): string {
+export function buildPayorReference(payerOrg: Organization): string {
   const payerId = getPayerId(payerOrg);
   if (isValidUUID(payerOrg.id ?? '')) return `Organization/${payerOrg.id}`;
   if (!payerId) throw new Error('payerId unexpectedly missing from payer organization');

--- a/packages/zambdas/src/billing/update-billing-non-insurance-org/index.ts
+++ b/packages/zambdas/src/billing/update-billing-non-insurance-org/index.ts
@@ -1,0 +1,162 @@
+import Oystehr, { BatchInputRequest } from '@oystehr/sdk';
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { randomUUID } from 'crypto';
+import { FhirResource, Organization } from 'fhir/r4b';
+import { makeOptimisticLockIfMatchHeader } from 'utils/lib/fhir/helpers';
+import { SavedResourceResponse } from 'utils/lib/types/data/billing/billing.types';
+import { INVALID_INPUT_ERROR } from 'utils/lib/types/errors';
+import { checkOrCreateM2MClientToken } from '../../shared/auth';
+import { wrapHandler } from '../../shared/sentry';
+import { ZambdaInput } from '../../shared/types/common';
+import {
+  buildCoverageOrganization,
+  buildNioAffiliation,
+  buildNioOrganization,
+  computeCoverageChanges,
+  fetchNioCoveragePairs,
+  isNonInsuranceOrganization,
+  NioCoveragePair,
+  NioPayerReference,
+  resolveWcPayerReference,
+} from '../non-insurance-org.helpers';
+import { createBillingClient, fetchById } from '../shared';
+import { UpdateNonInsuranceOrgParams, validateRequestParameters } from './validateRequestParameters';
+
+let m2mToken: string;
+const ZAMBDA_NAME = 'update-billing-non-insurance-org';
+
+export const index = wrapHandler(ZAMBDA_NAME, async (input: ZambdaInput): Promise<APIGatewayProxyResult> => {
+  console.group('validateRequestParameters');
+  const params = validateRequestParameters(input);
+  const { secrets, ...restOfParams } = params;
+  console.groupEnd();
+  console.debug('validateRequestParameters success', restOfParams);
+
+  m2mToken = await checkOrCreateM2MClientToken(m2mToken, secrets);
+  const oystehr = createBillingClient(m2mToken, secrets);
+
+  console.group('complexValidation');
+  const { existing, pairs, payerRef } = await complexValidation(oystehr, params);
+  console.groupEnd();
+  console.debug('complexValidation success');
+
+  console.group('performEffect');
+  const response = await performEffect(oystehr, params, existing, pairs, payerRef);
+  console.groupEnd();
+  console.debug('performEffect success', response);
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(response),
+  };
+});
+
+async function complexValidation(
+  oystehr: Oystehr,
+  params: UpdateNonInsuranceOrgParams
+): Promise<{ existing: Organization; pairs: NioCoveragePair[]; payerRef?: NioPayerReference }> {
+  const existing = await fetchById<Organization>(oystehr, 'Organization', params.nioId);
+  if (!isNonInsuranceOrganization(existing)) {
+    throw INVALID_INPUT_ERROR(`Organization ${params.nioId} is not a non-insurance organization`);
+  }
+  const [pairs, payerRef] = await Promise.all([
+    fetchNioCoveragePairs(oystehr, params.nioId),
+    resolveWcPayerReference(oystehr, params.covers),
+  ]);
+  return { existing, pairs, payerRef };
+}
+
+// Full replace: the whole entity is rewritten and the covers set reconciled — newly checked
+// categories create (or reactivate) their pair, unchecked ones deactivate theirs — in one
+// transaction with an optimistic lock on every updated resource.
+export async function performEffect(
+  oystehr: Oystehr,
+  params: UpdateNonInsuranceOrgParams,
+  existing: Organization,
+  pairs: NioCoveragePair[],
+  payerRef?: NioPayerReference
+): Promise<SavedResourceResponse> {
+  const nioReference = `Organization/${existing.id}`;
+  const requests: BatchInputRequest<FhirResource>[] = [
+    {
+      method: 'PUT',
+      url: nioReference,
+      resource: buildNioOrganization(params, existing),
+      ifMatch: makeOptimisticLockIfMatchHeader(existing),
+    },
+  ];
+
+  const changes = computeCoverageChanges(params.covers ?? [], pairs);
+
+  for (const coverage of changes.creates) {
+    const coverageUrn = `urn:uuid:${randomUUID()}`;
+    requests.push({
+      method: 'POST',
+      url: '/Organization',
+      resource: buildCoverageOrganization({
+        nioName: params.name,
+        coverage,
+        payerRef: coverage.category === 'workers-comp' ? payerRef : undefined,
+      }),
+      fullUrl: coverageUrn,
+    });
+    requests.push({
+      method: 'POST',
+      url: '/OrganizationAffiliation',
+      resource: buildNioAffiliation({
+        nioReference,
+        coverageReference: coverageUrn,
+        category: coverage.category,
+      }),
+    });
+  }
+
+  for (const { coverage, pair } of changes.updates) {
+    // computeCoverageChanges only reuses pairs that still have their coverage org.
+    const coverageOrg = pair.coverageOrg!;
+    requests.push({
+      method: 'PUT',
+      url: `Organization/${coverageOrg.id}`,
+      resource: buildCoverageOrganization({
+        nioName: params.name,
+        coverage,
+        payerRef: coverage.category === 'workers-comp' ? payerRef : undefined,
+        existing: coverageOrg,
+      }),
+      ifMatch: makeOptimisticLockIfMatchHeader(coverageOrg),
+    });
+    if (pair.affiliation.active === false) {
+      requests.push({
+        method: 'PUT',
+        url: `OrganizationAffiliation/${pair.affiliation.id}`,
+        resource: buildNioAffiliation({
+          nioReference,
+          coverageReference: `Organization/${coverageOrg.id}`,
+          category: coverage.category,
+          existing: pair.affiliation,
+        }),
+        ifMatch: makeOptimisticLockIfMatchHeader(pair.affiliation),
+      });
+    }
+  }
+
+  for (const pair of changes.deactivates) {
+    requests.push({
+      method: 'PUT',
+      url: `OrganizationAffiliation/${pair.affiliation.id}`,
+      resource: { ...pair.affiliation, active: false },
+      ifMatch: makeOptimisticLockIfMatchHeader(pair.affiliation),
+    });
+    if (pair.coverageOrg && pair.coverageOrg.active !== false) {
+      requests.push({
+        method: 'PUT',
+        url: `Organization/${pair.coverageOrg.id}`,
+        resource: { ...pair.coverageOrg, active: false },
+        ifMatch: makeOptimisticLockIfMatchHeader(pair.coverageOrg),
+      });
+    }
+  }
+
+  await oystehr.fhir.transaction<FhirResource>({ requests });
+  return { id: existing.id };
+}

--- a/packages/zambdas/src/billing/update-billing-non-insurance-org/validateRequestParameters.ts
+++ b/packages/zambdas/src/billing/update-billing-non-insurance-org/validateRequestParameters.ts
@@ -1,0 +1,23 @@
+import {
+  UpdateNonInsuranceOrgInput,
+  UpdateNonInsuranceOrgInputSchema,
+} from 'utils/lib/types/data/billing/non-insurance-org.schemas';
+import { MISSING_REQUEST_BODY, MISSING_REQUEST_SECRETS } from 'utils/lib/types/errors';
+import { validateJsonBody } from '../../shared/helpers';
+import { ZambdaInput } from '../../shared/types/common';
+import { safeValidate } from '../../shared/validation';
+
+export interface UpdateNonInsuranceOrgParams extends UpdateNonInsuranceOrgInput {
+  secrets: ZambdaInput['secrets'];
+}
+
+export function validateRequestParameters(input: ZambdaInput): UpdateNonInsuranceOrgParams {
+  if (!input.body) throw MISSING_REQUEST_BODY;
+  if (!input.secrets) throw MISSING_REQUEST_SECRETS;
+
+  const data = safeValidate(UpdateNonInsuranceOrgInputSchema, validateJsonBody(input));
+  return {
+    ...data,
+    secrets: input.secrets,
+  };
+}

--- a/packages/zambdas/test/integration/billing/non-insurance-org-crud.test.ts
+++ b/packages/zambdas/test/integration/billing/non-insurance-org-crud.test.ts
@@ -204,7 +204,9 @@ describe('non-insurance-org CRUD', () => {
       covers: [
         { category: 'workers-comp', billingMode: 'direct' },
         { category: 'occupational-medicine' },
-        { category: 'other', name: 'Medical Clearance' },
+        // Deliberately unnamed: an 'other' coverage without a name must still satisfy FHIR org-1
+        // (the coverage org carries a kind identifier instead of a name).
+        { category: 'other' },
       ],
     });
     const affiliationsAfter = await fetchAffiliations(nioId);

--- a/packages/zambdas/test/integration/billing/non-insurance-org-crud.test.ts
+++ b/packages/zambdas/test/integration/billing/non-insurance-org-crud.test.ts
@@ -1,0 +1,236 @@
+import Oystehr from '@oystehr/sdk';
+import { Organization, OrganizationAffiliation } from 'fhir/r4b';
+import { M2MClientMockType } from 'utils/lib/auth/user-me.helper';
+import { getNioReferenceUrl } from 'utils/lib/helpers/helpers';
+import {
+  BillingPayerOption,
+  CreatedResourceResponse,
+  DeletedResponse,
+  SavedResourceResponse,
+  SearchBillingPayersResponse,
+} from 'utils/lib/types/data/billing/billing.types';
+import { CreateNonInsuranceOrgInput } from 'utils/lib/types/data/billing/non-insurance-org.schemas';
+import {
+  ListNonInsuranceOrganizationsResponse,
+  NIO_KIND_CODE,
+  NIO_ORGANIZATION_KIND_SYSTEM,
+  NioWorkersCompCoverage,
+  SearchNonInsuranceOrgsResponse,
+} from 'utils/lib/types/data/billing/non-insurance-org.types';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { setupIntegrationTest } from '../../helpers/integration-test-seed-data-setup';
+
+// Happy-path NIO CRUD: create -> search/detail -> clinical directory -> update (covers
+// reconciliation incl. reactivation) -> soft delete. Exercises all five zambdas in sequence.
+describe('non-insurance-org CRUD', () => {
+  let oystehr: Oystehr; // admin billing client used to assert / clean up
+  let cleanup: () => Promise<void>;
+  let processId: string;
+
+  let nioName: string;
+  let nioId: string;
+  let payer: BillingPayerOption;
+
+  const searchDetail = async (id: string): Promise<SearchNonInsuranceOrgsResponse> =>
+    (await oystehr.zambda.execute({ id: 'search-billing-non-insurance-orgs', nioId: id }))
+      .output as SearchNonInsuranceOrgsResponse;
+
+  const fetchAffiliations = async (id: string): Promise<OrganizationAffiliation[]> =>
+    (
+      await oystehr.fhir.search<OrganizationAffiliation>({
+        resourceType: 'OrganizationAffiliation',
+        params: [{ name: 'organization', value: `Organization/${id}` }],
+      })
+    ).unbundle();
+
+  beforeAll(async () => {
+    const setup = await setupIntegrationTest('integration/non-insurance-org-crud.test.ts', M2MClientMockType.provider);
+    oystehr = setup.oystehrBilling;
+    cleanup = setup.cleanup;
+    processId = setup.processId;
+    nioName = `NioCrud ${processId}`;
+
+    const payersResponse = (await oystehr.zambda.execute({ id: 'search-billing-payers' }))
+      .output as SearchBillingPayersResponse;
+    expect(payersResponse.payers.length).toBeGreaterThan(0);
+    payer = payersResponse.payers[0];
+  }, 90_000);
+
+  afterAll(async () => {
+    // Hard-delete the NIO graph (the zambdas only soft-delete) before the shared cleanup.
+    try {
+      if (nioId) {
+        const affiliations = await fetchAffiliations(nioId);
+        await Promise.all(
+          affiliations.map((affiliation) =>
+            oystehr.fhir.delete({ resourceType: 'OrganizationAffiliation', id: affiliation.id! }).catch(() => undefined)
+          )
+        );
+        const coverageOrgIds = affiliations
+          .map((affiliation) => affiliation.participatingOrganization?.reference?.split('/')[1])
+          .filter((id): id is string => !!id);
+        await Promise.all(
+          [...new Set(coverageOrgIds)].map((id) =>
+            oystehr.fhir.delete({ resourceType: 'Organization', id }).catch(() => undefined)
+          )
+        );
+        await oystehr.fhir.delete({ resourceType: 'Organization', id: nioId }).catch(() => undefined);
+      }
+    } catch {
+      // best-effort cleanup
+    }
+    await cleanup();
+  }, 90_000);
+
+  it('create-billing-non-insurance-org creates the org, coverage orgs, and affiliations', async () => {
+    const input: CreateNonInsuranceOrgInput = {
+      name: nioName,
+      employer: true,
+      address: { line1: '1 Main St', city: 'Springfield', state: 'CA', zip: '90210' },
+      contacts: [{ name: 'Jane Smith', title: 'Billing Manager', phone: '555-123-4567', email: 'jane@example.com' }],
+      covers: [
+        { category: 'workers-comp', billingMode: 'insurance', payerId: payer.id },
+        { category: 'occupational-medicine', submission: { preferredMechanism: 'fax', fax: '555-999-0000' } },
+        { category: 'other', name: 'Medical Clearance', submission: { preferredMechanism: 'portal' } },
+      ],
+    };
+    const { id } = (await oystehr.zambda.execute({ id: 'create-billing-non-insurance-org', ...input }))
+      .output as CreatedResourceResponse;
+    expect(id).toBeTruthy();
+    nioId = id;
+
+    const org = await oystehr.fhir.get<Organization>({ resourceType: 'Organization', id });
+    expect(org.active).toBe(true);
+    expect(
+      org.type?.some(
+        (t) => t.coding?.some((c) => c.system === NIO_ORGANIZATION_KIND_SYSTEM && c.code === NIO_KIND_CODE)
+      )
+    ).toBe(true);
+
+    const affiliations = await fetchAffiliations(id);
+    expect(affiliations).toHaveLength(3);
+    expect(affiliations.every((affiliation) => affiliation.active)).toBe(true);
+
+    const detail = (await searchDetail(id)).organizations[0];
+    expect(detail).toMatchObject({
+      id,
+      name: nioName,
+      employer: true,
+      active: true,
+      address: input.address,
+      contacts: input.contacts,
+    });
+    expect(detail.covers.map((coverage) => coverage.category)).toEqual([
+      'workers-comp',
+      'occupational-medicine',
+      'other',
+    ]);
+    const workersComp = detail.covers[0] as NioWorkersCompCoverage;
+    expect(workersComp.billingMode).toBe('insurance');
+    // The stored payer reference round-trips into the same option PayerSelect stores.
+    expect(workersComp.payer?.id).toBe(payer.id);
+    expect(workersComp.payer?.payerId).toBe(payer.payerId);
+  }, 90_000);
+
+  it('search-billing-non-insurance-orgs lists the created org by name', async () => {
+    const response = (await oystehr.zambda.execute({ id: 'search-billing-non-insurance-orgs', name: nioName }))
+      .output as SearchNonInsuranceOrgsResponse;
+    expect(response.total).toBeGreaterThanOrEqual(1);
+    expect(response.organizations.some((org) => org.id === nioId)).toBe(true);
+  }, 90_000);
+
+  it('list-non-insurance-organizations serves the minimal clinical option with the reference token', async () => {
+    const response = (await oystehr.zambda.execute({ id: 'list-non-insurance-organizations', employerOnly: true }))
+      .output as ListNonInsuranceOrganizationsResponse;
+    const option = response.organizations.find((org) => org.id === nioId);
+    expect(option).toEqual({
+      id: nioId,
+      reference: getNioReferenceUrl(nioId),
+      name: nioName,
+      employer: true,
+      active: true,
+      address: { line1: '1 Main St', city: 'Springfield', state: 'CA', zip: '90210' },
+      coversCategories: ['workers-comp', 'occupational-medicine', 'other'],
+    });
+    // The minimal DTO never carries covers details or contacts.
+    expect(option).not.toHaveProperty('covers');
+    expect(option).not.toHaveProperty('contacts');
+  }, 90_000);
+
+  it('update reconciles the covers set: unchecked deactivates, re-checked reactivates the same pair', async () => {
+    const occMedAffiliationId = (await fetchAffiliations(nioId)).find(
+      (affiliation) =>
+        affiliation.code?.some((concept) => concept.coding?.some((coding) => coding.code === 'occupational-medicine'))
+    )?.id;
+    expect(occMedAffiliationId).toBeTruthy();
+
+    // Drop occ-med, flip workers-comp to direct billing.
+    const updated = (
+      await oystehr.zambda.execute({
+        id: 'update-billing-non-insurance-org',
+        nioId,
+        name: nioName,
+        employer: false,
+        covers: [
+          {
+            category: 'workers-comp',
+            billingMode: 'direct',
+            submission: { preferredMechanism: 'mail', mailAddress: { line1: 'PO Box 9' } },
+          },
+          { category: 'other', name: 'Medical Clearance' },
+        ],
+      })
+    ).output as SavedResourceResponse;
+    expect(updated.id).toBe(nioId);
+
+    const detail = (await searchDetail(nioId)).organizations[0];
+    expect(detail.employer).toBe(false);
+    expect(detail.covers.map((coverage) => coverage.category)).toEqual(['workers-comp', 'other']);
+    const workersComp = detail.covers[0] as NioWorkersCompCoverage;
+    expect(workersComp.billingMode).toBe('direct');
+    expect(workersComp.submission).toEqual({ preferredMechanism: 'mail', mailAddress: { line1: 'PO Box 9' } });
+
+    const occMedAffiliation = (await fetchAffiliations(nioId)).find(
+      (affiliation) => affiliation.id === occMedAffiliationId
+    );
+    expect(occMedAffiliation?.active).toBe(false);
+
+    // Re-check occ-med: the same inactive pair comes back to life instead of duplicating.
+    await oystehr.zambda.execute({
+      id: 'update-billing-non-insurance-org',
+      nioId,
+      name: nioName,
+      employer: false,
+      covers: [
+        { category: 'workers-comp', billingMode: 'direct' },
+        { category: 'occupational-medicine' },
+        { category: 'other', name: 'Medical Clearance' },
+      ],
+    });
+    const affiliationsAfter = await fetchAffiliations(nioId);
+    expect(affiliationsAfter).toHaveLength(3);
+    const reactivated = affiliationsAfter.find((affiliation) => affiliation.id === occMedAffiliationId);
+    expect(reactivated?.active).toBe(true);
+  }, 90_000);
+
+  it('delete soft-deletes the whole graph but keeps it resolvable by id', async () => {
+    const result = (await oystehr.zambda.execute({ id: 'delete-billing-non-insurance-org', nioId }))
+      .output as DeletedResponse;
+    expect(result.deleted).toBe(true);
+
+    const org = await oystehr.fhir.get<Organization>({ resourceType: 'Organization', id: nioId });
+    expect(org.active).toBe(false);
+    expect((await fetchAffiliations(nioId)).every((affiliation) => affiliation.active === false)).toBe(true);
+
+    // Gone from the list...
+    const list = (await oystehr.zambda.execute({ id: 'search-billing-non-insurance-orgs', name: nioName }))
+      .output as SearchNonInsuranceOrgsResponse;
+    expect(list.organizations.some((o) => o.id === nioId)).toBe(false);
+
+    // ...but a stored clinical reference still resolves, flagged inactive.
+    const byId = (await oystehr.zambda.execute({ id: 'list-non-insurance-organizations', nioId }))
+      .output as ListNonInsuranceOrganizationsResponse;
+    expect(byId.organizations[0]?.active).toBe(false);
+    expect(byId.organizations[0]?.name).toBe(nioName);
+  }, 90_000);
+});

--- a/packages/zambdas/test/integration/billing/non-insurance-org-crud.test.ts
+++ b/packages/zambdas/test/integration/billing/non-insurance-org-crud.test.ts
@@ -39,7 +39,7 @@ describe('non-insurance-org CRUD', () => {
     (
       await oystehr.fhir.search<OrganizationAffiliation>({
         resourceType: 'OrganizationAffiliation',
-        params: [{ name: 'organization', value: `Organization/${id}` }],
+        params: [{ name: 'primary-organization', value: `Organization/${id}` }],
       })
     ).unbundle();
 

--- a/packages/zambdas/test/unit/billing/non-insurance-org.test.ts
+++ b/packages/zambdas/test/unit/billing/non-insurance-org.test.ts
@@ -1,0 +1,499 @@
+import Oystehr from '@oystehr/sdk';
+import { Organization, OrganizationAffiliation } from 'fhir/r4b';
+import { getNioReferenceUrl } from 'utils/lib/helpers/helpers';
+import { CreateNonInsuranceOrgInput } from 'utils/lib/types/data/billing/non-insurance-org.schemas';
+import {
+  NIO_COVERAGE_CATEGORY_SYSTEM,
+  NIO_ORGANIZATION_KIND_SYSTEM,
+  NIO_PORTAL_NOTES_EXTENSION_URL,
+  NIO_PREFERRED_SUBMISSION_EXTENSION_URL,
+  NIO_WC_BILLING_MODE_EXTENSION_URL,
+  NIO_WC_PAYER_EXTENSION_URL,
+  NioWorkersCompCoverage,
+} from 'utils/lib/types/data/billing/non-insurance-org.types';
+import { describe, expect, it, vi } from 'vitest';
+import { performEffect as createNio } from '../../../src/billing/create-billing-non-insurance-org';
+import { performEffect as deleteNio } from '../../../src/billing/delete-billing-non-insurance-org';
+import { performEffect as listNios } from '../../../src/billing/list-non-insurance-organizations';
+import {
+  buildCoverageOrganization,
+  buildNioAffiliation,
+  buildNioOrganization,
+  computeCoverageChanges,
+  mapNonInsuranceOrganization,
+  resolveWcPayerReference,
+} from '../../../src/billing/non-insurance-org.helpers';
+import { performEffect as searchNios } from '../../../src/billing/search-billing-non-insurance-orgs';
+import { performEffect as updateNio } from '../../../src/billing/update-billing-non-insurance-org';
+
+const NIO_ID = '11111111-1111-4111-8111-111111111111';
+const PAYER_RCM_ID = '22222222-2222-4222-8222-222222222222';
+const PAYER_URL = 'https://rcm-api.zapehr.com/v1/payer/PAYER123';
+
+const fullInput: CreateNonInsuranceOrgInput = {
+  name: 'FedEx',
+  employer: true,
+  address: { line1: '1 Main St', line2: 'Suite 2', city: 'Springfield', state: 'CA', zip: '90210' },
+  contacts: [{ name: 'Jane Smith', title: 'Billing Manager', phone: '555-123-4567', email: 'jane@fedex.com' }],
+  covers: [
+    { category: 'workers-comp', billingMode: 'insurance', payerId: PAYER_RCM_ID },
+    {
+      category: 'occupational-medicine',
+      submission: {
+        preferredMechanism: 'fax',
+        fax: '555-999-0000',
+        email: 'occmed@fedex.com',
+        portalNotes: 'portal.fedex.com',
+        mailAddress: { line1: 'PO Box 5', city: 'Memphis' },
+      },
+    },
+    { category: 'other', name: 'Medical Clearance', submission: { preferredMechanism: 'portal' } },
+  ],
+};
+
+function kindCoding(org: Organization, code: string): boolean {
+  return !!org.type?.some((t) => t.coding?.some((c) => c.system === NIO_ORGANIZATION_KIND_SYSTEM && c.code === code));
+}
+
+const wcCoverageOrg: Organization = {
+  resourceType: 'Organization',
+  id: 'cov-wc',
+  active: true,
+  meta: { versionId: '2' },
+  name: 'FedEx — Workers Comp',
+  type: [
+    { coding: [{ system: NIO_ORGANIZATION_KIND_SYSTEM, code: 'nio-coverage' }] },
+    { coding: [{ system: NIO_COVERAGE_CATEGORY_SYSTEM, code: 'workers-comp' }] },
+  ],
+  extension: [
+    { url: NIO_WC_BILLING_MODE_EXTENSION_URL, valueCode: 'insurance' },
+    {
+      url: NIO_WC_PAYER_EXTENSION_URL,
+      valueReference: { reference: PAYER_URL, display: 'Acme Insurance (PAYER123)' },
+    },
+  ],
+};
+
+const wcAffiliation: OrganizationAffiliation = {
+  resourceType: 'OrganizationAffiliation',
+  id: 'aff-wc',
+  active: true,
+  meta: { versionId: '1' },
+  organization: { reference: `Organization/${NIO_ID}` },
+  participatingOrganization: { reference: 'Organization/cov-wc' },
+  code: [{ coding: [{ system: NIO_COVERAGE_CATEGORY_SYSTEM, code: 'workers-comp' }] }],
+};
+
+const nioOrg: Organization = {
+  ...buildNioOrganization(fullInput),
+  id: NIO_ID,
+  meta: { versionId: '3' },
+};
+
+describe('non-insurance-org FHIR mapping', () => {
+  it('round-trips a full input through the FHIR graph back to the DTO', () => {
+    const org = { ...buildNioOrganization(fullInput), id: NIO_ID };
+    const coverageOrgs = fullInput.covers!.map((coverage, i) => ({
+      ...buildCoverageOrganization({
+        nioName: fullInput.name,
+        coverage,
+        payerRef:
+          coverage.category === 'workers-comp'
+            ? { reference: PAYER_URL, display: 'Acme Insurance (PAYER123)' }
+            : undefined,
+      }),
+      id: `cov-${i}`,
+    }));
+    const affiliations = fullInput.covers!.map((coverage, i) =>
+      buildNioAffiliation({
+        nioReference: `Organization/${NIO_ID}`,
+        coverageReference: `Organization/cov-${i}`,
+        category: coverage.category,
+      })
+    );
+
+    const item = mapNonInsuranceOrganization({
+      org,
+      affiliations,
+      coverageOrgsById: new Map(coverageOrgs.map((c) => [c.id!, c])),
+    });
+
+    expect(item).toEqual({
+      id: NIO_ID,
+      name: 'FedEx',
+      employer: true,
+      active: true,
+      address: fullInput.address,
+      contacts: fullInput.contacts,
+      covers: [
+        {
+          category: 'workers-comp',
+          billingMode: 'insurance',
+          // No live RCM resolution in this test — the stored reference + display fill the option.
+          payer: { id: '', name: 'Acme Insurance (PAYER123)', payerId: 'PAYER123' },
+        },
+        {
+          category: 'occupational-medicine',
+          submission: fullInput.covers![1].submission,
+        },
+        { category: 'other', name: 'Medical Clearance', submission: { preferredMechanism: 'portal' } },
+      ],
+    });
+  });
+
+  it('marks employer with an extra kind coding only when toggled on', () => {
+    expect(kindCoding(buildNioOrganization(fullInput), 'employer')).toBe(true);
+    expect(kindCoding(buildNioOrganization({ ...fullInput, employer: false }), 'employer')).toBe(false);
+    expect(kindCoding(buildNioOrganization(fullInput), 'non-insurance-organization')).toBe(true);
+  });
+
+  it("keeps 'other' coverage org name exactly as entered and derives names for coded categories", () => {
+    const other = buildCoverageOrganization({
+      nioName: 'FedEx',
+      coverage: { category: 'other', name: 'Medical Clearance' },
+    });
+    expect(other.name).toBe('Medical Clearance');
+    const unnamedOther = buildCoverageOrganization({ nioName: 'FedEx', coverage: { category: 'other' } });
+    expect(unnamedOther.name).toBeUndefined();
+    const occMed = buildCoverageOrganization({
+      nioName: 'FedEx',
+      coverage: { category: 'occupational-medicine' },
+    });
+    expect(occMed.name).toBe('FedEx — Occupational Medicine');
+  });
+
+  it('writes submission details to telecom, address, and extensions', () => {
+    const org = buildCoverageOrganization({ nioName: 'FedEx', coverage: fullInput.covers![1] });
+    expect(org.telecom).toEqual([
+      { system: 'email', value: 'occmed@fedex.com' },
+      { system: 'fax', value: '555-999-0000' },
+    ]);
+    expect(org.address).toEqual([{ line: ['PO Box 5'], city: 'Memphis' }]);
+    expect(org.extension).toEqual([
+      { url: NIO_PREFERRED_SUBMISSION_EXTENSION_URL, valueCode: 'fax' },
+      { url: NIO_PORTAL_NOTES_EXTENSION_URL, valueString: 'portal.fedex.com' },
+    ]);
+  });
+});
+
+describe('computeCoverageChanges', () => {
+  const inactiveOtherPair = {
+    affiliation: {
+      ...wcAffiliation,
+      id: 'aff-other',
+      active: false,
+      participatingOrganization: { reference: 'Organization/cov-other' },
+      code: [{ coding: [{ system: NIO_COVERAGE_CATEGORY_SYSTEM, code: 'other' }] }],
+    },
+    coverageOrg: { ...wcCoverageOrg, id: 'cov-other', active: false },
+  };
+
+  it('keeps, reactivates, creates, and deactivates per the input covers set', () => {
+    const pairs = [{ affiliation: wcAffiliation, coverageOrg: wcCoverageOrg }, inactiveOtherPair];
+    const changes = computeCoverageChanges(
+      [
+        { category: 'workers-comp', billingMode: 'direct' },
+        { category: 'other', name: 'Med Clearance' },
+        { category: 'occupational-medicine' },
+      ],
+      pairs
+    );
+    expect(changes.creates.map((c) => c.category)).toEqual(['occupational-medicine']);
+    expect(changes.updates.map((u) => [u.coverage.category, u.pair.affiliation.id])).toEqual([
+      ['workers-comp', 'aff-wc'],
+      ['other', 'aff-other'],
+    ]);
+    expect(changes.deactivates).toEqual([]);
+  });
+
+  it('deactivates active pairs whose category was unchecked', () => {
+    const changes = computeCoverageChanges([], [{ affiliation: wcAffiliation, coverageOrg: wcCoverageOrg }]);
+    expect(changes.creates).toEqual([]);
+    expect(changes.updates).toEqual([]);
+    expect(changes.deactivates.map((p) => p.affiliation.id)).toEqual(['aff-wc']);
+  });
+
+  it('recreates a category whose pair lost its coverage org instead of reusing it', () => {
+    const orglessPair = { affiliation: wcAffiliation, coverageOrg: undefined };
+    const changes = computeCoverageChanges([{ category: 'workers-comp', billingMode: 'direct' }], [orglessPair]);
+    expect(changes.creates.map((c) => c.category)).toEqual(['workers-comp']);
+    expect(changes.deactivates).toEqual([orglessPair]);
+  });
+});
+
+interface MockOystehr {
+  oystehr: Oystehr;
+  transaction: ReturnType<typeof vi.fn>;
+  search: ReturnType<typeof vi.fn>;
+  getPayer: ReturnType<typeof vi.fn>;
+  getPayerByUrl: ReturnType<typeof vi.fn>;
+}
+
+function makeOystehr(): MockOystehr {
+  const transaction = vi.fn().mockImplementation(({ requests }) =>
+    Promise.resolve({
+      entry: requests.map((request: { resource?: { id?: string }; method: string }, index: number) => ({
+        resource: request.resource ? { ...request.resource, id: request.resource.id ?? `created-${index}` } : undefined,
+      })),
+    })
+  );
+  const search = vi.fn();
+  const getPayer = vi.fn();
+  const getPayerByUrl = vi.fn();
+  const oystehr = { fhir: { transaction, search }, rcm: { getPayer, getPayerByUrl } } as unknown as Oystehr;
+  return { oystehr, transaction, search, getPayer, getPayerByUrl };
+}
+
+describe('create-billing-non-insurance-org', () => {
+  it('writes the NIO, coverage orgs, and affiliations in one urn-linked transaction', async () => {
+    const { oystehr, transaction } = makeOystehr();
+
+    const result = await createNio(oystehr, { ...fullInput, secrets: null }, { reference: PAYER_URL });
+
+    expect(result).toEqual({ id: 'created-0' });
+    expect(transaction).toHaveBeenCalledTimes(1);
+    const requests = transaction.mock.calls[0][0].requests;
+    expect(requests).toHaveLength(1 + 3 * 2);
+    expect(requests[0].method).toBe('POST');
+    expect(requests[0].fullUrl).toMatch(/^urn:uuid:/);
+    expect(kindCoding(requests[0].resource, 'non-insurance-organization')).toBe(true);
+
+    const affiliations = requests.filter(
+      (r: { resource: { resourceType: string } }) => r.resource.resourceType === 'OrganizationAffiliation'
+    );
+    expect(affiliations).toHaveLength(3);
+    for (const request of affiliations) {
+      expect(request.resource.organization.reference).toBe(requests[0].fullUrl);
+      const coverageRequest = requests.find(
+        (r: { fullUrl?: string }) => r.fullUrl === request.resource.participatingOrganization.reference
+      );
+      expect(coverageRequest).toBeDefined();
+      expect(kindCoding(coverageRequest.resource, 'nio-coverage')).toBe(true);
+    }
+
+    const wcOrg = requests[1].resource;
+    expect(wcOrg.extension).toContainEqual({ url: NIO_WC_BILLING_MODE_EXTENSION_URL, valueCode: 'insurance' });
+    expect(wcOrg.extension).toContainEqual({
+      url: NIO_WC_PAYER_EXTENSION_URL,
+      valueReference: { reference: PAYER_URL },
+    });
+  });
+});
+
+describe('update-billing-non-insurance-org', () => {
+  const params = { ...fullInput, nioId: NIO_ID, secrets: null };
+
+  it('rewrites the org, updates kept coverage, creates new pairs, all with optimistic locks', async () => {
+    const { oystehr, transaction } = makeOystehr();
+    const pairs = [{ affiliation: wcAffiliation, coverageOrg: wcCoverageOrg }];
+
+    const result = await updateNio(oystehr, params, nioOrg, pairs, { reference: PAYER_URL });
+
+    expect(result).toEqual({ id: NIO_ID });
+    const requests = transaction.mock.calls[0][0].requests;
+
+    expect(requests[0]).toMatchObject({ method: 'PUT', url: `Organization/${NIO_ID}`, ifMatch: 'W/"3"' });
+    expect(requests[0].resource.active).toBe(true);
+
+    const wcPut = requests.find((r: { url?: string }) => r.url === 'Organization/cov-wc');
+    expect(wcPut).toMatchObject({ method: 'PUT', ifMatch: 'W/"2"' });
+
+    // occ-med and other are new: 2 coverage POSTs + 2 affiliation POSTs, pointed at the stored NIO id.
+    const posts = requests.filter((r: { method: string }) => r.method === 'POST');
+    expect(posts).toHaveLength(4);
+    const postedAffiliations = posts.filter(
+      (r: { resource: { resourceType: string } }) => r.resource.resourceType === 'OrganizationAffiliation'
+    );
+    postedAffiliations.forEach((request: { resource: OrganizationAffiliation }) => {
+      expect(request.resource.organization?.reference).toBe(`Organization/${NIO_ID}`);
+    });
+  });
+
+  it('reactivates an inactive pair when its category is re-checked', async () => {
+    const { oystehr, transaction } = makeOystehr();
+    const inactivePair = {
+      affiliation: { ...wcAffiliation, active: false },
+      coverageOrg: { ...wcCoverageOrg, active: false },
+    };
+
+    await updateNio(
+      oystehr,
+      { ...params, covers: [{ category: 'workers-comp', billingMode: 'direct' }] },
+      nioOrg,
+      [inactivePair],
+      undefined
+    );
+
+    const requests = transaction.mock.calls[0][0].requests;
+    const affiliationPut = requests.find((r: { url?: string }) => r.url === 'OrganizationAffiliation/aff-wc');
+    expect(affiliationPut.resource.active).toBe(true);
+    const coveragePut = requests.find((r: { url?: string }) => r.url === 'Organization/cov-wc');
+    expect(coveragePut.resource.active).toBe(true);
+    expect(coveragePut.resource.extension).toContainEqual({
+      url: NIO_WC_BILLING_MODE_EXTENSION_URL,
+      valueCode: 'direct',
+    });
+  });
+
+  it('deactivates the pair for an unchecked category', async () => {
+    const { oystehr, transaction } = makeOystehr();
+
+    await updateNio(oystehr, { ...params, covers: [] }, nioOrg, [
+      { affiliation: wcAffiliation, coverageOrg: wcCoverageOrg },
+    ]);
+
+    const requests = transaction.mock.calls[0][0].requests;
+    expect(requests).toHaveLength(3);
+    const affiliationPut = requests.find((r: { url?: string }) => r.url === 'OrganizationAffiliation/aff-wc');
+    expect(affiliationPut.resource.active).toBe(false);
+    const coveragePut = requests.find((r: { url?: string }) => r.url === 'Organization/cov-wc');
+    expect(coveragePut.resource.active).toBe(false);
+  });
+});
+
+describe('delete-billing-non-insurance-org', () => {
+  it('soft-deletes the whole graph in one transaction', async () => {
+    const { oystehr, transaction } = makeOystehr();
+
+    const result = await deleteNio(oystehr, nioOrg, [{ affiliation: wcAffiliation, coverageOrg: wcCoverageOrg }]);
+
+    expect(result).toEqual({ deleted: true });
+    const requests = transaction.mock.calls[0][0].requests;
+    expect(requests).toHaveLength(3);
+    requests.forEach((request: { method: string; resource: { active: boolean }; ifMatch?: string }) => {
+      expect(request.method).toBe('PUT');
+      expect(request.resource.active).toBe(false);
+      expect(request.ifMatch).toBeDefined();
+    });
+  });
+});
+
+describe('search-billing-non-insurance-orgs', () => {
+  it('maps a page of orgs with covers resolved from one affiliation search', async () => {
+    const { oystehr, search, getPayerByUrl } = makeOystehr();
+    search.mockImplementation(({ resourceType }) => {
+      if (resourceType === 'Organization') {
+        return Promise.resolve({ unbundle: () => [nioOrg], total: 1 });
+      }
+      return Promise.resolve({ unbundle: () => [wcAffiliation, wcCoverageOrg] });
+    });
+    getPayerByUrl.mockResolvedValue({
+      resourceType: 'Organization',
+      id: PAYER_RCM_ID,
+      name: 'Acme Insurance',
+      identifier: [{ system: 'https://identifiers.fhir.oystehr.com/rcm-payer-id', value: 'PAYER123' }],
+    });
+
+    const result = await searchNios(oystehr, { secrets: null });
+
+    expect(result.total).toBe(1);
+    expect(result.organizations).toHaveLength(1);
+    const item = result.organizations[0];
+    expect(item.name).toBe('FedEx');
+    const wc = item.covers.find((c) => c.category === 'workers-comp') as NioWorkersCompCoverage;
+    expect(wc.billingMode).toBe('insurance');
+    expect(wc.payer).toEqual({ id: PAYER_RCM_ID, name: 'Acme Insurance', payerId: 'PAYER123' });
+
+    const orgParams = search.mock.calls[0][0].params;
+    expect(orgParams).toContainEqual({
+      name: 'type',
+      value: `${NIO_ORGANIZATION_KIND_SYSTEM}|non-insurance-organization`,
+    });
+    expect(orgParams).toContainEqual({ name: 'active', value: 'true' });
+  });
+
+  it('falls back to the stored payer display when RCM resolution fails', async () => {
+    const { oystehr, search, getPayerByUrl } = makeOystehr();
+    search.mockImplementation(({ resourceType }) =>
+      resourceType === 'Organization'
+        ? Promise.resolve({ unbundle: () => [nioOrg], total: 1 })
+        : Promise.resolve({ unbundle: () => [wcAffiliation, wcCoverageOrg] })
+    );
+    getPayerByUrl.mockRejectedValue(new Error('rcm down'));
+
+    const result = await searchNios(oystehr, { secrets: null });
+    const wc = result.organizations[0].covers.find((c) => c.category === 'workers-comp') as NioWorkersCompCoverage;
+    expect(wc.payer).toEqual({ id: '', name: 'Acme Insurance (PAYER123)', payerId: 'PAYER123' });
+  });
+});
+
+describe('list-non-insurance-organizations', () => {
+  it('returns minimal clinical options carrying the NIO reference token', async () => {
+    const { oystehr, search } = makeOystehr();
+    search.mockImplementation(({ resourceType }) =>
+      resourceType === 'Organization'
+        ? Promise.resolve({ unbundle: () => [nioOrg] })
+        : Promise.resolve({ unbundle: () => [wcAffiliation] })
+    );
+
+    const result = await listNios(oystehr, { employerOnly: true, secrets: null });
+
+    expect(result.organizations).toEqual([
+      {
+        id: NIO_ID,
+        reference: getNioReferenceUrl(NIO_ID),
+        name: 'FedEx',
+        employer: true,
+        active: true,
+        address: fullInput.address,
+        coversCategories: ['workers-comp'],
+      },
+    ]);
+
+    const orgParams = search.mock.calls[0][0].params;
+    expect(orgParams).toContainEqual({ name: 'type', value: `${NIO_ORGANIZATION_KIND_SYSTEM}|employer` });
+    // The affiliation pass never asks for the coverage orgs.
+    expect(search.mock.calls[1][0].params.some((p: { name: string }) => p.name === '_include')).toBe(false);
+  });
+
+  it('resolves a deleted NIO by id with active=false', async () => {
+    const { oystehr, search } = makeOystehr();
+    search.mockImplementation(({ resourceType }) =>
+      resourceType === 'Organization'
+        ? Promise.resolve({ unbundle: () => [{ ...nioOrg, active: false }] })
+        : Promise.resolve({ unbundle: () => [] })
+    );
+
+    const result = await listNios(oystehr, { nioId: NIO_ID, secrets: null });
+
+    expect(result.organizations[0].active).toBe(false);
+    const orgParams = search.mock.calls[0][0].params;
+    expect(orgParams).toContainEqual({ name: '_id', value: NIO_ID });
+    expect(orgParams.some((p: { name: string }) => p.name === 'active')).toBe(false);
+  });
+});
+
+describe('resolveWcPayerReference', () => {
+  it('persists a UUID RCM payer as a plain Organization reference with display', async () => {
+    const { oystehr, getPayer } = makeOystehr();
+    getPayer.mockResolvedValue({
+      resourceType: 'Organization',
+      id: PAYER_RCM_ID,
+      name: 'Acme Insurance',
+      identifier: [{ system: 'https://identifiers.fhir.oystehr.com/rcm-payer-id', value: 'PAYER123' }],
+    });
+
+    const ref = await resolveWcPayerReference(oystehr, [
+      { category: 'workers-comp', billingMode: 'insurance', payerId: PAYER_RCM_ID },
+    ]);
+
+    expect(ref).toEqual({ reference: `Organization/${PAYER_RCM_ID}`, display: 'Acme Insurance (PAYER123)' });
+  });
+
+  it('throws INVALID_INPUT for an unknown payer id', async () => {
+    const { oystehr, getPayer } = makeOystehr();
+    getPayer.mockRejectedValue(new Error('not found'));
+
+    await expect(
+      resolveWcPayerReference(oystehr, [{ category: 'workers-comp', billingMode: 'insurance', payerId: 'nope' }])
+    ).rejects.toMatchObject({ message: expect.stringContaining('Unknown payer id') });
+  });
+
+  it('returns undefined when no workers-comp payer was selected', async () => {
+    const { oystehr, getPayer } = makeOystehr();
+    await expect(
+      resolveWcPayerReference(oystehr, [{ category: 'workers-comp', billingMode: 'direct' }])
+    ).resolves.toBeUndefined();
+    expect(getPayer).not.toHaveBeenCalled();
+  });
+});

--- a/packages/zambdas/test/unit/billing/non-insurance-org.test.ts
+++ b/packages/zambdas/test/unit/billing/non-insurance-org.test.ts
@@ -492,6 +492,25 @@ describe('list-non-insurance-organizations', () => {
     expect(orgParams).toContainEqual({ name: '_id', value: NIO_ID });
     expect(orgParams.some((p: { name: string }) => p.name === 'active')).toBe(false);
   });
+
+  it('follows next links so more than one page of NIOs comes back complete', async () => {
+    const secondNioId = '33333333-3333-4333-8333-333333333333';
+    const { oystehr, search } = makeOystehr();
+    let orgPage = 0;
+    search.mockImplementation(({ resourceType }) => {
+      if (resourceType !== 'Organization') return Promise.resolve({ unbundle: () => [] });
+      orgPage += 1;
+      return orgPage === 1
+        ? Promise.resolve({ unbundle: () => [nioOrg], link: [{ relation: 'next', url: 'next-page' }] })
+        : Promise.resolve({ unbundle: () => [{ ...nioOrg, id: secondNioId, name: 'UPS' }] });
+    });
+
+    const result = await listNios(oystehr, { secrets: null });
+
+    expect(result.organizations.map((org) => org.id)).toEqual([NIO_ID, secondNioId]);
+    const secondPageParams = search.mock.calls[1][0].params;
+    expect(secondPageParams).toContainEqual({ name: '_offset', value: '1000' });
+  });
 });
 
 describe('resolveWcPayerReference', () => {

--- a/packages/zambdas/test/unit/billing/non-insurance-org.test.ts
+++ b/packages/zambdas/test/unit/billing/non-insurance-org.test.ts
@@ -20,6 +20,7 @@ import {
   buildNioAffiliation,
   buildNioOrganization,
   computeCoverageChanges,
+  fetchNioCoveragePairs,
   mapNonInsuranceOrganization,
   resolveWcPayerReference,
 } from '../../../src/billing/non-insurance-org.helpers';
@@ -244,6 +245,21 @@ function makeOystehr(): MockOystehr {
   return { oystehr, transaction, search, getPayer, getPayerByUrl };
 }
 
+describe('fetchNioCoveragePairs', () => {
+  it('queries affiliations by the primary-organization search parameter and pairs the included orgs', async () => {
+    const { oystehr, search } = makeOystehr();
+    search.mockResolvedValue({ unbundle: () => [wcAffiliation, wcCoverageOrg] });
+
+    const pairs = await fetchNioCoveragePairs(oystehr, NIO_ID);
+
+    expect(pairs).toEqual([{ affiliation: wcAffiliation, coverageOrg: wcCoverageOrg }]);
+    expect(search.mock.calls[0][0].params).toContainEqual({
+      name: 'primary-organization',
+      value: `Organization/${NIO_ID}`,
+    });
+  });
+});
+
 describe('create-billing-non-insurance-org', () => {
   it('writes the NIO, coverage orgs, and affiliations in one urn-linked transaction', async () => {
     const { oystehr, transaction } = makeOystehr();
@@ -400,6 +416,11 @@ describe('search-billing-non-insurance-orgs', () => {
       value: `${NIO_ORGANIZATION_KIND_SYSTEM}|non-insurance-organization`,
     });
     expect(orgParams).toContainEqual({ name: 'active', value: 'true' });
+    // R4 names the OrganizationAffiliation.organization search parameter primary-organization.
+    expect(search.mock.calls[1][0].params).toContainEqual({
+      name: 'primary-organization',
+      value: `Organization/${NIO_ID}`,
+    });
   });
 
   it('falls back to the stored payer display when RCM resolution fails', async () => {
@@ -442,7 +463,11 @@ describe('list-non-insurance-organizations', () => {
 
     const orgParams = search.mock.calls[0][0].params;
     expect(orgParams).toContainEqual({ name: 'type', value: `${NIO_ORGANIZATION_KIND_SYSTEM}|employer` });
-    // The affiliation pass never asks for the coverage orgs.
+    // The affiliation pass filters by primary-organization and never asks for the coverage orgs.
+    expect(search.mock.calls[1][0].params).toContainEqual({
+      name: 'primary-organization',
+      value: `Organization/${NIO_ID}`,
+    });
     expect(search.mock.calls[1][0].params.some((p: { name: string }) => p.name === '_include')).toBe(false);
   });
 

--- a/packages/zambdas/test/unit/billing/non-insurance-org.test.ts
+++ b/packages/zambdas/test/unit/billing/non-insurance-org.test.ts
@@ -163,6 +163,12 @@ describe('non-insurance-org FHIR mapping', () => {
     expect(occMed.name).toBe('FedEx — Occupational Medicine');
   });
 
+  it('always carries the kind identifier so FHIR org-1 holds even for an unnamed coverage org', () => {
+    const unnamedOther = buildCoverageOrganization({ nioName: 'FedEx', coverage: { category: 'other' } });
+    expect(unnamedOther.name).toBeUndefined();
+    expect(unnamedOther.identifier).toEqual([{ system: NIO_ORGANIZATION_KIND_SYSTEM, value: 'nio-coverage' }]);
+  });
+
   it('writes submission details to telecom, address, and extensions', () => {
     const org = buildCoverageOrganization({ nioName: 'FedEx', coverage: fullInput.covers![1] });
     expect(org.telecom).toEqual([

--- a/packages/zambdas/test/unit/billing/non-insurance-org.test.ts
+++ b/packages/zambdas/test/unit/billing/non-insurance-org.test.ts
@@ -391,14 +391,11 @@ describe('delete-billing-non-insurance-org', () => {
 });
 
 describe('search-billing-non-insurance-orgs', () => {
-  it('maps a page of orgs with covers resolved from one affiliation search', async () => {
+  it('maps a page of orgs with covers riding along in the one search', async () => {
     const { oystehr, search, getPayerByUrl } = makeOystehr();
-    search.mockImplementation(({ resourceType }) => {
-      if (resourceType === 'Organization') {
-        return Promise.resolve({ unbundle: () => [nioOrg], total: 1 });
-      }
-      return Promise.resolve({ unbundle: () => [wcAffiliation, wcCoverageOrg] });
-    });
+    // NIO rows, their affiliations, and coverage orgs all come back from one Organization search
+    // (_revinclude + _include:iterate); the kind coding separates rows from included coverage orgs.
+    search.mockResolvedValue({ unbundle: () => [nioOrg, wcAffiliation, wcCoverageOrg], total: 1 });
     getPayerByUrl.mockResolvedValue({
       resourceType: 'Organization',
       id: PAYER_RCM_ID,
@@ -416,26 +413,37 @@ describe('search-billing-non-insurance-orgs', () => {
     expect(wc.billingMode).toBe('insurance');
     expect(wc.payer).toEqual({ id: PAYER_RCM_ID, name: 'Acme Insurance', payerId: 'PAYER123' });
 
+    expect(search).toHaveBeenCalledTimes(1);
     const orgParams = search.mock.calls[0][0].params;
     expect(orgParams).toContainEqual({
       name: 'type',
       value: `${NIO_ORGANIZATION_KIND_SYSTEM}|non-insurance-organization`,
     });
     expect(orgParams).toContainEqual({ name: 'active', value: 'true' });
-    // R4 names the OrganizationAffiliation.organization search parameter primary-organization.
-    expect(search.mock.calls[1][0].params).toContainEqual({
-      name: 'primary-organization',
-      value: `Organization/${NIO_ID}`,
+    // The element is OrganizationAffiliation.organization; its R4 search parameter is
+    // primary-organization, and the coverage orgs hop along off the rev-included affiliations.
+    expect(orgParams).toContainEqual({ name: '_revinclude', value: 'OrganizationAffiliation:primary-organization' });
+    expect(orgParams).toContainEqual({
+      name: '_include:iterate',
+      value: 'OrganizationAffiliation:participating-organization',
     });
+  });
+
+  it('drops rev-included inactive affiliations so retired covers stay hidden', async () => {
+    const { oystehr, search } = makeOystehr();
+    search.mockResolvedValue({
+      unbundle: () => [nioOrg, { ...wcAffiliation, active: false }, wcCoverageOrg],
+      total: 1,
+    });
+
+    const result = await searchNios(oystehr, { secrets: null });
+
+    expect(result.organizations[0].covers).toEqual([]);
   });
 
   it('falls back to the stored payer display when RCM resolution fails', async () => {
     const { oystehr, search, getPayerByUrl } = makeOystehr();
-    search.mockImplementation(({ resourceType }) =>
-      resourceType === 'Organization'
-        ? Promise.resolve({ unbundle: () => [nioOrg], total: 1 })
-        : Promise.resolve({ unbundle: () => [wcAffiliation, wcCoverageOrg] })
-    );
+    search.mockResolvedValue({ unbundle: () => [nioOrg, wcAffiliation, wcCoverageOrg], total: 1 });
     getPayerByUrl.mockRejectedValue(new Error('rcm down'));
 
     const result = await searchNios(oystehr, { secrets: null });
@@ -447,11 +455,8 @@ describe('search-billing-non-insurance-orgs', () => {
 describe('list-non-insurance-organizations', () => {
   it('returns minimal clinical options carrying the NIO reference token', async () => {
     const { oystehr, search } = makeOystehr();
-    search.mockImplementation(({ resourceType }) =>
-      resourceType === 'Organization'
-        ? Promise.resolve({ unbundle: () => [nioOrg] })
-        : Promise.resolve({ unbundle: () => [wcAffiliation] })
-    );
+    // Affiliations ride along in the one Organization search via _revinclude.
+    search.mockResolvedValue({ unbundle: () => [nioOrg, wcAffiliation] });
 
     const result = await listNios(oystehr, { employerOnly: true, secrets: null });
 
@@ -467,23 +472,18 @@ describe('list-non-insurance-organizations', () => {
       },
     ]);
 
+    expect(search).toHaveBeenCalledTimes(1);
     const orgParams = search.mock.calls[0][0].params;
     expect(orgParams).toContainEqual({ name: 'type', value: `${NIO_ORGANIZATION_KIND_SYSTEM}|employer` });
-    // The affiliation pass filters by primary-organization and never asks for the coverage orgs.
-    expect(search.mock.calls[1][0].params).toContainEqual({
-      name: 'primary-organization',
-      value: `Organization/${NIO_ID}`,
-    });
-    expect(search.mock.calls[1][0].params.some((p: { name: string }) => p.name === '_include')).toBe(false);
+    // Affiliations arrive via _revinclude (its R4 name is primary-organization); the directory
+    // never asks for the coverage orgs themselves.
+    expect(orgParams).toContainEqual({ name: '_revinclude', value: 'OrganizationAffiliation:primary-organization' });
+    expect(orgParams.some((p: { name: string }) => p.name.startsWith('_include'))).toBe(false);
   });
 
   it('resolves a deleted NIO by id with active=false', async () => {
     const { oystehr, search } = makeOystehr();
-    search.mockImplementation(({ resourceType }) =>
-      resourceType === 'Organization'
-        ? Promise.resolve({ unbundle: () => [{ ...nioOrg, active: false }] })
-        : Promise.resolve({ unbundle: () => [] })
-    );
+    search.mockResolvedValue({ unbundle: () => [{ ...nioOrg, active: false }] });
 
     const result = await listNios(oystehr, { nioId: NIO_ID, secrets: null });
 
@@ -497,8 +497,7 @@ describe('list-non-insurance-organizations', () => {
     const secondNioId = '33333333-3333-4333-8333-333333333333';
     const { oystehr, search } = makeOystehr();
     let orgPage = 0;
-    search.mockImplementation(({ resourceType }) => {
-      if (resourceType !== 'Organization') return Promise.resolve({ unbundle: () => [] });
+    search.mockImplementation(() => {
       orgPage += 1;
       return orgPage === 1
         ? Promise.resolve({ unbundle: () => [nioOrg], link: [{ relation: 'next', url: 'next-page' }] })

--- a/packages/zambdas/test/unit/validate-request-parameters/non-insurance-org.test.ts
+++ b/packages/zambdas/test/unit/validate-request-parameters/non-insurance-org.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'vitest';
+import { validateRequestParameters as validateCreate } from '../../../src/billing/create-billing-non-insurance-org/validateRequestParameters';
+import { validateRequestParameters as validateDelete } from '../../../src/billing/delete-billing-non-insurance-org/validateRequestParameters';
+import { validateRequestParameters as validateList } from '../../../src/billing/list-non-insurance-organizations/validateRequestParameters';
+import { validateRequestParameters as validateSearch } from '../../../src/billing/search-billing-non-insurance-orgs/validateRequestParameters';
+import { validateRequestParameters as validateUpdate } from '../../../src/billing/update-billing-non-insurance-org/validateRequestParameters';
+import { createMockSecrets, createMockZambdaInput } from './helpers';
+
+const NIO_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('non-insurance-org zambdas - validateRequestParameters', () => {
+  const secrets = createMockSecrets();
+
+  test('create returns validated params for a valid request', () => {
+    const input = createMockZambdaInput(
+      {
+        name: 'FedEx',
+        employer: true,
+        covers: [{ category: 'workers-comp', billingMode: 'insurance', payerId: 'payer-1' }],
+      },
+      { secrets }
+    );
+    expect(validateCreate(input)).toEqual({
+      name: 'FedEx',
+      employer: true,
+      covers: [{ category: 'workers-comp', billingMode: 'insurance', payerId: 'payer-1' }],
+      secrets,
+    });
+  });
+
+  test('create rejects a missing body and missing secrets', () => {
+    expect(() => validateCreate(createMockZambdaInput(null, { secrets }))).toThrow();
+    expect(() => validateCreate(createMockZambdaInput({ name: 'FedEx', employer: false }))).toThrow();
+  });
+
+  test('create rejects a schema violation (duplicate coverage category)', () => {
+    const input = createMockZambdaInput(
+      { name: 'FedEx', employer: false, covers: [{ category: 'other' }, { category: 'other' }] },
+      { secrets }
+    );
+    expect(() => validateCreate(input)).toThrow();
+  });
+
+  test('update requires nioId', () => {
+    expect(() => validateUpdate(createMockZambdaInput({ name: 'FedEx', employer: false }, { secrets }))).toThrow();
+    expect(
+      validateUpdate(createMockZambdaInput({ nioId: NIO_ID, name: 'FedEx', employer: false }, { secrets }))
+    ).toEqual({ nioId: NIO_ID, name: 'FedEx', employer: false, secrets });
+  });
+
+  test('search accepts an empty object body', () => {
+    expect(validateSearch(createMockZambdaInput({}, { secrets }))).toEqual({ secrets });
+  });
+
+  test('delete requires nioId', () => {
+    expect(() => validateDelete(createMockZambdaInput({}, { secrets }))).toThrow();
+    expect(validateDelete(createMockZambdaInput({ nioId: NIO_ID }, { secrets }))).toEqual({ nioId: NIO_ID, secrets });
+  });
+
+  test('list accepts directory filters and rejects employerOnly=false', () => {
+    expect(validateList(createMockZambdaInput({ employerOnly: true, search: 'fed' }, { secrets }))).toEqual({
+      employerOnly: true,
+      search: 'fed',
+      secrets,
+    });
+    expect(() => validateList(createMockZambdaInput({ employerOnly: false }, { secrets }))).toThrow();
+  });
+});


### PR DESCRIPTION
🤖 generated code and description below. @alexwillingham co-authored and reviewed this, editing code and comments along the way.

## What this adds

Non-Insurance Organizations (NIOs) — organizations the practice bills directly under contract, commonly patient employers — managed in the **billing app**, replacing the clinical app's legacy Employers feature (which a stacked follow-up PR wires up and retires behind a clinical-side flag).

### FHIR model
- One `Organization` per NIO, kind-coded `non-insurance-organization` (+ `employer` when it can be selected as a visit employer) under `https://fhir.ottehr.com/billing/organization-kind`.
- One coverage `Organization` per checked "covers" category (`workers-comp`, `occupational-medicine`, `other`), linked via `OrganizationAffiliation` with the category on `affiliation.code`. Workers' comp carries billing mode (insurance vs direct) and an optional payer reference; submission preferences live in extensions.
- Coverage orgs always carry a kind `identifier` so FHIR's `org-1` invariant holds for unnamed categories.
- Contacts map to `contact.name.text` / `purpose.text` / telecom, matching the paperwork-harvest precedent.
- Everything is meta-tagged `billing-resource` and read/written through the workspace-tagged billing client.

### Zambdas (all registered in `config/billing-app-core/zambdas.json`)
- `create` / `update` / `search` / `delete-billing-non-insurance-org` — full CRUD as `urn:uuid` transactions with `If-Match` optimistic locking; delete is a soft-delete (`active=false`) across the whole graph. Granted to `BILLING_ADMIN`.
- `list-non-insurance-organizations` — the **clinical directory**: the one door clinical code gets to billing NIO data. Returns a deliberately minimal option shape (id, name, employer, active, covers categories) whose `reference` is a stable URL token (`https://fhir.ottehr.com/billing/non-insurance-organization/{id}`, `getPayerUrl`-style) that clinical code stores verbatim — clinical never reads billing FHIR. EHR-staff roles only; patients can't reach it.

### Billing app UI
`Non-Insurance Organizations` page (list + search + add dialog + detail with editable sections: details, covers, contacts), available unconditionally — NIO management always lives in the billing app. The `nonInsuranceOrganizationsEnabled` feature flag only toggles the clinical side between legacy Employers and this directory; that wiring arrives with the stacked EHR-wiring PR.

### Tests
- Zod schema matrix (19), zambda helper/builder units (20), request-validation units (7), and an end-to-end CRUD integration test (create → read → update twice → soft-delete, exercising affiliation search by `primary-organization` and the org-1 edge).
- Billing app component tests for the page (7).

### Notes for reviewers
- `OrganizationAffiliation` is searched with the R4 `primary-organization` parameter (the element is named `organization`; the search parameter is not).
- Stacked follow-up: `claude/nio-ehr-wiring-2i58e9` reroutes the EHR occ-med employer picker to the directory, validates token references on visit saves, carries tokens through harvest/prepopulation/PDF, gates the legacy employer surfaces, and adds the Candid-vs-NIO deploy guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsBbwj7TpkY4k8DqRBoVjE