### PR TITLE
Billng App. Show Claim's PCN only when it exists

### DIFF
--- a/apps/billing/src/pages/ClaimDetail.tsx
+++ b/apps/billing/src/pages/ClaimDetail.tsx
@@ -358,7 +358,7 @@ export default function ClaimDetail(): ReactElement {
               <Meta label="Date of Service" value={dos} />
               <Meta label="Claim ID" value={claim.id} copyable={true} />
               <Meta label="Claim Type" value={formatAntCaseString(claim.type)} />
-              <Meta label="PCN" value={claim.pcn.toUpperCase()} copyable={true} />
+              {claim.pcn && <Meta label="PCN" value={claim.pcn.toUpperCase()} copyable={true} />}
               <Meta label="Service" value={formatAntCaseString(claim.service)} />
               <Meta label="Patient DOB" value={claim.patientDob} />
             </Box>
@@ -389,7 +389,7 @@ export default function ClaimDetail(): ReactElement {
                     ))}
                   </Select>
                 </Box>
-                <Meta label="PCN" value={claim.pcn.toUpperCase()} />
+                {claim.pcn && <Meta label="PCN" value={claim.pcn.toUpperCase()} />}
                 <Box>
                   <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
                     Service

--- a/packages/utils/lib/types/data/billing/billing.types.ts
+++ b/packages/utils/lib/types/data/billing/billing.types.ts
@@ -490,7 +490,7 @@ export interface ClaimDetailResponse {
     cptCodes: string[];
   }[];
   tags: string[];
-  pcn: string;
+  pcn?: string;
   billType: string;
   patientDischargeStatusCode: string;
   admissionType: string;

--- a/packages/zambdas/src/billing/claim-search.ts
+++ b/packages/zambdas/src/billing/claim-search.ts
@@ -13,7 +13,6 @@ import { isValidUUID } from 'utils/lib/validation/helper';
 import { fetchClaimResponsesByClaimIds, fetchPatientPaidByClaimId, summarizeClaimPayments } from './claim-amounts';
 import {
   CLAIM_PCN_IDENTIFIER_SYSTEM,
-  claimIdFromPcn,
   ClaimSearchParam,
   determineRulesEngineForClaim,
   fhirName,
@@ -236,16 +235,6 @@ export function buildClaimSearchTextQueries({
       {
         name: '_id',
         value: text,
-      },
-    ]);
-  }
-
-  const pcnClaimId = claimIdFromPcn(text);
-  if (pcnClaimId) {
-    queries.push([
-      {
-        name: '_id',
-        value: pcnClaimId,
       },
     ]);
   }

--- a/packages/zambdas/src/billing/era-remits.ts
+++ b/packages/zambdas/src/billing/era-remits.ts
@@ -39,7 +39,7 @@ export function eraPatientAccountNumber(
 ): string {
   const echoed = claimResponses.map((cr) => getEraExtensionString(cr, ERA_PCN_EXTENSION)).find(Boolean);
   if (echoed) return echoed;
-  return matched && claim ? getClaimPcn(claim) : '';
+  return matched && claim ? getClaimPcn(claim) ?? '' : '';
 }
 
 // The member id the payer reported the insured under. In the 835 it rides on NM1*IL NM109 when

--- a/packages/zambdas/src/billing/shared.ts
+++ b/packages/zambdas/src/billing/shared.ts
@@ -499,19 +499,6 @@ export function getClaimPcn(claim: Pick<Claim, 'id' | 'identifier'>): string | u
   return claim.identifier?.find((id) => id.system === CLAIM_PCN_IDENTIFIER_SYSTEM)?.value;
 }
 
-export function claimIdFromPcn(pcn: string): string | undefined {
-  const minified = pcn.toLowerCase();
-  if (!/^[0-9a-f]{32}$/.test(minified)) return undefined;
-  const claimId = [
-    minified.slice(0, 8),
-    minified.slice(8, 12),
-    minified.slice(12, 16),
-    minified.slice(16, 20),
-    minified.slice(20),
-  ].join('-');
-  return isValidUUID(claimId) ? claimId : undefined;
-}
-
 export const TAG_CODE_SYSTEM = 'https://fhir.ottehr.com/billing/tag';
 export const TAG_DESCRIPTION_URL = 'https://fhir.ottehr.com/billing/tag-description';
 export const TAG_IS_SYSTEM_TAG_URL = 'https://fhir.ottehr.com/billing/is-system-tag';

