### PR TITLE
fix: run report searches as async-bulk jobs, in date windows

### DIFF
--- a/apps/ehr/src/features/report-builder/page/ReportBuilderPage.tsx
+++ b/apps/ehr/src/features/report-builder/page/ReportBuilderPage.tsx
@@ -2,6 +2,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import SaveIcon from '@mui/icons-material/Save';
 import {
+  Alert,
   Box,
   Button,
   CircularProgress,
@@ -149,9 +150,9 @@ export default function ReportBuilderPage(): React.ReactElement {
           </Box>
 
           {rb.error && (
-            <Box sx={{ mb: 2, p: 2, bgcolor: 'error.light', borderRadius: 1 }}>
-              <Typography color="error">{rb.error}</Typography>
-            </Box>
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {rb.error}
+            </Alert>
           )}
 
           {rb.canCreate && (
@@ -193,9 +194,9 @@ export default function ReportBuilderPage(): React.ReactElement {
           )}
 
           {rb.generateError && (
-            <Box sx={{ mb: 2, p: 2, bgcolor: 'error.light', borderRadius: 1 }}>
-              <Typography color="error">{rb.generateError}</Typography>
-            </Box>
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {rb.generateError}
+            </Alert>
           )}
 
           {rb.unavailableRequest && (
@@ -314,12 +315,10 @@ export default function ReportBuilderPage(): React.ReactElement {
                   </Collapse>
 
                   {rb.renderError && (
-                    <Box sx={{ mb: 2, p: 2, bgcolor: 'warning.light', borderRadius: 1 }}>
-                      <Typography variant="body2">
-                        The report failed to run: {rb.renderError}.{' '}
-                        {rb.canCreate ? 'Adjust your request and regenerate.' : 'Ask an administrator to rebuild it.'}
-                      </Typography>
-                    </Box>
+                    <Alert severity="warning" sx={{ mb: 2 }}>
+                      The report failed to run: {rb.renderError}.{' '}
+                      {rb.canCreate ? 'Adjust your request and regenerate.' : 'Ask an administrator to rebuild it.'}
+                    </Alert>
                   )}
 
                   <Box

--- a/packages/zambdas/src/shared/adhoc-report.ts
+++ b/packages/zambdas/src/shared/adhoc-report.ts
@@ -4,7 +4,6 @@ import { randomUUID } from 'crypto';
 import {
   Address,
   Appointment,
-  Bundle,
   Encounter,
   FhirResource,
   Location,
@@ -54,6 +53,7 @@ const REPORT_BUDGET_MS = 13 * 60 * 1000;
 const DEFAULT_JOB_TIMEOUT_MS = 10 * 60 * 1000;
 
 let reportDeadlineMs = 0;
+
 export function beginReportBudget(): void {
   reportDeadlineMs = Date.now() + REPORT_BUDGET_MS;
 }
@@ -65,82 +65,131 @@ function jobWait(): { pollIntervalMs: number; timeoutMs: number } {
   return { pollIntervalMs: 2000, timeoutMs: remaining };
 }
 
-const ASYNC_PAGE_SIZE = 1000;
+const FAILURE_BODY_CHARS = 800;
 
-function readSearchsets<T extends FhirResource>(
-  completion: Bundle
-): { resources: T[]; matchedIds: string[]; hasNext: boolean } {
-  const resources: T[] = [];
-  const matchedIds: string[] = [];
-  let hasNext = false;
-  for (const outer of completion.entry ?? []) {
-    // A failed search arrives as an entry with a non-2xx status and NO searchset. Skipping it
-    // silently is how a search answering "400 Internal Error" became a successful empty report.
-    const status = outer.response?.status;
-    if (status && !status.startsWith('2')) {
-      const issues = (outer.response?.outcome as OperationOutcome | undefined)?.issue
-        ?.map((issue) => issue.details?.text || issue.diagnostics || issue.code)
-        .join('; ');
-      throw new Error(`FHIR search failed with ${status}${issues ? `: ${issues}` : ''}`);
+async function logAsyncJobFailure(oystehr: Oystehr, jobId: string, label: string): Promise<void> {
+  if (!jobId) return;
+  try {
+    const status = (await oystehr.fhir.getAsyncJob(jobId)) as {
+      status?: number;
+      mode?: string;
+      outcome?: OperationOutcome;
+      manifest?: { output?: { url?: string }[]; requiresAccessToken?: boolean };
+      bundle?: unknown;
+      body?: unknown;
+    };
+    const parts = [`status=${status.status ?? 'none'}`, `mode=${status.mode ?? 'none'}`];
+    if (status.outcome) parts.push(`outcome=${JSON.stringify(status.outcome).slice(0, FAILURE_BODY_CHARS)}`);
+    if (status.manifest) {
+      parts.push(
+        `manifestFiles=${status.manifest.output?.length ?? 0}`,
+        `requiresAccessToken=${status.manifest.requiresAccessToken ?? 'none'}`
+      );
     }
-    const searchset = outer.resource as Bundle | undefined;
-    if (!searchset || searchset.resourceType !== 'Bundle' || searchset.type !== 'searchset') continue;
-    if (searchset.link?.some((link) => link.relation === 'next')) hasNext = true;
-    for (const entry of searchset.entry ?? []) {
-      const resource = entry.resource;
-      const mode = entry.search?.mode ?? 'match';
-      if (!resource || mode === 'outcome') continue;
-      resources.push(resource as T);
-      // Only matched resources advance the offset; _include ones ride along outside the page count.
-      if (mode === 'match' && resource.id) matchedIds.push(resource.id);
+
+    if (status.body && !status.manifest && !status.bundle) {
+      parts.push(`body=${JSON.stringify(status.body).slice(0, FAILURE_BODY_CHARS)}`);
     }
+
+    console.error(`[adhoc] ${label}: job ${jobId} ${parts.join(' ')}`);
+  } catch (error) {
+    console.error(
+      `[adhoc] ${label}: could not read job ${jobId}: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
-  return { resources, matchedIds, hasNext };
 }
 
-async function searchAllAsync<T extends FhirResource>(
+// The bulk output files are downloaded here rather than through the SDK's waitForAsyncBulkOutput.
+// Measured: the manifest reports requiresAccessToken=true, so the SDK adds an Authorization header,
+// and the storage rejects a pre-signed url that also carries one with "400". The same url fetched
+// with no auth at all returns 200. The SDK offers no way to skip the header — it throws when the
+// manifest asks for a token and none is given.
+async function downloadNdjson<T extends FhirResource>(url: string): Promise<T[]> {
+  // fetch has no timeout of its own, so a stalled download would hang until the lambda itself is
+  // killed, ignoring the report budget. Bound it by whatever is left of that budget — and jobWait
+  // throws first when nothing is left, so an already-doomed download never starts.
+  const { timeoutMs } = jobWait();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { method: 'GET', signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(
+        `downloading ${url.split('?')[0]} answered ${response.status}: ${(await response.text()).slice(
+          0,
+          FAILURE_BODY_CHARS
+        )}`
+      );
+    }
+    const ndjson = await response.text();
+    const resources: T[] = [];
+    for (const line of ndjson.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed) resources.push(JSON.parse(trimmed) as T);
+    }
+    return resources;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function searchAsyncBulk<T extends FhirResource>(
   oystehr: Oystehr,
   resourceType: T['resourceType'],
   params: { name: string; value: string }[]
 ): Promise<T[]> {
-  const out: T[] = [];
-  const seen = new Set<string>();
-  let offset = 0;
-  let progressed = true;
-  while (progressed) {
-    const pageParams = [
-      ...params,
-      { name: '_count', value: String(ASYNC_PAGE_SIZE) },
-      { name: '_offset', value: String(offset) },
-      { name: '_sort', value: '_id' },
-    ];
-    const handle = await oystehr.fhir.search<T>({ resourceType, params: pageParams }, { mode: 'async-bundle' });
-    const status = await oystehr.fhir.waitForAsyncJob<T>(handle.jobId, jobWait());
-    if (status.status !== 200 || !('mode' in status) || status.mode !== 'bundle') {
-      throw new Error(`Async search for ${resourceType} did not complete in bundle mode`);
+  const label = `${resourceType} by ${params.map((p) => p.name).join(',')}`;
+  const startedAt = Date.now();
+  let jobId = '';
+  try {
+    const handle = await oystehr.fhir.search<T>({ resourceType, params }, { mode: 'async-bulk' });
+    jobId = handle.jobId;
+    const status = await oystehr.fhir.waitForAsyncJob<T>(jobId, jobWait());
+    if (status.status !== 200 || !('mode' in status) || status.mode !== 'bulk') {
+      throw new Error(`job answered status ${status.status}, mode ${'mode' in status ? status.mode : 'none'}`);
     }
-    const { resources, matchedIds, hasNext } = readSearchsets<T>(status.bundle as Bundle);
-    out.push(...resources);
-    const newMatched = matchedIds.filter((id) => !seen.has(id));
-    newMatched.forEach((id) => seen.add(id));
-    offset += matchedIds.length;
-    progressed = hasNext && newMatched.length > 0;
+
+    const files = await Promise.all(
+      (status.manifest.output ?? []).map(async (file) => ({
+        type: file.type,
+        resources: await downloadNdjson<T>(file.url),
+      }))
+    );
+    const resources = files.flatMap((file) => file.resources);
+    console.log(
+      `[adhoc] ${label}: job=${jobId} ms=${Date.now() - startedAt} files=${files.length} ` +
+        `resources=${resources.length} ` +
+        `perFile=${JSON.stringify(files.map((file) => ({ type: file.type, count: file.resources.length })))}`
+    );
+    return resources;
+  } catch (error) {
+    console.error(
+      `[adhoc] ${label}: FAILED job=${jobId || 'not started'} ms=${Date.now() - startedAt} ` +
+        `code=${(error as { code?: unknown })?.code ?? 'none'} message=${
+          error instanceof Error ? error.message : String(error)
+        }`
+    );
+
+    await logAsyncJobFailure(oystehr, jobId, label);
+
+    captureException(error, { extra: { resourceType, jobId, params } });
+
+    throw new Error(
+      `Could not load ${resourceType} for the report (job ${jobId || 'not started'}): ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
   }
-  return out;
 }
 
 const REPORT_APPOINTMENT_STATUSES = 'proposed,pending,booked,arrived,fulfilled,checked-in,waitlist,cancelled,noshow';
 
 export const REPORT_ATTENDED_APPOINTMENT_STATUSES = 'proposed,pending,booked,arrived,fulfilled,checked-in,waitlist';
 
-// The main search pulls a whole include graph per appointment, so its size follows the requested
-// date range, not a list we control. A five-month range came back empty; a one-month range over the
-// same data returned every row. Raise this only with a measurement to back it up.
-const REPORT_WINDOW_DAYS = 30;
+// currently async bulk removes the limit on how much the server may SEND, not the limit on the query it has to RUN:
+const REPORT_WINDOW_DAYS = 3;
 const REPORT_WINDOW_CONCURRENCY = 4;
 
-// Cuts a range into consecutive windows of at most REPORT_WINDOW_DAYS. A range that already fits,
-// or one whose bounds do not parse, is returned unchanged so the search behaves exactly as before.
 function reportWindows(dateRange: { start: string; end: string }): { start: string; end: string }[] {
   const start = DateTime.fromISO(dateRange.start);
   const end = DateTime.fromISO(dateRange.end);
@@ -151,8 +200,7 @@ function reportWindows(dateRange: { start: string; end: string }): { start: stri
   while (cursor < end) {
     const next = DateTime.min(cursor.plus({ days: REPORT_WINDOW_DAYS }), end);
     windows.push({ start: cursor.toISO()!, end: next.toISO()! });
-    // The next window starts where this one ended; `date=ge`/`le` are inclusive on both sides, so
-    // step off the boundary by a millisecond to keep an appointment out of two windows.
+    // `date=ge`/`le` include both bounds, so step off the boundary by a millisecond to keep an appointment out of two windows.
     cursor = next.plus({ milliseconds: 1 });
   }
   return windows;
@@ -167,7 +215,7 @@ export async function fetchAppointmentReportResources<T extends FhirResource>(
   }
 ): Promise<T[]> {
   const searchWindow = (window: { start: string; end: string }): Promise<T[]> =>
-    searchAllAsync<T>(oystehr, 'Appointment', [
+    searchAsyncBulk<T>(oystehr, 'Appointment', [
       { name: 'date', value: `ge${window.start}` },
       { name: 'date', value: `le${window.end}` },
       { name: 'status', value: opts.statuses ?? REPORT_APPOINTMENT_STATUSES },
@@ -175,15 +223,14 @@ export async function fetchAppointmentReportResources<T extends FhirResource>(
       { name: '_include', value: 'Appointment:patient' },
       { name: '_include', value: 'Appointment:location' },
       { name: '_revinclude', value: 'Encounter:appointment' },
-      { name: '_include:iterate', value: 'Encounter:participant:Practitioner' },
       ...(opts.extraParams ?? []),
     ]);
 
   const windows = reportWindows(opts.dateRange);
-  if (windows.length === 1) return searchWindow(windows[0]);
-
   const out: T[] = [];
   const seen = new Set<string>();
+  const startedAt = Date.now();
+
   for (let i = 0; i < windows.length; i += REPORT_WINDOW_CONCURRENCY) {
     const group = await Promise.all(windows.slice(i, i + REPORT_WINDOW_CONCURRENCY).map(searchWindow));
     for (const resources of group) {
@@ -196,12 +243,31 @@ export async function fetchAppointmentReportResources<T extends FhirResource>(
       }
     }
   }
+
+  out.push(...(await fetchAttendingPractitioners<T>(oystehr, out)));
+  console.log(
+    `[adhoc] Appointment search: windows=${windows.length} resources=${out.length} ms=${Date.now() - startedAt}`
+  );
   return out;
 }
 
-// One search per batch of scoping values. Measured: a comma list of 1249 encounter references
-// (63891 bytes) answers "400 Bad Request / Internal Error", while 100 references answer 200. The
-// limit between the two is not documented, so the batch size stays conservative.
+// (Temporarily, while async-bulk isn't working as expected): the attending providers used to ride along on the main search as _include:iterate through the
+// Encounter, which made every window carry a fourth resource type in full. Only the attending one is
+// ever read, and only its name, so they are fetched separately: by id, in batches, two fields each —
+// the same shape as every other heavy part of a report.
+async function fetchAttendingPractitioners<T extends FhirResource>(oystehr: Oystehr, resources: T[]): Promise<T[]> {
+  const ids = new Set<string>();
+  for (const resource of resources) {
+    if (resource.resourceType !== 'Encounter') continue;
+    const id = getAttendingPractitionerId(resource as Encounter);
+    if (id) ids.add(id);
+  }
+  if (ids.size === 0) return [];
+  return fetchScopedResources<T>(oystehr, 'Practitioner', '_id', Array.from(ids), [
+    { name: '_elements', value: 'id,name' },
+  ]);
+}
+
 const SCOPED_BATCH_SIZE = 100;
 const SCOPED_BATCH_CONCURRENCY = 4;
 
@@ -220,23 +286,10 @@ export async function fetchScopedResources<T extends FhirResource>(
     batches.push(values.slice(i, i + SCOPED_BATCH_SIZE));
   }
 
-  // A failed batch used to return an empty list, so the layer came back partly filled and the
-  // report looked complete. A report on missing data is worse than a report that says it failed.
-  const searchBatch = async (batch: string[]): Promise<T[]> => {
-    try {
-      return await searchAllAsync<T>(oystehr, resourceType, [
-        { name: paramName, value: batch.join(',') },
-        ...extraParams,
-      ]);
-    } catch (error) {
-      captureException(error, { extra: { resourceType, paramName, valueCount: batch.length } });
-      throw new Error(
-        `Could not load ${resourceType} for the report (${batch.length} of ${values.length} by ${paramName}): ` +
-          `${error instanceof Error ? error.message : String(error)}`
-      );
-    }
-  };
+  const searchBatch = (batch: string[]): Promise<T[]> =>
+    searchAsyncBulk<T>(oystehr, resourceType, [{ name: paramName, value: batch.join(',') }, ...extraParams]);
 
+  const startedAt = Date.now();
   const out: T[] = [];
   for (let i = 0; i < batches.length; i += SCOPED_BATCH_CONCURRENCY) {
     const group = await Promise.all(batches.slice(i, i + SCOPED_BATCH_CONCURRENCY).map(searchBatch));
@@ -244,7 +297,7 @@ export async function fetchScopedResources<T extends FhirResource>(
   }
   console.log(
     `[adhoc] ${resourceType} by ${paramName}: values=${values.length} batches=${batches.length} ` +
-      `returned=${out.length}`
+      `resources=${out.length} ms=${Date.now() - startedAt}`
   );
   return out;
 }

--- a/packages/zambdas/src/subscriptions/sub-adhoc-report/index.ts
+++ b/packages/zambdas/src/subscriptions/sub-adhoc-report/index.ts
@@ -42,52 +42,90 @@ function readParams(task: Task): ReportParams {
   return JSON.parse(raw) as ReportParams;
 }
 
-async function buildOutputJson(oystehr: Oystehr, params: ReportParams): Promise<string> {
+async function buildOutputJson(oystehr: Oystehr, params: ReportParams): Promise<{ json: string; rowCount: number }> {
   const { datasetId, dateRange, options } = params;
   switch (datasetId) {
     case 'encounters-comprehensive': {
       const input = AdHocEncountersInputSchema.parse({ dateRange, ...layerIncludeFlags(ENCOUNTER_LAYERS, options) });
       const rows = await fetchAdHocEncounterRows(oystehr, input);
-      return JSON.stringify(validateOutputWithSchema(AdHocEncountersOutputSchema, { encounters: rows }, ZAMBDA_NAME));
+      const json = JSON.stringify(
+        validateOutputWithSchema(AdHocEncountersOutputSchema, { encounters: rows }, ZAMBDA_NAME)
+      );
+      return { json, rowCount: rows.length };
     }
     case 'patients': {
       const input = AdHocPatientsInputSchema.parse({ dateRange, ...layerIncludeFlags(PATIENT_LAYERS, options) });
       const rows = await fetchAdHocPatientRows(oystehr, input);
-      return JSON.stringify(validateOutputWithSchema(AdHocPatientsOutputSchema, { patients: rows }, ZAMBDA_NAME));
+      const json = JSON.stringify(validateOutputWithSchema(AdHocPatientsOutputSchema, { patients: rows }, ZAMBDA_NAME));
+      return { json, rowCount: rows.length };
     }
     case 'billing': {
       const input = AdHocBillingInputSchema.parse({ dateRange, ...layerIncludeFlags(BILLING_LAYERS, options) });
       const rows = await fetchAdHocBillingRows(oystehr, input);
-      return JSON.stringify(validateOutputWithSchema(AdHocBillingOutputSchema, { rows }, ZAMBDA_NAME));
+      const json = JSON.stringify(validateOutputWithSchema(AdHocBillingOutputSchema, { rows }, ZAMBDA_NAME));
+      return { json, rowCount: rows.length };
     }
     default:
       throw new Error(`Unknown ad-hoc dataset "${datasetId}"`);
   }
 }
 
+async function stage<T>(
+  name: string,
+  taskId: string | undefined,
+  startedAt: number,
+  run: () => Promise<T>
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    console.error(
+      `[adhoc] ${name} FAILED task=${taskId} ms=${Date.now() - startedAt} ` +
+        `code=${(error as { code?: unknown })?.code ?? 'none'} ` +
+        `message=${error instanceof Error ? error.message : String(error)}`
+    );
+    throw error;
+  }
+}
+
 export const index = wrapTaskHandler(ZAMBDA_NAME, async (input, oystehr) => {
   const { task, secrets } = input;
+  const startedAt = Date.now();
 
   beginReportBudget();
-  const json = await buildOutputJson(oystehr, readParams(task));
-  const z3Url = await uploadAdHocReportJsonToZ3(oystehr, secrets, json);
+  const params = await stage('read params', task.id, startedAt, async () => readParams(task));
 
-  await oystehr.fhir.patch({
-    resourceType: 'Task',
-    id: task.id!,
-    operations: [
-      {
-        op: 'add',
-        path: '/output',
-        value: [
-          {
-            type: { coding: [{ system: ADHOC_REPORT_TASK_SYSTEM, code: ADHOC_REPORT_OUTPUT_URL_CODE }] },
-            valueString: z3Url,
-          },
-        ],
-      },
-    ],
-  });
+  console.log(
+    `[adhoc] start task=${task.id} dataset=${params.datasetId} ` +
+      `range=${params.dateRange.start}..${params.dateRange.end} ` +
+      `layers=${JSON.stringify(Object.keys(params.options ?? {}).filter((id) => params.options[id]))}`
+  );
 
+  const { json, rowCount } = await stage('build data', task.id, startedAt, () => buildOutputJson(oystehr, params));
+  console.log(`[adhoc] data ready task=${task.id} ms=${Date.now() - startedAt} rows=${rowCount} bytes=${json.length}`);
+
+  const z3Url = await stage('upload', task.id, startedAt, () => uploadAdHocReportJsonToZ3(oystehr, secrets, json));
+  console.log(`[adhoc] uploaded task=${task.id} ms=${Date.now() - startedAt}`);
+
+  await stage('record output on task', task.id, startedAt, () =>
+    oystehr.fhir.patch({
+      resourceType: 'Task',
+      id: task.id!,
+      operations: [
+        {
+          op: 'add',
+          path: '/output',
+          value: [
+            {
+              type: { coding: [{ system: ADHOC_REPORT_TASK_SYSTEM, code: ADHOC_REPORT_OUTPUT_URL_CODE }] },
+              valueString: z3Url,
+            },
+          ],
+        },
+      ],
+    })
+  );
+
+  console.log(`[adhoc] done task=${task.id} ms=${Date.now() - startedAt}`);
   return { taskStatus: 'completed' as const, statusReason: 'Ad-hoc report data generated' };
 });

--- a/packages/zambdas/test/adhoc-async-pagination.test.ts
+++ b/packages/zambdas/test/adhoc-async-pagination.test.ts
@@ -1,101 +1,95 @@
 import Oystehr from '@oystehr/sdk';
-import { Appointment, FhirResource } from 'fhir/r4b';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { Appointment, FhirResource, Patient } from 'fhir/r4b';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchAppointmentReportResources } from '../src/shared/adhoc-report';
 
 const appt = (id: string): Appointment => ({ resourceType: 'Appointment', id, status: 'fulfilled', participant: [] });
+const patient = (id: string): Patient => ({ resourceType: 'Patient', id });
 
-// Scripted pages keyed by the requested _offset: two non-empty pages then a terminal empty page.
-function matchesForOffset(offset: number): Appointment[] {
-  if (offset === 0) return Array.from({ length: 1000 }, (_, i) => appt(`appt-${i}`));
-  if (offset === 1000) return [appt('appt-1000'), appt('appt-1001')];
-  return [];
-}
+const APPOINTMENT_URL = 'https://example.test/Appointment.ndjson';
+const PATIENT_URL = 'https://example.test/Patient.ndjson';
 
-// Every window the code asks for, in request order — a window is identified by its `date=ge…` bound.
-const requestedWindows: string[] = [];
+const ndjson = (resources: FhirResource[]): string => resources.map((resource) => JSON.stringify(resource)).join('\n');
 
-// A completion bundle (batch-response) whose first entry is the searchset. Page 1000 also carries an
-// 'outcome'-mode entry and a non-searchset outer entry, both of which must be ignored. A page with
-// results carries link[next], which is what tells the loop to ask for the following page.
+const bodyByUrl = new Map<string, string>([
+  [APPOINTMENT_URL, ndjson(Array.from({ length: 1002 }, (_, i) => appt(`appt-${i}`)))],
+  // An _include lands in its own file rather than inside the matched resources.
+  [PATIENT_URL, ndjson([patient('pat-1'), patient('pat-2')])],
+]);
+
+const requestedUrls: string[] = [];
+const searchCalls: { name: string; value: string }[][] = [];
+
+// Stubbed rather than assigned, so vitest restores the real fetch even if a test throws — a leaked
+// stub would silently change the behaviour of whatever file runs next in this worker.
+vi.stubGlobal('fetch', (async (input: RequestInfo | URL) => {
+  const url = String(input);
+  requestedUrls.push(url);
+  const body = bodyByUrl.get(url);
+  if (body === undefined) return { ok: false, status: 404, text: async () => 'not found' };
+  return { ok: true, status: 200, text: async () => body };
+}) as unknown as typeof fetch);
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+// The manifest asks for a token: the SDK would add an Authorization header and the storage would
+// answer 400, which is why the zambda downloads the files itself, unauthenticated.
 const fakeOystehr = {
   fhir: {
     search: async ({ params }: { resourceType: string; params?: { name: string; value: string }[] }) => {
-      const from = params?.find((p) => p.name === 'date' && p.value.startsWith('ge'))?.value ?? '';
-      requestedWindows.push(from);
-      return {
-        jobId: params?.find((p) => p.name === '_offset')?.value ?? '0',
-        contentLocation: '',
-        mode: 'bundle',
-      };
+      searchCalls.push(params ?? []);
+      return { jobId: 'job', contentLocation: '', mode: 'bulk' };
     },
-    waitForAsyncJob: async (jobId: string) => {
-      const offset = Number(jobId);
-      const matches = matchesForOffset(offset);
-      const searchsetEntries = matches.map((resource) => ({ resource, search: { mode: 'match' } }));
-      if (offset === 1000) {
-        searchsetEntries.push({
-          resource: { resourceType: 'OperationOutcome' } as unknown as Appointment,
-          search: { mode: 'outcome' },
-        });
-      }
-      return {
-        status: 200,
-        mode: 'bundle',
-        bundle: {
-          resourceType: 'Bundle',
-          type: 'batch-response',
-          entry: [
-            {
-              resource: {
-                resourceType: 'Bundle',
-                type: 'searchset',
-                entry: searchsetEntries,
-                ...(matches.length ? { link: [{ relation: 'next', url: 'https://example.test/next' }] } : {}),
-              },
-            },
-            ...(offset === 1000 ? [{ resource: { resourceType: 'OperationOutcome' } }] : []),
-          ],
-        },
-      };
-    },
+    waitForAsyncJob: async () => ({
+      status: 200,
+      mode: 'bulk',
+      manifest: {
+        requiresAccessToken: true,
+        output: [
+          { type: 'Appointment', url: APPOINTMENT_URL },
+          { type: 'Patient', url: PATIENT_URL },
+        ],
+      },
+    }),
   },
 } as unknown as Oystehr;
 
-// Inside one 30-day window, so this range is searched in a single pass.
-const dateRange = { start: '2026-07-01T00:00:00.000Z', end: '2026-07-28T23:59:59.999Z' };
-
-describe('searchAllAsync pagination (via fetchAppointmentReportResources)', () => {
+describe('async-bulk search (via fetchAppointmentReportResources)', () => {
   beforeEach(() => {
-    requestedWindows.length = 0;
+    searchCalls.length = 0;
+    requestedUrls.length = 0;
   });
 
-  it('walks every page until an empty page and returns all matched resources', async () => {
+  it('downloads every file in the manifest and returns all of their resources', async () => {
+    // Inside one window, so the manifest is fetched once.
+    const dateRange = { start: '2026-07-01T00:00:00.000Z', end: '2026-07-02T23:59:59.999Z' };
     const resources = await fetchAppointmentReportResources<FhirResource>(fakeOystehr, { dateRange });
-    const appointments = resources.filter((r) => r.resourceType === 'Appointment');
-    // 1000 from page 0 + 2 from page 1000; the terminal empty page stops the loop.
-    expect(appointments).toHaveLength(1002);
-    expect(new Set(appointments.map((a) => a.id)).size).toBe(1002);
-    // A range this short is one window, so every request carried the same lower bound.
-    expect(new Set(requestedWindows).size).toBe(1);
-  });
 
-  it('ignores outcome-mode entries and non-searchset completion entries', async () => {
-    const resources = await fetchAppointmentReportResources<FhirResource>(fakeOystehr, { dateRange });
-    expect(resources.some((r) => r.resourceType === 'OperationOutcome')).toBe(false);
+    expect(requestedUrls).toEqual([APPOINTMENT_URL, PATIENT_URL]);
+    expect(resources.filter((r) => r.resourceType === 'Appointment')).toHaveLength(1002);
+    expect(resources.filter((r) => r.resourceType === 'Patient')).toHaveLength(2);
   });
 
   it('splits a long range into windows and returns each resource once', async () => {
-    // 100 days: the server answered a five-month range with 400 Internal Error, so the range is cut
-    // into windows and searched window by window.
-    const longRange = { start: '2026-01-01T00:00:00.000Z', end: '2026-04-11T00:00:00.000Z' };
-    const resources = await fetchAppointmentReportResources<FhirResource>(fakeOystehr, { dateRange: longRange });
+    // Bulk lifts the limit on how much the server may send, not on the query it has to run: a
+    // six-month range failed the job itself, so the range is searched window by window.
+    const dateRange = { start: '2026-01-01T00:00:00.000Z', end: '2026-01-10T00:00:00.000Z' };
+    const resources = await fetchAppointmentReportResources<FhirResource>(fakeOystehr, { dateRange });
 
-    const bounds = Array.from(new Set(requestedWindows)).sort();
-    expect(bounds).toHaveLength(4);
+    const bounds = Array.from(
+      new Set(
+        searchCalls
+          .flatMap((params) => params.filter((p) => p.name === 'date' && p.value.startsWith('ge')))
+          .map((p) => p.value)
+      )
+    ).sort();
+    // Nine days in windows of three.
+    expect(bounds).toHaveLength(3);
     // Windows start where the previous one ended, and the last one stops at the requested end.
     expect(bounds[0]).toContain('2026-01-01');
-    expect(requestedWindows.some((b) => b.includes('2026-04-11'))).toBe(false);
+    expect(bounds.some((b) => b.includes('2026-01-10'))).toBe(false);
 
     // The fake serves the same ids for every window; a resource must not be reported twice.
     const appointments = resources.filter((r) => r.resourceType === 'Appointment');

--- a/packages/zambdas/test/adhoc-datasets-fixture.test.ts
+++ b/packages/zambdas/test/adhoc-datasets-fixture.test.ts
@@ -25,7 +25,7 @@ import {
 } from 'utils/lib/types/api/medication-administration.constants';
 import { CREATED_BY_SYSTEM } from 'utils/lib/types/common';
 import { PRACTITIONER_CODINGS } from 'utils/lib/types/data/appointments/appointments.types';
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it, vi } from 'vitest';
 import { fetchAdHocBillingRows } from '../src/shared/adhoc-datasets/billing';
 import { fetchAdHocEncounterRows } from '../src/shared/adhoc-datasets/encounters';
 import { fetchAdHocPatientRows } from '../src/shared/adhoc-datasets/patients';
@@ -285,8 +285,11 @@ const paymentNotices: FhirResource[] = [
   paymentNotice('pay-3', 10, '2026-07-01T19:00:00.000Z'),
 ];
 
-const rootResources: FhirResource[] = [appointment, encounter, patient, location, practitioner];
+// The attending provider is not an _include on the main search: it is fetched by id afterwards, so
+// the fake serves Practitioner as a scoped type rather than alongside the appointment graph.
+const rootResources: FhirResource[] = [appointment, encounter, patient, location];
 const scopedByType: Record<string, FhirResource[]> = {
+  Practitioner: [practitioner],
   Condition: [condition],
   Observation: observations,
   MedicationAdministration: medicationAdministrations,
@@ -295,38 +298,45 @@ const scopedByType: Record<string, FhirResource[]> = {
 const resourcesFor = (resourceType: string): FhirResource[] =>
   resourceType === 'Appointment' ? rootResources : scopedByType[resourceType] ?? [];
 
-// Emulates the async-bundle path the zambdas use: search returns a job handle (jobId encodes the
-// resource type and the requested offset), and waitForAsyncJob returns the completion bundle
-// (batch-response) whose first entry holds the searchset. The fixtures all fit on the first page,
-// so a non-zero offset returns an empty page — matching how searchAllAsync terminates.
+// Emulates the async-bulk path the zambdas use: the job answers with a manifest of file urls, and
+// the zambda downloads each file itself — the NDJSON is served by the stubbed fetch below.
+const ndjsonByUrl = new Map<string, string>();
+
+const manifestFor = (jobId: string): { output: { type: string; url: string }[]; requiresAccessToken: boolean } => {
+  const byType = new Map<string, FhirResource[]>();
+  for (const resource of resourcesFor(jobId)) {
+    byType.set(resource.resourceType, [...(byType.get(resource.resourceType) ?? []), resource]);
+  }
+  const output = Array.from(byType.entries()).map(([type, resources]) => {
+    const url = `https://example.test/${jobId}/${type}.ndjson`;
+    ndjsonByUrl.set(url, resources.map((resource) => JSON.stringify(resource)).join('\n'));
+    return { type, url };
+  });
+  // The manifest asks for a token, which is exactly the case where the SDK's own downloader fails.
+  return { output, requiresAccessToken: true };
+};
+
+// Stubbed rather than assigned, so vitest restores the real fetch even if a test throws — a leaked
+// stub would silently change the behaviour of whatever file runs next in this worker.
+vi.stubGlobal('fetch', (async (input: RequestInfo | URL) => {
+  const url = String(input);
+  const ndjson = ndjsonByUrl.get(url);
+  if (ndjson === undefined) return { ok: false, status: 404, text: async () => 'not found' };
+  return { ok: true, status: 200, text: async () => ndjson };
+}) as unknown as typeof fetch);
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
 const fakeOystehr = {
   fhir: {
-    search: async ({ resourceType, params }: { resourceType: string; params?: { name: string; value: string }[] }) => ({
-      jobId: `${resourceType}#${params?.find((p) => p.name === '_offset')?.value ?? '0'}`,
+    search: async ({ resourceType }: { resourceType: string }) => ({
+      jobId: resourceType,
       contentLocation: '',
-      mode: 'bundle',
+      mode: 'bulk',
     }),
-    waitForAsyncJob: async (jobId: string) => {
-      const [resourceType, offset] = jobId.split('#');
-      const resources = Number(offset) === 0 ? resourcesFor(resourceType) : [];
-      return {
-        status: 200,
-        mode: 'bundle',
-        bundle: {
-          resourceType: 'Bundle',
-          type: 'batch-response',
-          entry: [
-            {
-              resource: {
-                resourceType: 'Bundle',
-                type: 'searchset',
-                entry: resources.map((resource) => ({ resource })),
-              },
-            },
-          ],
-        },
-      };
-    },
+    waitForAsyncJob: async (jobId: string) => ({ status: 200, mode: 'bulk', manifest: manifestFor(jobId) }),
   },
   user: { list: async () => [] },
 } as unknown as Oystehr;


### PR DESCRIPTION
`async-bulk` currently has some issues, so this PR provides solutions to make large requests work as they did before. At the same time, the PR keeps using `async-bulk` so that we can remove these temporary workarounds once the SDK is fixed.