### PR TITLE
prefill patient phone number with phone telecom from patient resource

### DIFF
--- a/packages/utils/lib/helpers/paperwork/prePopulation.ts
+++ b/packages/utils/lib/helpers/paperwork/prePopulation.ts
@@ -165,7 +165,7 @@ export const makePrepopulatedItemsForPatient = (input: PrePopulationInput): Ques
   const patientLastName = getLastName(patient) ?? '';
 
   const patientPhone =
-    patient?.telecom?.find((c) => c.system === 'phone' && c.period?.end === undefined)?.value ??
+    patient?.telecom?.find((c) => c.system === 'phone' && c.period?.end === undefined)?.value ||
     formattedVerifiedPhoneNumber;
 
   // https://github.com/masslight/ottehr/issues/5984 - because the "additional info / tell us more" field gets appended

--- a/packages/utils/lib/helpers/paperwork/prePopulation.ts
+++ b/packages/utils/lib/helpers/paperwork/prePopulation.ts
@@ -164,6 +164,10 @@ export const makePrepopulatedItemsForPatient = (input: PrePopulationInput): Ques
   const patientFirstName = getFirstName(patient) ?? '';
   const patientLastName = getLastName(patient) ?? '';
 
+  const patientPhone =
+    patient?.telecom?.find((c) => c.system === 'phone' && c.period?.end === undefined)?.value ??
+    formattedVerifiedPhoneNumber;
+
   // https://github.com/masslight/ottehr/issues/5984 - because the "additional info / tell us more" field gets appended
   // to the selected reason for visit, before it is passed in here, we need to normalize it back to just the selected option
   // or it could break any fields that depend on exact matching of the reason for visit logical field value.
@@ -237,8 +241,8 @@ export const makePrepopulatedItemsForPatient = (input: PrePopulationInput): Ques
           if (linkId === 'common-well-consent' && patientCommonWellConsent !== undefined) {
             answer = makeAnswer(patientCommonWellConsent, 'Boolean');
           }
-          if (linkId === 'patient-number' && formattedVerifiedPhoneNumber) {
-            answer = makeAnswer(formatPhoneNumberDisplay(formattedVerifiedPhoneNumber));
+          if (linkId === 'patient-number' && patientPhone) {
+            answer = makeAnswer(formatPhoneNumberDisplay(patientPhone));
           }
           if (linkId === 'patient-birth-sex' && patientSex) {
             answer = makeAnswer(patientSex);


### PR DESCRIPTION
https://linear.app/zapehr/issue/HOST-1061/patient-app-mobile-phone-number-is-empty-on-the-contact-information

Right now we are pre-filling this field with the verified phone number (the phone number associated with the user), in the case where there are two we are unable to decide so it’s blank. Seems wrong that we are pre-filing with this number though when there’s a phone number present on the patient resource. 

So for example if you log in with 333 333 3333 and fill in 111 111 1111 in that field, 111 111 1111 is stored on the patient but the next time around 333 333 3333 is prefilled in the paperwork. 

This change prioritizes the number from the patient resource and falls back on the verified phone number, if there is one. 