--- a/packages/zambdas/src/billing/shared.ts
+++ b/packages/zambdas/src/billing/shared.ts
@@ -495,12 +495,8 @@ export function getEraCheckNumber(
 
 export const CLAIM_PCN_IDENTIFIER_SYSTEM = 'https://identifiers.fhir.oystehr.com/rcm-claim-patient-control-number';
 
-export function getClaimPcn(claim: Pick<Claim, 'id' | 'identifier'>): string {
-  return (
-    claim.identifier?.find((id) => id.system === CLAIM_PCN_IDENTIFIER_SYSTEM)?.value ??
-    claim.id?.replaceAll('-', '') ??
-    ''
-  );
+export function getClaimPcn(claim: Pick<Claim, 'id' | 'identifier'>): string | undefined {
+  return claim.identifier?.find((id) => id.system === CLAIM_PCN_IDENTIFIER_SYSTEM)?.value;
 }
 
 export function claimIdFromPcn(pcn: string): string | undefined {

--- a/packages/zambdas/test/integration/billing/search-billing-claims.test.ts
+++ b/packages/zambdas/test/integration/billing/search-billing-claims.test.ts
@@ -224,10 +224,6 @@ describe('search-billing-claims search text', () => {
     expect(await idsFor(createdClaimIds[0])).toEqual([createdClaimIds[0]]);
   }, 60_000);
 
-  it('finds the claim by the PCN shown in the UI, which is its id with dashes stripped', async () => {
-    expect(await idsFor(createdClaimIds[0].replaceAll('-', ''))).toEqual([createdClaimIds[0]]);
-  }, 60_000);
-
   it('finds a claim by an explicit patient control number identifier', async () => {
     expect(await idsFor(`${customPcn}-${unique}`)).toEqual([createdClaimIds[1]]);
   }, 60_000);

--- a/packages/zambdas/test/unit/billing/claim-pcn.test.ts
+++ b/packages/zambdas/test/unit/billing/claim-pcn.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { CLAIM_PCN_IDENTIFIER_SYSTEM, claimIdFromPcn, getClaimPcn } from '../../../src/billing/shared';
+import { CLAIM_PCN_IDENTIFIER_SYSTEM, getClaimPcn } from '../../../src/billing/shared';
 
 const CLAIM_ID = '3f2b9c1a-7d4e-4a8b-9c6d-0e1f2a3b4c5d';
-const MINIFIED_CLAIM_ID = '3f2b9c1a7d4e4a8b9c6d0e1f2a3b4c5d';
 
 describe('getClaimPcn', () => {
   it('prefers the patient control number identifier when one is present', () => {
@@ -18,10 +17,6 @@ describe('getClaimPcn', () => {
     expect(pcn).toBe('CUSTOM-PCN-1');
   });
 
-  it('falls back to the claim id with dashes stripped', () => {
-    expect(getClaimPcn({ id: CLAIM_ID })).toBe(MINIFIED_CLAIM_ID);
-  });
-
   it('ignores identifiers in other systems', () => {
     const pcn = getClaimPcn({
       id: CLAIM_ID,
@@ -32,36 +27,10 @@ describe('getClaimPcn', () => {
         },
       ],
     });
-    expect(pcn).toBe(MINIFIED_CLAIM_ID);
+    expect(pcn).toBeUndefined();
   });
 
-  it('returns an empty string for a claim with neither', () => {
-    expect(getClaimPcn({})).toBe('');
-  });
-});
-
-describe('claimIdFromPcn', () => {
-  it('round-trips a dash-stripped claim id back into its claim id', () => {
-    expect(claimIdFromPcn(MINIFIED_CLAIM_ID)).toBe(CLAIM_ID);
-    expect(claimIdFromPcn(getClaimPcn({ id: CLAIM_ID }))).toBe(CLAIM_ID);
-  });
-
-  it('accepts a capitalized PCN, since resource ids are lowercase', () => {
-    expect(claimIdFromPcn(MINIFIED_CLAIM_ID.toUpperCase())).toBe(CLAIM_ID);
-  });
-
-  it('returns undefined for a PCN that is not a dash-stripped uuid', () => {
-    expect(claimIdFromPcn('Smith')).toBeUndefined();
-    expect(claimIdFromPcn('CUSTOM-PCN-1')).toBeUndefined();
-    expect(claimIdFromPcn(CLAIM_ID)).toBeUndefined();
-    expect(claimIdFromPcn('')).toBeUndefined();
-  });
-
-  it('returns undefined for 32 characters that are not hex', () => {
-    expect(claimIdFromPcn('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz')).toBeUndefined();
-  });
-
-  it('returns undefined when the restored id is not a valid uuid', () => {
-    expect(claimIdFromPcn('3f2b9c1a7d4e9a8b9c6d0e1f2a3b4c5d')).toBeUndefined();
+  it('returns undefined for a claim with neither', () => {
+    expect(getClaimPcn({})).toBeUndefined();
   });
 });

--- a/packages/zambdas/test/unit/billing/claim-search-text.test.ts
+++ b/packages/zambdas/test/unit/billing/claim-search-text.test.ts
@@ -12,7 +12,6 @@ import {
 import { CLAIM_PCN_IDENTIFIER_SYSTEM } from '../../../src/billing/shared';
 
 const CLAIM_ID = '3f2b9c1a-7d4e-4a8b-9c6d-0e1f2a3b4c5d';
-const MINIFIED_CLAIM_ID = '3f2b9c1a7d4e4a8b9c6d0e1f2a3b4c5d';
 const PATIENT_ID = '8a1c4e2f-5b6d-4c3a-9e8f-1d2c3b4a5e6f';
 
 const NAME_CLAUSES = [
@@ -82,13 +81,7 @@ describe('buildClaimSearchTextQueries', () => {
 
   it('keeps the fan-out to at most eight clauses', () => {
     expect(buildClaimSearchTextQueries({ searchText: 'Smith' })).toHaveLength(8);
-    expect(buildClaimSearchTextQueries({ searchText: MINIFIED_CLAIM_ID })).toHaveLength(9);
     expect(buildClaimSearchTextQueries({ searchText: CLAIM_ID })).toHaveLength(9);
-    expect(
-      buildClaimSearchTextQueries({
-        searchText: CLAIM_ID,
-      })
-    ).toHaveLength(8);
   });
 
   it('trims the text and searches nothing when it is blank', () => {

--- a/packages/zambdas/test/unit/billing/claim-search-text.test.ts
+++ b/packages/zambdas/test/unit/billing/claim-search-text.test.ts
@@ -80,22 +80,6 @@ describe('buildClaimSearchTextQueries', () => {
     expect(clauseNames('Smith')).not.toContain('patient');
   });
 
-  it('restores a dash-stripped PCN into a claim id clause', () => {
-    expect(clauseNames(MINIFIED_CLAIM_ID)).toEqual([
-      ...NAME_CLAUSES,
-      'identifier',
-      'patient.identifier',
-      'patient.identifier',
-      '_id',
-    ]);
-    expect(clauseFor(MINIFIED_CLAIM_ID, '_id')).toEqual([
-      {
-        name: '_id',
-        value: CLAIM_ID,
-      },
-    ]);
-  });
-
   it('keeps the fan-out to at most eight clauses', () => {
     expect(buildClaimSearchTextQueries({ searchText: 'Smith' })).toHaveLength(8);
     expect(buildClaimSearchTextQueries({ searchText: MINIFIED_CLAIM_ID })).toHaveLength(9);
@@ -104,7 +88,7 @@ describe('buildClaimSearchTextQueries', () => {
       buildClaimSearchTextQueries({
         searchText: CLAIM_ID,
       })
-    ).toHaveLength(9);
+    ).toHaveLength(8);
   });
 
   it('trims the text and searches nothing when it is blank', () => {
@@ -124,21 +108,6 @@ describe('buildClaimSearchTextQueries', () => {
 
     it('searches only the patient name for plain text', () => {
       expect(scopedClauseNames('Smith')).toEqual(['patient.name']);
-    });
-
-    it('adds an exact claim id lookup for UUIDs', () => {
-      expect(scopedClauseNames(CLAIM_ID)).toEqual(['patient.name', '_id']);
-      expect(scopedClauseNames(MINIFIED_CLAIM_ID)).toEqual(['patient.name', '_id']);
-      expect(
-        buildClaimSearchTextQueries({ searchText: MINIFIED_CLAIM_ID, patientNameOnly: true })
-          .flat()
-          .filter((p) => p.name === '_id')
-      ).toEqual([
-        {
-          name: '_id',
-          value: CLAIM_ID,
-        },
-      ]);
     });
   });
 });

--- a/packages/zambdas/test/unit/billing/era-remits.test.ts
+++ b/packages/zambdas/test/unit/billing/era-remits.test.ts
@@ -437,7 +437,6 @@ describe('eraPatientAccountNumber', () => {
     const cr = claimResponse();
     const claim = submittedClaim({ identifier: [{ system: CLAIM_PCN_IDENTIFIER_SYSTEM, value: 'PCN-42' }] });
     expect(eraPatientAccountNumber([cr], claim, true)).toBe('PCN-42');
-    expect(eraPatientAccountNumber([cr], submittedClaim({ id: 'aaaa-bbbb' }), true)).toBe('aaaabbbb');
     // an unmatched row's claim id is synthetic, so it must never leak out as an account number
     expect(eraPatientAccountNumber([cr], submittedClaim({ id: 'unmatched-cr-1' }), false)).toBe('');
     expect(eraPatientAccountNumber([], undefined, false)).toBe('');


### PR DESCRIPTION
Claim's PCN exists as an identifier on a Claim resource. If a claim doesn't have PCN assigned Oystehr's RCM service assigns a globally unique PCN to a claim during claim submission. If a Claim resource doesn't have an identifier with `system: CLAIM_PCN_IDENTIFIER_SYSTEM` then a Claim doesn't have a PCN yet so it's not correct to use Claim resource's id with dashes stripped as PCN.