### PR TITLE
Vertex AI empty responses in interview summaries

### DIFF
--- a/packages/zambdas/src/shared/ai.ts
+++ b/packages/zambdas/src/shared/ai.ts
@@ -153,7 +153,12 @@ export async function invokeChatbotVertexAI(
 
   let resolved = false;
   let terminal = false; // a non-retryable status came back; further attempts would just resend the payload
-  let terminalError: Error | undefined; // that status's own error, so it is reported instead of the ladder's
+  // Promise.any cannot reject until every attempt has, so on its own a rejected terminal attempt left the
+  // caller waiting out the later attempts' backoff sleeps. Racing this against the ladder surfaces it now.
+  let failTerminally: (error: Error) => void = () => undefined;
+  const terminalFailure = new Promise<never>((_resolve, reject) => {
+    failTerminally = reject;
+  });
   const requests = backoffTimes.map(async (backoffTime) => {
     await new Promise((resolve) => setTimeout(resolve, backoffTime));
 
@@ -190,10 +195,11 @@ export async function invokeChatbotVertexAI(
           throw new Error(`Retryable error: ${response.status} ${errorBody.slice(0, 500)}`);
         }
         terminal = true;
-        terminalError = new Error(
+        const failure = new Error(
           `Vertex AI request failed: ${response.status} ${response.statusText} ${errorBody.slice(0, 1000)}`
         );
-        throw terminalError;
+        failTerminally(failure);
+        throw failure;
       }
 
       const body = await response.text();
@@ -216,17 +222,17 @@ export async function invokeChatbotVertexAI(
       // lands a blank transcript on the chart, and it would do so with the attempt already counted a success.
       if (typeof text !== 'string' || text.trim().length === 0) {
         // No candidate text means the model refused, was cut off (safety block, MAX_TOKENS finishReason), or
-        // spent the whole turn on thinking tokens and emitted none.
-        const reason = JSON.stringify({
-          finishReason: candidate?.finishReason,
-          promptFeedback: parsed?.promptFeedback,
-          usageMetadata: parsed?.usageMetadata,
-        });
-        // Normally the reason and not the body: a cut-off candidate can still carry partial transcript. But a
-        // candidate with no `content` holds nothing the model generated, and those are exactly the bodies
-        // whose reason fields are all absent too — `{}` on its own is as undiagnosable as the old TypeError.
-        const detail = candidate?.content == null ? `${reason} ${body.slice(0, 1000)}` : reason;
-        throw new Error(`Vertex AI returned no text: ${detail}`);
+        // spent the whole turn on thinking tokens and emitted none. Everything outside `candidates` is
+        // metadata — quota, model build, response id, prompt feedback — so it is reported whole: it names the
+        // cause where a hand-picked field or two left `{}`. `candidates` is dropped wholesale rather than
+        // inspected shape by shape, because one that was cut off can still hold a partial transcript and a
+        // sibling can hold a whole one, and neither belongs in a log or a Sentry issue.
+        // Capped like every other body interpolated here: dropping `candidates` bounds what this can say
+        // about a Gemini response, but not about a gateway envelope that carries the request back, which on
+        // the transcription path is the base64 audio — and this reason is logged and shipped to Sentry.
+        const { candidates: _candidates, ...metadata } = parsed ?? {};
+        const reason = JSON.stringify({ finishReason: candidate?.finishReason, ...metadata }).slice(0, 1000);
+        throw new Error(`Vertex AI returned no text: ${reason}`);
       }
 
       // Only an attempt that produced usable text may win. This used to be set on `response.ok` alone, so a
@@ -246,17 +252,15 @@ export async function invokeChatbotVertexAI(
   try {
     // Every attempt now resolves only with validated text, so Promise.any picks the first usable result
     // rather than the first HTTP 200.
-    return await Promise.any(requests);
+    return await Promise.race([Promise.any(requests), terminalFailure]);
   } catch (error) {
-    // A status no resend can recover from is its own diagnosis; wrapping it in the ladder's message would
-    // bury it and group it with exhausted ladders in Sentry.
-    if (terminalError != null) throw terminalError;
+    // Only Promise.any rejects with an AggregateError; anything else came from the terminal signal. Such a
+    // status is its own diagnosis, and wrapping it in the ladder's message would bury it and group it with
+    // exhausted ladders in Sentry.
+    if (!(error instanceof AggregateError)) throw error;
     // AggregateError's own message is just "All promises were rejected", so unpack the reasons — otherwise
     // the most common failure mode stays as opaque as the TypeError this used to throw.
-    const reasons =
-      error instanceof AggregateError
-        ? error.errors.map((reason) => (reason instanceof Error ? reason.message : String(reason)))
-        : [error instanceof Error ? error.message : String(error)];
+    const reasons = error.errors.map((reason) => (reason instanceof Error ? reason.message : String(reason)));
     throw new Error(`Vertex AI request failed after ${requests.length} attempts: ${reasons.join('; ')}`);
   }
 }

--- a/packages/zambdas/src/shared/ai.ts
+++ b/packages/zambdas/src/shared/ai.ts
@@ -214,29 +214,21 @@ export async function invokeChatbotVertexAI(
         throw new Error(`Vertex AI returned a non-JSON body: ${body.slice(0, 1000)}`);
       }
 
-      // Unchecked, an error body fell through to `candidates[0]` and every Vertex failure surfaced as
-      // `TypeError: Cannot read properties of undefined` with an empty stack.
       const candidate = parsed?.candidates?.[0];
       const text = candidate?.content?.parts?.[0]?.text;
-      // Whitespace is not output: it satisfies every downstream caller's type but dies in the JSON parse or
-      // lands a blank transcript on the chart, and it would do so with the attempt already counted a success.
+      // Whitespace-only output satisfies every downstream caller's type but dies in the JSON parse or lands a
+      // blank transcript on the chart.
       if (typeof text !== 'string' || text.trim().length === 0) {
-        // No candidate text means the model refused, was cut off (safety block, MAX_TOKENS finishReason), or
-        // spent the whole turn on thinking tokens and emitted none. Everything outside `candidates` is
-        // metadata — quota, model build, response id, prompt feedback — so it is reported whole: it names the
-        // cause where a hand-picked field or two left `{}`. `candidates` is dropped wholesale rather than
-        // inspected shape by shape, because one that was cut off can still hold a partial transcript and a
-        // sibling can hold a whole one, and neither belongs in a log or a Sentry issue.
-        // Capped like every other body interpolated here: dropping `candidates` bounds what this can say
-        // about a Gemini response, but not about a gateway envelope that carries the request back, which on
-        // the transcription path is the base64 audio — and this reason is logged and shipped to Sentry.
+        // Everything outside `candidates` is metadata — quota, model build, response id, prompt feedback — and
+        // reporting it whole is what names the cause; hand-picking a field or two left `{}`. `candidates` is
+        // dropped wholesale because any of them can hold partial or whole transcript, which must not reach a
+        // log or Sentry. The cap bounds a gateway envelope that echoes the request back — on the transcription
+        // path, the base64 audio.
         const { candidates: _candidates, ...metadata } = parsed ?? {};
         const reason = JSON.stringify({ finishReason: candidate?.finishReason, ...metadata }).slice(0, 1000);
         throw new Error(`Vertex AI returned no text: ${reason}`);
       }
 
-      // Only an attempt that produced usable text may win. This used to be set on `response.ok` alone, so a
-      // 200 carrying no candidates resolved the ladder and the remaining attempts were skipped as superseded.
       resolved = true;
       return text;
     } catch (error) {
@@ -250,8 +242,6 @@ export async function invokeChatbotVertexAI(
   });
 
   try {
-    // Every attempt now resolves only with validated text, so Promise.any picks the first usable result
-    // rather than the first HTTP 200.
     return await Promise.race([Promise.any(requests), terminalFailure]);
   } catch (error) {
     // Only Promise.any rejects with an AggregateError; anything else came from the terminal signal. Such a

--- a/packages/zambdas/src/shared/ai.ts
+++ b/packages/zambdas/src/shared/ai.ts
@@ -153,6 +153,7 @@ export async function invokeChatbotVertexAI(
 
   let resolved = false;
   let terminal = false; // a non-retryable status came back; further attempts would just resend the payload
+  let terminalError: Error | undefined; // that status's own error, so it is reported instead of the ladder's
   const requests = backoffTimes.map(async (backoffTime) => {
     await new Promise((resolve) => setTimeout(resolve, backoffTime));
 
@@ -182,17 +183,56 @@ export async function invokeChatbotVertexAI(
         }
       );
 
-      if (!response.ok && shouldRetry(response.status)) {
-        // Carry Vertex's own message: if every attempt fails this is all the caller gets to go on.
-        throw new Error(`Retryable error: ${response.status} ${(await response.text()).slice(0, 500)}`);
+      if (!response.ok) {
+        const errorBody = await response.text();
+        if (shouldRetry(response.status)) {
+          // Carry Vertex's own message: if every attempt fails this is all the caller gets to go on.
+          throw new Error(`Retryable error: ${response.status} ${errorBody.slice(0, 500)}`);
+        }
+        terminal = true;
+        terminalError = new Error(
+          `Vertex AI request failed: ${response.status} ${response.statusText} ${errorBody.slice(0, 1000)}`
+        );
+        throw terminalError;
       }
 
-      if (response.ok) {
-        resolved = true;
-      } else {
-        terminal = true;
+      const body = await response.text();
+      // Size only: on a transcription call the body is the transcript, which is PHI.
+      console.log(`Vertex AI responded with ${body.length} bytes`);
+
+      let parsed: any;
+      try {
+        parsed = JSON.parse(body);
+      } catch {
+        // A proxy's HTML error page or a truncated response would otherwise throw a bare SyntaxError.
+        throw new Error(`Vertex AI returned a non-JSON body: ${body.slice(0, 1000)}`);
       }
-      return response;
+
+      // Unchecked, an error body fell through to `candidates[0]` and every Vertex failure surfaced as
+      // `TypeError: Cannot read properties of undefined` with an empty stack.
+      const candidate = parsed?.candidates?.[0];
+      const text = candidate?.content?.parts?.[0]?.text;
+      // Whitespace is not output: it satisfies every downstream caller's type but dies in the JSON parse or
+      // lands a blank transcript on the chart, and it would do so with the attempt already counted a success.
+      if (typeof text !== 'string' || text.trim().length === 0) {
+        // No candidate text means the model refused, was cut off (safety block, MAX_TOKENS finishReason), or
+        // spent the whole turn on thinking tokens and emitted none.
+        const reason = JSON.stringify({
+          finishReason: candidate?.finishReason,
+          promptFeedback: parsed?.promptFeedback,
+          usageMetadata: parsed?.usageMetadata,
+        });
+        // Normally the reason and not the body: a cut-off candidate can still carry partial transcript. But a
+        // candidate with no `content` holds nothing the model generated, and those are exactly the bodies
+        // whose reason fields are all absent too — `{}` on its own is as undiagnosable as the old TypeError.
+        const detail = candidate?.content == null ? `${reason} ${body.slice(0, 1000)}` : reason;
+        throw new Error(`Vertex AI returned no text: ${detail}`);
+      }
+
+      // Only an attempt that produced usable text may win. This used to be set on `response.ok` alone, so a
+      // 200 carrying no candidates resolved the ladder and the remaining attempts were skipped as superseded.
+      resolved = true;
+      return text;
     } catch (error) {
       // One attempt failing is not an incident — the ladder exists because Vertex sheds load with 429s and a
       // later attempt usually succeeds. Keep it in the log for the trace, but don't report it: reporting here
@@ -203,10 +243,14 @@ export async function invokeChatbotVertexAI(
     }
   });
 
-  let settled: Response;
   try {
-    settled = await Promise.any(requests);
+    // Every attempt now resolves only with validated text, so Promise.any picks the first usable result
+    // rather than the first HTTP 200.
+    return await Promise.any(requests);
   } catch (error) {
+    // A status no resend can recover from is its own diagnosis; wrapping it in the ladder's message would
+    // bury it and group it with exhausted ladders in Sentry.
+    if (terminalError != null) throw terminalError;
     // AggregateError's own message is just "All promises were rejected", so unpack the reasons — otherwise
     // the most common failure mode stays as opaque as the TypeError this used to throw.
     const reasons =
@@ -215,35 +259,6 @@ export async function invokeChatbotVertexAI(
         : [error instanceof Error ? error.message : String(error)];
     throw new Error(`Vertex AI request failed after ${requests.length} attempts: ${reasons.join('; ')}`);
   }
-
-  const body = await settled.text();
-  // Unchecked, an error body fell through to `candidates[0]` and every Vertex failure surfaced as
-  // `TypeError: Cannot read properties of undefined` with an empty stack.
-  if (!settled.ok) {
-    throw new Error(`Vertex AI request failed: ${settled.status} ${settled.statusText} ${body.slice(0, 1000)}`);
-  }
-
-  // Size only: on a transcription call the body is the transcript, which is PHI.
-  console.log(`Vertex AI responded with ${body.length} bytes`);
-  let response: any;
-  try {
-    response = JSON.parse(body);
-  } catch {
-    // A proxy's HTML error page or a truncated response would otherwise throw a bare SyntaxError.
-    throw new Error(`Vertex AI returned a non-JSON body: ${body.slice(0, 1000)}`);
-  }
-  const text = response?.candidates?.[0]?.content?.parts?.[0]?.text;
-  if (typeof text !== 'string') {
-    // No candidate text means the model refused or was cut off (safety block, MAX_TOKENS finishReason).
-    // Report the reason, not the body — a cut-off candidate can still carry partial transcript.
-    const reason = JSON.stringify({
-      finishReason: response?.candidates?.[0]?.finishReason,
-      promptFeedback: response?.promptFeedback,
-      usageMetadata: response?.usageMetadata,
-    });
-    throw new Error(`Vertex AI returned no text: ${reason}`);
-  }
-  return text;
 }
 
 /**

--- a/packages/zambdas/test/unit/vertex-ai-error-handling.test.ts
+++ b/packages/zambdas/test/unit/vertex-ai-error-handling.test.ts
@@ -45,6 +45,42 @@ const respondWith = (status: number, body: unknown): void => {
   );
 };
 
+// Per-attempt scripted responses that each take fake-clock time to arrive, so one attempt's request can
+// still be in flight when another settles. Those interleavings are where a late rejection could escape.
+const respondAfter = (...script: [delayMs: number, status: number, body: unknown][]): void => {
+  let call = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      const [delay, status, body] = script[Math.min(call++, script.length - 1)];
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      return responseOf(status, body);
+    })
+  );
+};
+
+// Runs a scenario with this file's own unhandledRejection listener as the only one installed, then drains
+// every remaining timer and gives Node a real tick to reach its unhandled-rejection checkpoint. Vitest's
+// own listeners are detached for the duration so the assertion below is the single source of truth.
+const unhandledDuring = async (scenario: () => Promise<void>): Promise<unknown[]> => {
+  const seen: unknown[] = [];
+  const record = (reason: unknown): void => void seen.push(reason);
+  const vitestListeners = process.listeners('unhandledRejection');
+  vitestListeners.forEach((listener) => process.off('unhandledRejection', listener));
+  process.on('unhandledRejection', record);
+  try {
+    await scenario();
+    await vi.advanceTimersByTimeAsync(30_000); // outlast every backoff and scripted fetch delay
+    vi.useRealTimers(); // Node reports unhandled rejections on a real tick, not a microtask
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    vi.useFakeTimers();
+  } finally {
+    process.off('unhandledRejection', record);
+    vitestListeners.forEach((listener) => process.on('unhandledRejection', listener));
+  }
+  return seen;
+};
+
 // One entry per attempt, for the retry paths; the last entry repeats if the ladder runs longer.
 const respondInSequence = (...responses: [number, unknown][]): void => {
   let attempt = 0;
@@ -80,6 +116,21 @@ const invoke = async (): Promise<string> => {
   return result.value;
 };
 
+// How far the fake clock has to advance before the call settles. The retry ladder sleeps 3s and 6s before
+// its later attempts, so this distinguishes a failure that surfaces at once from one that merely happens to
+// make the same number of fetches — which is all a fetch-count assertion can see.
+const settleDelay = async (): Promise<number> => {
+  const start = Date.now();
+  let elapsed = -1;
+  const record = (): void => {
+    if (elapsed < 0) elapsed = Date.now() - start;
+  };
+  const outcome = invokeChatbotVertexAI([{ text: 'hello' }], secrets).then(record, record);
+  await vi.advanceTimersByTimeAsync(10_000);
+  await outcome;
+  return elapsed;
+};
+
 // The same call as `invoke`, but through the wrapper every zambda is deployed behind — so the assertions
 // below are about what Sentry actually receives in production, not about a hand-rolled catch block.
 const invokeThroughHandler = async (): Promise<APIGatewayProxyResult> => {
@@ -103,6 +154,9 @@ describe('invokeChatbotVertexAI error handling', () => {
     });
 
     await expect(invoke()).rejects.toThrow(/Vertex AI request failed: 400 Bad Request.*INVALID_ARGUMENT/s);
+    // And it stands alone rather than being wrapped in the ladder's message: a 400 is not an exhausted
+    // ladder, and grouping the two together in Sentry is what made the empty-response issue hard to read.
+    await expect(invoke()).rejects.not.toThrow(/after \d+ attempts/);
   });
 
   test('a non-retryable failure is not retried', async () => {
@@ -111,6 +165,15 @@ describe('invokeChatbotVertexAI error handling', () => {
     await expect(invoke()).rejects.toThrow(/Vertex AI request failed/);
     // Resending a multi-megabyte inline audio payload two more times can only fail the same way.
     expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+
+  test('a non-retryable failure surfaces at once, not after the backoff sleeps', async () => {
+    // Not retrying is only half of it. Promise.any cannot reject until every attempt has, so a rejected
+    // terminal attempt left the caller waiting for attempts 1 and 2 to wake from their 3s and 6s sleeps and
+    // find the ladder abandoned — 6s of lambda time spent on a 400 that was known immediately.
+    respondWith(400, { error: { code: 400, status: 'INVALID_ARGUMENT' } });
+
+    expect(await settleDelay()).toBe(0);
   });
 
   test('a 200 with no candidate text reports the reason, not the body', async () => {
@@ -326,23 +389,27 @@ describe('invokeChatbotVertexAI empty-output retries', () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(3);
   });
 
-  test('a body with no candidates carries the body, since the reason fields are absent too', async () => {
-    // `{}` serializes every reason field to undefined, leaving `Vertex AI returned no text: {}` — no more
-    // actionable than the TypeError it replaced. No candidate means no generated output to leak.
-    respondWith(200, {});
+  test('a candidate-less body reports the metadata that names the cause', async () => {
+    // The production shape: no candidates, so the whole account of what happened is the top-level metadata.
+    // Hand-picking two fields left `Vertex AI returned no text: {}` and dropped the identifiers — the model
+    // build and response id — that a Google support thread would ask for first.
+    respondWith(200, {
+      usageMetadata: { promptTokenCount: 1525, totalTokenCount: 1798, thoughtsTokenCount: 273 },
+      modelVersion: 'gemini-3.1-flash-lite',
+      responseId: 'ddf9bee1-21ef',
+    });
 
     const error = await invoke().then(
       () => null,
       (error: Error) => error
     );
-    expect(error?.message).toMatch(/Vertex AI returned no text/);
-    expect(error?.message).not.toMatch(/no text: \{\}$/);
-    expect(error?.message).toContain('{}');
+    expect(error?.message).toMatch(/thoughtsTokenCount/);
+    expect(error?.message).toMatch(/gemini-3\.1-flash-lite/);
+    expect(error?.message).toMatch(/ddf9bee1-21ef/);
   });
 
-  test('a candidate carrying content still reports the reason only', async () => {
-    // The other side of that: `content` present means the model produced something, and a sibling part can
-    // hold partial transcript. This is the case that must never widen to include the body.
+  test('a candidate carrying content is never quoted', async () => {
+    // `content` present means the model produced something, and a sibling part can hold partial transcript.
     respondWith(200, {
       candidates: [{ finishReason: 'MAX_TOKENS', content: { parts: [{ inlineData: 'patient reports chest pain' }] } }],
     });
@@ -353,5 +420,169 @@ describe('invokeChatbotVertexAI empty-output retries', () => {
     );
     expect(error?.message).toMatch(/MAX_TOKENS/);
     expect(error?.message).not.toContain('chest pain');
+  });
+
+  test('the reason is capped, so a 200 that echoes the request cannot dump it', async () => {
+    // Stripping `candidates` bounds a Gemini body but not a gateway envelope holding the request — on the
+    // transcription path that is base64 audio. Uncapped it would be console.warned once per attempt and then
+    // joined three times into the ladder's message on its way to CloudWatch and Sentry.
+    respondWith(200, { echoedRequest: 'A'.repeat(20_000) });
+
+    const error = await invoke().then(
+      () => null,
+      (error: Error) => error
+    );
+    expect(error?.message).toMatch(/Vertex AI returned no text/);
+    // Three attempts, each capped at 1000, plus the ladder's own wrapper.
+    expect(error?.message.length).toBeLessThan(3500);
+  });
+
+  test('a later candidate with text is never quoted either', async () => {
+    // candidateCount is never set, so Vertex returns one candidate — but the report must not depend on that.
+    // Deciding what is safe to include by looking at candidates[0] alone quotes candidate 1's text here.
+    respondWith(200, {
+      candidates: [{ finishReason: 'SAFETY' }, { content: { parts: [{ text: 'patient reports chest pain' }] } }],
+      usageMetadata: { totalTokenCount: 1798 },
+    });
+
+    const error = await invoke().then(
+      () => null,
+      (error: Error) => error
+    );
+    expect(error?.message).toMatch(/Vertex AI returned no text/);
+    expect(error?.message).toMatch(/SAFETY/);
+    expect(error?.message).not.toContain('chest pain');
+  });
+});
+
+// The ladder is Promise.race([Promise.any(attempts), terminalFailure]), so several promises can reject after
+// the outer call has already settled. That is only safe because race and any attach their handlers when they
+// are constructed, not when their inputs settle. These force each interleaving and assert nothing escapes.
+describe('invokeChatbotVertexAI promise lifecycle', () => {
+  const TEXT_200 = { candidates: [{ content: { parts: [{ text: 'the transcript' }] } }] };
+  const EMPTY_200 = { usageMetadata: { totalTokenCount: 1798, thoughtsTokenCount: 273 } };
+
+  // Kick the call off without touching the clock, for the scenarios that observe mid-flight state.
+  const start = (): Promise<string> =>
+    invokeChatbotVertexAI([{ text: 'hello' }], secrets).then(
+      (value) => `resolved: ${value}`,
+      (error: Error) => `rejected: ${error.message}`
+    );
+
+  // The same, with the clock driven far enough to finish the ladder. Awaiting the call before advancing the
+  // clock would deadlock, so the outcome is captured as a value.
+  const settle = async (): Promise<string> => {
+    const outcome = start();
+    await vi.advanceTimersByTimeAsync(30_000);
+    return outcome;
+  };
+
+  test('the watch detects an unhandled rejection, so the assertions below are not vacuous', async () => {
+    const seen = await unhandledDuring(async () => {
+      void Promise.reject(new Error('deliberately unhandled'));
+    });
+
+    expect(seen).toHaveLength(1);
+    expect((seen[0] as Error).message).toBe('deliberately unhandled');
+  });
+
+  test('1. a valid response wins and the later attempts are superseded', async () => {
+    respondWith(200, TEXT_200);
+    let outcome = '';
+
+    const seen = await unhandledDuring(async () => {
+      outcome = await settle();
+    });
+
+    expect(outcome).toBe('resolved: the transcript');
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+    expect(seen).toEqual([]);
+  });
+
+  test('2. an empty 200 rejects its attempt and the next one wins', async () => {
+    respondInSequence([200, EMPTY_200], [200, TEXT_200]);
+    let outcome = '';
+
+    const seen = await unhandledDuring(async () => {
+      outcome = await settle();
+    });
+
+    expect(outcome).toBe('resolved: the transcript');
+    expect(seen).toEqual([]);
+  });
+
+  test('3+4. a terminal status settles at once, and its superseded attempts stay handled', async () => {
+    // The sharpest case: the outer call throws at t=0, then Promise.any rejects with its AggregateError at
+    // ~6s once attempts 1 and 2 wake and find the ladder abandoned — long after race stopped listening.
+    respondAfter([0, 403, { error: { code: 403, status: 'PERMISSION_DENIED' } }]);
+    let outcome = '';
+
+    const seen = await unhandledDuring(async () => {
+      const pending = start();
+      await vi.advanceTimersByTimeAsync(100); // far short of the 3s and 6s sleeps
+      outcome = await pending;
+      // Settled with both backoff sleeps still armed, which is the point of the race.
+      expect(vi.getTimerCount()).toBe(2);
+    });
+
+    expect(outcome).toMatch(/^rejected: Vertex AI request failed: 403 .*PERMISSION_DENIED/s);
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+    expect(seen).toEqual([]);
+  });
+
+  test('5. an exhausted ladder handles its AggregateError, leaving terminalFailure pending forever', async () => {
+    // terminalFailure never settles here. A permanently pending promise is not a leak — nothing references
+    // it once the call returns — but it must not be what the catch block reports.
+    respondWith(503, { error: { code: 503, message: 'The service is currently unavailable.' } });
+    let outcome = '';
+
+    const seen = await unhandledDuring(async () => {
+      outcome = await settle();
+    });
+
+    expect(outcome).toMatch(/^rejected: Vertex AI request failed after 3 attempts/);
+    expect(outcome).toMatch(/503.*currently unavailable/s);
+    expect(seen).toEqual([]);
+  });
+
+  test('6. a terminal failure arriving after a success cannot disturb the settled result', async () => {
+    // Attempt 0 is slow but good; attempt 1 starts at 3s and its 400 lands at 5s, a second after attempt 0
+    // has already won and the caller has its text. failTerminally is called on an ignored promise.
+    respondAfter([4000, 200, TEXT_200], [2000, 400, { error: { code: 400, status: 'INVALID_ARGUMENT' } }]);
+    let outcome = '';
+
+    const seen = await unhandledDuring(async () => {
+      outcome = await settle();
+    });
+
+    // The success stands: a late terminal rejection cannot turn a delivered result into a failure.
+    expect(outcome).toBe('resolved: the transcript');
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(seen).toEqual([]);
+  });
+
+  test('7. backoff timers outlive the settle but do no observable work when they fire', async () => {
+    // Lambda freezes the container on return with these still armed, so they run on the next thaw. The
+    // superseded throw sits outside the try/catch, so a thawed attempt makes no request, logs nothing and
+    // reports nothing — it only rejects into the handler Promise.any attached at construction.
+    respondAfter([0, 401, { error: { code: 401, status: 'UNAUTHENTICATED' } }]);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const pending = start();
+    await vi.advanceTimersByTimeAsync(100);
+    await pending;
+
+    expect(vi.getTimerCount()).toBe(2); // the 3s and 6s sleeps, still armed after the caller has its error
+    const callsAtSettle = { fetch: vi.mocked(globalThis.fetch).mock.calls.length, warn: warn.mock.calls.length };
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(vi.mocked(globalThis.fetch).mock.calls.length).toBe(callsAtSettle.fetch);
+    expect(warn.mock.calls.length).toBe(callsAtSettle.warn);
+    expect(log).not.toHaveBeenCalled();
+
+    warn.mockRestore();
+    log.mockRestore();
   });
 });

--- a/packages/zambdas/test/unit/vertex-ai-error-handling.test.ts
+++ b/packages/zambdas/test/unit/vertex-ai-error-handling.test.ts
@@ -6,8 +6,6 @@ import { lambdaResponse } from '../../src/shared/lambda';
 import { wrapHandler } from '../../src/shared/sentry';
 import { ZambdaInput } from '../../src/shared/types/common';
 
-// Stands in for the SDK the real handler wrapper is built on: captureException is the only call whose
-// arguments matter here, the rest exist so `wrapHandler` runs its actual code instead of a stub.
 const captureException = vi.fn();
 vi.mock('@sentry/aws-serverless', () => ({
   captureException: (...args: unknown[]) => captureException(...args),
@@ -19,7 +17,6 @@ vi.mock('@sentry/aws-serverless', () => ({
   wrapHandler: (handler: unknown) => handler, // the real one only adds tracing
 }));
 
-// Keyed off SecretsKeys so the test breaks if the code starts reading a different secret.
 const secrets: Secrets = {
   [SecretsKeys.GOOGLE_CLOUD_PROJECT_ID]: 'test-project',
   [SecretsKeys.GOOGLE_CLOUD_API_KEY]: 'test-key',
@@ -81,7 +78,6 @@ const unhandledDuring = async (scenario: () => Promise<void>): Promise<unknown[]
   return seen;
 };
 
-// One entry per attempt, for the retry paths; the last entry repeats if the ladder runs longer.
 const respondInSequence = (...responses: [number, unknown][]): void => {
   let attempt = 0;
   vi.stubGlobal(
@@ -147,8 +143,6 @@ const invokeThroughHandler = async (): Promise<APIGatewayProxyResult> => {
 
 describe('invokeChatbotVertexAI error handling', () => {
   test('a 400 surfaces the status and Vertex message instead of a TypeError', async () => {
-    // The body Vertex returned for the unparseable upload. It used to fall through to `candidates[0]`, so
-    // every failure looked like "TypeError: Cannot read properties of undefined" with an empty stack.
     respondWith(400, {
       error: { code: 400, message: 'Request contains an invalid argument.', status: 'INVALID_ARGUMENT' },
     });
@@ -168,16 +162,12 @@ describe('invokeChatbotVertexAI error handling', () => {
   });
 
   test('a non-retryable failure surfaces at once, not after the backoff sleeps', async () => {
-    // Not retrying is only half of it. Promise.any cannot reject until every attempt has, so a rejected
-    // terminal attempt left the caller waiting for attempts 1 and 2 to wake from their 3s and 6s sleeps and
-    // find the ladder abandoned — 6s of lambda time spent on a 400 that was known immediately.
     respondWith(400, { error: { code: 400, status: 'INVALID_ARGUMENT' } });
 
     expect(await settleDelay()).toBe(0);
   });
 
   test('a 200 with no candidate text reports the reason, not the body', async () => {
-    // e.g. a safety block or a MAX_TOKENS finishReason: valid JSON, no text to return.
     // Partial transcript in a sibling part here: the error reaches logs and Sentry, so it must carry none.
     respondWith(200, {
       candidates: [{ finishReason: 'MAX_TOKENS', content: { parts: [{ inlineData: 'patient reports chest pain' }] } }],
@@ -208,7 +198,6 @@ describe('invokeChatbotVertexAI error handling', () => {
   });
 
   test('a 200 that is not JSON is reported as such', async () => {
-    // A proxy's HTML error page or a truncated response: JSON.parse would throw a bare SyntaxError.
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => ({ ok: true, status: 200, statusText: 'OK', text: async () => '<html>502 Bad Gateway</html>' }))
@@ -262,7 +251,6 @@ describe('invokeChatbotVertexAI error handling', () => {
 
     expect(response.statusCode).toBe(500);
     expect(captureException).toHaveBeenCalledOnce();
-    // And it carries the diagnosis, not a bare AggregateError, so the Sentry issue is actionable.
     const reported = captureException.mock.calls[0][0] as Error;
     expect(reported.message).toMatch(/Vertex AI request failed after 3 attempts/);
     expect(reported.message).toMatch(/503.*currently unavailable/s);
@@ -462,15 +450,13 @@ describe('invokeChatbotVertexAI promise lifecycle', () => {
   const TEXT_200 = { candidates: [{ content: { parts: [{ text: 'the transcript' }] } }] };
   const EMPTY_200 = { usageMetadata: { totalTokenCount: 1798, thoughtsTokenCount: 273 } };
 
-  // Kick the call off without touching the clock, for the scenarios that observe mid-flight state.
   const start = (): Promise<string> =>
     invokeChatbotVertexAI([{ text: 'hello' }], secrets).then(
       (value) => `resolved: ${value}`,
       (error: Error) => `rejected: ${error.message}`
     );
 
-  // The same, with the clock driven far enough to finish the ladder. Awaiting the call before advancing the
-  // clock would deadlock, so the outcome is captured as a value.
+  // Awaiting the call before advancing the clock would deadlock, so the outcome is captured as a value.
   const settle = async (): Promise<string> => {
     const outcome = start();
     await vi.advanceTimersByTimeAsync(30_000);
@@ -555,7 +541,6 @@ describe('invokeChatbotVertexAI promise lifecycle', () => {
       outcome = await settle();
     });
 
-    // The success stands: a late terminal rejection cannot turn a delivered result into a failure.
     expect(outcome).toBe('resolved: the transcript');
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
     expect(seen).toEqual([]);

--- a/packages/zambdas/test/unit/vertex-ai-error-handling.test.ts
+++ b/packages/zambdas/test/unit/vertex-ai-error-handling.test.ts
@@ -243,3 +243,115 @@ describe('invokeChatbotVertexAI error handling', () => {
     expect(url).toContain('key=test-key');
   });
 });
+
+// HTTP 200 is not enough to call an attempt successful — it has to have produced text. These cover the
+// production failure in ai-interview-summary: gemini-3.1-flash-lite answered 200 with usageMetadata and no
+// `candidates` at all, having spent the turn on thinking tokens. `resolved` was set on `response.ok`, so
+// that empty body won Promise.any and the two remaining attempts were skipped as superseded.
+describe('invokeChatbotVertexAI empty-output retries', () => {
+  const EMPTY_200 = {
+    usageMetadata: { promptTokenCount: 1525, totalTokenCount: 1798, thoughtsTokenCount: 273 },
+  };
+  const TEXT_200 = { candidates: [{ content: { parts: [{ text: 'the summary' }] } }] };
+
+  test('a valid 200 wins on the first attempt, with no further request', async () => {
+    respondWith(200, TEXT_200);
+
+    await expect(invoke()).resolves.toBe('the summary');
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+
+  test('an empty 200 is retried, and the next attempt wins', async () => {
+    respondInSequence([200, EMPTY_200], [200, TEXT_200]);
+
+    await expect(invoke()).resolves.toBe('the summary');
+    // Two: the empty attempt no longer resolves the ladder, and the winner stops the third.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('an empty 200 fails as a diagnosable error, not a TypeError', async () => {
+    respondWith(200, EMPTY_200);
+
+    const error = await invoke().then(
+      () => null,
+      (error: Error) => error
+    );
+    // `response.candidates[0]` on a candidate-less body is where the old TypeError came from.
+    expect(error).not.toBeInstanceOf(TypeError);
+    expect(error?.message).toMatch(/Vertex AI returned no text/);
+    // The reason has to name the cause, or the Sentry issue says only that something was empty.
+    expect(error?.message).toMatch(/thoughtsTokenCount/);
+  });
+
+  test('a ladder of empty 200s is exhausted rather than resolved with an empty result', async () => {
+    respondWith(200, EMPTY_200);
+
+    const error = await invoke().then(
+      () => null,
+      (error: Error) => error
+    );
+    expect(error?.message).toMatch(/Vertex AI request failed after 3 attempts/);
+    expect(error?.message).toMatch(/Vertex AI returned no text/);
+    // The whole point: all three attempts are spent, where the first empty 200 used to end the ladder.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  // Every shape short of usable text has to stay retryable, and none may throw on the way there.
+  test.each([
+    ['no candidates property', EMPTY_200],
+    ['an empty candidates array', { candidates: [] }],
+    ['an empty first candidate', { candidates: [{}] }],
+    ['no content', { candidates: [{ finishReason: 'SAFETY' }] }],
+    ['no parts', { candidates: [{ content: {} }] }],
+    ['an empty parts array', { candidates: [{ content: { parts: [] } }] }],
+    ['a part with no text', { candidates: [{ content: { parts: [{ inlineData: 'x' }] } }] }],
+    ['empty text', { candidates: [{ content: { parts: [{ text: '' }] } }] }],
+    // Whitespace has a non-zero length, so a bare `length === 0` guard let it through as a success and the
+    // caller died in fixAndParseJsonObjectFromString instead — or charted a blank transcript.
+    ['whitespace-only text', { candidates: [{ content: { parts: [{ text: '\n  \t' }] } }] }],
+  ])('a 200 with %s stays retryable', async (_name, body) => {
+    respondInSequence([200, body], [200, TEXT_200]);
+
+    await expect(invoke()).resolves.toBe('the summary');
+  });
+
+  test('a whitespace-only ladder fails rather than returning blank text', async () => {
+    respondWith(200, { candidates: [{ content: { parts: [{ text: '\n' }] } }] });
+
+    const error = await invoke().then(
+      () => null,
+      (error: Error) => error
+    );
+    expect(error?.message).toMatch(/Vertex AI returned no text/);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('a body with no candidates carries the body, since the reason fields are absent too', async () => {
+    // `{}` serializes every reason field to undefined, leaving `Vertex AI returned no text: {}` — no more
+    // actionable than the TypeError it replaced. No candidate means no generated output to leak.
+    respondWith(200, {});
+
+    const error = await invoke().then(
+      () => null,
+      (error: Error) => error
+    );
+    expect(error?.message).toMatch(/Vertex AI returned no text/);
+    expect(error?.message).not.toMatch(/no text: \{\}$/);
+    expect(error?.message).toContain('{}');
+  });
+
+  test('a candidate carrying content still reports the reason only', async () => {
+    // The other side of that: `content` present means the model produced something, and a sibling part can
+    // hold partial transcript. This is the case that must never widen to include the body.
+    respondWith(200, {
+      candidates: [{ finishReason: 'MAX_TOKENS', content: { parts: [{ inlineData: 'patient reports chest pain' }] } }],
+    });
+
+    const error = await invoke().then(
+      () => null,
+      (error: Error) => error
+    );
+    expect(error?.message).toMatch(/MAX_TOKENS/);
+    expect(error?.message).not.toContain('chest pain');
+  });
+});


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-3357/investigate-vertex-ai-empty-responses-in-interview-summaries

<html><head></head><body><h2>Context</h2><p>We investigated the production case where Vertex AI returned HTTP 200 but no usable model output.</p><p>There are two distinct problems here:</p><ol><li><p><strong>Why Vertex returned an empty response</strong> — the production logs give us a concrete root cause.</p></li><li><p><strong>Why that empty response caused the visit summary to fail instead of falling back to another attempt</strong> — this is the problem fixed by this PR.</p></li></ol><p>This PR fixes 2nd. The underlying Vertex configuration issue in 1st is a separate issue to investigate.</p><hr><h2>0. Root cause of the empty response</h2><p>The 27 Aug production log for request <code inline="">ddf9bee1</code> contains:</p><pre><code class="language-text">promptTokenCount: 1525
thoughtsTokenCount: 273
totalTokenCount: 1798
</code></pre><p>There are no <code inline="">candidates</code> and therefore no output text.</p><p>The token counts account for the entire turn:</p><pre><code class="language-text">1525 prompt tokens + 273 thinking tokens = 1798 total tokens
</code></pre><p>So the model produced <strong>zero output tokens</strong> after spending tokens on thinking.</p><p>The model was also changed from the non-thinking <code inline="">gemini-2.5-flash-lite</code> to <code inline="">gemini-3.1-flash-lite</code> in #6760 / #7636. The current invocation does not configure <code inline="">thinkingConfig</code> or <code inline="">maxOutputTokens</code>.</p><p>This gives us a concrete explanation for the production empty response: the thinking model consumed the available turn without producing output.</p><p><strong>This PR does not fix that underlying model/configuration issue.</strong></p><p>What this PR fixes is the second defect that this empty response exposed: our retry ladder treated an HTTP 200 as a successful attempt even when the response contained no usable text.</p><p>We reproduced that behaviour in a test using the exact production response body.</p><hr><h2>1. Main fix: an empty 200 must not win the retry ladder</h2><p>Before this change, an attempt was considered successful when its HTTP request fulfilled, regardless of whether the Vertex response contained usable text.</p><p>The flow was effectively:</p><ol><li><p>An attempt receives HTTP 200.</p></li><li><p>The attempt sets <code inline="">resolved = true</code>.</p></li><li><p>Its response fulfils <code inline="">Promise.any()</code>.</p></li><li><p>The response is then parsed outside the attempt.</p></li><li><p>If there is no text, the whole operation fails.</p></li></ol><p>The remaining attempts are already prevented from helping: once <code inline="">resolved</code> is true, they wake up and are rejected as <code inline="">superseded</code> before making their requests.</p><p>The fix moves the existing response validation <strong>inside the individual attempt</strong>:</p><ul><li><p>HTTP 200 alone is no longer sufficient for success.</p></li><li><p>The response must contain usable text.</p></li><li><p>An empty response rejects that attempt.</p></li><li><p><code inline="">resolved = true</code> is set only after the response has passed validation.</p></li></ul><p>Therefore an empty 200 can no longer win <code inline="">Promise.any()</code>. The next attempt in the ladder can run instead.</p><p><strong>This is the actual behavioural fix for the production failure.</strong></p><hr><h2>2. Regression fix caused by the main fix</h2><p>Moving validation inside the attempts changes the promise lifecycle for terminal failures.</p><p>Previously, the terminal attempt returned the HTTP <code inline="">Response</code> even for a 400. <code inline="">Promise.any()</code> therefore fulfilled immediately, after which the caller inspected <code inline="">!settled.ok</code> and threw the terminal error.</p><p>After the main fix, terminal failures reject from inside the attempt.</p><p>That interacts with the contract of <code inline="">Promise.any()</code>: it only rejects once <strong>every input promise has rejected</strong>.</p><p>On a 400, only the first attempt makes a request. Attempts 2 and 3 are still sleeping in their 3 s and 6 s backoff timers; they have not made requests. Once the first attempt rejects, <code inline="">Promise.any()</code> therefore waits for those sleeping attempts to wake up and reject as <code inline="">superseded</code>.</p><p>In practice this changed a terminal 400 from immediate failure to approximately 6 seconds (measured at ~5979 ms).</p><p>To preserve the previous fast terminal-failure behaviour, the caller now uses:</p><pre><code class="language-text">Promise.race([
  Promise.any(requests),
  terminalFailure
])
</code></pre><p>The catch handling also changes so that terminal failures are surfaced directly rather than being wrapped in the generic:</p><pre><code class="language-text">after 3 attempts: ...
</code></pre><p>error:</p><pre><code class="language-text">if (!(error instanceof AggregateError)) throw error
</code></pre><p>This keeps terminal failures separate from an actually exhausted retry ladder and preserves their existing Sentry grouping/semantics.</p><p><strong>This is a regression fix caused by the main change above, not a separate hypothesis about empty responses.</strong></p><hr><h2>3. Diagnostics</h2>

The existing `returned no text` guard already reported `finishReason`, `promptFeedback`, and `usageMetadata`.

What is new is that we now preserve **the rest of the top-level response metadata** as well — notably `modelVersion` and `responseId`. `modelVersion` identifies the model build, while `responseId` gives us an identifier that can be used to correlate a specific response.

More importantly, this fixes a degenerate case in the old diagnostic logic.

The old code only copied three hand-picked top-level fields. If Vertex returned a body containing none of them — for example `{}` or `{"candidates":[]}` — the resulting error was literally:

```text id="7k4m2p"
Vertex AI returned no text: {}
```

That provided essentially no more information than the `TypeError` that existed before the explicit guard was introduced.

The new diagnostic preserves the other top-level response fields, so these otherwise-undiagnosable responses retain whatever metadata Vertex provided.

There are also three small improvements to the same guard:

### Whitespace-only output

The text is checked with `trim()` so whitespace-only output cannot pass the success predicate.

Without this, a whitespace string could be considered valid, resolve the attempt, and only fail later in `fixAndParseJsonObjectFromString` (or result in an effectively blank transcript).

### Strip `candidates` from diagnostics

The diagnostic payload removes `candidates` before logging the response metadata.

This is a **PHI safeguard**: any candidate may contain a partial or complete transcript, so including it in the error payload would unnecessarily put potentially sensitive clinical content into Sentry.

This was added following review feedback on this PR.

### Restore the existing log-size cap

The diagnostic payload is capped at 1000 characters.

This restores the invariant already used by the sibling interpolations in the same function, which have existing 500/1000/1000-character limits. The cap was lost when the surrounding branch was rewritten; it is not a new logging policy.
<hr>
</body></html>

Description generated by Claude, I've read and confirm.