### PR TITLE
Add Create Task action to the command palette (OTR-3380)

### DIFF
--- a/apps/ehr/src/App.tsx
+++ b/apps/ehr/src/App.tsx
@@ -22,6 +22,7 @@ import { GLOBAL_ACTION_LOG_VIEWER_ROLES } from 'utils/lib/types/api/action-logs.
 import { RoleType } from 'utils/lib/types/api/user.types';
 import Banner from './components/Banner';
 import { CommandPalette } from './components/CommandPalette';
+import { CommandPaletteCreateTask } from './components/CommandPaletteCreateTask';
 import { CommandPaletteRegistrations } from './components/CommandPaletteRegistrations';
 import LogoutWarning from './components/dialogs/LogoutWarning';
 import { LoadingScreen } from './components/LoadingScreen';
@@ -345,6 +346,7 @@ function App(): ReactElement {
         </Routes>
         <CommandPaletteRegistrations />
         <CommandPalette />
+        <CommandPaletteCreateTask />
         <SnackbarProvider maxSnack={5} autoHideDuration={6000} />
       </BrowserRouter>
     </CustomThemeProvider>

--- a/apps/ehr/src/App.tsx
+++ b/apps/ehr/src/App.tsx
@@ -64,6 +64,7 @@ import { QuestionnaireNew } from './features/visits/telemed/components/admin/que
 import RadiologyQuickPickDetailPage from './features/visits/telemed/components/admin/RadiologyQuickPickDetailPage';
 import { useApiClients } from './hooks/useAppClients';
 import useEvolveUser from './hooks/useEvolveUser';
+import { PRIMARY_EHR_STAFF_ROLES } from './hooks/useNavigationQuickPicks';
 import AddEmployeePage from './pages/AddEmployeePage';
 import AddPatient from './pages/AddPatient';
 import { AdminPage } from './pages/AdminPage';
@@ -98,15 +99,6 @@ setupSentry({
 });
 
 const InPersonRoutingLazy = lazy(() => import('./features/visits/in-person/routing/InPersonRouting'));
-
-const PRIMARY_EHR_STAFF_ROLES = [
-  RoleType.Administrator,
-  RoleType.Staff,
-  RoleType.Manager,
-  RoleType.Provider,
-  RoleType.Clinician,
-  RoleType.CustomerSupport,
-];
 
 const MUI_X_LICENSE_KEY = import.meta.env.VITE_APP_MUI_X_LICENSE_KEY;
 if (MUI_X_LICENSE_KEY != null) {

--- a/apps/ehr/src/components/CommandPaletteCreateTask.tsx
+++ b/apps/ehr/src/components/CommandPaletteCreateTask.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { matchPath, useLocation } from 'react-router-dom';
 import { getPatientLabel } from '../features/tasks/common';
 import { CreateTaskDialog } from '../features/tasks/components/CreateTaskDialog';
@@ -23,6 +23,11 @@ export const CommandPaletteCreateTask: FC = () => {
     : (matchPath('/patient/:id/*', pathname) ?? matchPath('/patient/:id', pathname))?.params.id;
   const { patient } = useGetPatient(open ? patientId : undefined);
 
+  const initialPatient = useMemo(
+    () => (patient?.id ? { id: patient.id, name: getPatientLabel(patient) } : undefined),
+    [patient]
+  );
+
   if (!open) {
     return null;
   }
@@ -32,7 +37,7 @@ export const CommandPaletteCreateTask: FC = () => {
       open
       handleClose={() => setCreateTaskDialogOpen(false)}
       appointmentId={visitId}
-      initialPatient={patient?.id ? { id: patient.id, name: getPatientLabel(patient) } : undefined}
+      initialPatient={initialPatient}
     />
   );
 };

--- a/apps/ehr/src/components/CommandPaletteCreateTask.tsx
+++ b/apps/ehr/src/components/CommandPaletteCreateTask.tsx
@@ -8,7 +8,8 @@ import { useCommandPaletteStore } from '../state/command-palette.store';
 /**
  * Mounts the create-task dialog at App level so the command palette's
  * "Create Task" action can open it from anywhere without navigating.
- * Prefills the visit on visit pages and the patient on patient-chart pages.
+ * Prefills the visit on visit pages (in-person progress note and visit details)
+ * and the patient on patient-chart pages.
  * Rendered only while open: the dialog fires several option-loading queries
  * as soon as it mounts.
  */
@@ -17,7 +18,7 @@ export const CommandPaletteCreateTask: FC = () => {
   const setCreateTaskDialogOpen = useCommandPaletteStore((state) => state.setCreateTaskDialogOpen);
   const { pathname } = useLocation();
 
-  const visitId = matchPath('/in-person/:id/*', pathname)?.params.id;
+  const visitId = (matchPath('/in-person/:id/*', pathname) ?? matchPath('/visit/:id', pathname))?.params.id;
   const patientId = visitId
     ? undefined
     : (matchPath('/patient/:id/*', pathname) ?? matchPath('/patient/:id', pathname))?.params.id;

--- a/apps/ehr/src/components/CommandPaletteCreateTask.tsx
+++ b/apps/ehr/src/components/CommandPaletteCreateTask.tsx
@@ -1,0 +1,38 @@
+import { FC } from 'react';
+import { matchPath, useLocation } from 'react-router-dom';
+import { getPatientLabel } from '../features/tasks/common';
+import { CreateTaskDialog } from '../features/tasks/components/CreateTaskDialog';
+import { useGetPatient } from '../hooks/useGetPatient';
+import { useCommandPaletteStore } from '../state/command-palette.store';
+
+/**
+ * Mounts the create-task dialog at App level so the command palette's
+ * "Create Task" action can open it from anywhere without navigating.
+ * Prefills the visit on visit pages and the patient on patient-chart pages.
+ * Rendered only while open: the dialog fires several option-loading queries
+ * as soon as it mounts.
+ */
+export const CommandPaletteCreateTask: FC = () => {
+  const open = useCommandPaletteStore((state) => state.createTaskDialogOpen);
+  const setCreateTaskDialogOpen = useCommandPaletteStore((state) => state.setCreateTaskDialogOpen);
+  const { pathname } = useLocation();
+
+  const visitId = matchPath('/in-person/:id/*', pathname)?.params.id;
+  const patientId = visitId
+    ? undefined
+    : (matchPath('/patient/:id/*', pathname) ?? matchPath('/patient/:id', pathname))?.params.id;
+  const { patient } = useGetPatient(open ? patientId : undefined);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <CreateTaskDialog
+      open
+      handleClose={() => setCreateTaskDialogOpen(false)}
+      appointmentId={visitId}
+      initialPatient={patient?.id ? { id: patient.id, name: getPatientLabel(patient) } : undefined}
+    />
+  );
+};

--- a/apps/ehr/src/components/CommandPaletteCreateTask.tsx
+++ b/apps/ehr/src/components/CommandPaletteCreateTask.tsx
@@ -25,8 +25,8 @@ export const CommandPaletteCreateTask: FC = () => {
   const { patient } = useGetPatient(open ? patientId : undefined);
 
   const initialPatient = useMemo(
-    () => (patient?.id ? { id: patient.id, name: getPatientLabel(patient) } : undefined),
-    [patient]
+    () => (patient?.id && patient.id === patientId ? { id: patient.id, name: getPatientLabel(patient) } : undefined),
+    [patient, patientId]
   );
 
   if (!open) {

--- a/apps/ehr/src/components/CommandPaletteRegistrations.tsx
+++ b/apps/ehr/src/components/CommandPaletteRegistrations.tsx
@@ -1,9 +1,11 @@
 import { FC } from 'react';
+import { useActionQuickPicks } from '../hooks/useActionQuickPicks';
 import { useGlobalQuickPicks } from '../hooks/useGlobalQuickPicks';
 import { useNavigationQuickPicks } from '../hooks/useNavigationQuickPicks';
 
 export const CommandPaletteRegistrations: FC = () => {
   useNavigationQuickPicks();
+  useActionQuickPicks();
 
   return null;
 };

--- a/apps/ehr/src/components/input/LocationSelectInput.tsx
+++ b/apps/ehr/src/components/input/LocationSelectInput.tsx
@@ -77,7 +77,7 @@ export const LocationSelectInput: React.FC<Props> = ({ name, label, multiple, re
   );
 };
 
-function getLocationLabel(location: Location): string {
+export function getLocationLabel(location: Location): string {
   if (!location.name) {
     return 'Unknown Location';
   }

--- a/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
+++ b/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
@@ -49,6 +49,14 @@ export const CreateTaskDialog: React.FC<Props> = ({
   // deliberately cleared isn't re-filled when a dep changes identity mid-open.
   const prefillApplied = useRef({ patient: false, location: false });
 
+  // StrictMode double-invokes mount effects but refs survive the simulated remount;
+  // reset on cleanup so each mount's prefill pass starts fresh.
+  useEffect(() => {
+    return () => {
+      prefillApplied.current = { patient: false, location: false };
+    };
+  }, []);
+
   useEffect(() => {
     if (!open) {
       methods.reset();

--- a/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
+++ b/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
@@ -28,9 +28,18 @@ import {
 interface Props {
   open: boolean;
   handleClose: () => void;
+  /** Appointment to prefill; falls back to the `:id` url param when omitted. */
+  appointmentId?: string;
+  /** Patient to prefill when no appointment supplies one (appointment prefill wins). */
+  initialPatient?: { id: string; name: string };
 }
 
-export const CreateTaskDialog: React.FC<Props> = ({ open, handleClose }) => {
+export const CreateTaskDialog: React.FC<Props> = ({
+  open,
+  handleClose,
+  appointmentId: appointmentIdProp,
+  initialPatient,
+}) => {
   const methods = useForm();
   const formValue = methods.watch();
 
@@ -126,7 +135,7 @@ export const CreateTaskDialog: React.FC<Props> = ({ open, handleClose }) => {
   }, [formValue.appointment, formValue.category, methods]);
 
   const urlParams = useParams();
-  const appointmentId = urlParams['id'];
+  const appointmentId = appointmentIdProp ?? urlParams['id'];
   const appointment = useAppointmentData(appointmentId);
   useEffect(() => {
     if (appointment.patient && open) {
@@ -137,6 +146,12 @@ export const CreateTaskDialog: React.FC<Props> = ({ open, handleClose }) => {
       methods.setValue('appointment', appointmentId);
     }
   }, [appointmentId, appointment, methods, open]);
+
+  useEffect(() => {
+    if (open && initialPatient && !appointment.patient && !methods.getValues('patient')) {
+      methods.setValue('patient', initialPatient);
+    }
+  }, [open, initialPatient, appointment.patient, methods]);
 
   useEffect(() => {
     if (!open) {

--- a/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
+++ b/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import { EmployeeSelectInput } from 'src/components/input/EmployeeSelectInput';
-import { LocationSelectInput } from 'src/components/input/LocationSelectInput';
+import { getLocationLabel, LocationSelectInput } from 'src/components/input/LocationSelectInput';
 import { PatientSelectInput } from 'src/components/input/PatientSelectInput';
 import { SelectInput } from 'src/components/input/SelectInput';
 import { TextInput } from 'src/components/input/TextInput';
@@ -185,6 +185,13 @@ export const CreateTaskDialog: React.FC<Props> = ({
     methods.setValue('assignee', null);
     methods.setValue('location', null);
   }, [orderFullUrl, serviceRequestId, procedureId, methods, open]);
+
+  // Visit context implies the location; declared after the URL-context effect above so its 'location' clear on open runs first.
+  useEffect(() => {
+    if (open && appointment.location?.id && !methods.getValues('location')) {
+      methods.setValue('location', { id: appointment.location.id, name: getLocationLabel(appointment.location) });
+    }
+  }, [open, appointment.location, methods]);
 
   return (
     <InPersonModal

--- a/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
+++ b/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import { EmployeeSelectInput } from 'src/components/input/EmployeeSelectInput';
@@ -45,9 +45,14 @@ export const CreateTaskDialog: React.FC<Props> = ({
 
   const [refreshKey, setRefreshKey] = useState(0);
 
+  // Context prefills apply at most once per dialog open, so a field the user
+  // deliberately cleared isn't re-filled when a dep changes identity mid-open.
+  const prefillApplied = useRef({ patient: false, location: false });
+
   useEffect(() => {
     if (!open) {
       methods.reset();
+      prefillApplied.current = { patient: false, location: false };
     }
     setRefreshKey(Date.now());
   }, [open, methods]);
@@ -148,8 +153,15 @@ export const CreateTaskDialog: React.FC<Props> = ({
   }, [appointmentId, appointment, methods, open]);
 
   useEffect(() => {
-    if (open && initialPatient && !appointment.patient && !methods.getValues('patient')) {
+    if (
+      open &&
+      initialPatient &&
+      !prefillApplied.current.patient &&
+      !appointment.patient &&
+      !methods.getValues('patient')
+    ) {
       methods.setValue('patient', initialPatient);
+      prefillApplied.current.patient = true;
     }
   }, [open, initialPatient, appointment.patient, methods]);
 
@@ -188,8 +200,9 @@ export const CreateTaskDialog: React.FC<Props> = ({
 
   // Visit context implies the location; declared after the URL-context effect above so its 'location' clear on open runs first.
   useEffect(() => {
-    if (open && appointment.location?.id && !methods.getValues('location')) {
+    if (open && appointment.location?.id && !prefillApplied.current.location && !methods.getValues('location')) {
       methods.setValue('location', { id: appointment.location.id, name: getLocationLabel(appointment.location) });
+      prefillApplied.current.location = true;
     }
   }, [open, appointment.location, methods]);
 

--- a/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
+++ b/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
@@ -153,13 +153,14 @@ export const CreateTaskDialog: React.FC<Props> = ({
     }
   }, [open, initialPatient, appointment.patient, methods]);
 
+  // useParams() returns an unstable {} outside a matched Route, so the effect deps must be the primitive params, not the object.
+  const orderFullUrl = urlParams['*'];
+  const serviceRequestId = urlParams['serviceRequestID'];
+  const procedureId = urlParams['procedureId'];
   useEffect(() => {
     if (!open) {
       return;
     }
-    const orderFullUrl = urlParams['*'];
-    const serviceRequestId = urlParams['serviceRequestID'];
-    const procedureId = urlParams['procedureId'];
     if (orderFullUrl?.startsWith('in-house-lab-orders') && serviceRequestId) {
       methods.setValue('category', MANUAL_TASK.category.inHouseLab);
       methods.setValue('order', serviceRequestId);
@@ -183,7 +184,7 @@ export const CreateTaskDialog: React.FC<Props> = ({
     methods.setValue('taskDetails', null);
     methods.setValue('assignee', null);
     methods.setValue('location', null);
-  }, [urlParams, methods, open]);
+  }, [orderFullUrl, serviceRequestId, procedureId, methods, open]);
 
   return (
     <InPersonModal

--- a/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
+++ b/apps/ehr/src/features/tasks/components/CreateTaskDialog.tsx
@@ -25,6 +25,12 @@ import {
   useRadiologyOrdersOptions,
 } from '../common';
 
+const noPrefillApplied = (): { appointment: boolean; patient: boolean; location: boolean } => ({
+  appointment: false,
+  patient: false,
+  location: false,
+});
+
 interface Props {
   open: boolean;
   handleClose: () => void;
@@ -47,20 +53,20 @@ export const CreateTaskDialog: React.FC<Props> = ({
 
   // Context prefills apply at most once per dialog open, so a field the user
   // deliberately cleared isn't re-filled when a dep changes identity mid-open.
-  const prefillApplied = useRef({ patient: false, location: false });
+  const prefillApplied = useRef(noPrefillApplied());
 
   // StrictMode double-invokes mount effects but refs survive the simulated remount;
   // reset on cleanup so each mount's prefill pass starts fresh.
   useEffect(() => {
     return () => {
-      prefillApplied.current = { patient: false, location: false };
+      prefillApplied.current = noPrefillApplied();
     };
   }, []);
 
   useEffect(() => {
     if (!open) {
       methods.reset();
-      prefillApplied.current = { patient: false, location: false };
+      prefillApplied.current = noPrefillApplied();
     }
     setRefreshKey(Date.now());
   }, [open, methods]);
@@ -151,14 +157,15 @@ export const CreateTaskDialog: React.FC<Props> = ({
   const appointmentId = appointmentIdProp ?? urlParams['id'];
   const appointment = useAppointmentData(appointmentId);
   useEffect(() => {
-    if (appointment.patient && open) {
+    if (appointment.patient && open && !prefillApplied.current.appointment) {
       methods.setValue('patient', {
         id: appointment.patient.id,
         name: getPatientLabel(appointment.patient),
       });
       methods.setValue('appointment', appointmentId);
+      prefillApplied.current.appointment = true;
     }
-  }, [appointmentId, appointment, methods, open]);
+  }, [appointmentId, appointment.patient, methods, open]);
 
   useEffect(() => {
     if (

--- a/apps/ehr/src/hooks/useActionQuickPicks.ts
+++ b/apps/ehr/src/hooks/useActionQuickPicks.ts
@@ -1,18 +1,8 @@
 import { useMemo } from 'react';
-import { RoleType } from 'utils/lib/types/api/user.types';
 import { CommandPaletteItem, useCommandPaletteStore } from '../state/command-palette.store';
 import { useCommandPaletteSource } from './useCommandPaletteSource';
 import useEvolveUser from './useEvolveUser';
-
-// Mirrors the /tasks route gating in App.tsx (union of both staff role blocks).
-const TASK_CREATION_ROLES = [
-  RoleType.Administrator,
-  RoleType.Manager,
-  RoleType.CustomerSupport,
-  RoleType.Staff,
-  RoleType.Provider,
-  RoleType.Clinician,
-];
+import { PRIMARY_EHR_STAFF_ROLES } from './useNavigationQuickPicks';
 
 /** Registers global action items (currently just "Create Task") in the command palette. */
 export function useActionQuickPicks(): void {
@@ -20,7 +10,7 @@ export function useActionQuickPicks(): void {
   const setCreateTaskDialogOpen = useCommandPaletteStore((state) => state.setCreateTaskDialogOpen);
 
   const items = useMemo<CommandPaletteItem[]>(() => {
-    if (!currentUser || !currentUser.hasRole(TASK_CREATION_ROLES)) {
+    if (!currentUser || !currentUser.hasRole(PRIMARY_EHR_STAFF_ROLES)) {
       return [];
     }
 

--- a/apps/ehr/src/hooks/useActionQuickPicks.ts
+++ b/apps/ehr/src/hooks/useActionQuickPicks.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import { RoleType } from 'utils/lib/types/api/user.types';
+import { CommandPaletteItem, useCommandPaletteStore } from '../state/command-palette.store';
+import { useCommandPaletteSource } from './useCommandPaletteSource';
+import useEvolveUser from './useEvolveUser';
+
+// Mirrors the /tasks route gating in App.tsx (union of both staff role blocks).
+const TASK_CREATION_ROLES = [
+  RoleType.Administrator,
+  RoleType.Manager,
+  RoleType.CustomerSupport,
+  RoleType.Staff,
+  RoleType.Provider,
+  RoleType.Clinician,
+];
+
+/** Registers global action items (currently just "Create Task") in the command palette. */
+export function useActionQuickPicks(): void {
+  const currentUser = useEvolveUser();
+  const setCreateTaskDialogOpen = useCommandPaletteStore((state) => state.setCreateTaskDialogOpen);
+
+  const items = useMemo<CommandPaletteItem[]>(() => {
+    if (!currentUser || !currentUser.hasRole(TASK_CREATION_ROLES)) {
+      return [];
+    }
+
+    return [
+      {
+        id: 'action-create-task',
+        label: 'Create Task',
+        category: 'Actions',
+        keywords: ['task', 'new task', 'create task', 'todo', 'assign'],
+        onSelect: () => setCreateTaskDialogOpen(true),
+      },
+    ];
+  }, [currentUser, setCreateTaskDialogOpen]);
+
+  useCommandPaletteSource('actions', items);
+}

--- a/apps/ehr/src/hooks/useGetPatient.ts
+++ b/apps/ehr/src/hooks/useGetPatient.ts
@@ -88,7 +88,8 @@ export const useGetPatient = (
   useEffect(() => {
     async function getPatient(): Promise<void> {
       if (!oystehr) {
-        throw new Error('oystehr is not defined');
+        // Client not ready yet (or id undefined, so the queries stay disabled); the effect re-runs once oystehr exists.
+        return;
       }
 
       if (!patientResources || !otherPatientsWithSameNameResources) {

--- a/apps/ehr/src/hooks/useGetPatient.ts
+++ b/apps/ehr/src/hooks/useGetPatient.ts
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/react';
 import { useMutation, UseMutationResult, useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
 import { FhirResource, Patient, Person, QuestionnaireResponse, RelatedPerson } from 'fhir/r4b';
 import { enqueueSnackbar } from 'notistack';
@@ -121,7 +122,10 @@ export const useGetPatient = (
       setLoading(false);
     }
 
-    getPatient().catch((error) => console.log(error));
+    getPatient().catch((error) => {
+      console.error(error);
+      captureException(error);
+    });
   }, [id, oystehr, patientResources, otherPatientsWithSameNameResources]);
 
   return {

--- a/apps/ehr/src/hooks/useNavigationQuickPicks.ts
+++ b/apps/ehr/src/hooks/useNavigationQuickPicks.ts
@@ -34,7 +34,8 @@ interface NavigationDestination {
 }
 
 const ADMIN_ROLES = [RoleType.Administrator, RoleType.Manager, RoleType.CustomerSupport];
-const VISIT_CREATION_ROLES = [
+// Mirrors the /tasks and visit-creation route gating in App.tsx (union of both staff role blocks).
+export const PRIMARY_EHR_STAFF_ROLES = [
   RoleType.Administrator,
   RoleType.Manager,
   RoleType.CustomerSupport,
@@ -98,7 +99,7 @@ const NAVIGATION_DESTINATIONS: NavigationDestination[] = [
     label: 'Add New Visit',
     to: '/visits/add',
     icon: LocalHospitalIcon,
-    roles: VISIT_CREATION_ROLES,
+    roles: PRIMARY_EHR_STAFF_ROLES,
     keywords: ['create appointment', 'new patient visit', 'walk-in'],
   },
   {

--- a/apps/ehr/src/state/command-palette.store.ts
+++ b/apps/ehr/src/state/command-palette.store.ts
@@ -27,18 +27,21 @@ interface CommandPaletteState {
   isOpen: boolean;
   sources: Record<string, CommandPaletteSource>;
   pendingQuickPick: PendingQuickPick | null;
+  createTaskDialogOpen: boolean;
   open: () => void;
   close: () => void;
   toggle: () => void;
   registerSource: (sourceId: string, items: CommandPaletteItem[]) => void;
   unregisterSource: (sourceId: string) => void;
   setPendingQuickPick: (pending: PendingQuickPick | null) => void;
+  setCreateTaskDialogOpen: (open: boolean) => void;
 }
 
 export const useCommandPaletteStore = create<CommandPaletteState>()((set) => ({
   isOpen: false,
   sources: {},
   pendingQuickPick: null,
+  createTaskDialogOpen: false,
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false }),
   toggle: () => set((state) => ({ isOpen: !state.isOpen })),
@@ -66,4 +69,5 @@ export const useCommandPaletteStore = create<CommandPaletteState>()((set) => ({
       return { sources: remainingSources };
     }),
   setPendingQuickPick: (pendingQuickPick) => set({ pendingQuickPick }),
+  setCreateTaskDialogOpen: (createTaskDialogOpen) => set({ createTaskDialogOpen }),
 }));


### PR DESCRIPTION
## What

Adds a **Create Task** action to the EHR command palette (Cmd+K → "Actions" group) that opens the existing task-creation dialog in place — no navigation — and prefills whatever context the current page provides:

- **Visit chart** (any `/in-person/:id/*` tab): patient, visit, **and the visit's location** prefill.
- **Patient chart** (`/patient/:id` pages): patient prefills; the visit dropdown offers that patient's history.
- **Anywhere else**: dialog opens empty, same as the Tasks page.

Gated to the same roles as the `/tasks` route (now a shared `PRIMARY_EHR_STAFF_ROLES` constant).

## How

~140 net lines, no backend changes, no new UI beyond a thin wrapper:

- `CreateTaskDialog` gains optional `appointmentId` / `initialPatient` props (existing call sites unchanged) and a location prefill from the appointment store's `location` resource.
- A `CommandPaletteCreateTask` wrapper mounted next to the palette resolves context from the URL via `matchPath` and conditionally mounts the dialog (its option queries don't fire until invoked).
- One palette item registered via a new `useActionQuickPicks` hook, following the existing quick-picks conventions.

## Bugs found and fixed along the way

- **Pre-existing:** the dialog's initialize-from-URL effect depended on the `useParams()` object, which is a fresh `{}` on every render outside a matched Route — at App level it re-fired on every form change and wiped the location/title/details/assignee the user just entered. Now depends on the primitive param values.
- **Pre-existing:** `useGetPatient` threw (and console-logged) "oystehr is not defined" before the client was ready; now returns early, and its catch reports to Sentry via `captureException` instead of swallowing.
- Context prefills apply **once per open** (ref latch, reset on unmount) so a field the user deliberately clears isn't re-filled by a background refetch — with the latch made StrictMode-safe.

## Testing

- `tsc --noEmit` and eslint clean on all touched files.
- Verified in-browser on synth: palette action from tracking board (empty dialog), from a visit chart (patient + visit + location prefilled), location selection persists, cleared location stays cleared through subsequent form edits, Tasks-page and visit-header dialogs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9fX9o3x1nrMiKy8Xv67Cu