### PR TITLE
Billing App. Rules Engine. Allow to set claim facility's point of service as service line's point of service

### DIFF
--- a/apps/billing/src/components/rules/RuleBuilder.tsx
+++ b/apps/billing/src/components/rules/RuleBuilder.tsx
@@ -21,8 +21,11 @@ import {
   DATE_SOURCE_CATALOG,
   DateSourceSelectValue,
   EXACT_DATE_SOURCE,
+  EXACT_POS_SOURCE,
   getRuleFieldDef,
   getServiceLinePropertyDef,
+  POS_SOURCE_CATALOG,
+  PosSourceSelectValue,
   RULE_FIELD_CATALOG,
   RULE_FIELD_GROUP_LABELS,
   RULE_VALUE_FORMATS,
@@ -58,6 +61,7 @@ import {
   SERVICE_LINE_MATCH_TYPE,
   ServiceLineMatch,
   ServiceLineSetOperation,
+  ServiceLineSetValue,
 } from 'utils/lib/types/data/billing/rules-engine.schemas';
 import { HOLD_TAG_NAME } from 'utils/lib/types/data/billing/system-tags';
 import { otherColors } from '../../themes/ottehr/colors';
@@ -550,6 +554,68 @@ function DateOrSourceInput({
   );
 }
 
+// Place-of-service-or-derived-source input for updateServiceLines' placeOfService property — parallel
+// to DateOrSourceInput above, but for the one non-date property that accepts a derived value. "Exact
+// code" (the default) falls through to the property's usual code dropdown via ServiceLineValueInput.
+function PosOrSourceInput({
+  def,
+  value,
+  onChange,
+  label,
+  required,
+  error,
+  helperText,
+  inputRef,
+}: {
+  def: ServiceLinePropertyDef | undefined;
+  value: ServiceLineSetValue | null | undefined;
+  onChange: (value: ServiceLineSetValue) => void;
+  label?: string;
+} & ValueInputValidationProps): ReactElement {
+  const source: PosSourceSelectValue =
+    value && typeof value === 'object' && value.source === 'facilityPlaceOfService' ? value.source : EXACT_POS_SOURCE;
+  return (
+    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+      <FormControl size="small" sx={{ minWidth: 220 }}>
+        <InputLabel>{label ? `${label} source` : 'Place of service source'}</InputLabel>
+        <Select
+          label={label ? `${label} source` : 'Place of service source'}
+          value={source}
+          inputRef={source !== EXACT_POS_SOURCE ? inputRef : undefined}
+          onChange={(e) => {
+            const next = e.target.value as PosSourceSelectValue;
+            onChange(next === EXACT_POS_SOURCE ? '' : { source: next });
+          }}
+        >
+          {POS_SOURCE_CATALOG.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </Select>
+        {source !== EXACT_POS_SOURCE && helperText != null && (
+          <FormHelperText error={error}>{helperText}</FormHelperText>
+        )}
+      </FormControl>
+      {source === EXACT_POS_SOURCE && (
+        <ServiceLineValueInput
+          def={def}
+          multiple={false}
+          value={typeof value === 'string' ? value : ''}
+          onChange={(v) => onChange(typeof v === 'string' ? v : v[0] ?? '')}
+          label={label}
+          required={required}
+          error={error}
+          helperText={helperText}
+          inputRef={inputRef}
+          // The only clearable scalar line property; an explicit empty entry means "clear it".
+          allowEmptyOption
+        />
+      )}
+    </Box>
+  );
+}
+
 // --- Condition ---
 
 function ConditionEditor({ name }: { name: string }): ReactElement | null {
@@ -921,7 +987,11 @@ function AddServiceLineEditor({ name }: { name: string }): ReactElement {
 // properties: replace / add / remove), and the value.
 function ServiceLineSetEditor({ name }: { name: string }): ReactElement | null {
   const { control, clearErrors } = useFormContext();
-  const { value, replace } = useNode<{ property: string; value: DateValue; operation?: ServiceLineSetOperation }>(name);
+  const { value, replace } = useNode<{
+    property: string;
+    value: ServiceLineSetValue;
+    operation?: ServiceLineSetOperation;
+  }>(name);
   if (!value) return null;
   const def = getServiceLinePropertyDef(value.property);
   const isList = def?.valueType === 'list';
@@ -986,6 +1056,17 @@ function ServiceLineSetEditor({ name }: { name: string }): ReactElement | null {
         render={({ field: { ref, value: fieldValue, onChange }, fieldState: { error } }) =>
           def?.valueType === 'date' ? (
             <DateOrSourceInput
+              value={fieldValue}
+              onChange={onChange}
+              label={valueLabel}
+              required={valueRequired}
+              error={!!error}
+              helperText={error?.message ?? formatHint(def)}
+              inputRef={ref}
+            />
+          ) : def?.id === 'placeOfService' ? (
+            <PosOrSourceInput
+              def={def}
               value={fieldValue}
               onChange={onChange}
               label={valueLabel}

--- a/apps/billing/src/components/rules/RuleBuilder.tsx
+++ b/apps/billing/src/components/rules/RuleBuilder.tsx
@@ -1050,7 +1050,7 @@ function ServiceLineSetEditor({ name }: { name: string }): ReactElement | null {
         name={`${name}.value`}
         control={control}
         rules={{
-          validate: (v: DateValue | null | undefined) =>
+          validate: (v: ServiceLineSetValue | null | undefined) =>
             def ? serviceLineSetValueProblem(def, value.operation, v) ?? true : true,
         }}
         render={({ field: { ref, value: fieldValue, onChange }, fieldState: { error } }) =>

--- a/docs/billing-rules-engine.md
+++ b/docs/billing-rules-engine.md
@@ -287,7 +287,7 @@ A matched branch's outcome is a list of actions, applied in order:
 | Set a property (`setField`) | Sets one of the settable claim properties above to a new value. Setting an empty value clears the property. The change is written to the claim's working-copy resources and recorded in the claim history, attributed to the specific rule that made it (linked from the history view). If the property cannot be set (unknown or read-only property, invalid value, or the target resource is missing from the claim), the rule fails and the claim is held. |
 | Apply a tag (`applyTag`) | Adds a tag to the claim (no-op if the claim already carries it). Applying the **Hold** tag holds the claim: the run stops and the on-success effect does not happen. |
 | Add a service line (`addServiceLine`) | Appends a new service line built from the fields below and recomputes the claim's billed total. Blank optional fields use the claim editor's defaults, and the new line is tied to the claim's rendering provider when one is set. The service date can be a literal date or one of the derived sources below. An invalid field value fails the rule and holds the claim. |
-| Update service lines (`updateServiceLines`) | Applies one change (an updatable service line property + value; for modifiers, a set/add/remove operation) to every line matching the action's line predicate. When updating the service date, the value can be a literal date or one of the derived sources below. Zero matching lines is a no-op, not a failure — pair the action with a condition when a match must exist. An invalid value or an operation that doesn't apply to the property fails the rule and holds the claim. Changing charges recomputes the claim's billed total. |
+| Update service lines (`updateServiceLines`) | Applies one change (an updatable service line property + value; for modifiers, a set/add/remove operation) to every line matching the action's line predicate. When updating the service date, the value can be a literal date or one of the derived sources below; when updating the place of service, the value can be a literal CMS code or copied from the claim's facility (see Place of service sources). Zero matching lines is a no-op, not a failure — pair the action with a condition when a match must exist. An invalid value or an operation that doesn't apply to the property fails the rule and holds the claim. Changing charges recomputes the claim's billed total. |
 | Remove service lines (`removeServiceLines`) | Removes every line matching the action's line predicate (all lines when the predicate is "all service lines"). Surviving lines are re-sequenced and the claim's billed total is recomputed. Zero matching lines is a no-op. |
 | Apply charge master prices (`applyChargeMasterPrices`) | Re-prices every line matching the action's line predicate from the best applicable charge master: the active charge master designated as the default for the claim's billing type (insurance when the claim carries a real coverage, self-pay otherwise) whose effective date is the most recent on or before the claim's date of service. Each matched line's charges are set from the entry for its CPT code — an entry with a matching modifier for lines with modifiers, a modifier-less entry otherwise. A matched line the charge master has no entry for (or that has no CPT code) keeps its existing charges. The claim's billed total is recomputed when any line was re-priced. Zero matching lines is a no-op. This action never fails the rule or holds the claim — when no charge master applies (or the claim has no date of service to select one by), no lines are changed. Add a separate rule to hold claims whose lines are missing a price. |
 | Do nothing (`noop`) | Explicitly does nothing. Useful as an else branch that intentionally takes no action. |
@@ -319,5 +319,17 @@ The service date on "Add a service line", and on "Update service lines" when upd
 "Exact date" is the default. On "Add a service line", leaving it blank is equivalent to "First
 service line's date" (kept for rules saved before this option existed). Service line **matching**
 always compares against a literal date.
+
+### Place of service sources
+
+The place of service on "Update service lines", when updating the `placeOfService` property, can
+come from one of:
+
+| Source | Description |
+| --- | --- |
+| Exact code | A literal CMS place-of-service code entered on the rule. |
+| Claim's facility place of service | The CMS place-of-service code configured on the claim's service facility. |
+
+"Exact code" is the default. Service line **matching** always compares against a literal code.
 
 Actions after a failed action or after the **Hold** tag do not run.

--- a/packages/utils/lib/types/data/billing/rules-engine.docs.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.docs.ts
@@ -2,6 +2,7 @@ import { RULES_ENGINE_TYPES, RULES_ENGINES } from './rules-engine.constants';
 import {
   ADD_SERVICE_LINE_FIELDS,
   DATE_SOURCE_CATALOG,
+  POS_SOURCE_CATALOG,
   RULE_FIELD_CATALOG,
   RULE_FIELD_GROUP_LABELS,
   RULE_FIELD_GROUPS,
@@ -144,6 +145,12 @@ function renderDateSourceTable(): string {
   return lines.join('\n');
 }
 
+function renderPosSourceTable(): string {
+  const lines = ['| Source | Description |', '| --- | --- |'];
+  for (const option of POS_SOURCE_CATALOG) lines.push(`| ${cell(option.label)} | ${cell(option.description)} |`);
+  return lines.join('\n');
+}
+
 function renderEnginesTable(): string {
   const lines = ['| Rules | Run automatically | When every rule passes |', '| --- | --- | --- |'];
   for (const type of RULES_ENGINE_TYPES) {
@@ -233,7 +240,7 @@ A matched branch's outcome is a list of actions, applied in order:
 | Set a property (\`setField\`) | Sets one of the settable claim properties above to a new value. Setting an empty value clears the property. The change is written to the claim's working-copy resources and recorded in the claim history, attributed to the specific rule that made it (linked from the history view). If the property cannot be set (unknown or read-only property, invalid value, or the target resource is missing from the claim), the rule fails and the claim is held. |
 | Apply a tag (\`applyTag\`) | Adds a tag to the claim (no-op if the claim already carries it). Applying the **${HOLD_TAG_NAME}** tag holds the claim: the run stops and the on-success effect does not happen. |
 | Add a service line (\`addServiceLine\`) | Appends a new service line built from the fields below and recomputes the claim's billed total. Blank optional fields use the claim editor's defaults, and the new line is tied to the claim's rendering provider when one is set. The service date can be a literal date or one of the derived sources below. An invalid field value fails the rule and holds the claim. |
-| Update service lines (\`updateServiceLines\`) | Applies one change (an updatable service line property + value; for modifiers, a set/add/remove operation) to every line matching the action's line predicate. When updating the service date, the value can be a literal date or one of the derived sources below. Zero matching lines is a no-op, not a failure — pair the action with a condition when a match must exist. An invalid value or an operation that doesn't apply to the property fails the rule and holds the claim. Changing charges recomputes the claim's billed total. |
+| Update service lines (\`updateServiceLines\`) | Applies one change (an updatable service line property + value; for modifiers, a set/add/remove operation) to every line matching the action's line predicate. When updating the service date, the value can be a literal date or one of the derived sources below; when updating the place of service, the value can be a literal CMS code or copied from the claim's facility (see Place of service sources). Zero matching lines is a no-op, not a failure — pair the action with a condition when a match must exist. An invalid value or an operation that doesn't apply to the property fails the rule and holds the claim. Changing charges recomputes the claim's billed total. |
 | Remove service lines (\`removeServiceLines\`) | Removes every line matching the action's line predicate (all lines when the predicate is "all service lines"). Surviving lines are re-sequenced and the claim's billed total is recomputed. Zero matching lines is a no-op. |
 | Apply charge master prices (\`applyChargeMasterPrices\`) | Re-prices every line matching the action's line predicate from the best applicable charge master: the active charge master designated as the default for the claim's billing type (insurance when the claim carries a real coverage, self-pay otherwise) whose effective date is the most recent on or before the claim's date of service. Each matched line's charges are set from the entry for its CPT code — an entry with a matching modifier for lines with modifiers, a modifier-less entry otherwise. A matched line the charge master has no entry for (or that has no CPT code) keeps its existing charges. The claim's billed total is recomputed when any line was re-priced. Zero matching lines is a no-op. This action never fails the rule or holds the claim — when no charge master applies (or the claim has no date of service to select one by), no lines are changed. Add a separate rule to hold claims whose lines are missing a price. |
 | Do nothing (\`noop\`) | Explicitly does nothing. Useful as an else branch that intentionally takes no action. |
@@ -252,6 +259,15 @@ ${renderDateSourceTable()}
 "Exact date" is the default. On "Add a service line", leaving it blank is equivalent to "First
 service line's date" (kept for rules saved before this option existed). Service line **matching**
 always compares against a literal date.
+
+### Place of service sources
+
+The place of service on "Update service lines", when updating the \`placeOfService\` property, can
+come from one of:
+
+${renderPosSourceTable()}
+
+"Exact code" is the default. Service line **matching** always compares against a literal code.
 
 Actions after a failed action or after the **${HOLD_TAG_NAME}** tag do not run.`);
 

--- a/packages/utils/lib/types/data/billing/rules-engine.field-catalog.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.field-catalog.ts
@@ -18,6 +18,8 @@ import {
   operatorIsRegex,
   operatorNeedsValue,
   operatorTakesFragment,
+  POS_SOURCE_KIND,
+  PosSourceKind,
   RuleAction,
   RuleCondition,
   RuleConditional,
@@ -26,6 +28,7 @@ import {
   RuleOutcome,
   ServiceLineMatch,
   ServiceLineSetOperation,
+  ServiceLineSetValue,
 } from './rules-engine.schemas';
 
 // Catalog of the logical claim fields rules can condition on and (where settable) set. This is the
@@ -1009,11 +1012,36 @@ export const DATE_SOURCE_CATALOG: { value: DateSourceSelectValue; label: string;
 
 // A date-typed rule value's problem when it may be a derived source instead of a literal date. A
 // literal is accepted as-is here (format is checked by each caller, since blank handling differs
-// between addServiceLine and updateServiceLines); a source object must name a known kind.
-export function derivedDateValueProblem(value: DateValue): string | undefined {
+// between addServiceLine and updateServiceLines); a source object must name a known kind. Takes
+// either DateValue (addServiceLine's serviceDate) or ServiceLineSetValue (updateServiceLines' set
+// value, when the target property is serviceDate) — both carry the same DerivedDateSource shape.
+export function derivedDateValueProblem(value: DateValue | ServiceLineSetValue): string | undefined {
   if (typeof value !== 'object') return undefined;
   const known: string[] = Object.values(DATE_SOURCE_KIND);
   return known.includes(value.source) ? undefined : 'Unknown date source';
+}
+
+// The place-of-service source options exposed by "Update service lines" when its target property is
+// placeOfService — parallel to DATE_SOURCE_CATALOG above, but for the one non-date property that
+// accepts a derived value. "exact" (the default) is the literal-code form every existing rule uses.
+export const EXACT_POS_SOURCE = 'exact' as const;
+export type PosSourceSelectValue = PosSourceKind | typeof EXACT_POS_SOURCE;
+
+export const POS_SOURCE_CATALOG: { value: PosSourceSelectValue; label: string; description: string }[] = [
+  { value: 'exact', label: 'Exact code', description: 'A literal CMS place-of-service code entered on the rule.' },
+  {
+    value: 'facilityPlaceOfService',
+    label: "Claim's facility place of service",
+    description: "The CMS place-of-service code configured on the claim's service facility.",
+  },
+];
+
+// A placeOfService rule value's problem when it may be a derived source instead of a literal code —
+// mirrors derivedDateValueProblem above for the one non-date property that accepts a derived value.
+export function derivedPosValueProblem(value: ServiceLineSetValue): string | undefined {
+  if (typeof value !== 'object') return undefined;
+  const known: string[] = Object.values(POS_SOURCE_KIND);
+  return known.includes(value.source) ? undefined : 'Unknown place of service source';
 }
 
 // One add-line field's format problem, or undefined when the value is acceptable. Shared by the rule
@@ -1181,16 +1209,18 @@ export function serviceLineMatchValueProblem(
 
 // An updateServiceLines set value's problem — mirrors the line writers exactly: units require a
 // positive number, charges a non-negative number, cptCode/serviceDate a value; placeOfService and
-// modifiers-with-"set" allow empty (clears). A derived date-source object is only valid when the
-// target property is date-typed — there is no blank-fallback on update, unlike addServiceLine.
+// modifiers-with-"set" allow empty (clears). A derived-source object is only valid when the target
+// property is date-typed (firstServiceLineDate) or is placeOfService (facilityPlaceOfService) — there
+// is no blank-fallback on update, unlike addServiceLine.
 export function serviceLineSetValueProblem(
   def: Pick<ServiceLinePropertyDef, 'id' | 'valueType' | 'options' | 'format'>,
   operation: ServiceLineSetOperation | undefined,
-  value: DateValue | null | undefined
+  value: ServiceLineSetValue | null | undefined
 ): string | undefined {
   if (typeof value === 'object' && value != null) {
-    if (def.valueType !== 'date') return 'This property does not accept a derived date value';
-    return derivedDateValueProblem(value);
+    if (def.valueType === 'date') return derivedDateValueProblem(value);
+    if (def.id === 'placeOfService') return derivedPosValueProblem(value);
+    return 'This property does not accept a derived value';
   }
   const trimmed = value?.trim() ?? '';
   if (def.valueType === 'list') {

--- a/packages/utils/lib/types/data/billing/rules-engine.schemas.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.schemas.ts
@@ -205,10 +205,29 @@ export type DateSourceKind = (typeof DATE_SOURCE_KIND)[keyof typeof DATE_SOURCE_
 export const DerivedDateSourceSchema = z.object({ source: z.literal(DATE_SOURCE_KIND.firstServiceLineDate) });
 export type DerivedDateSource = z.output<typeof DerivedDateSourceSchema>;
 
+// Likewise, an updateServiceLines placeOfService value can be derived from the claim's service
+// facility instead of typed literally — copying whatever CMS place-of-service code is configured on
+// the facility (serviceFacility.posCode) rather than a code picked by hand.
+export const POS_SOURCE_KIND = {
+  facilityPlaceOfService: 'facilityPlaceOfService',
+} as const;
+export type PosSourceKind = (typeof POS_SOURCE_KIND)[keyof typeof POS_SOURCE_KIND];
+
+export const DerivedPosSourceSchema = z.object({ source: z.literal(POS_SOURCE_KIND.facilityPlaceOfService) });
+export type DerivedPosSource = z.output<typeof DerivedPosSourceSchema>;
+
 // A literal ISO date string (default; blank/omitted keeps addServiceLine's legacy implicit
 // fallback-to-first-line-date behavior) or a derived source.
 export const DateValueSchema = z.union([z.string(), DerivedDateSourceSchema]);
 export type DateValue = z.output<typeof DateValueSchema>;
+
+// The updateServiceLines action's set value: a literal string (the default; used as-is for every
+// property) or, for the two properties that support it, a derived source — firstServiceLineDate for
+// serviceDate, facilityPlaceOfService for placeOfService. Distinct from DateValueSchema (which is
+// strictly date-shaped) because this value is shared across every settable service line property, not
+// just serviceDate.
+export const ServiceLineSetValueSchema = z.union([z.string(), DerivedDateSourceSchema, DerivedPosSourceSchema]);
+export type ServiceLineSetValue = z.output<typeof ServiceLineSetValueSchema>;
 
 // The fields of a new service line added by the addServiceLine action. All values are strings (the
 // rule value model) and are validated at save time (format) and apply time (claim-dependent checks);
@@ -248,7 +267,7 @@ export type RuleAction =
   | {
       type: 'updateServiceLines';
       match: ServiceLineMatch;
-      set: { property: string; value: DateValue; operation?: ServiceLineSetOperation };
+      set: { property: string; value: ServiceLineSetValue; operation?: ServiceLineSetOperation };
     }
   | { type: 'removeServiceLines'; match: ServiceLineMatch }
   // Re-prices the matching lines from the best applicable charge master (resolved by the engine at
@@ -275,9 +294,10 @@ export const RuleActionSchema = z.discriminatedUnion('type', [
       property: z.string().min(1),
       // Empty is meaningful only for list-valued properties ("clear the modifiers"); scalar-property
       // writers reject it at apply time and the engine holds the claim. A derived-source object is
-      // only meaningful for the serviceDate property — save-time validation (field-catalog) rejects
-      // it for any other property, since the schema alone can't see the sibling `property` value.
-      value: DateValueSchema,
+      // only meaningful for the serviceDate property (firstServiceLineDate) and the placeOfService
+      // property (facilityPlaceOfService) — save-time validation (field-catalog) rejects a derived
+      // source on any other property, since the schema alone can't see the sibling `property` value.
+      value: ServiceLineSetValueSchema,
       operation: z.enum(SERVICE_LINE_SET_OPERATIONS).optional(),
     }),
   }),

--- a/packages/utils/lib/types/data/billing/rules-engine.test.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.test.ts
@@ -317,7 +317,16 @@ describe('rule value validation', () => {
     expect(serviceLineSetValueProblem(lineDate, undefined, { source: 'firstServiceLineDate' })).toBeUndefined();
     expect(serviceLineSetValueProblem(lineDate, undefined, { source: 'bogus' } as never)).toBe('Unknown date source');
     expect(serviceLineSetValueProblem(units, undefined, { source: 'firstServiceLineDate' } as never)).toBe(
-      'This property does not accept a derived date value'
+      'This property does not accept a derived value'
+    );
+
+    // A derived place-of-service source is only accepted on the placeOfService property.
+    expect(serviceLineSetValueProblem(pos, undefined, { source: 'facilityPlaceOfService' })).toBeUndefined();
+    expect(serviceLineSetValueProblem(pos, undefined, { source: 'bogus' } as never)).toBe(
+      'Unknown place of service source'
+    );
+    expect(serviceLineSetValueProblem(units, undefined, { source: 'facilityPlaceOfService' } as never)).toBe(
+      'This property does not accept a derived value'
     );
   });
 
@@ -718,7 +727,7 @@ describe('validateRuleFieldReferences', () => {
     );
     expect(problems).toHaveLength(1);
     expect(problems[0]).toContain('updates service line property "cptCode" with an invalid value');
-    expect(problems[0]).toContain('does not accept a derived date value');
+    expect(problems[0]).toContain('does not accept a derived value');
   });
 
   it('validates the applyChargeMasterPrices line match like the other service-line actions', () => {

--- a/packages/zambdas/src/billing/rules-engine/claim-model.ts
+++ b/packages/zambdas/src/billing/rules-engine/claim-model.ts
@@ -37,7 +37,7 @@ import {
   isValidClaimStatusValue,
 } from 'utils/lib/types/data/billing/claim-status';
 import { getServiceLinePropertyDef } from 'utils/lib/types/data/billing/rules-engine.field-catalog';
-import { DateValue, ServiceLineSetOperation } from 'utils/lib/types/data/billing/rules-engine.schemas';
+import { ServiceLineSetOperation, ServiceLineSetValue } from 'utils/lib/types/data/billing/rules-engine.schemas';
 import { isoDateRegex, taxIdRegex, zipRegex } from 'utils/lib/validation/regex';
 import { updateExtension } from '../../shared/helpers';
 import { getCLIA, getPlaceOfServiceCode } from '../service-facility.helpers';
@@ -284,7 +284,15 @@ const resolveFirstServiceLineDate = (model: RulesEngineClaimModel): DateValueRes
 // error for a bad literal). Blank/omitted, and the explicit firstServiceLineDate source, both fall
 // back to the claim's first service line's date — addServiceLine's long-standing implicit behavior,
 // now this resolver's single definition of it.
-export const resolveDateValue = (value: DateValue | undefined, model: RulesEngineClaimModel): DateValueResolution => {
+//
+// Takes ServiceLineSetValue (not the narrower DateValue) because updateServiceLines' set.value is
+// shared across every settable property — the caller only reaches here once it knows the target
+// property is date-typed, but the value's static type still carries the other derived-source shapes,
+// which fall through to the "Unknown date source" error below like any other bad source.
+export const resolveDateValue = (
+  value: ServiceLineSetValue | undefined,
+  model: RulesEngineClaimModel
+): DateValueResolution => {
   if (value != null && typeof value === 'object') {
     return value.source === 'firstServiceLineDate'
       ? resolveFirstServiceLineDate(model)
@@ -292,6 +300,15 @@ export const resolveDateValue = (value: DateValue | undefined, model: RulesEngin
   }
   const literal = value?.trim();
   return literal ? { value: literal } : resolveFirstServiceLineDate(model);
+};
+
+// Resolve the facilityPlaceOfService derived source: the CMS place-of-service code configured on the
+// claim's service facility (model.serviceFacility, prefetched from Claim.facility). Unlike
+// resolveDateValue there is no blank-fallback — a claim without a service facility, or a facility
+// without a place-of-service code set, is a rule failure rather than a silent no-op.
+export const resolveFacilityPlaceOfService = (model: RulesEngineClaimModel): DateValueResolution => {
+  const code = model.serviceFacility ? getPlaceOfServiceCode(model.serviceFacility) : undefined;
+  return code ? { value: code } : { error: "the claim's facility has no place-of-service code configured" };
 };
 
 // The claim's billed total is the sum of line charges (the invariant the claim editor maintains);

--- a/packages/zambdas/src/billing/rules-engine/claim-model.ts
+++ b/packages/zambdas/src/billing/rules-engine/claim-model.ts
@@ -309,7 +309,7 @@ export const resolveDateValue = (
 export const resolveFacilityPlaceOfService = (model: RulesEngineClaimModel): DateValueResolution => {
   if (!model.serviceFacility) {
     return {
-      error: 'The claim has no facility',
+      error: 'The claim has no service facility set',
     };
   }
   const code = getPlaceOfServiceCode(model.serviceFacility);

--- a/packages/zambdas/src/billing/rules-engine/claim-model.ts
+++ b/packages/zambdas/src/billing/rules-engine/claim-model.ts
@@ -306,7 +306,7 @@ export const resolveDateValue = (
 // claim's service facility (model.serviceFacility, prefetched from Claim.facility). Unlike
 // resolveDateValue there is no blank-fallback — a claim without a service facility, or a facility
 // without a place-of-service code set, is a rule failure rather than a silent no-op.
-export const resolveFacilityPlaceOfService = (model: RulesEngineClaimModel): DateValueResolution => {
+export const resolveFacilityPlaceOfService = (model: RulesEngineClaimModel): { value: string } | { error: string } => {
   if (!model.serviceFacility) {
     return {
       error: 'The claim has no service facility set',

--- a/packages/zambdas/src/billing/rules-engine/claim-model.ts
+++ b/packages/zambdas/src/billing/rules-engine/claim-model.ts
@@ -307,8 +307,13 @@ export const resolveDateValue = (
 // resolveDateValue there is no blank-fallback — a claim without a service facility, or a facility
 // without a place-of-service code set, is a rule failure rather than a silent no-op.
 export const resolveFacilityPlaceOfService = (model: RulesEngineClaimModel): DateValueResolution => {
-  const code = model.serviceFacility ? getPlaceOfServiceCode(model.serviceFacility) : undefined;
-  return code ? { value: code } : { error: "the claim's facility has no place-of-service code configured" };
+  if (!model.serviceFacility) {
+    return {
+      error: 'The claim has no facility',
+    };
+  }
+  const code = getPlaceOfServiceCode(model.serviceFacility);
+  return code ? { value: code } : { error: "Claim's facility has no place-of-service code configured" };
 };
 
 // The claim's billed total is the sum of line charges (the invariant the claim editor maintains);

--- a/packages/zambdas/src/billing/rules-engine/evaluator.ts
+++ b/packages/zambdas/src/billing/rules-engine/evaluator.ts
@@ -331,7 +331,7 @@ const applyServiceLineUpdate = (
       }
       literalValue = resolution.value;
     }
-  } else if (def?.id === 'placeOfService' && typeof action.set.value === 'object') {
+  } else if (def?.id === 'placeOfService' && action.set.value != null && typeof action.set.value === 'object') {
     if (action.set.value.source !== 'facilityPlaceOfService') {
       return `could not update service line property "${action.set.property}" — unknown place of service source`;
     }

--- a/packages/zambdas/src/billing/rules-engine/evaluator.ts
+++ b/packages/zambdas/src/billing/rules-engine/evaluator.ts
@@ -27,6 +27,7 @@ import {
   readServiceLineProperty,
   recomputeClaimTotal,
   resolveDateValue,
+  resolveFacilityPlaceOfService,
   RulesEngineClaimModel,
   writeField,
   writeServiceLineProperty,
@@ -330,12 +331,22 @@ const applyServiceLineUpdate = (
       }
       literalValue = resolution.value;
     }
+  } else if (def?.id === 'placeOfService' && typeof action.set.value === 'object') {
+    if (action.set.value.source !== 'facilityPlaceOfService') {
+      return `could not update service line property "${action.set.property}" — unknown place of service source`;
+    }
+    // Resolve once, before mutating any line, mirroring resolveDateValue above.
+    const resolution = resolveFacilityPlaceOfService(model);
+    if ('error' in resolution) {
+      return `could not update service line property "${action.set.property}" — ${resolution.error}`;
+    }
+    literalValue = resolution.value;
   } else if (typeof action.set.value === 'string') {
     literalValue = action.set.value;
   } else {
-    // Save-time validation rejects a derived-source value on a non-date property; fail safe rather
+    // Save-time validation rejects a derived-source value on any other property; fail safe rather
     // than crash if one reaches here anyway (e.g. a rule created directly through the API).
-    return `could not update service line property "${action.set.property}" — this property does not accept a derived date value`;
+    return `could not update service line property "${action.set.property}" — this property does not accept a derived value`;
   }
 
   const matching = (model.claim.item ?? []).filter((line) => serviceLineMatches(line, action.match));

--- a/packages/zambdas/src/billing/rules-engine/evaluator.ts
+++ b/packages/zambdas/src/billing/rules-engine/evaluator.ts
@@ -333,7 +333,7 @@ const applyServiceLineUpdate = (
     }
   } else if (def?.id === 'placeOfService' && action.set.value != null && typeof action.set.value === 'object') {
     if (action.set.value.source !== 'facilityPlaceOfService') {
-      return `could not update service line property "${action.set.property}" — unknown place of service source`;
+      return `could not update service line property "${action.set.property}" — unknown place of service source "${action.set.value.source}"`;
     }
     // Resolve once, before mutating any line, mirroring resolveDateValue above.
     const resolution = resolveFacilityPlaceOfService(model);

--- a/packages/zambdas/test/unit/billing/rules-engine.test.ts
+++ b/packages/zambdas/test/unit/billing/rules-engine.test.ts
@@ -11,7 +11,7 @@ import {
 } from 'fhir/r4b';
 import { CPT_CODE_SYSTEM, FHIR_IDENTIFIER_NPI } from 'utils/lib/fhir/constants';
 import { getPayerUrl } from 'utils/lib/helpers/helpers';
-import { EXTENSION_URL_CPT_MODIFIER } from 'utils/lib/helpers/rcm/constants';
+import { CODE_SYSTEM_CMS_PLACE_OF_SERVICE, EXTENSION_URL_CPT_MODIFIER } from 'utils/lib/helpers/rcm/constants';
 import { CLAIM_TAG_SYSTEM } from 'utils/lib/types/data/billing/billing.constants';
 import { BillingInsuranceType } from 'utils/lib/types/data/billing/billing.schemas';
 import { RULES_ENGINE_TYPES } from 'utils/lib/types/data/billing/rules-engine.constants';
@@ -27,6 +27,7 @@ import {
   readField,
   readServiceLineProperty,
   resolveDateValue,
+  resolveFacilityPlaceOfService,
   RulesEngineClaimModel,
   SERVICE_LINE_READABLE_PROPERTY_IDS,
   SERVICE_LINE_WRITABLE_PROPERTY_IDS,
@@ -215,6 +216,29 @@ describe('resolveDateValue', () => {
     m.claim.item = [];
     expect(resolveDateValue({ source: 'firstServiceLineDate' }, m)).toEqual({
       error: 'no service date could be resolved — the claim has no existing service lines to inherit one from',
+    });
+  });
+});
+
+describe('resolveFacilityPlaceOfService', () => {
+  it("reads the CMS place-of-service code off the claim's service facility", () => {
+    const m = makeModel();
+    m.serviceFacility!.extension = [{ url: CODE_SYSTEM_CMS_PLACE_OF_SERVICE, valueString: '11' }];
+    expect(resolveFacilityPlaceOfService(m)).toEqual({ value: '11' });
+  });
+
+  it('errors when the facility has no place-of-service code configured', () => {
+    const m = makeModel();
+    expect(resolveFacilityPlaceOfService(m)).toEqual({
+      error: "the claim's facility has no place-of-service code configured",
+    });
+  });
+
+  it('errors when the claim has no service facility at all', () => {
+    const m = makeModel();
+    m.serviceFacility = undefined;
+    expect(resolveFacilityPlaceOfService(m)).toEqual({
+      error: "the claim's facility has no place-of-service code configured",
     });
   });
 });
@@ -648,6 +672,36 @@ describe('service line actions', () => {
         m
       )
     ).toContain('units');
+  });
+
+  it("sets a line's place of service from the claim's facility", () => {
+    const m = makeModel();
+    m.serviceFacility!.extension = [{ url: CODE_SYSTEM_CMS_PLACE_OF_SERVICE, valueString: '11' }];
+    const error = applyAction(
+      {
+        type: 'updateServiceLines',
+        match: { type: 'all' },
+        set: { property: 'placeOfService', value: { source: 'facilityPlaceOfService' } },
+      },
+      m
+    );
+    expect(error).toBeUndefined();
+    expect(readServiceLineProperty(m.claim.item![0], 'placeOfService')).toBe('11');
+  });
+
+  it('fails the rule when the facility place-of-service source cannot be resolved', () => {
+    const m = makeModel();
+    const error = applyAction(
+      {
+        type: 'updateServiceLines',
+        match: { type: 'all' },
+        set: { property: 'placeOfService', value: { source: 'facilityPlaceOfService' } },
+      },
+      m
+    );
+    expect(error).toContain("the claim's facility has no place-of-service code configured");
+    // The line's original place of service is untouched.
+    expect(readServiceLineProperty(m.claim.item![0], 'placeOfService')).toBe('20');
   });
 
   it('removes matching lines, re-sequences survivors, and recomputes the total', () => {

--- a/packages/zambdas/test/unit/billing/rules-engine.test.ts
+++ b/packages/zambdas/test/unit/billing/rules-engine.test.ts
@@ -230,7 +230,7 @@ describe('resolveFacilityPlaceOfService', () => {
   it('errors when the facility has no place-of-service code configured', () => {
     const m = makeModel();
     expect(resolveFacilityPlaceOfService(m)).toEqual({
-      error: "the claim's facility has no place-of-service code configured",
+      error: "Claim's facility has no place-of-service code configured",
     });
   });
 
@@ -238,7 +238,7 @@ describe('resolveFacilityPlaceOfService', () => {
     const m = makeModel();
     m.serviceFacility = undefined;
     expect(resolveFacilityPlaceOfService(m)).toEqual({
-      error: "the claim's facility has no place-of-service code configured",
+      error: 'The claim has no service facility set',
     });
   });
 });
@@ -699,7 +699,7 @@ describe('service line actions', () => {
       },
       m
     );
-    expect(error).toContain("the claim's facility has no place-of-service code configured");
+    expect(error).toContain("Claim's facility has no place-of-service code configured");
     // The line's original place of service is untouched.
     expect(readServiceLineProperty(m.claim.item![0], 'placeOfService')).toBe('20');
   });


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-3149/add-rule-action-to-set-pos-from-claim-associated-sf-on-service-lines