### PR TITLE
test(zambdas): first coverage for get-standalone-paperwork and the form PDF handler

### DIFF
--- a/packages/zambdas/test/unit/get-standalone-paperwork.test.ts
+++ b/packages/zambdas/test/unit/get-standalone-paperwork.test.ts
@@ -1,0 +1,209 @@
+import { Appointment, Encounter, Patient, Questionnaire, QuestionnaireResponse } from 'fhir/r4b';
+import { PRACTICE_MANAGED_QUESTIONNAIRE_TAG } from 'utils/lib/fhir/constants';
+import { getQuestionnaireForQR } from 'utils/lib/fhir/questionnaires';
+import { MANAGED_QUESTIONNAIRE_ERROR, NO_READ_ACCESS_TO_PATIENT_ERROR } from 'utils/lib/types/errors';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { index } from '../../src/patient/paperwork/get-standalone-paperwork';
+import { getUser, userHasAccessToPatient } from '../../src/shared/auth';
+import { createClinicalOystehrClient } from '../../src/shared/helpers';
+import { ZambdaInput } from '../../src/shared/types/common';
+
+/**
+ * First tests of any kind for get-standalone-paperwork — the endpoint that serves
+ * practice-managed (standalone) forms to patients. Covers input validation, the
+ * patient-access authorization gate, the managed-questionnaire tag gate, the resource
+ * graph requirements, and the response shape. The FHIR client and auth helpers are
+ * mocked; questionnaire item mapping and response assembly run for real.
+ */
+
+vi.mock('@sentry/aws-serverless', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@sentry/aws-serverless')>();
+  return { ...original, wrapHandler: (handler: unknown) => handler, captureException: vi.fn() };
+});
+
+vi.mock('../../src/shared/getAuth0Token', () => ({ getAuth0Token: vi.fn().mockResolvedValue('m2m-token') }));
+
+vi.mock('../../src/shared/helpers', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../src/shared/helpers')>();
+  return { ...original, createClinicalOystehrClient: vi.fn() };
+});
+
+vi.mock('../../src/shared/auth', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../src/shared/auth')>();
+  return { ...original, getUser: vi.fn(), userHasAccessToPatient: vi.fn() };
+});
+
+vi.mock('utils/lib/fhir/questionnaires', async (importOriginal) => {
+  const original = await importOriginal<typeof import('utils/lib/fhir/questionnaires')>();
+  return { ...original, getQuestionnaireForQR: vi.fn() };
+});
+
+const mockCreateClient = vi.mocked(createClinicalOystehrClient);
+const mockGetUser = vi.mocked(getUser);
+const mockUserHasAccess = vi.mocked(userHasAccessToPatient);
+const mockGetQuestionnaireForQR = vi.mocked(getQuestionnaireForQR);
+
+const QR_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+const questionnaireResponse = (overrides: Partial<QuestionnaireResponse> = {}): QuestionnaireResponse => ({
+  resourceType: 'QuestionnaireResponse',
+  id: QR_ID,
+  status: 'in-progress',
+  subject: { reference: 'Patient/pat-1' },
+  encounter: { reference: 'Encounter/enc-1' },
+  item: [],
+  ...overrides,
+});
+
+const managedQuestionnaire = (managed = true): Questionnaire => ({
+  resourceType: 'Questionnaire',
+  id: 'q-1',
+  status: 'active',
+  title: 'Injury Follow-Up Form',
+  ...(managed ? { meta: { tag: [{ ...PRACTICE_MANAGED_QUESTIONNAIRE_TAG }] } } : {}),
+  item: [
+    {
+      linkId: 'follow-up-page',
+      type: 'group',
+      item: [{ linkId: 'pain-level', type: 'string', text: 'Current pain level' }],
+    },
+  ],
+});
+
+const GRAPH_ENCOUNTER: Encounter = {
+  resourceType: 'Encounter',
+  id: 'enc-1',
+  status: 'finished',
+  class: { code: 'AMB' },
+};
+const GRAPH_APPOINTMENT: Appointment = {
+  resourceType: 'Appointment',
+  id: 'appt-1',
+  status: 'fulfilled',
+  start: '2026-08-01T15:00:00Z',
+  participant: [{ status: 'accepted' }],
+};
+const GRAPH_PATIENT: Patient = {
+  resourceType: 'Patient',
+  id: 'pat-1',
+  name: [{ given: ['Pat', 'Quincy'], family: 'Doe' }],
+  birthDate: '1990-05-01',
+  gender: 'female',
+};
+
+interface OystehrMock {
+  fhir: { get: ReturnType<typeof vi.fn>; search: ReturnType<typeof vi.fn> };
+}
+
+const makeOystehr = (qr: QuestionnaireResponse, graph: unknown[] = []): OystehrMock => ({
+  fhir: {
+    get: vi.fn().mockResolvedValue(qr),
+    search: vi.fn().mockResolvedValue({ unbundle: () => graph }),
+  },
+});
+
+const invoke = async (
+  oystehr: OystehrMock,
+  body: unknown = { questionnaireResponseId: QR_ID }
+): Promise<{ statusCode: number; body: string }> => {
+  mockCreateClient.mockReturnValue(oystehr as never);
+  const input = {
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+    headers: { Authorization: 'Bearer patient-token' },
+    secrets: { ENVIRONMENT: 'testing' },
+  } as unknown as ZambdaInput;
+  return (index as unknown as (i: ZambdaInput) => Promise<{ statusCode: number; body: string }>)(input);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUser.mockResolvedValue({ id: 'user-1' } as never);
+  mockUserHasAccess.mockResolvedValue(true);
+  mockGetQuestionnaireForQR.mockResolvedValue(managedQuestionnaire());
+});
+
+describe('get-standalone-paperwork', () => {
+  const fullGraph = [GRAPH_ENCOUNTER, GRAPH_APPOINTMENT, GRAPH_PATIENT];
+
+  test('returns the mapped items, patient summary, and questionnaire title', async () => {
+    const result = await invoke(makeOystehr(questionnaireResponse(), fullGraph));
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.questionnaireTitle).toBe('Injury Follow-Up Form');
+    expect(body.allItems).toHaveLength(1);
+    expect(body.allItems[0].linkId).toBe('follow-up-page');
+    // extensions are structured into typed props by the mapper
+    expect(body.allItems[0].item[0]).toMatchObject({ linkId: 'pain-level', type: 'string' });
+    expect(body.patient).toMatchObject({
+      id: 'pat-1',
+      firstName: 'Pat',
+      middleName: 'Quincy',
+      lastName: 'Doe',
+      dateOfBirth: '1990-05-01',
+      sex: 'Female',
+    });
+    expect(body.appointment).toMatchObject({ id: 'appt-1', serviceMode: 'in-person' });
+    expect(body.questionnaireResponse.id).toBe(QR_ID);
+  });
+
+  test('rejects a request without a valid questionnaireResponseId', async () => {
+    const oystehr = makeOystehr(questionnaireResponse(), fullGraph);
+    const missing = await invoke(oystehr, {});
+    expect(missing.statusCode).toBeGreaterThanOrEqual(400);
+    const notUuid = await invoke(oystehr, { questionnaireResponseId: 'not-a-uuid' });
+    expect(notUuid.statusCode).toBeGreaterThanOrEqual(400);
+    expect(oystehr.fhir.get).not.toHaveBeenCalled();
+  });
+
+  // Internal invariant failures (plain Error throws) surface as a generic body: the
+  // wrapper deliberately does not leak internal messages to the caller.
+  test('fails closed with a generic internal error when the QR subject is not a Patient', async () => {
+    const oystehr = makeOystehr(questionnaireResponse({ subject: { reference: 'Group/team-1' } }), fullGraph);
+    const result = await invoke(oystehr);
+    expect(result.statusCode).toBeGreaterThanOrEqual(400);
+    expect(JSON.parse(result.body)).toEqual({ error: 'Internal error' });
+    // and it fails before any authorization or questionnaire work happens
+    expect(mockGetQuestionnaireForQR).not.toHaveBeenCalled();
+  });
+
+  test('denies callers without access to the patient', async () => {
+    mockUserHasAccess.mockResolvedValue(false);
+    const result = await invoke(makeOystehr(questionnaireResponse(), fullGraph));
+    expect(result.statusCode).toBeGreaterThanOrEqual(400);
+    expect(result.body).toContain(NO_READ_ACCESS_TO_PATIENT_ERROR.code);
+    expect(mockGetQuestionnaireForQR).not.toHaveBeenCalled();
+  });
+
+  test('denies unauthenticated callers outright', async () => {
+    mockCreateClient.mockReturnValue(makeOystehr(questionnaireResponse(), fullGraph) as never);
+    const input = {
+      body: JSON.stringify({ questionnaireResponseId: QR_ID }),
+      headers: {},
+      secrets: { ENVIRONMENT: 'testing' },
+    } as unknown as ZambdaInput;
+    const result = await (index as unknown as (i: ZambdaInput) => Promise<{ statusCode: number; body: string }>)(input);
+    expect(result.statusCode).toBeGreaterThanOrEqual(400);
+    expect(result.body).toContain(NO_READ_ACCESS_TO_PATIENT_ERROR.code);
+    expect(mockUserHasAccess).not.toHaveBeenCalled();
+  });
+
+  test('rejects questionnaires that are not practice-managed', async () => {
+    mockGetQuestionnaireForQR.mockResolvedValue(managedQuestionnaire(false));
+    const result = await invoke(makeOystehr(questionnaireResponse(), fullGraph));
+    expect(result.statusCode).toBeGreaterThanOrEqual(400);
+    expect(result.body).toContain('not compatible with the standalone form path');
+    expect(result.body).toContain(MANAGED_QUESTIONNAIRE_ERROR('x').code);
+  });
+
+  test('fails closed when the QR has no encounter to anchor the resource graph', async () => {
+    const result = await invoke(makeOystehr(questionnaireResponse({ encounter: undefined }), fullGraph));
+    expect(result.statusCode).toBeGreaterThanOrEqual(400);
+    expect(JSON.parse(result.body)).toEqual({ error: 'Internal error' });
+  });
+
+  test('errors when the encounter graph is missing the patient', async () => {
+    const result = await invoke(makeOystehr(questionnaireResponse(), [GRAPH_ENCOUNTER, GRAPH_APPOINTMENT]));
+    expect(result.statusCode).toBeGreaterThanOrEqual(400);
+    expect(result.body).toContain('No patient found for Encounter/enc-1');
+  });
+});

