### PR TITLE
Only send extract-photo-id errors to Sentry after all retries fail

### DIFF
--- a/apps/ehr/src/features/visits/shared/stores/audioRecording.store.ts
+++ b/apps/ehr/src/features/visits/shared/stores/audioRecording.store.ts
@@ -35,8 +35,8 @@ const MIME_TYPES = ['audio/webm', 'audio/wav', 'audio/mpeg', 'audio/mp4', 'audio
 const STOP_FALLBACK_MS = 5000;
 
 // Per-recording state, reached only through that recorder's own handlers. `chunks` especially must not live
-// on the shared `capture` below: a recorder outliving its session would append fragments to the *next*
-// recording, producing two interleaved streams no decoder (or Vertex) can read.
+// on the shared `capture` below: a recorder outliving its session would append its chunks to the *next*
+// recording, interleaving two recordings into one file that no decoder (or Vertex) can read.
 interface ActiveCapture {
   visitID: string;
   recorder: MediaRecorder;

--- a/apps/ehr/src/features/visits/shared/utils/audio-container.helper.test.ts
+++ b/apps/ehr/src/features/visits/shared/utils/audio-container.helper.test.ts
@@ -8,6 +8,10 @@ const FTYP = [0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 
 const RIFF_WAVE = [0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45]; // `RIFF....WAVE`
 const ID3 = [0x49, 0x44, 0x33, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // MP3 with an ID3v2 tag
 const MP3_FRAME_SYNC = [0xff, 0xfb, 0x90, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // bare MP3 frame
+// Copied from the recording that actually failed in production: a chunk from the middle of a recording,
+// where the file's opening bytes should be. A recorder writes its header once and then appends audio chunks;
+// two recorders writing into one buffer pushed the header into the middle, leaving this at the front.
+const HEADERLESS_CHUNK = [0x00, 0x00, 0x01, 0x24, 0x6d, 0x6f, 0x6f, 0x66, 0x00, 0x00, 0x00, 0x00];
 
 describe('detectAudioContainerType', () => {
   // Every type MIME_TYPES lets MediaRecorder pick: a narrower list throws away valid audio.
@@ -22,20 +26,15 @@ describe('detectAudioContainerType', () => {
   });
 
   test('rejects a buffer that starts mid-stream', async () => {
-    // The production failure: a bare `moof` fragment where the init segment should be.
-    const moofFragment = [0x00, 0x00, 0x01, 0x24, 0x6d, 0x6f, 0x6f, 0x66, 0x00, 0x00, 0x00, 0x00];
-
-    await expect(detectAudioContainerType(blobOf(...moofFragment), 'audio/mp4')).rejects.toThrow(
+    await expect(detectAudioContainerType(blobOf(...HEADERLESS_CHUNK), 'audio/mp4')).rejects.toThrow(
       /no audio\/mp4 container header \(first bytes: 00 00 01 24 6d 6f 6f 66/
     );
   });
 
   test('a headerless recording is rejected under either spelling of its container', async () => {
-    const moofFragment = [0x00, 0x00, 0x01, 0x24, 0x6d, 0x6f, 0x6f, 0x66, 0x00, 0x00, 0x00, 0x00];
-
     // MIME_TYPES lists `audio/mp3` next to `audio/mpeg`. Without the alias this took the pass-through branch
     // as a "container we have no signature for", uploading the corrupt recording the check exists to catch.
-    await expect(detectAudioContainerType(blobOf(...moofFragment), 'audio/mp3')).rejects.toThrow(
+    await expect(detectAudioContainerType(blobOf(...HEADERLESS_CHUNK), 'audio/mp3')).rejects.toThrow(
       /no audio\/mpeg container header/
     );
   });

--- a/apps/ehr/src/features/visits/shared/utils/audio-container.helper.ts
+++ b/apps/ehr/src/features/visits/shared/utils/audio-container.helper.ts
@@ -4,10 +4,11 @@ const CONTAINER_HEADER_BYTES = 12;
 const ascii = (head: Uint8Array, offset: number, length: number): string =>
   String.fromCharCode(...head.subarray(offset, offset + length));
 
-// One entry per container MediaRecorder may produce (see MIME_TYPES in audioRecording.store), mapping magic
-// bytes to the MIME type those bytes *are*. MP4 carries `ftyp` in the second word; the others lead with theirs.
+// Every audio format opens with a short fixed marker identifying it — the same trick `file(1)` uses. One entry
+// per container MediaRecorder may produce (see MIME_TYPES in audioRecording.store), mapping that marker to the
+// MIME type those bytes *are*. MP4 puts its marker (`ftyp`) in bytes 4-8; the others lead with theirs.
 // `aliases` are other spellings MIME_TYPES uses for the same container: a recording declared one of those is
-// still a recording we have a signature for, so a missing header has to fail rather than pass through.
+// still a recording we have a signature for, so a missing marker has to fail rather than pass through.
 const CONTAINERS: { mimeType: string; aliases?: string[]; matches: (head: Uint8Array) => boolean }[] = [
   { mimeType: 'audio/mp4', matches: (head) => ascii(head, 4, 4) === 'ftyp' }, // iOS Safari
   {
@@ -27,9 +28,9 @@ const CONTAINERS: { mimeType: string; aliases?: string[]; matches: (head: Uint8A
  *
  * The bytes decide rather than `MediaRecorder.mimeType`, because the stored Content-Type is what the backend
  * forwards to Vertex as `inlineData.mimeType`, and a type disagreeing with the actual container earns the
- * same opaque 400 INVALID_ARGUMENT as an unparseable one. Throws when the buffer doesn't start at the
- * declared container's boundary — the production failure, where the init segment ended up mid-file — so the
- * caller can tell the provider instead of losing the note to a backend error.
+ * same opaque 400 INVALID_ARGUMENT as an unparseable one. Throws when the recording doesn't begin with the
+ * marker its declared container should start with — the production failure, where the file began partway
+ * through the audio — so the caller can tell the provider instead of losing the note to a backend error.
  */
 export const detectAudioContainerType = async (blob: Blob, declaredType: string): Promise<string> => {
   if (blob.size === 0) {

--- a/apps/ehr/tests/unit/audio-recording-store.test.ts
+++ b/apps/ehr/tests/unit/audio-recording-store.test.ts
@@ -18,12 +18,12 @@ vi.mock('notistack', () => ({
   enqueueSnackbar: (...args: unknown[]) => enqueueSnackbar(...args),
 }));
 
-// EBML magic — what a healthy desktop (WebM) recording starts with.
+// The marker a WebM file opens with — a healthy desktop recording.
 const EBML_HEADER = [0x1a, 0x45, 0xdf, 0xa3, 0x01, 0x00, 0x00, 0x00];
-// The recording that broke transcription in production: a bare `moof` fragment, because a second
-// recorder's chunks were mixed in and the init segment ended up mid-file.
-const HEADERLESS_FRAGMENT = [0x00, 0x00, 0x01, 0x24, 0x6d, 0x6f, 0x6f, 0x66];
-// An ISO-BMFF/MP4 header (`....ftypisom`) — what iOS Safari actually produces.
+// Copied from the recording that broke transcription in production: a chunk from the middle of a recording,
+// with no opening marker, because a second recorder's chunks were mixed in and pushed the header mid-file.
+const HEADERLESS_CHUNK = [0x00, 0x00, 0x01, 0x24, 0x6d, 0x6f, 0x6f, 0x66];
+// The marker an MP4 file carries in bytes 4-8 (`ftyp`) — what iOS Safari produces.
 const FTYP_HEADER = [0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d];
 
 // Minimal MediaRecorder/getUserMedia stubs — jsdom/node don't provide the media capture APIs.
@@ -298,7 +298,7 @@ describe('audioRecording.store', () => {
 
     const hex = await uploadedHex();
     expect(hex).not.toContain('deadbeef'); // the stale recorder's bytes stayed out
-    expect(hex.startsWith('1a45dfa3')).toBe(true); // enc-2 still begins with its own init segment
+    expect(hex.startsWith('1a45dfa3')).toBe(true); // enc-2 still begins with its own opening marker
   });
 
   test('a recording with no container header is not uploaded', async () => {
@@ -307,8 +307,9 @@ describe('audioRecording.store', () => {
     );
 
     await audioRecordingActions.startRecording({ visitID: 'enc-1', oystehr });
-    // A fragment where the init segment should be: uploading it buys an opaque Vertex 400 and no note.
-    MockMediaRecorder.instances[0].emit(HEADERLESS_FRAGMENT);
+    // A chunk from mid-recording, where the opening marker should be: uploading it buys an opaque Vertex
+    // 400 and no note.
+    MockMediaRecorder.instances[0].emit(HEADERLESS_CHUNK);
     audioRecordingActions.stop();
 
     await vi.waitFor(() => expect(enqueueSnackbar).toHaveBeenCalled());

--- a/packages/zambdas/src/shared/ai.ts
+++ b/packages/zambdas/src/shared/ai.ts
@@ -194,8 +194,11 @@ export async function invokeChatbotVertexAI(
       }
       return response;
     } catch (error) {
-      console.error('Error invoking Vertex AI:', error);
-      captureException(error);
+      // One attempt failing is not an incident — the ladder exists because Vertex sheds load with 429s and a
+      // later attempt usually succeeds. Keep it in the log for the trace, but don't report it: reporting here
+      // raised a Sentry alert for every self-healed retry, and double-reported the ones that did fail, since
+      // whatever this function finally throws reaches Sentry once via the handler's topLevelCatch.
+      console.warn('Vertex AI attempt failed:', error);
       throw error;
     }
   });

--- a/packages/zambdas/test/unit/vertex-ai-error-handling.test.ts
+++ b/packages/zambdas/test/unit/vertex-ai-error-handling.test.ts
@@ -3,7 +3,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { invokeChatbotVertexAI } from '../../src/shared/ai';
 
 // Sentry is initialised at module scope in the lambda wrapper; captureException is all this path touches.
-vi.mock('@sentry/aws-serverless', () => ({ captureException: vi.fn() }));
+const captureException = vi.fn();
+vi.mock('@sentry/aws-serverless', () => ({
+  captureException: (...args: unknown[]) => captureException(...args),
+}));
 
 // Keyed off SecretsKeys so the test breaks if the code starts reading a different secret.
 const secrets: Secrets = {
@@ -11,19 +14,37 @@ const secrets: Secrets = {
   [SecretsKeys.GOOGLE_CLOUD_API_KEY]: 'test-key',
 };
 
+const responseOf = (
+  status: number,
+  body: unknown
+): { ok: boolean; status: number; statusText: string; text: () => Promise<string> } => ({
+  ok: status >= 200 && status < 300,
+  status,
+  statusText: status === 400 ? 'Bad Request' : status === 429 ? 'Too Many Requests' : 'OK',
+  text: async () => JSON.stringify(body),
+});
+
 const respondWith = (status: number, body: unknown): void => {
   vi.stubGlobal(
     'fetch',
-    vi.fn(async () => ({
-      ok: status >= 200 && status < 300,
-      status,
-      statusText: status === 400 ? 'Bad Request' : 'OK',
-      text: async () => JSON.stringify(body),
-    }))
+    vi.fn(async () => responseOf(status, body))
+  );
+};
+
+// One entry per attempt, for the retry paths; the last entry repeats if the ladder runs longer.
+const respondInSequence = (...responses: [number, unknown][]): void => {
+  let attempt = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      const [status, body] = responses[Math.min(attempt++, responses.length - 1)];
+      return responseOf(status, body);
+    })
   );
 };
 
 beforeEach(() => {
+  captureException.mockClear();
   vi.useFakeTimers(); // the retry ladder sleeps up to ~6s between attempts
 });
 
@@ -105,6 +126,26 @@ describe('invokeChatbotVertexAI error handling', () => {
     await expect(invoke()).rejects.toThrow(/Vertex AI returned a non-JSON body.*502 Bad Gateway/s);
   });
 
+  test('a 429 that a retry recovers from is not reported to Sentry', async () => {
+    // The production sequence: attempt 0 is shed by Vertex's shared quota, the next attempt succeeds and the
+    // caller never sees a failure. Reporting the shed attempt raised an alert for a self-healed retry.
+    respondInSequence(
+      [
+        429,
+        { error: { code: 429, message: 'Resource exhausted. Please try again later.', status: 'RESOURCE_EXHAUSTED' } },
+      ],
+      [200, { candidates: [{ content: { parts: [{ text: 'the transcript' }] } }] }]
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(invoke()).resolves.toBe('the transcript');
+    expect(captureException).not.toHaveBeenCalled();
+    // Still in the log, so the retry is visible when reading a slow invocation's trace.
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Vertex AI attempt failed'), expect.anything());
+
+    warn.mockRestore();
+  });
+
   test('exhausting the retry ladder reports the statuses, not a bare AggregateError', async () => {
     respondWith(503, { error: { code: 503, message: 'The service is currently unavailable.' } });
 
@@ -116,6 +157,9 @@ describe('invokeChatbotVertexAI error handling', () => {
     expect(error?.message).toMatch(/Vertex AI request failed after 3 attempts/);
     expect(error?.message).toMatch(/503.*currently unavailable/s);
     expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    // One failure, one Sentry event. Each attempt used to report itself, so a single exhausted ladder
+    // raised three — before the handler's topLevelCatch reported the thrown error as a fourth.
+    expect(captureException).not.toHaveBeenCalled();
   });
 
   test('a successful response returns the candidate text', async () => {

--- a/packages/zambdas/test/unit/vertex-ai-error-handling.test.ts
+++ b/packages/zambdas/test/unit/vertex-ai-error-handling.test.ts
@@ -1,11 +1,22 @@
+import { APIGatewayProxyResult } from 'aws-lambda';
 import { Secrets, SecretsKeys } from 'utils/lib/secrets';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { invokeChatbotVertexAI } from '../../src/shared/ai';
+import { lambdaResponse } from '../../src/shared/lambda';
+import { wrapHandler } from '../../src/shared/sentry';
+import { ZambdaInput } from '../../src/shared/types/common';
 
-// Sentry is initialised at module scope in the lambda wrapper; captureException is all this path touches.
+// Stands in for the SDK the real handler wrapper is built on: captureException is the only call whose
+// arguments matter here, the rest exist so `wrapHandler` runs its actual code instead of a stub.
 const captureException = vi.fn();
 vi.mock('@sentry/aws-serverless', () => ({
   captureException: (...args: unknown[]) => captureException(...args),
+  captureMessage: vi.fn(),
+  init: vi.fn(),
+  isInitialized: vi.fn(() => true),
+  setTag: vi.fn(),
+  setTags: vi.fn(),
+  wrapHandler: (handler: unknown) => handler, // the real one only adds tracing
 }));
 
 // Keyed off SecretsKeys so the test breaks if the code starts reading a different secret.
@@ -13,6 +24,9 @@ const secrets: Secrets = {
   [SecretsKeys.GOOGLE_CLOUD_PROJECT_ID]: 'test-project',
   [SecretsKeys.GOOGLE_CLOUD_API_KEY]: 'test-key',
 };
+
+// sendErrors drops events on 'local', so a deployed environment is what proves reporting still happens.
+const deployedSecrets: Secrets = { ...secrets, [SecretsKeys.ENVIRONMENT]: 'development' };
 
 const responseOf = (
   status: number,
@@ -64,6 +78,20 @@ const invoke = async (): Promise<string> => {
   const result = await outcome;
   if (!result.ok) throw result.error;
   return result.value;
+};
+
+// The same call as `invoke`, but through the wrapper every zambda is deployed behind — so the assertions
+// below are about what Sentry actually receives in production, not about a hand-rolled catch block.
+const invokeThroughHandler = async (): Promise<APIGatewayProxyResult> => {
+  const handler = wrapHandler('test-ai-zambda', async (input: ZambdaInput) => {
+    const text = await invokeChatbotVertexAI([{ text: 'hello' }], input.secrets);
+    return lambdaResponse(200, { text });
+  }) as unknown as (input: ZambdaInput) => Promise<APIGatewayProxyResult>;
+
+  // The handler swallows the throw into a 500, so nothing here is ever an unhandled rejection.
+  const outcome = handler({ headers: null, body: null, secrets: deployedSecrets });
+  await vi.advanceTimersByTimeAsync(10_000);
+  return outcome;
 };
 
 describe('invokeChatbotVertexAI error handling', () => {
@@ -159,6 +187,48 @@ describe('invokeChatbotVertexAI error handling', () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(3);
     // One failure, one Sentry event. Each attempt used to report itself, so a single exhausted ladder
     // raised three — before the handler's topLevelCatch reported the thrown error as a fourth.
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  test('an exhausted retry ladder still reaches Sentry — exactly once — through the handler', async () => {
+    // The counterpart to the two assertions above: dropping captureException from the attempt only holds up
+    // if the failure a caller actually sees is still reported. It is, by the handler, once per invocation.
+    respondWith(503, { error: { code: 503, message: 'The service is currently unavailable.' } });
+
+    const response = await invokeThroughHandler();
+
+    expect(response.statusCode).toBe(500);
+    expect(captureException).toHaveBeenCalledOnce();
+    // And it carries the diagnosis, not a bare AggregateError, so the Sentry issue is actionable.
+    const reported = captureException.mock.calls[0][0] as Error;
+    expect(reported.message).toMatch(/Vertex AI request failed after 3 attempts/);
+    expect(reported.message).toMatch(/503.*currently unavailable/s);
+  });
+
+  test('a non-retryable failure reaches Sentry once, on its only attempt', async () => {
+    // With no retry there is no second attempt to report the error later, so this is the case where moving
+    // reporting to the handler could plausibly have lost the event altogether.
+    respondWith(400, {
+      error: { code: 400, message: 'Request contains an invalid argument.', status: 'INVALID_ARGUMENT' },
+    });
+
+    const response = await invokeThroughHandler();
+
+    expect(response.statusCode).toBe(500);
+    expect(captureException).toHaveBeenCalledOnce();
+    expect((captureException.mock.calls[0][0] as Error).message).toMatch(
+      /Vertex AI request failed: 400 Bad Request.*INVALID_ARGUMENT/s
+    );
+  });
+
+  test('a success reports nothing at all', async () => {
+    // Guards the other direction: a handler that reported on the happy path would satisfy every assertion
+    // above while re-creating the alert noise this change removed.
+    respondWith(200, { candidates: [{ content: { parts: [{ text: 'the transcript' }] } }] });
+
+    const response = await invokeThroughHandler();
+
+    expect(response.statusCode).toBe(200);
     expect(captureException).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
https://linear.app/zapehr/issue/HOST-1049/only-send-extract-photo-id-errors-to-sentry-after-all-retries-fail