### PR TITLE
fix: return 400 for invalid insurance card images

### DIFF
--- a/packages/zambdas/src/ehr/extract-insurance-card/helpers.ts
+++ b/packages/zambdas/src/ehr/extract-insurance-card/helpers.ts
@@ -159,7 +159,12 @@ export async function extractInsuranceCardFieldsFromImage(
   } catch (error) {
     // A 4xx from Vertex AI means the uploaded image itself was rejected (e.g. unreadable or
     // unsupported content). Surface that as a 400 bad-request rather than crashing with a 500.
-    if (error instanceof VertexAIRequestError && error.status !== undefined && error.status >= 400 && error.status < 500) {
+    if (
+      error instanceof VertexAIRequestError &&
+      error.status !== undefined &&
+      error.status >= 400 &&
+      error.status < 500
+    ) {
       throw INVALID_INPUT_ERROR(
         'The uploaded insurance card image could not be processed. Please upload a clearer image of the insurance card.'
       );

--- a/packages/zambdas/src/ehr/extract-insurance-card/helpers.ts
+++ b/packages/zambdas/src/ehr/extract-insurance-card/helpers.ts
@@ -6,7 +6,8 @@ import {
   InsuranceCardExtraction,
   InsuranceCardExtractionFields,
 } from 'utils/lib/types/data/documents';
-import { invokeChatbotVertexAI } from '../../shared/ai';
+import { INVALID_INPUT_ERROR } from 'utils/lib/types/errors';
+import { invokeChatbotVertexAI, VertexAIRequestError } from '../../shared/ai';
 import {
   assertBooleanClassifier,
   buildExtractionExtension as buildGenericExtractionExtension,
@@ -148,11 +149,23 @@ export async function extractInsuranceCardFieldsFromImage(
     return { isInsuranceCard: false, fields: null, readable: null, unsupportedContentType: true };
   }
 
-  const rawModelResponse = await invokeChatbotVertexAI(
-    [{ text: EXTRACTION_PROMPT }, { inlineData: { mimeType, data: bytes.toString('base64') } }],
-    secrets,
-    insuranceCardResponseSchema
-  );
+  let rawModelResponse: string;
+  try {
+    rawModelResponse = await invokeChatbotVertexAI(
+      [{ text: EXTRACTION_PROMPT }, { inlineData: { mimeType, data: bytes.toString('base64') } }],
+      secrets,
+      insuranceCardResponseSchema
+    );
+  } catch (error) {
+    // A 4xx from Vertex AI means the uploaded image itself was rejected (e.g. unreadable or
+    // unsupported content). Surface that as a 400 bad-request rather than crashing with a 500.
+    if (error instanceof VertexAIRequestError && error.status !== undefined && error.status >= 400 && error.status < 500) {
+      throw INVALID_INPUT_ERROR(
+        'The uploaded insurance card image could not be processed. Please upload a clearer image of the insurance card.'
+      );
+    }
+    throw error;
+  }
   const parsed = parseModelResponse(rawModelResponse);
   return { ...parsed, unsupportedContentType: false };
 }

--- a/packages/zambdas/src/shared/ai.ts
+++ b/packages/zambdas/src/shared/ai.ts
@@ -125,6 +125,16 @@ const AI_RESPONSE_KEY_TO_FIELD = {
   procedures: AiObservationField.Procedures,
 };
 
+export class VertexAIRequestError extends Error {
+  readonly status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'VertexAIRequestError';
+    this.status = status;
+  }
+}
+
 export const VERTEX_AI_MODEL = 'gemini-3.1-flash-lite';
 
 export async function invokeChatbotVertexAI(
@@ -220,7 +230,10 @@ export async function invokeChatbotVertexAI(
   // Unchecked, an error body fell through to `candidates[0]` and every Vertex failure surfaced as
   // `TypeError: Cannot read properties of undefined` with an empty stack.
   if (!settled.ok) {
-    throw new Error(`Vertex AI request failed: ${settled.status} ${settled.statusText} ${body.slice(0, 1000)}`);
+    throw new VertexAIRequestError(
+      `Vertex AI request failed: ${settled.status} ${settled.statusText} ${body.slice(0, 1000)}`,
+      settled.status
+    );
   }
 
   // Size only: on a transcription call the body is the transcript, which is PHI.

--- a/packages/zambdas/test/unit/extract-insurance-card-helpers.test.ts
+++ b/packages/zambdas/test/unit/extract-insurance-card-helpers.test.ts
@@ -1,0 +1,60 @@
+import { APIErrorCode } from 'utils/lib/types/errors';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { extractInsuranceCardFieldsFromImage } from '../../src/ehr/extract-insurance-card/helpers';
+import { VertexAIRequestError } from '../../src/shared/ai';
+
+// Keep the real VertexAIRequestError class (the helper does `instanceof` checks against it) and only
+// replace the network-bound invokeChatbotVertexAI with a mock we can drive per-test.
+vi.mock('../../src/shared/ai', async () => {
+  const actual = await vi.importActual<typeof import('../../src/shared/ai')>('../../src/shared/ai');
+  return {
+    ...actual,
+    invokeChatbotVertexAI: vi.fn(),
+  };
+});
+
+// Pulling in the helper's dependency graph shouldn't drag the real Sentry SDK into a unit test.
+vi.mock('@sentry/aws-serverless', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  init: vi.fn(),
+  isInitialized: vi.fn(() => true),
+  setTag: vi.fn(),
+  setTags: vi.fn(),
+  wrapHandler: (handler: unknown) => handler,
+}));
+
+const { invokeChatbotVertexAI } = await import('../../src/shared/ai');
+const mockInvoke = vi.mocked(invokeChatbotVertexAI);
+
+afterEach(() => {
+  mockInvoke.mockReset();
+});
+
+describe('extractInsuranceCardFieldsFromImage error translation', () => {
+  test('a Vertex 4xx is translated into an INVALID_INPUT APIError (renders as HTTP 400)', async () => {
+    mockInvoke.mockRejectedValueOnce(
+      new VertexAIRequestError('Vertex AI request failed: 400 Bad Request Request contains an invalid argument.', 400)
+    );
+
+    const error = await extractInsuranceCardFieldsFromImage(Buffer.from('x'), 'image/png', null).then(
+      () => null,
+      (error: unknown) => error
+    );
+
+    expect(error).not.toBeNull();
+    expect((error as { code?: number }).code).toBe(APIErrorCode.INVALID_INPUT);
+  });
+
+  test('a Vertex 5xx is NOT translated — it stays a server error', async () => {
+    const original = new VertexAIRequestError('Vertex AI request failed: 500 Internal Server Error', 500);
+    mockInvoke.mockRejectedValueOnce(original);
+
+    const error = await extractInsuranceCardFieldsFromImage(Buffer.from('x'), 'image/png', null).then(
+      () => null,
+      (error: unknown) => error
+    );
+
+    expect(error).toBe(original);
+  });
+});

--- a/packages/zambdas/test/unit/vertex-ai-error-handling.test.ts
+++ b/packages/zambdas/test/unit/vertex-ai-error-handling.test.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { Secrets, SecretsKeys } from 'utils/lib/secrets';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { invokeChatbotVertexAI } from '../../src/shared/ai';
+import { invokeChatbotVertexAI, VertexAIRequestError } from '../../src/shared/ai';
 import { lambdaResponse } from '../../src/shared/lambda';
 import { wrapHandler } from '../../src/shared/sentry';
 import { ZambdaInput } from '../../src/shared/types/common';
@@ -103,6 +103,15 @@ describe('invokeChatbotVertexAI error handling', () => {
     });
 
     await expect(invoke()).rejects.toThrow(/Vertex AI request failed: 400 Bad Request.*INVALID_ARGUMENT/s);
+
+    // The thrown error carries the HTTP status so callers can translate a Vertex 4xx into a 400 instead
+    // of letting it crash as a 500.
+    const error = await invoke().then(
+      () => null,
+      (error: unknown) => error
+    );
+    expect(error).toBeInstanceOf(VertexAIRequestError);
+    expect((error as VertexAIRequestError).status).toBe(400);
   });
 
   test('a non-retryable failure is not retried', async () => {


### PR DESCRIPTION
## Summary

When Vertex AI rejects an insurance card image with a `400 Bad Request` (e.g. an unreadable or unsupported image), `invokeChatbotVertexAI` threw a plain `Error`. That propagated through the `extract-insurance-card` (EHR) and `get-insurance-card-suggestions` (patient) zambdas, and `topLevelCatch` / `handleErrorResult` renders any non-`APIError` as **HTTP 500** — so an invalid image crashed the endpoint and paged Sentry (see the Sentry error `Vertex AI request failed: 400 Bad Request`).

This change makes an invalid image return a clean **HTTP 400** instead.

Fixes [HOST-1069](https://linear.app/zapehr/issue/HOST-1069/return-400-for-invalid-insurance-card-images).

## Changes

- **`packages/zambdas/src/shared/ai.ts`** — Added a typed `VertexAIRequestError extends Error` that carries the HTTP `status`. The terminal (non-retryable) Vertex failure now throws this error with `settled.status` attached. The error message string is unchanged, and no other throw sites were touched (the PHI-bearing transcription path still surfaces as a plain server error).
- **`packages/zambdas/src/ehr/extract-insurance-card/helpers.ts`** — `extractInsuranceCardFieldsFromImage` now wraps the Vertex call and translates a Vertex **4xx** (`>= 400 && < 500`) into `INVALID_INPUT_ERROR(...)`, which renders as HTTP 400 with a clean `{ message, code }` body and no longer pages Sentry as a server error. Any other failure (5xx, etc.) is rethrown unchanged and stays a 500. Because the conversion lives in this shared helper, **both** the EHR and patient endpoints are fixed at once.

## Tests

- New `packages/zambdas/test/unit/extract-insurance-card-helpers.test.ts`: a Vertex 400 → the helper throws an `INVALID_INPUT` `APIError`; a Vertex 500 → the original error is rethrown untouched.
- Extended `packages/zambdas/test/unit/vertex-ai-error-handling.test.ts` to assert the thrown error is a `VertexAIRequestError` with `.status === 400`.

> Note: unit tests/lint could not be executed in this environment (no `node_modules`; npm registry egress is blocked). The changes are mechanical and were statically reviewed against the source; CI should confirm.

## Context

Slack thread: https://masslight.slack.com/archives/C090W5LNP0C/p1788281903487839?thread_ts=1788278514.417239&cid=C090W5LNP0C

---
_Generated by [Claude Code](https://claude.ai/code/session_017bvE3T537CA9Yo4VP1Ebje)_