--- a/packages/zambdas/test/unit/get-standalone-paperwork.test.ts
+++ b/packages/zambdas/test/unit/get-standalone-paperwork.test.ts
@@ -8,14 +8,6 @@ import { getUser, userHasAccessToPatient } from '../../src/shared/auth';
 import { createClinicalOystehrClient } from '../../src/shared/helpers';
 import { ZambdaInput } from '../../src/shared/types/common';
 
-/**
- * First tests of any kind for get-standalone-paperwork — the endpoint that serves
- * practice-managed (standalone) forms to patients. Covers input validation, the
- * patient-access authorization gate, the managed-questionnaire tag gate, the resource
- * graph requirements, and the response shape. The FHIR client and auth helpers are
- * mocked; questionnaire item mapping and response assembly run for real.
- */
-
 vi.mock('@sentry/aws-serverless', async (importOriginal) => {
   const original = await importOriginal<typeof import('@sentry/aws-serverless')>();
   return { ...original, wrapHandler: (handler: unknown) => handler, captureException: vi.fn() };

--- a/packages/zambdas/test/unit/task-pdf-handler.test.ts
+++ b/packages/zambdas/test/unit/task-pdf-handler.test.ts
@@ -1,0 +1,213 @@
+import { Encounter, Location, Patient, Questionnaire, QuestionnaireResponse } from 'fhir/r4b';
+import { DateTime } from 'luxon';
+import { createFilesDocumentReferences } from 'utils/lib/fhir/helpers';
+import { getQuestionnaireForQR } from 'utils/lib/fhir/questionnaires';
+import { EXPORTED_QUESTIONNAIRE_CODE } from 'utils/lib/types/data/paperwork/paperwork.constants';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { handleReviewTaskAndPdf, renderQrPdf } from '../../src/patient/paperwork/submit-paperwork/taskPdfHandler';
+import { sendErrors } from '../../src/shared/errors';
+import { createPresignedUrl, uploadObjectToZ3 } from '../../src/shared/z3Utils';
+
+/**
+ * First tests for the submit-paperwork finalization side effects: rendering the completed
+ * standalone form to PDF, uploading it, filing the DocumentReference, and creating the
+ * staff follow-up Task. The design contract under test is that this whole path is
+ * NON-FATAL — the patient's submission already succeeded, so any failure here is swallowed
+ * and reported rather than surfaced. PDF rendering runs for real (pdf-lib, offline);
+ * storage and FHIR writers are mocked at their seams.
+ */
+
+vi.mock('utils/lib/fhir/helpers', async (importOriginal) => {
+  const original = await importOriginal<typeof import('utils/lib/fhir/helpers')>();
+  return { ...original, createFilesDocumentReferences: vi.fn() };
+});
+
+vi.mock('utils/lib/fhir/questionnaires', async (importOriginal) => {
+  const original = await importOriginal<typeof import('utils/lib/fhir/questionnaires')>();
+  return { ...original, getQuestionnaireForQR: vi.fn() };
+});
+
+vi.mock('../../src/shared/z3Utils', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../src/shared/z3Utils')>();
+  return { ...original, createPresignedUrl: vi.fn(), uploadObjectToZ3: vi.fn() };
+});
+
+vi.mock('../../src/shared/errors', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../src/shared/errors')>();
+  return { ...original, sendErrors: vi.fn() };
+});
+
+const mockCreateFilesDocumentReferences = vi.mocked(createFilesDocumentReferences);
+const mockGetQuestionnaireForQR = vi.mocked(getQuestionnaireForQR);
+const mockCreatePresignedUrl = vi.mocked(createPresignedUrl);
+const mockUploadObjectToZ3 = vi.mocked(uploadObjectToZ3);
+const mockSendErrors = vi.mocked(sendErrors);
+
+const SECRETS = { ENVIRONMENT: 'testing', PROJECT_ID: 'proj-123', PROJECT_API: 'https://project.api' } as never;
+
+const QUESTIONNAIRE: Questionnaire = {
+  resourceType: 'Questionnaire',
+  id: 'q-1',
+  status: 'active',
+  title: 'Injury Follow-Up Form',
+  item: [
+    {
+      linkId: 'follow-up-page',
+      type: 'group',
+      text: 'Follow up',
+      item: [
+        { linkId: 'pain-level', type: 'string', text: 'Current pain level' },
+        {
+          linkId: 'hidden-calc',
+          type: 'string',
+          extension: [{ url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-hidden', valueBoolean: true }],
+        },
+      ],
+    },
+  ],
+};
+
+const PATIENT: Patient = {
+  resourceType: 'Patient',
+  id: 'pat-1',
+  name: [{ given: ['Pat'], family: 'Doe' }],
+  birthDate: '1990-05-01',
+};
+
+const qrFixture = (overrides: Partial<QuestionnaireResponse> = {}): QuestionnaireResponse => ({
+  resourceType: 'QuestionnaireResponse',
+  id: 'qr-1',
+  status: 'completed',
+  subject: { reference: 'Patient/pat-1' },
+  encounter: { reference: 'Encounter/enc-1' },
+  item: [
+    {
+      linkId: 'follow-up-page',
+      item: [
+        // The em-dash and ≥ exercise the WinAnsi sanitization path in the PDF renderer.
+        { linkId: 'pain-level', answer: [{ valueString: 'pain ≥ 7 — worse at night' }] },
+        { linkId: 'hidden-calc', answer: [{ valueString: 'internal' }] },
+      ],
+    },
+  ],
+  ...overrides,
+});
+
+const ENCOUNTER: Encounter = {
+  resourceType: 'Encounter',
+  id: 'enc-1',
+  status: 'finished',
+  class: { code: 'AMB' },
+  location: [{ location: { reference: 'Location/loc-1' } }],
+};
+
+const LOCATION: Location = { resourceType: 'Location', id: 'loc-1', name: 'Sunset Clinic' };
+
+interface OystehrMock {
+  fhir: {
+    get: ReturnType<typeof vi.fn>;
+    search: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+}
+
+const makeOystehr = (): OystehrMock => ({
+  fhir: {
+    get: vi.fn(async ({ resourceType }: { resourceType: string }) => {
+      if (resourceType === 'Encounter') return ENCOUNTER;
+      if (resourceType === 'Patient') return PATIENT;
+      if (resourceType === 'Location') return LOCATION;
+      throw new Error(`unexpected get ${resourceType}`);
+    }),
+    search: vi.fn().mockResolvedValue({ unbundle: () => [] }),
+    create: vi.fn(async (resource: unknown) => resource),
+  },
+});
+
+const run = (oystehr: OystehrMock, qr: QuestionnaireResponse = qrFixture()): Promise<void> =>
+  handleReviewTaskAndPdf({
+    questionnaireResponse: qr,
+    oystehr: oystehr as never,
+    secrets: SECRETS,
+    oystehrToken: 'm2m-token',
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetQuestionnaireForQR.mockResolvedValue(QUESTIONNAIRE);
+  mockCreatePresignedUrl.mockResolvedValue('https://z3.presigned/upload');
+  mockUploadObjectToZ3.mockResolvedValue(undefined as never);
+  mockCreateFilesDocumentReferences.mockResolvedValue({
+    docRefs: [{ resourceType: 'DocumentReference', id: 'docref-1', status: 'current', content: [] }],
+    listResources: undefined,
+  });
+});
+
+describe('renderQrPdf', () => {
+  test('renders a completed form, including WinAnsi-unsafe characters, to PDF bytes', async () => {
+    const bytes = await renderQrPdf(qrFixture(), QUESTIONNAIRE, PATIENT, DateTime.fromISO('2026-08-20T15:00:00Z'));
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  test('renders even without a questionnaire definition (labels fall back to linkIds)', async () => {
+    const bytes = await renderQrPdf(qrFixture(), undefined, PATIENT, DateTime.now());
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+});
+
+describe('handleReviewTaskAndPdf', () => {
+  test('uploads the PDF, files a DocumentReference, and creates the follow-up task', async () => {
+    const oystehr = makeOystehr();
+    await run(oystehr);
+
+    // Upload used the presigned url for the same file the DocumentReference points at
+    expect(mockCreatePresignedUrl).toHaveBeenCalledWith('m2m-token', expect.any(String), 'upload');
+    const baseFileUrl = mockCreatePresignedUrl.mock.calls[0][1];
+    expect(mockUploadObjectToZ3).toHaveBeenCalledWith(expect.any(Uint8Array), 'https://z3.presigned/upload');
+
+    const docRefInput = mockCreateFilesDocumentReferences.mock.calls[0][0];
+    expect(docRefInput.files).toEqual([{ url: baseFileUrl, title: expect.stringContaining('Injury Follow-Up Form') }]);
+    expect(docRefInput.type.coding?.[0].code).toBe(EXPORTED_QUESTIONNAIRE_CODE);
+    expect(docRefInput.references).toEqual({
+      subject: { reference: 'Patient/pat-1' },
+      context: { encounter: [{ reference: 'Encounter/enc-1' }] },
+    });
+
+    expect(oystehr.fhir.create).toHaveBeenCalledTimes(1);
+    const task = oystehr.fhir.create.mock.calls[0][0];
+    expect(task.resourceType).toBe('Task');
+    const inputValues = JSON.stringify(task.input);
+    expect(inputValues).toContain('Pat Doe completed Injury Follow-Up Form');
+    expect(inputValues).toContain('Patient/pat-1');
+    expect(inputValues).toContain('docref-1');
+    expect(mockSendErrors).not.toHaveBeenCalled();
+  });
+
+  test('creates the task without a document reference input when none was filed', async () => {
+    mockCreateFilesDocumentReferences.mockResolvedValue({ docRefs: [], listResources: undefined });
+    const oystehr = makeOystehr();
+    await run(oystehr);
+    const task = oystehr.fhir.create.mock.calls[0][0];
+    expect(JSON.stringify(task.input)).not.toContain('docref-1');
+  });
+
+  test('swallows and reports a malformed QR instead of failing the submission', async () => {
+    const oystehr = makeOystehr();
+    await expect(run(oystehr, qrFixture({ subject: undefined }))).resolves.toBeUndefined();
+    expect(mockSendErrors).toHaveBeenCalledWith(
+      expect.stringContaining('Erroring handling form finalization'),
+      'testing'
+    );
+    expect(mockUploadObjectToZ3).not.toHaveBeenCalled();
+    expect(oystehr.fhir.create).not.toHaveBeenCalled();
+  });
+
+  test('swallows and reports mid-flight failures without creating the task', async () => {
+    mockCreateFilesDocumentReferences.mockRejectedValue(new Error('docref service down'));
+    const oystehr = makeOystehr();
+    await expect(run(oystehr)).resolves.toBeUndefined();
+    expect(mockSendErrors).toHaveBeenCalledWith(expect.stringContaining('docref service down'), 'testing');
+    expect(oystehr.fhir.create).not.toHaveBeenCalled();
+  });
+});

--- a/packages/zambdas/test/unit/task-pdf-handler.test.ts
+++ b/packages/zambdas/test/unit/task-pdf-handler.test.ts
@@ -8,14 +8,8 @@ import { handleReviewTaskAndPdf, renderQrPdf } from '../../src/patient/paperwork
 import { sendErrors } from '../../src/shared/errors';
 import { createPresignedUrl, uploadObjectToZ3 } from '../../src/shared/z3Utils';
 
-/**
- * First tests for the submit-paperwork finalization side effects: rendering the completed
- * standalone form to PDF, uploading it, filing the DocumentReference, and creating the
- * staff follow-up Task. The design contract under test is that this whole path is
- * NON-FATAL — the patient's submission already succeeded, so any failure here is swallowed
- * and reported rather than surfaced. PDF rendering runs for real (pdf-lib, offline);
- * storage and FHIR writers are mocked at their seams.
- */
+// This path is NON-FATAL by design — the patient's submission already succeeded, so any
+// failure here is swallowed and reported rather than surfaced.
 
 vi.mock('utils/lib/fhir/helpers', async (importOriginal) => {
   const original = await importOriginal<typeof import('utils/lib/fhir/helpers')>();


### PR DESCRIPTION
**PR 9 of the paperwork factory-certification plan** (`docs/paperwork-testing-strategy.md`, Tier 4 item 4). Independent of PRs 7 and 8 — not stacked.

## What

`get-standalone-paperwork` had **zero tests of any kind**, and `submit-paperwork/taskPdfHandler.ts` (the review-task + PDF finalization) was equally uncovered.

**`test/unit/get-standalone-paperwork.test.ts`** (8 tests) drives the real handler (FHIR client and auth helpers mocked; item mapping and response assembly real):
- input validation: missing/malformed `questionnaireResponseId` rejected before any FHIR read
- **the authorization gate**: callers without access to the patient — and unauthenticated callers — get `NO_READ_ACCESS_TO_PATIENT_ERROR` before any questionnaire work happens
- the practice-managed-tag gate for questionnaires that don't belong on the standalone path
- fail-closed generic `Internal error` bodies for invariant violations (non-Patient subject, missing encounter) — pinning that internal messages don't leak to callers
- the missing-graph-resource error, and the full happy-path response shape (mapped items, patient summary with title-cased sex, appointment summary with service mode, questionnaire title)

**`test/unit/task-pdf-handler.test.ts`** (6 tests):
- `renderQrPdf` produces real PDF bytes via pdf-lib — including the WinAnsi sanitization path for unicode answers (≥, em-dashes) that would otherwise crash Helvetica encoding, and the no-questionnaire fallback
- `handleReviewTaskAndPdf` uploads the rendered PDF via a presigned url, files the DocumentReference (exported-questionnaire LOINC code, pointing at the same file url), and creates the staff follow-up Task — with and without a docref input
- **the design contract pinned explicitly**: this path is non-fatal. A malformed QR or a mid-flight failure is swallowed and reported via `sendErrors`, never failing the patient's already-completed submission.

## Verification

- 14/14 passing under `--project unit`; full zambdas unit project: 4,169 tests pass, only the 6 pre-existing `config/.env/local.json` import failures remain locally (they pass in CI). eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gi6xrcRXg1MuDceiDv7xw2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi6xrcRXg1MuDceiDv7xw2)_