### PR TITLE
Billing rules: conditions and set-action for the claim's non-insurance organization

### DIFF
--- a/apps/billing/src/components/NioSelect.tsx
+++ b/apps/billing/src/components/NioSelect.tsx
@@ -10,7 +10,7 @@ import { useDebounce } from '../hooks/useDebounce';
 // list's NIO filter use. Selecting only real organizations (no free text) is the point.
 
 // The slice of a directory organization the picker needs.
-interface NioOption {
+export interface NioOption {
   id: string;
   name: string;
 }
@@ -20,6 +20,12 @@ interface NioSelectProps {
   value: string | string[] | null | undefined;
   onChange: (value: string | string[]) => void;
   label?: string;
+  // Options the caller already knows (e.g. the claim's current payer), so a stored id shows its
+  // display name before any search has run.
+  initialOptions?: NioOption[];
+  // Offer only active organizations — claim editing picks a payer to bill, while the rule builder
+  // and the claims-list filter search the whole directory.
+  activeOnly?: boolean;
   required?: boolean;
   // Validation display + react-hook-form focus ref, for use inside Controller-registered forms.
   error?: boolean;
@@ -32,7 +38,10 @@ const optionLabel = (o: NioOption): string => o.name || o.id;
 // Debounced server-side search plus a memory of organizations we've seen, so a selected
 // organization keeps its label even after the option list changes (or on edit, once it shows up in
 // a search).
-function useNioSearch(): {
+function useNioSearch(
+  initialOptions?: NioOption[],
+  activeOnly?: boolean
+): {
   options: NioOption[];
   known: Record<string, NioOption>;
   search: (query?: string) => void;
@@ -40,13 +49,17 @@ function useNioSearch(): {
   const { oystehrZambda } = useApiClients();
   const { debounce } = useDebounce(300);
   const [options, setOptions] = useState<NioOption[]>([]);
-  const [known, setKnown] = useState<Record<string, NioOption>>({});
+  const [known, setKnown] = useState<Record<string, NioOption>>(() =>
+    Object.fromEntries((initialOptions ?? []).filter((o) => o.id).map((o) => [o.id, o]))
+  );
 
   const runSearch = async (query?: string): Promise<void> => {
     if (!oystehrZambda) return;
     try {
       const res = await searchBillingNonInsuranceOrgs(oystehrZambda, query ? { name: query } : {});
-      const orgs = (res.organizations ?? []).map(({ id, name }) => ({ id, name }));
+      const orgs = (res.organizations ?? [])
+        .filter((org) => !activeOnly || org.active)
+        .map(({ id, name }) => ({ id, name }));
       setOptions(orgs);
       setKnown((prev) => {
         const next = { ...prev };
@@ -70,12 +83,14 @@ export function NioSelect({
   value,
   onChange,
   label = 'Non-insurance organization',
+  initialOptions,
+  activeOnly,
   required,
   error,
   helperText,
   inputRef,
 }: NioSelectProps): ReactElement {
-  const { options, known, search } = useNioSearch();
+  const { options, known, search } = useNioSearch(initialOptions, activeOnly);
 
   // Props shared by the single- and multi-select variants. Callbacks are typed with their own
   // (narrower) signatures so the object is assignable to both Autocomplete generic instantiations.

--- a/apps/billing/src/components/NioSelect.tsx
+++ b/apps/billing/src/components/NioSelect.tsx
@@ -1,0 +1,137 @@
+import { Autocomplete, AutocompleteInputChangeReason, AutocompleteRenderInputParams, TextField } from '@mui/material';
+import { HTMLAttributes, ReactElement, ReactNode, Ref, SyntheticEvent, useState } from 'react';
+import { searchBillingNonInsuranceOrgs } from '../api/api';
+import { useApiClients } from '../hooks/useAppClients';
+import { useDebounce } from '../hooks/useDebounce';
+
+// Searchable non-insurance organization picker backed by the NIO directory
+// (search-billing-non-insurance-orgs). It displays the organization's name but stores its
+// Organization id — the token the rules engine's nonInsurancePayerId reader/writer and the claims
+// list's NIO filter use. Selecting only real organizations (no free text) is the point.
+
+// The slice of a directory organization the picker needs.
+interface NioOption {
+  id: string;
+  name: string;
+}
+
+interface NioSelectProps {
+  multiple: boolean;
+  value: string | string[] | null | undefined;
+  onChange: (value: string | string[]) => void;
+  label?: string;
+  required?: boolean;
+  // Validation display + react-hook-form focus ref, for use inside Controller-registered forms.
+  error?: boolean;
+  helperText?: ReactNode;
+  inputRef?: Ref<HTMLInputElement>;
+}
+
+const optionLabel = (o: NioOption): string => o.name || o.id;
+
+// Debounced server-side search plus a memory of organizations we've seen, so a selected
+// organization keeps its label even after the option list changes (or on edit, once it shows up in
+// a search).
+function useNioSearch(): {
+  options: NioOption[];
+  known: Record<string, NioOption>;
+  search: (query?: string) => void;
+} {
+  const { oystehrZambda } = useApiClients();
+  const { debounce } = useDebounce(300);
+  const [options, setOptions] = useState<NioOption[]>([]);
+  const [known, setKnown] = useState<Record<string, NioOption>>({});
+
+  const runSearch = async (query?: string): Promise<void> => {
+    if (!oystehrZambda) return;
+    try {
+      const res = await searchBillingNonInsuranceOrgs(oystehrZambda, query ? { name: query } : {});
+      const orgs = (res.organizations ?? []).map(({ id, name }) => ({ id, name }));
+      setOptions(orgs);
+      setKnown((prev) => {
+        const next = { ...prev };
+        orgs.forEach((o) => (next[o.id] = o));
+        return next;
+      });
+    } catch {
+      setOptions([]);
+    }
+  };
+
+  return { options, known, search: (query?: string) => debounce(() => void runSearch(query)) };
+}
+
+// Resolve a stored id to a display option, falling back to a synthetic option showing the raw id.
+const resolve = (id: string, known: Record<string, NioOption>, options: NioOption[]): NioOption =>
+  known[id] ?? options.find((o) => o.id === id) ?? { id, name: '' };
+
+export function NioSelect({
+  multiple,
+  value,
+  onChange,
+  label = 'Non-insurance organization',
+  required,
+  error,
+  helperText,
+  inputRef,
+}: NioSelectProps): ReactElement {
+  const { options, known, search } = useNioSearch();
+
+  // Props shared by the single- and multi-select variants. Callbacks are typed with their own
+  // (narrower) signatures so the object is assignable to both Autocomplete generic instantiations.
+  const shared = {
+    size: 'small' as const,
+    filterOptions: (x: NioOption[]): NioOption[] => x,
+    isOptionEqualToValue: (o: NioOption, v: NioOption): boolean => o.id === v.id,
+    getOptionLabel: optionLabel,
+    renderOption: (props: HTMLAttributes<HTMLLIElement>, o: NioOption): ReactElement => (
+      <li {...props} key={o.id}>
+        {optionLabel(o)}
+      </li>
+    ),
+    onOpen: () => search(),
+    onInputChange: (_: SyntheticEvent, v: string, reason: AutocompleteInputChangeReason): void => {
+      if (reason === 'input') search(v || undefined);
+    },
+    renderInput: (params: AutocompleteRenderInputParams): ReactElement => (
+      <TextField
+        {...params}
+        label={label}
+        placeholder="Search non-insurance organizations…"
+        required={required}
+        error={error}
+        helperText={helperText}
+        inputRef={inputRef}
+      />
+    ),
+  };
+
+  if (multiple) {
+    const ids = Array.isArray(value) ? value : value ? [value] : [];
+    const selected = ids.map((id) => resolve(id, known, options));
+    const merged = [...selected.filter((s) => !options.some((o) => o.id === s.id)), ...options];
+    return (
+      <Autocomplete<NioOption, true, false, false>
+        {...shared}
+        multiple
+        options={merged}
+        value={selected}
+        onChange={(_, opts) => onChange(opts.map((o) => o.id))}
+        sx={{ minWidth: 260 }}
+      />
+    );
+  }
+
+  const id = typeof value === 'string' ? value : '';
+  const selected = id ? resolve(id, known, options) : null;
+  const merged = selected && !options.some((o) => o.id === selected.id) ? [selected, ...options] : options;
+  return (
+    <Autocomplete<NioOption, false, false, false>
+      {...shared}
+      options={merged}
+      value={selected}
+      onChange={(_, o) => onChange(o?.id ?? '')}
+      sx={{ minWidth: 240 }}
+    />
+  );
+}

--- a/apps/billing/src/components/rules/RuleBuilder.tsx
+++ b/apps/billing/src/components/rules/RuleBuilder.tsx
@@ -63,6 +63,7 @@ import { HOLD_TAG_NAME } from 'utils/lib/types/data/billing/system-tags';
 import { otherColors } from '../../themes/ottehr/colors';
 import { DateInput } from '../DateInput';
 import { FacilitySelect } from '../FacilitySelect';
+import { NioSelect } from '../NioSelect';
 import { PayerSelect } from '../PayerSelect';
 import { ProcedureCodeAutocomplete } from '../ProcedureCodeAutocomplete';
 import { ProviderSelect } from '../ProviderSelect';
@@ -341,6 +342,20 @@ function FieldValueInput({
   if (def?.valueType === 'payer') {
     return (
       <PayerSelect
+        multiple={multiple}
+        value={value}
+        onChange={onChange}
+        label={label}
+        required={required}
+        error={error}
+        helperText={helperText}
+        inputRef={inputRef}
+      />
+    );
+  }
+  if (def?.valueType === 'nio') {
+    return (
+      <NioSelect
         multiple={multiple}
         value={value}
         onChange={onChange}

--- a/apps/billing/src/pages/ClaimDetail.tsx
+++ b/apps/billing/src/pages/ClaimDetail.tsx
@@ -91,7 +91,6 @@ import {
   formatAntCaseString,
   formatClaimStatusValue,
 } from 'utils/lib/types/data/billing/claim-status';
-import { NonInsuranceOrganizationItem } from 'utils/lib/types/data/billing/non-insurance-org.types';
 import { RULES_ENGINES, RulesEngineDef } from 'utils/lib/types/data/billing/rules-engine.constants';
 import { formatCurrency } from 'utils/lib/utils/convert';
 import { REQUIRED_FIELD_ERROR_MESSAGE } from 'utils/lib/validation/constants';
@@ -108,7 +107,6 @@ import {
   renameClaimAttachment,
   runBillingRulesEngine,
   saveBillingServiceFacility,
-  searchBillingNonInsuranceOrgs,
   searchBillingTags,
   tagBillingClaim,
   updateBillingCoverage,
@@ -131,6 +129,7 @@ import {
   InstitutionalClaimAdditionalFields,
   InstitutionalClaimAdditionalFieldsData,
 } from '../components/InstitutionalClaimAdditionalFields';
+import { NioOption, NioSelect } from '../components/NioSelect';
 import { ProviderDetailForm } from '../components/ProviderDetailSection';
 import { ReadOnlySection, thSx } from '../components/ReadOnlySection';
 import { Row } from '../components/Row';
@@ -976,49 +975,28 @@ export function NonInsurancePayerSection({
   claim: ClaimDetailResponse;
   updateResource: UpdateFn;
 }): ReactElement {
-  const { oystehrZambda } = useApiClients();
-  const [options, setOptions] = useState<NonInsuranceOrganizationItem[]>([]);
   const [confirmingRemove, setConfirmingRemove] = useState(false);
   const [removing, setRemoving] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
 
-  const currentPayer = useMemo<NonInsuranceOrganizationItem | null>(
+  const currentPayer = useMemo<NioOption | null>(
     () =>
       claim.nonInsurancePayerFhirId
         ? {
             id: claim.nonInsurancePayerFhirId,
             name: claim.nonInsurancePayerName || claim.nonInsurancePayerFhirId,
-            employer: false,
-            active: true,
-            contacts: [],
-            covers: [],
           }
         : null,
     [claim.nonInsurancePayerFhirId, claim.nonInsurancePayerName]
   );
-  const [selected, setSelected] = useState<NonInsuranceOrganizationItem | null>(currentPayer);
+  const [selectedId, setSelectedId] = useState<string>(currentPayer?.id ?? '');
   useEffect(() => {
-    setSelected(currentPayer);
+    setSelectedId(currentPayer?.id ?? '');
   }, [currentPayer]);
 
-  const optionList = useMemo(() => {
-    if (!currentPayer || options.some((org) => org.id === currentPayer.id)) return options;
-    return [currentPayer, ...options];
-  }, [options, currentPayer]);
-
-  const loadOptions = async (): Promise<void> => {
-    if (!oystehrZambda || options.length) return;
-    try {
-      const data = await searchBillingNonInsuranceOrgs(oystehrZambda, { pageSize: 100 });
-      setOptions((data.organizations ?? []).filter((org) => org.active));
-    } catch {
-      // Leave the list empty; reopening the autocomplete retries.
-    }
-  };
-
   const handleSave = async (): Promise<string | null> => {
-    if (!selected) return 'Choose a non-insurance organization';
-    return updateResource('Claim', claim.id, { nonInsurancePayer: { id: selected.id } });
+    if (!selectedId) return 'Choose a non-insurance organization';
+    return updateResource('Claim', claim.id, { nonInsurancePayer: { id: selectedId } });
   };
 
   const handleRemove = async (): Promise<void> => {
@@ -1036,19 +1014,18 @@ export function NonInsurancePayerSection({
     <EditableSection
       title="Non-insurance Payer"
       onSave={handleSave}
-      onCancel={() => setSelected(currentPayer)}
+      onCancel={() => setSelectedId(currentPayer?.id ?? '')}
       editForm={
-        <Autocomplete
-          size="small"
-          options={optionList}
-          value={selected}
-          onChange={(_, v) => setSelected(v)}
-          onOpen={() => void loadOptions()}
-          getOptionLabel={(o) => o.name}
-          renderInput={(p) => <TextField {...p} size="small" label={hasPayer ? 'Payer' : 'Choose payer'} />}
-          isOptionEqualToValue={(o, v) => o.id === v.id}
-          sx={{ maxWidth: 480 }}
-        />
+        <Box sx={{ maxWidth: 480 }}>
+          <NioSelect
+            multiple={false}
+            activeOnly
+            value={selectedId}
+            onChange={(v) => setSelectedId(typeof v === 'string' ? v : v[0] ?? '')}
+            label={hasPayer ? 'Payer' : 'Choose payer'}
+            initialOptions={currentPayer ? [currentPayer] : []}
+          />
+        </Box>
       }
     >
       {hasPayer ? (

--- a/apps/billing/tests/component/ClaimDetail.test.tsx
+++ b/apps/billing/tests/component/ClaimDetail.test.tsx
@@ -637,11 +637,12 @@ describe('ClaimDetail — non-insurance payer section', () => {
     await user.click(within(section).getByRole('button', { name: 'Edit' }));
     await user.click(within(section).getByLabelText('Choose payer'));
 
-    expect(await screen.findByText('FedEx')).toBeInTheDocument();
+    // Generous timeout: the options wait on a 300ms-debounced fetch, slow enough to flake at 1s.
+    const fedEx = await screen.findByRole('option', { name: 'FedEx' }, { timeout: 5000 });
     // Inactive organizations can't be chosen as the payer.
-    expect(screen.queryByText('Inactive Org')).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Inactive Org' })).not.toBeInTheDocument();
 
-    await user.click(screen.getByText('FedEx'));
+    await user.click(fedEx);
     await user.click(within(section).getByRole('button', { name: 'Save' }));
 
     await waitFor(() =>
@@ -680,8 +681,10 @@ describe('ClaimDetail — non-insurance payer section', () => {
     expect(input).toHaveValue('FedEx');
 
     await user.click(input);
-    // The current payer appears once in the list, merged with the loaded options.
-    const options = await screen.findAllByRole('option');
+    // Wait out the debounced fetch, then check the current payer appears once, merged with the
+    // loaded options.
+    await screen.findByRole('option', { name: 'UPS' }, { timeout: 5000 });
+    const options = screen.getAllByRole('option');
     expect(options.map((o) => o.textContent)).toEqual(['FedEx', 'UPS']);
 
     await user.click(screen.getByRole('option', { name: 'UPS' }));

--- a/apps/billing/tests/component/ClaimsList.test.tsx
+++ b/apps/billing/tests/component/ClaimsList.test.tsx
@@ -469,7 +469,8 @@ describe('ClaimsList — non-insurance organization filter', () => {
 
     const input = await screen.findByLabelText('Non-insurance Organization');
     fireEvent.mouseDown(input);
-    fireEvent.click(await screen.findByRole('option', { name: 'FedEx' }));
+    // Generous timeout: the option waits on a 300ms-debounced fetch, slow enough to flake at 1s.
+    fireEvent.click(await screen.findByRole('option', { name: 'FedEx' }, { timeout: 5000 }));
 
     await waitFor(() =>
       expect(searchBillingClaimsMock).toHaveBeenCalledWith(

--- a/apps/billing/tests/component/Rules.test.tsx
+++ b/apps/billing/tests/component/Rules.test.tsx
@@ -8,21 +8,29 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConditionalEditor } from '../../src/components/rules/RuleBuilder';
 import Rules from '../../src/pages/Rules';
 
-const { getBillingRulesMock, saveBillingRulesMock, searchBillingProvidersMock, searchBillingTagsMock, stableClients } =
-  vi.hoisted(() => ({
-    getBillingRulesMock: vi.fn(),
-    saveBillingRulesMock: vi.fn(),
-    searchBillingProvidersMock: vi.fn(),
-    searchBillingTagsMock: vi.fn(),
-    stableClients: { oystehrZambda: {} },
-  }));
+const {
+  getBillingRulesMock,
+  saveBillingRulesMock,
+  searchBillingNonInsuranceOrgsMock,
+  searchBillingProvidersMock,
+  searchBillingTagsMock,
+  stableClients,
+} = vi.hoisted(() => ({
+  getBillingRulesMock: vi.fn(),
+  saveBillingRulesMock: vi.fn(),
+  searchBillingNonInsuranceOrgsMock: vi.fn(),
+  searchBillingProvidersMock: vi.fn(),
+  searchBillingTagsMock: vi.fn(),
+  stableClients: { oystehrZambda: {} },
+}));
 
 vi.mock('../../src/api/api', () => ({
   getBillingRules: getBillingRulesMock,
   saveBillingRules: saveBillingRulesMock,
   // PayerSelect (rendered for the payerId condition) searches payers on open/input, not on mount;
   // same for TagSelect (apply-tag action), ProcedureCodeAutocomplete (CPT inputs), and the
-  // provider/facility reference pickers.
+  // provider/facility/NIO reference pickers.
+  searchBillingNonInsuranceOrgs: searchBillingNonInsuranceOrgsMock,
   searchBillingPayers: () => Promise.resolve({ payers: [] }),
   searchBillingProcedureCodes: () => Promise.resolve({ codes: [] }),
   searchBillingProviders: searchBillingProvidersMock,
@@ -126,6 +134,60 @@ describe('ConditionalEditor', () => {
     render(<ConditionalForm conditional={ruleA.conditional} />);
     // ruleA has a payerId condition and a setField-payerId action — both should be payer pickers.
     expect(screen.getAllByPlaceholderText(/Search payers/)).toHaveLength(2);
+  });
+
+  it('uses the searchable NIO picker for the non-insurance organization field in both the condition and the action', () => {
+    const conditional: RuleConditional = {
+      branches: [
+        {
+          condition: { type: 'field', field: 'nonInsurancePayerId', operator: 'eq', value: 'nio-1' },
+          outcome: { type: 'actions', actions: [{ type: 'setField', field: 'nonInsurancePayerId', value: '' }] },
+        },
+      ],
+    };
+    render(<ConditionalForm conditional={conditional} />);
+    expect(screen.getAllByPlaceholderText(/Search non-insurance organizations/)).toHaveLength(2);
+  });
+
+  it('offers directory organizations in the set-NIO picker and stores the organization id', async () => {
+    searchBillingNonInsuranceOrgsMock.mockReset();
+    searchBillingNonInsuranceOrgsMock.mockResolvedValue({
+      organizations: [
+        {
+          id: '8f1f6f3e-1111-4222-8333-444455556666',
+          name: 'Acme Trucking',
+          employer: true,
+          active: true,
+          contacts: [],
+          covers: [],
+        },
+      ],
+      total: 1,
+    });
+    const conditional: RuleConditional = {
+      branches: [
+        {
+          condition: { type: 'all' },
+          outcome: { type: 'actions', actions: [{ type: 'setField', field: 'nonInsurancePayerId', value: '' }] },
+        },
+      ],
+    };
+    const onValid = vi.fn();
+    render(<ConditionalForm conditional={conditional} onValid={onValid} />);
+
+    const input = screen.getByPlaceholderText(/Search non-insurance organizations/);
+    fireEvent.mouseDown(input);
+    fireEvent.click(await screen.findByRole('option', { name: 'Acme Trucking' }));
+    expect(searchBillingNonInsuranceOrgsMock).toHaveBeenCalledWith(expect.anything(), {});
+
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(onValid).toHaveBeenCalled());
+    const action = onValid.mock.calls[0][0].conditional.branches[0].outcome.actions[0];
+    expect(action).toEqual({
+      type: 'setField',
+      field: 'nonInsurancePayerId',
+      value: '8f1f6f3e-1111-4222-8333-444455556666',
+    });
   });
 
   it('renders line match and set controls for an update-service-lines action', () => {

--- a/apps/billing/tests/component/Rules.test.tsx
+++ b/apps/billing/tests/component/Rules.test.tsx
@@ -177,7 +177,8 @@ describe('ConditionalEditor', () => {
 
     const input = screen.getByPlaceholderText(/Search non-insurance organizations/);
     fireEvent.mouseDown(input);
-    fireEvent.click(await screen.findByRole('option', { name: 'Acme Trucking' }));
+    // Generous timeout: the option waits on a 300ms-debounced fetch, slow enough to flake at 1s.
+    fireEvent.click(await screen.findByRole('option', { name: 'Acme Trucking' }, { timeout: 5000 }));
     expect(searchBillingNonInsuranceOrgsMock).toHaveBeenCalledWith(expect.anything(), {});
 
     fireEvent.click(screen.getByText('Save'));

--- a/docs/billing-rules-engine.md
+++ b/docs/billing-rules-engine.md
@@ -31,7 +31,7 @@ is performed.
 
 This reference lists every supported condition property, operator, and action. It is generated from
 the same catalog that drives the rule builder and the rule runs, so it always matches what the rules
-actually support (116 properties, 103 of them settable).
+actually support (117 properties, 104 of them settable).
 
 ## Conditions
 
@@ -72,6 +72,7 @@ Which operators a property supports depends on its type (see the property tables
 | Property | ID | Type | Operators | Settable | Description |
 | --- | --- | --- | --- | --- | --- |
 | Payer ID | `payerId` | payer ID | equals, does not equal, is one of, is not one of, contains, does not contain, starts with, does not start with, matches pattern, does not match pattern, is present, is empty | yes | The primary payer's ID. Setting it re-points the primary coverage's payer and the claim's insurer. Cannot be cleared — setting it requires a value. |
+| Non-insurance organization | `nonInsurancePayerId` | non-insurance organization ID | equals, does not equal, is one of, is not one of, is present, is empty | yes | The claim's non-insurance payer: a non-insurance organization from the Non-Insurance Organizations page (e.g. the visit's occupational-medicine employer). Setting it stamps the payer on the claim (shown on the claim screens, filterable on the claims list); setting an empty value clears it. |
 | Claim type | `type` | one of the listed values | equals, does not equal, is one of, is not one of, matches pattern, does not match pattern, is present, is empty | yes | The claim type (professional or institutional). Allowed values: `professional` (Professional), `institutional` (Institutional). Cannot be cleared — setting it requires a value. |
 | Service category | `service` | text | equals, does not equal, is one of, is not one of, contains, does not contain, starts with, does not start with, matches pattern, does not match pattern, is present, is empty | yes | The service category code on the claim (e.g. urgent-care, workers-comp). Categories are configurable, so the value is free text. |
 | Service date | `serviceDate` | date | equals, does not equal, is one of, is not one of, is after, is on or after, is before, is on or before, is present, is empty | yes | The date of service (read from the first service line). Setting it applies the one date to every service line, matching the claim editor. Cannot be cleared — setting it requires a value. |

--- a/packages/utils/lib/types/data/billing/rules-engine.docs.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.docs.ts
@@ -39,6 +39,7 @@ const VALUE_TYPE_LABELS: Record<RuleFieldValueType, string> = {
   payer: 'payer ID',
   provider: 'provider reference',
   facility: 'facility reference',
+  nio: 'non-insurance organization ID',
 };
 
 // Escape/normalize a string for use inside a markdown table cell.

--- a/packages/utils/lib/types/data/billing/rules-engine.field-catalog.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.field-catalog.ts
@@ -2,6 +2,7 @@ import { SUBSCRIBER_RELATIONSHIPS } from '../../../fhir/constants';
 import { isCLIAValid, isNPIValidWithChecksum } from '../../../helpers/helpers';
 import { CMS_PLACE_OF_SERVICE_CODE_SET, CMS_PLACE_OF_SERVICE_CODES } from '../../../helpers/rcm/constants';
 import { VALUE_SETS } from '../../../ottehr-config/value-sets';
+import { isValidUUID } from '../../../validation/helper';
 import { isoDateRegex, taxIdRegex, zipRegex } from '../../../validation/regex';
 import { AllStates, stateCodeToFullName } from '../../common';
 import { PERSON_GENDER_OPTIONS } from './billing.constants';
@@ -102,7 +103,17 @@ export const RULE_FIELD_GROUP_LABELS: Record<RuleFieldGroup, string> = {
 //   from the rendering/billing providers list (the def's providerRole picks which)
 // - facility: a service facility reference resource ("Location/<id>") chosen from the service
 //   facilities list
-export type RuleFieldValueType = 'string' | 'number' | 'date' | 'select' | 'list' | 'payer' | 'provider' | 'facility';
+// - nio: a non-insurance organization id chosen from the NIO directory
+export type RuleFieldValueType =
+  | 'string'
+  | 'number'
+  | 'date'
+  | 'select'
+  | 'list'
+  | 'payer'
+  | 'provider'
+  | 'facility'
+  | 'nio';
 
 export interface RuleFieldOption {
   value: string;
@@ -502,6 +513,18 @@ export const RULE_FIELD_CATALOG: RuleFieldDef[] = [
     settable: true,
     description: "The primary payer's ID. Setting it re-points the primary coverage's payer and the claim's insurer.",
     requiredOnSet: true,
+  },
+  {
+    id: 'nonInsurancePayerId',
+    label: 'Non-insurance organization',
+    group: 'claim',
+    valueType: 'nio',
+    operators: REF_OPS,
+    settable: true,
+    description:
+      "The claim's non-insurance payer: a non-insurance organization from the Non-Insurance Organizations page " +
+      "(e.g. the visit's occupational-medicine employer). Setting it stamps the payer on the claim (shown on the " +
+      'claim screens, filterable on the claims list); setting an empty value clears it.',
   },
   {
     id: 'type',
@@ -1118,6 +1141,9 @@ const strictValueProblem = (
   if (def.valueType === 'facility' && !FACILITY_REF_REGEX.test(value)) {
     return 'Must be a facility reference (Location/<id>)';
   }
+  if (def.valueType === 'nio' && !isValidUUID(value)) {
+    return 'Must be a non-insurance organization id';
+  }
   if (def.format) return RULE_VALUE_FORMATS[def.format].validate?.(value);
   return undefined;
 };
@@ -1291,6 +1317,21 @@ export function ruleReferencesPatientCoverage(rule: { conditional: RuleCondition
 export interface SetResourceRef {
   field: string;
   ref: string;
+}
+
+export const NON_INSURANCE_PAYER_FIELD_ID = 'nonInsurancePayerId';
+
+// The NIO organization ids a rule's setField actions assign as the claim's non-insurance payer
+// (deduped, in tree order) — save-billing-rules verifies each names a non-insurance organization,
+// and the engine prefetches them so the synchronous writer can stamp the claim with the payer's name.
+export function collectSetNioIds(rule: { conditional: RuleConditional }): string[] {
+  const ids: string[] = [];
+  forEachRuleAction(rule, (action) => {
+    if (action.type !== 'setField' || action.field !== NON_INSURANCE_PAYER_FIELD_ID) return;
+    const id = action.value?.trim();
+    if (id && !ids.includes(id)) ids.push(id);
+  });
+  return ids;
 }
 
 export function collectSetResourceRefs(rule: { conditional: RuleConditional }): SetResourceRef[] {

--- a/packages/utils/lib/types/data/billing/rules-engine.test.ts
+++ b/packages/utils/lib/types/data/billing/rules-engine.test.ts
@@ -3,6 +3,7 @@ import {
   ADD_SERVICE_LINE_FIELDS,
   addServiceLineFieldProblem,
   collectApplyTagNames,
+  collectSetNioIds,
   collectSetResourceRefs,
   getRuleFieldDef,
   getServiceLinePropertyDef,
@@ -442,6 +443,63 @@ describe('rule value validation', () => {
       { field: 'billingProvider.ref', ref: 'Organization/org-1' },
       { field: 'serviceFacility.ref', ref: 'Location/loc-1' },
     ]);
+  });
+
+  it('validates non-insurance organization values as directory ids', () => {
+    const nio = field('nonInsurancePayerId');
+    const uuid = '8f1f6f3e-1111-4222-8333-444455556666';
+    expect(setFieldValueProblem(nio, uuid)).toBeUndefined();
+    expect(setFieldValueProblem(nio, '')).toBeUndefined(); // clear is legal
+    expect(setFieldValueProblem(nio, 'not-a-uuid')).toContain('non-insurance organization id');
+
+    expect(ruleConditionValueProblem(nio, 'eq', uuid)).toBeUndefined();
+    expect(ruleConditionValueProblem(nio, 'in', [uuid, 'nope'])).toContain('non-insurance organization id');
+    expect(ruleConditionValueProblem(nio, 'exists', undefined)).toBeUndefined();
+  });
+
+  it('collects setField NIO ids across nested conditionals, deduped, skipping clears', () => {
+    const uuidA = '8f1f6f3e-1111-4222-8333-444455556666';
+    const uuidB = '2b9c0d1e-2222-4333-9444-555566667777';
+    const ids = collectSetNioIds({
+      conditional: {
+        branches: [
+          {
+            condition: { type: 'all' },
+            outcome: {
+              type: 'conditional',
+              conditional: {
+                branches: [
+                  {
+                    condition: { type: 'all' },
+                    outcome: {
+                      type: 'actions',
+                      actions: [
+                        { type: 'setField', field: 'nonInsurancePayerId', value: uuidA },
+                        // Other setFields and clears are not collected.
+                        { type: 'setField', field: 'patient.state', value: 'CA' },
+                        { type: 'setField', field: 'nonInsurancePayerId', value: '' },
+                      ],
+                    },
+                  },
+                ],
+                otherwise: {
+                  type: 'actions',
+                  actions: [{ type: 'setField', field: 'nonInsurancePayerId', value: uuidB }],
+                },
+              },
+            },
+          },
+          {
+            condition: { type: 'all' },
+            outcome: {
+              type: 'actions',
+              actions: [{ type: 'setField', field: 'nonInsurancePayerId', value: uuidA }],
+            },
+          },
+        ],
+      },
+    });
+    expect(ids).toEqual([uuidA, uuidB]);
   });
 
   it('detects applyChargeMasterPrices actions anywhere in the conditional tree', () => {

--- a/packages/zambdas/src/billing/rules-engine/claim-model.ts
+++ b/packages/zambdas/src/billing/rules-engine/claim-model.ts
@@ -11,7 +11,13 @@ import {
   Practitioner,
   RelatedPerson,
 } from 'fhir/r4b';
-import { getCoveragePlanType, setCoveragePlanType } from 'utils/lib/fhir/billing';
+import {
+  applyClaimNonInsurancePayerTag,
+  claimNonInsurancePayerExtension,
+  getClaimNonInsurancePayer,
+  getCoveragePlanType,
+  setCoveragePlanType,
+} from 'utils/lib/fhir/billing';
 import { SUBSCRIBER_RELATIONSHIP_CODE_MAP } from 'utils/lib/fhir/constants';
 import { codeableConcept, getCoding, getExtension, getNPI, getTaxID, setNpi } from 'utils/lib/fhir/helpers';
 import { INSURANCE_CANDID_PLAN_TYPE_CODES } from 'utils/lib/fhir/insurance';
@@ -36,6 +42,7 @@ import {
   getClaimStatusFieldValue,
   isValidClaimStatusValue,
 } from 'utils/lib/types/data/billing/claim-status';
+import { CLAIM_NON_INSURANCE_PAYER_EXTENSION_URL } from 'utils/lib/types/data/billing/non-insurance-org.types';
 import { getServiceLinePropertyDef } from 'utils/lib/types/data/billing/rules-engine.field-catalog';
 import { DateValue, ServiceLineSetOperation } from 'utils/lib/types/data/billing/rules-engine.schemas';
 import { isoDateRegex, taxIdRegex, zipRegex } from 'utils/lib/validation/regex';
@@ -94,6 +101,11 @@ export interface RulesEngineClaimModel {
   // references the "Coverage (from patient)" field. Read-only reference data like
   // referenceResources: the writer copies out of it, never mutates or persists it.
   patientCoverageContext?: PatientCoverageContext;
+  // The non-insurance organizations named by the rule set's "set non-insurance organization"
+  // actions, keyed by id, prefetched by the engine so the synchronous writer can stamp the claim
+  // with the payer's name. Read-only reference data like referenceResources — claims reference
+  // these masters directly, so no working copy is made.
+  nioOrganizations?: Map<string, Organization>;
   // Local placeholder ids of working copies minted by writers during this run. persistModel
   // POSTs them (fullUrl urn:uuid:<id>) in the same transaction as the claim's update; the
   // server resolves the claim's temporary urn references to the created ids, and the model
@@ -380,6 +392,7 @@ const READERS: Record<string, FieldReader> = {
   // The payer is the payor reference on the working-copy Coverage — always an Oystehr payer URL
   // encoding the id in the billing workspace.
   payerId: (m) => extractPayerIdFromUrl(primaryCoverage(m)?.payor?.[0]?.reference),
+  nonInsurancePayerId: (m) => getClaimNonInsurancePayer(m.claim)?.reference?.replace('Organization/', ''),
   type: (m) => getClaimType(m.claim),
   service: (m) => getClaimService(m.claim),
   serviceDate: (m) => m.claim.item?.[0]?.servicedPeriod?.start ?? m.claim.item?.[0]?.servicedDate,
@@ -899,8 +912,31 @@ const setFacilityPosCode = (facility: Location, value: string | null): void => {
   if (facility.extension.length === 0) facility.extension = undefined;
 };
 
+// Stamp or clear the claim's non-insurance payer — the same extension + searchable meta.tag pair
+// update-billing-claim writes. The claim references the NIO master directly (no working copy), so
+// setting only needs the prefetched organization for its name; an id missing from the prefetch
+// (deleted, or not a non-insurance organization) fails the rule.
+const setNonInsurancePayer = (model: RulesEngineClaimModel, value: string | null): boolean => {
+  const id = value?.trim();
+  const rest = (model.claim.extension ?? []).filter((ext) => ext.url !== CLAIM_NON_INSURANCE_PAYER_EXTENSION_URL);
+  if (!id) {
+    model.claim.extension = rest.length ? rest : undefined;
+    applyClaimNonInsurancePayerTag(model.claim, null);
+    return true;
+  }
+  const org = model.nioOrganizations?.get(id);
+  if (!org?.id) return false;
+  model.claim.extension = [
+    ...rest,
+    claimNonInsurancePayerExtension({ reference: `Organization/${org.id}`, display: org.name }),
+  ];
+  applyClaimNonInsurancePayerTag(model.claim, org.id);
+  return true;
+};
+
 const WRITERS: Record<string, FieldWriter> = {
   payerId: (m, v) => setPayerId(m, v),
+  nonInsurancePayerId: (m, v) => setNonInsurancePayer(m, v),
   type: (m, v) => setClaimType(m.claim, v),
   service: (m, v) => setClaimService(m.claim, v),
   serviceDate: (m, v) => setServiceDate(m.claim, v),

--- a/packages/zambdas/src/billing/save-billing-rules/index.ts
+++ b/packages/zambdas/src/billing/save-billing-rules/index.ts
@@ -1,13 +1,15 @@
 import Oystehr from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
 import { randomUUID } from 'crypto';
-import { List, Resource } from 'fhir/r4b';
+import { List, Organization, Resource } from 'fhir/r4b';
 import { getResourcesFromBatchInlineRequests } from 'utils/lib/fhir/helpers';
 import { getSecret, SecretsKeys } from 'utils/lib/secrets';
 import {
   collectApplyTagNames,
+  collectSetNioIds,
   collectSetResourceRefs,
   getRuleFieldDef,
+  NON_INSURANCE_PAYER_FIELD_ID,
 } from 'utils/lib/types/data/billing/rules-engine.field-catalog';
 import { BillingRule, BillingRulesResponse } from 'utils/lib/types/data/billing/rules-engine.schemas';
 import { isSystemManagedTagName } from 'utils/lib/types/data/billing/system-tags';
@@ -15,6 +17,7 @@ import { INVALID_INPUT_ERROR } from 'utils/lib/types/errors';
 import { checkOrCreateM2MClientToken } from '../../shared/auth';
 import { wrapHandler } from '../../shared/sentry';
 import { ZambdaInput } from '../../shared/types/common';
+import { isNonInsuranceOrganization } from '../non-insurance-org.helpers';
 import { rulesToList } from '../rules-engine/serialization';
 import {
   BILLING_WORKING_COPY_TAG,
@@ -49,6 +52,7 @@ export async function complexValidation(oystehr: Oystehr, params: SaveBillingRul
     findRulesEngineList(oystehr, params.engine),
     validateAppliedTagsExist(oystehr, params.rules),
     validateReferencedResourcesExist(oystehr, params.rules),
+    validateNioReferencesExist(oystehr, params.rules),
   ]);
   return existing;
 }
@@ -105,6 +109,40 @@ async function validateReferencedResourcesExist(
       .map((item) => `rule "${entry.name}" sets "${item.field}" to ${item.ref} — ${item.problem}`)
   );
   if (problems.length > 0) throw INVALID_INPUT_ERROR(problems.join('; '));
+}
+
+// Every non-insurance organization a rule assigns must exist and be a non-insurance organization
+// (the kind managed on the Non-Insurance Organizations page). One batched fetch covers all distinct
+// ids, and none runs when no rule sets one. The engine re-checks at apply time (an organization
+// deleted after save fails the rule and holds the claim).
+async function validateNioReferencesExist(oystehr: Oystehr, rules: SaveBillingRulesParams['rules']): Promise<void> {
+  const perRule = rules
+    .map((rule) => ({ name: rule.name, ids: collectSetNioIds(rule) }))
+    .filter((entry) => entry.ids.length > 0);
+  if (perRule.length === 0) return;
+
+  const distinct = [...new Set(perRule.flatMap((entry) => entry.ids))];
+  const resources = await getResourcesFromBatchInlineRequests(
+    oystehr,
+    distinct.map((id) => `/Organization?_id=${id}`)
+  );
+  const byId = new Map(
+    resources.filter((r): r is Organization => r.resourceType === 'Organization' && !!r.id).map((r) => [r.id, r])
+  );
+
+  const problems = perRule.flatMap((entry) =>
+    entry.ids
+      .map((id) => ({ id, problem: nioReferenceProblem(byId.get(id)) }))
+      .filter((item) => item.problem)
+      .map((item) => `rule "${entry.name}" sets "${NON_INSURANCE_PAYER_FIELD_ID}" to ${item.id} — ${item.problem}`)
+  );
+  if (problems.length > 0) throw INVALID_INPUT_ERROR(problems.join('; '));
+}
+
+function nioReferenceProblem(org: Organization | undefined): string | undefined {
+  if (!org) return 'no such organization exists';
+  if (!isNonInsuranceOrganization(org)) return 'it is not a non-insurance organization';
+  return undefined;
 }
 
 function referencedResourceProblem(resource: Resource | undefined, field: string): string | undefined {

--- a/packages/zambdas/src/subscriptions/task/sub-rules-engine/index.ts
+++ b/packages/zambdas/src/subscriptions/task/sub-rules-engine/index.ts
@@ -24,6 +24,7 @@ import { CLAIM_PROVENANCE_AGENT_TYPE } from 'utils/lib/types/data/billing/claim-
 import { ClaimHistoryRuleRef } from 'utils/lib/types/data/billing/claim-history';
 import { RULES_ENGINES, RulesEngineType } from 'utils/lib/types/data/billing/rules-engine.constants';
 import {
+  collectSetNioIds,
   collectSetResourceRefs,
   ruleReferencesPatientCoverage,
   ruleUsesChargeMasterPrices,
@@ -31,6 +32,7 @@ import {
 import { BillingRule, RULE_ACTION_TYPE } from 'utils/lib/types/data/billing/rules-engine.schemas';
 import { HOLD_TAG_NAME } from 'utils/lib/types/data/billing/system-tags';
 import { activeDefaultChargeMasterSearchParams } from '../../../billing/charge-master.helpers';
+import { isNonInsuranceOrganization } from '../../../billing/non-insurance-org.helpers';
 import {
   addErrorProvenanceForClaimSubmission,
   claimProvenanceRequest,
@@ -153,14 +155,16 @@ export async function complexValidation(
 ): Promise<ValidatedRulesRun> {
   console.log(`[rules-engine] ${engine} starting for Claim/${claimId}`);
   const [rules, model] = await Promise.all([loadRules(oystehr, engine, env), loadClaimModel(oystehr, claimId)]);
-  const [referenceResources, chargeMasters, patientCoverageContext] = await Promise.all([
+  const [referenceResources, chargeMasters, patientCoverageContext, nioOrganizations] = await Promise.all([
     loadReferenceResources(oystehr, rules),
     loadChargeMasters(oystehr, rules),
     loadPatientCoverageContext(oystehr, rules, model.patient),
+    loadNioOrganizations(oystehr, rules),
   ]);
   model.referenceResources = referenceResources;
   model.chargeMasters = chargeMasters;
   model.patientCoverageContext = patientCoverageContext;
+  model.nioOrganizations = nioOrganizations;
   console.log(
     `[rules-engine] loaded ${rules.length} rule(s); patient=${model.patient?.id ?? 'none'}, ` +
       `coverages=${model.coverages.length}, renderingProvider=${model.renderingProvider?.id ?? 'none'}, ` +
@@ -168,7 +172,10 @@ export async function complexValidation(
       `serviceFacility=${model.serviceFacility?.id ?? 'none'}, subscribers=${model.subscribers.length}` +
       (model.referenceResources ? `, referenceResources=${model.referenceResources.size}` : '') +
       (model.chargeMasters ? `, chargeMasters=${model.chargeMasters.length}` : '') +
-      (model.patientCoverageContext ? `, patientCoverages=${model.patientCoverageContext.typeByCoverageRef.size}` : '')
+      (model.patientCoverageContext
+        ? `, patientCoverages=${model.patientCoverageContext.typeByCoverageRef.size}`
+        : '') +
+      (model.nioOrganizations ? `, nioOrganizations=${model.nioOrganizations.size}` : '')
   );
   return { engine, claimId, rules, model, skipRules: skipRules ?? false };
 }
@@ -200,6 +207,29 @@ async function loadReferenceResources(
     const typed = resource as Practitioner | Organization | Location;
     if (!typed.id || hasTag(typed, BILLING_WORKING_COPY_TAG.system, BILLING_WORKING_COPY_TAG.code)) continue;
     map.set(`${resourceType}/${typed.id}`, typed);
+  }
+  return map;
+}
+
+// The non-insurance organizations named by the rule set's "set non-insurance organization" actions,
+// prefetched so the synchronous writer can stamp the claim with the payer's name. An id that is
+// missing — deleted, or not a non-insurance organization — finds no entry and fails at apply time,
+// holding the claim rather than stamping a bad payer.
+async function loadNioOrganizations(
+  oystehr: Oystehr,
+  rules: BillingRule[]
+): Promise<RulesEngineClaimModel['nioOrganizations']> {
+  const ids = new Set(rules.filter((rule) => rule.enabled).flatMap((rule) => collectSetNioIds(rule)));
+  if (!ids.size) return undefined;
+  const resources = await getResourcesFromBatchInlineRequests(
+    oystehr,
+    [...ids].map((id) => `/Organization?_id=${id}`)
+  );
+  const map: NonNullable<RulesEngineClaimModel['nioOrganizations']> = new Map();
+  for (const resource of resources) {
+    if (resource.resourceType !== 'Organization') continue;
+    const org = resource as Organization;
+    if (org.id && isNonInsuranceOrganization(org)) map.set(org.id, org);
   }
   return map;
 }

--- a/packages/zambdas/test/unit/billing/rules-engine.test.ts
+++ b/packages/zambdas/test/unit/billing/rules-engine.test.ts
@@ -14,6 +14,10 @@ import { getPayerUrl } from 'utils/lib/helpers/helpers';
 import { EXTENSION_URL_CPT_MODIFIER } from 'utils/lib/helpers/rcm/constants';
 import { CLAIM_TAG_SYSTEM } from 'utils/lib/types/data/billing/billing.constants';
 import { BillingInsuranceType } from 'utils/lib/types/data/billing/billing.schemas';
+import {
+  CLAIM_NON_INSURANCE_PAYER_EXTENSION_URL,
+  CLAIM_NON_INSURANCE_PAYER_TAG_SYSTEM,
+} from 'utils/lib/types/data/billing/non-insurance-org.types';
 import { RULES_ENGINE_TYPES } from 'utils/lib/types/data/billing/rules-engine.constants';
 import {
   RULE_FIELD_CATALOG,
@@ -1252,6 +1256,88 @@ describe('provider/facility reference swap', () => {
     expect(writeField(m, 'renderingProvider.ref', '')).toBe(false); // no "clear the provider"
     expect(m.createdCopyIds).toBeUndefined();
     expect(m.claim.provider).toEqual({});
+  });
+});
+
+describe('non-insurance payer field', () => {
+  const nioOrg: Organization = { resourceType: 'Organization', id: 'nio-1', name: 'Acme Trucking' };
+  const nioTags = (m: RulesEngineClaimModel): string[] =>
+    (m.claim.meta?.tag ?? [])
+      .filter((t) => t.system === CLAIM_NON_INSURANCE_PAYER_TAG_SYSTEM)
+      .map((t) => t.code as string);
+
+  it('reads the stamped extension as the organization id, absent when unstamped', () => {
+    const m = makeModel();
+    expect(readField(m, 'nonInsurancePayerId')).toBeUndefined();
+    m.claim.extension = [
+      ...(m.claim.extension ?? []),
+      {
+        url: CLAIM_NON_INSURANCE_PAYER_EXTENSION_URL,
+        valueReference: { reference: 'Organization/nio-1', display: 'Acme Trucking' },
+      },
+    ];
+    expect(readField(m, 'nonInsurancePayerId')).toBe('nio-1');
+  });
+
+  it('stamps the extension + searchable tag from the prefetched organization, replacing a previous payer', () => {
+    const m = makeModel();
+    m.nioOrganizations = new Map([
+      ['nio-1', nioOrg],
+      ['nio-2', { resourceType: 'Organization', id: 'nio-2', name: 'Beta Fleet' }],
+    ]);
+
+    expect(writeField(m, 'nonInsurancePayerId', 'nio-1')).toBe(true);
+    expect(m.claim.extension).toContainEqual({
+      url: CLAIM_NON_INSURANCE_PAYER_EXTENSION_URL,
+      valueReference: { reference: 'Organization/nio-1', display: 'Acme Trucking' },
+    });
+    expect(nioTags(m)).toEqual(['nio-1']);
+    expect(readField(m, 'nonInsurancePayerId')).toBe('nio-1');
+
+    expect(writeField(m, 'nonInsurancePayerId', 'nio-2')).toBe(true);
+    const stamps = (m.claim.extension ?? []).filter((ext) => ext.url === CLAIM_NON_INSURANCE_PAYER_EXTENSION_URL);
+    expect(stamps).toEqual([
+      {
+        url: CLAIM_NON_INSURANCE_PAYER_EXTENSION_URL,
+        valueReference: { reference: 'Organization/nio-2', display: 'Beta Fleet' },
+      },
+    ]);
+    expect(nioTags(m)).toEqual(['nio-2']);
+  });
+
+  it('clears the extension and tag on an empty value, keeping other extensions and tags', () => {
+    const m = makeModel();
+    m.claim.meta = { tag: [{ system: CLAIM_TAG_SYSTEM, code: 'VIP' }] };
+    m.nioOrganizations = new Map([['nio-1', nioOrg]]);
+    expect(writeField(m, 'nonInsurancePayerId', 'nio-1')).toBe(true);
+    const otherExtensions = (m.claim.extension ?? []).filter(
+      (ext) => ext.url !== CLAIM_NON_INSURANCE_PAYER_EXTENSION_URL
+    );
+
+    // Clearing needs no prefetched organization — an empty value always succeeds.
+    m.nioOrganizations = undefined;
+    expect(writeField(m, 'nonInsurancePayerId', '')).toBe(true);
+    expect(m.claim.extension).toEqual(otherExtensions);
+    expect(readField(m, 'nonInsurancePayerId')).toBeUndefined();
+    expect(nioTags(m)).toEqual([]);
+    expect(claimTags(m)).toEqual(['VIP']);
+
+    // A claim whose only extension was the stamp ends with none at all.
+    const bare = makeModel();
+    bare.claim.extension = undefined;
+    bare.nioOrganizations = new Map([['nio-1', nioOrg]]);
+    expect(writeField(bare, 'nonInsurancePayerId', 'nio-1')).toBe(true);
+    expect(writeField(bare, 'nonInsurancePayerId', '')).toBe(true);
+    expect(bare.claim.extension).toBeUndefined();
+  });
+
+  it('fails the write when the organization was not prefetched (missing or not an NIO)', () => {
+    const m = makeModel();
+    const before = structuredClone(m.claim);
+    expect(writeField(m, 'nonInsurancePayerId', 'nio-1')).toBe(false); // nothing prefetched
+    m.nioOrganizations = new Map([['nio-1', nioOrg]]);
+    expect(writeField(m, 'nonInsurancePayerId', 'nio-other')).toBe(false);
+    expect(m.claim).toEqual(before);
   });
 });
 

--- a/packages/zambdas/test/unit/billing/save-billing-rules.test.ts
+++ b/packages/zambdas/test/unit/billing/save-billing-rules.test.ts
@@ -1,5 +1,6 @@
 import Oystehr from '@oystehr/sdk';
 import { Basic, Bundle, List, Organization, Resource } from 'fhir/r4b';
+import { NIO_KIND_CODE, NIO_ORGANIZATION_KIND_SYSTEM } from 'utils/lib/types/data/billing/non-insurance-org.types';
 import { DEFAULT_RULES_ENGINE, RulesEngineType } from 'utils/lib/types/data/billing/rules-engine.constants';
 import { BillingRuleInput } from 'utils/lib/types/data/billing/rules-engine.schemas';
 import {
@@ -256,6 +257,70 @@ describe('save-billing-rules complexValidation (provider/facility refs must exis
 
   it('skips the lookup entirely when no rule sets a provider or facility', async () => {
     await expect(complexValidation(oystehr, params([rule('Plain')]))).resolves.toBeUndefined();
+    expect(batch).not.toHaveBeenCalled();
+  });
+});
+
+describe('save-billing-rules complexValidation (non-insurance organizations must exist)', () => {
+  const nioRule = (name: string, id: string): BillingRuleInput => ({
+    name,
+    description: '',
+    enabled: true,
+    conditional: {
+      branches: [
+        {
+          condition: { type: 'all' },
+          outcome: { type: 'actions', actions: [{ type: 'setField', field: 'nonInsurancePayerId', value: id }] },
+        },
+      ],
+    },
+  });
+
+  // The shape getResourcesFromBatchInlineRequests parses: a batch-response of searchset bundles.
+  const batchResponse = (resources: Resource[]): Bundle => ({
+    resourceType: 'Bundle',
+    type: 'batch-response',
+    entry: resources.map((resource) => ({
+      response: { status: '200', outcome: { resourceType: 'OperationOutcome' as const, id: 'ok', issue: [] } },
+      resource: { resourceType: 'Bundle', type: 'searchset', entry: [{ resource }] } as Bundle,
+    })),
+  });
+
+  const nioOrg = (id: string): Organization => ({
+    resourceType: 'Organization',
+    id,
+    name: `NIO ${id}`,
+    type: [{ coding: [{ system: NIO_ORGANIZATION_KIND_SYSTEM, code: NIO_KIND_CODE }] }],
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    search.mockResolvedValue({ unbundle: () => [] });
+  });
+
+  it('passes when the assigned organization exists and is a non-insurance organization', async () => {
+    batch.mockResolvedValue(batchResponse([nioOrg('nio-1')]));
+    await expect(complexValidation(oystehr, params([nioRule('Stamp employer', 'nio-1')]))).resolves.toBeUndefined();
+    expect(batch).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an organization that does not exist, naming the rule and field', async () => {
+    batch.mockResolvedValue(batchResponse([]));
+    await expect(complexValidation(oystehr, params([nioRule('Stamp employer', 'nio-gone')]))).rejects.toThrow(
+      /rule "Stamp employer" sets "nonInsurancePayerId" to nio-gone — no such organization exists/
+    );
+  });
+
+  it('rejects an organization that is not a non-insurance organization', async () => {
+    const plainOrg: Organization = { resourceType: 'Organization', id: 'org-1', name: 'A payer' };
+    batch.mockResolvedValue(batchResponse([plainOrg]));
+    await expect(complexValidation(oystehr, params([nioRule('Stamp employer', 'org-1')]))).rejects.toThrow(
+      /it is not a non-insurance organization/
+    );
+  });
+
+  it('skips the lookup for clearing actions and rules that set nothing', async () => {
+    await expect(complexValidation(oystehr, params([nioRule('Clear it', ''), rule('Plain')]))).resolves.toBeUndefined();
     expect(batch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Rules in the billing rules engines can now match on the claim's non-insurance organization and set (or clear) it, completing the NIO feature set ([#9322](https://github.com/masslight/ottehr/pull/9322), [#9514](https://github.com/masslight/ottehr/pull/9514)).

## What rules can do

- **Condition on the claim's NIO**: a new "Non-insurance organization" property in the claim group with the reference operators (equals, does not equal, is one of, is not one of, is present, is empty). The rule builder renders a searchable directory picker (same UX as the payer picker).
- **Set or clear the NIO** via the existing "Set a property" action: setting stamps the claim with the same extension + searchable `meta.tag` pair the claim-detail edit writes, so it shows on the claim screens, the claims-list column, and the NIO filter. A blank value clears it.

## How it works

- **Field catalog** (`rules-engine.field-catalog.ts`): new `nonInsurancePayerId` field with a `'nio'` value type, id (UUID) validation, and a `collectSetNioIds` collector shared by save-time validation and the engine prefetch.
- **Claim model**: the reader returns the org id from the claim's NIO extension; the writer stamps or clears the extension + tag pair, taking the display name from the prefetched organization.
- **Engine** (`sub-rules-engine`): `loadNioOrganizations` batch-fetches the organizations named by enabled rules' set actions, keeping only real non-insurance organizations. An id missing from the prefetch (deleted, or not an NIO) fails the rule and holds the claim rather than stamping a bad payer.
- **save-billing-rules**: `validateNioReferencesExist` rejects saves that assign an organization that doesn't exist or isn't a non-insurance organization, naming the rule.
- **Rule builder**: new `NioSelect` component (PayerSelect pattern, backed by `search-billing-non-insurance-orgs`) wired into `FieldValueInput` for conditions and set actions.
- **Docs**: generated `docs/billing-rules-engine.md` regenerated (guarded by the docs freshness test).

## Testing

- `packages/utils` — catalog validation for the new value type (set/condition/clear semantics, UUID check), `collectSetNioIds` dedupe/skip-clears, docs freshness: 37 tests pass.
- `packages/zambdas` — reader/writer coverage (stamp, replace, clear keeps other extensions/tags, missing-prefetch fails and leaves the claim untouched), catalog/claim-model pairing, save-time rejection paths: 150 tests pass.
- `apps/billing` — component tests: the NIO picker renders for both the condition and the set action, and picking an organization stores its id: 22 tests pass.
- Typecheck clean in `utils`, `zambdas`, and `apps/billing`; eslint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsBbwj7TpkY4k8DqRBoVjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsBbwj7TpkY4k8DqRBoVjE)_