### PR TITLE
perf(chart-data): Phase 0 quick wins on get-chart-data (2/6)

### DIFF
--- a/apps/ehr/src/features/visits/AccidentField.tsx
+++ b/apps/ehr/src/features/visits/AccidentField.tsx
@@ -24,7 +24,7 @@ interface FormData {
 export const AccidentField: FC<Props> = ({ readOnly }) => {
   const {
     data: chartDataFields,
-    refetch,
+    setQueryCache,
     isLoading: isChartDataLoading,
   } = useChartFields({
     requestedFields: {
@@ -80,9 +80,14 @@ export const AccidentField: FC<Props> = ({ readOnly }) => {
         }
         if (types.length === 0) {
           if (chartDataFields?.accident != null) {
-            deleteChartData({
-              accident: chartDataFields?.accident,
-            });
+            deleteChartData(
+              {
+                accident: chartDataFields?.accident,
+              },
+              {
+                onSuccess: () => setQueryCache({ accident: undefined }),
+              }
+            );
           }
           return;
         }
@@ -115,13 +120,13 @@ export const AccidentField: FC<Props> = ({ readOnly }) => {
             },
           },
           {
-            onSuccess: () => void refetch(),
+            onSuccess: (data) => setQueryCache({ accident: data.chartData.accident }),
           }
         );
       },
     });
     return () => callback();
-  }, [methods, chartDataFields, deleteChartData, saveChartData, refetch]);
+  }, [methods, chartDataFields, deleteChartData, saveChartData, setQueryCache]);
 
   const disabled = isChartDataLoading || readOnly;
 

--- a/apps/ehr/src/features/visits/in-person/components/follow-up-note/FollowUpNoteDetails.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/follow-up-note/FollowUpNoteDetails.tsx
@@ -10,10 +10,9 @@ import { PrescribedMedicationsContainer } from 'src/features/visits/shared/compo
 import { ProceduresContainer } from 'src/features/visits/shared/components/review-tab/components/ProceduresContainer';
 import { SurgicalHistoryContainer } from 'src/features/visits/shared/components/review-tab/components/SurgicalHistoryContainer';
 import { SectionList } from 'src/features/visits/shared/components/SectionList';
-import { useChartFields } from 'src/features/visits/shared/hooks/useChartFields';
 import { usePatientInstructionsVisibility } from 'src/features/visits/shared/hooks/usePatientInstructionsVisibility';
+import { useProgressNoteChartFields } from 'src/features/visits/shared/hooks/useProgressNoteChartFields';
 import { useAppointmentData, useChartData } from 'src/features/visits/shared/stores/appointment/appointment.store';
-import { progressNoteChartDataRequestedFields } from 'utils/lib/helpers/visit-note/progress-note-chart-data-requested-fields.helper';
 import { NOTE_TYPE } from 'utils/lib/types/api/chart-data/chart-data.types';
 import { LabType } from 'utils/lib/types/data/labs/labs.types';
 import { dataTestIds } from '../../../../../constants/data-test-ids';
@@ -24,7 +23,7 @@ import { InHouseMedicationsContainer } from '../progress-note/InHouseMedications
 
 export const FollowUpNoteDetails: FC = () => {
   const { encounter } = useAppointmentData();
-  const { data: chartFields } = useChartFields({ requestedFields: progressNoteChartDataRequestedFields });
+  const { data: chartFields } = useProgressNoteChartFields();
   const { chartData } = useChartData();
   const { medications: inHouseMedications } = useMedicationAPI();
 

--- a/apps/ehr/src/features/visits/in-person/components/progress-note/HospitalizationContainer.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/progress-note/HospitalizationContainer.tsx
@@ -6,12 +6,12 @@ import {
   SectionHeading,
   useNoteSectionTitleInCardHeader,
 } from 'src/features/visits/shared/components/NoteSectionHeading';
-import { useChartFields } from 'src/features/visits/shared/hooks/useChartFields';
+import { useProgressNoteChartFields } from 'src/features/visits/shared/hooks/useProgressNoteChartFields';
 import { NoteDTO } from 'utils/lib/types/api/chart-data/chart-data.types';
 
 export const HospitalizationContainer: FC<{ notes?: NoteDTO[] }> = ({ notes }) => {
   const titleInCardHeader = useNoteSectionTitleInCardHeader();
-  const { data: chartData } = useChartFields({ requestedFields: { episodeOfCare: {} } });
+  const { data: chartData } = useProgressNoteChartFields();
   const theme = useTheme();
 
   const episodeOfCare = chartData?.episodeOfCare;

--- a/apps/ehr/src/features/visits/in-person/components/progress-note/ProgressNoteDetails.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/progress-note/ProgressNoteDetails.tsx
@@ -31,17 +31,16 @@ import { ReviewOfSystemsContainer } from 'src/features/visits/shared/components/
 import { SurgicalHistoryContainer } from 'src/features/visits/shared/components/review-tab/components/SurgicalHistoryContainer';
 import { RosBody } from 'src/features/visits/shared/components/ros-tab/RosBody';
 import { RosReviewContainer } from 'src/features/visits/shared/components/ros-tab/RosReviewContainer';
-import { useChartFields } from 'src/features/visits/shared/hooks/useChartFields';
 import { useGetAppointmentAccessibility } from 'src/features/visits/shared/hooks/useGetAppointmentAccessibility';
 import { useOystehrAPIClient } from 'src/features/visits/shared/hooks/useOystehrAPIClient';
 import { usePatientInstructionsVisibility } from 'src/features/visits/shared/hooks/usePatientInstructionsVisibility';
+import { useProgressNoteChartFields } from 'src/features/visits/shared/hooks/useProgressNoteChartFields';
 import { useAppointmentData, useChartData } from 'src/features/visits/shared/stores/appointment/appointment.store';
 import { useRosObservationsStore } from 'src/features/visits/shared/stores/appointment/ros-observations.store';
 import { useSignAppointmentMutation } from 'src/features/visits/shared/stores/tracking-board/tracking-board.queries';
 import { isEligibleSupervisor } from 'src/helpers';
 import useEvolveUser from 'src/hooks/useEvolveUser';
 import { INCOMPATIBLE_EXAM_VERSION_MESSAGE } from 'utils/lib/fhir/constants';
-import { progressNoteChartDataRequestedFields } from 'utils/lib/helpers/visit-note/progress-note-chart-data-requested-fields.helper';
 import { examConfig } from 'utils/lib/ottehr-config/examination';
 import { NOTE_TYPE } from 'utils/lib/types/api/chart-data/chart-data.types';
 import { LabType } from 'utils/lib/types/data/labs/labs.types';
@@ -89,7 +88,7 @@ export const ProgressNoteDetails: FC = () => {
   const user = useEvolveUser();
   const navigate = useNavigate();
 
-  const { data: chartFields } = useChartFields({ requestedFields: progressNoteChartDataRequestedFields });
+  const { data: chartFields } = useProgressNoteChartFields();
   const { chartData } = useChartData();
   const { medications: inHouseMedications } = useMedicationAPI();
 

--- a/apps/ehr/src/features/visits/in-person/layout/InPersonLayout.tsx
+++ b/apps/ehr/src/features/visits/in-person/layout/InPersonLayout.tsx
@@ -7,7 +7,7 @@ import {
   lightTheme,
   MeetingProvider,
 } from 'amazon-chime-sdk-component-library-react';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Outlet } from 'react-router-dom';
 import { CommandPaletteInPersonRegistrations } from 'src/components/CommandPaletteRegistrations';
 import { dataTestIds } from 'src/constants/data-test-ids';
@@ -15,12 +15,16 @@ import { useApiClients } from 'src/hooks/useAppClients';
 import { ThemeProvider } from 'styled-components';
 import { isTelemedAppointment } from 'utils/lib/fhir/moduleIdentification';
 import { getSelectors } from 'utils/lib/store';
+import { GetChartDataResponse } from 'utils/lib/types/api/chart-data/get-chart-data.types';
 import { isVisitFinished } from 'utils/lib/utils/visitUtils';
 import { Sidebar } from '../../shared/components/Sidebar';
 import { useAiResourcesPolling } from '../../shared/components/useAiResourcesPolling';
+import { AI_CHAT_REQUESTED_FIELDS } from '../../shared/hooks/aiChartRequests';
 import { useAiSuggestionsPolling } from '../../shared/hooks/useAiSuggestionsPolling';
 import { useAssignedProvider } from '../../shared/hooks/useAssignedProvider';
+import { useChartFields } from '../../shared/hooks/useChartFields';
 import { useGetAppointmentAccessibility } from '../../shared/hooks/useGetAppointmentAccessibility';
+import { useInvalidateChartFieldsOnNavigate } from '../../shared/hooks/useInvalidateChartFieldsOnNavigate';
 import { useResetAppointmentStore } from '../../shared/hooks/useResetAppointmentStore';
 import { useStopAmbientScribeOnLeave } from '../../shared/hooks/useStopAmbientScribeOnLeave';
 import { useAppointmentData, useChartData } from '../../shared/stores/appointment/appointment.store';
@@ -66,7 +70,21 @@ export const InPersonLayout: React.FC = () => {
   // Keep the Ambient Scribe recording alive across rotation; stop & save it on leaving the visit.
   useStopAmbientScribeOnLeave({ hostKey: encounter.id ?? '' });
   const { chartData, refetch: refetchChartData } = useChartData({ shouldUpdateExams: true });
+  useInvalidateChartFieldsOnNavigate();
   const { oystehr } = useApiClients();
+  const aiDocumentCount = chartData?.aiChat?.documents?.length ?? 0;
+  const hasPendingRecording = Boolean(chartData?.aiChat?.hasPendingRecording);
+  // Each poll tick fetches only the AI chat documents; the unscoped chart, which the Ambient Scribe panel
+  // and the sidebar read aiChat from, is refetched once they change rather than on every tick.
+  const { refetch: refetchAiChat } = useChartFields({ requestedFields: AI_CHAT_REQUESTED_FIELDS, enabled: false });
+  const refetchAiResources = useCallback(async (): Promise<void> => {
+    const result = await refetchAiChat();
+    const aiChat = (result.data as Pick<GetChartDataResponse, 'aiChat'> | undefined)?.aiChat;
+    const changed =
+      (aiChat?.documents?.length ?? 0) !== aiDocumentCount ||
+      Boolean(aiChat?.hasPendingRecording) !== hasPendingRecording;
+    if (changed) await refetchChartData();
+  }, [refetchAiChat, refetchChartData, aiDocumentCount, hasPendingRecording]);
   // Mounted here (not in the OttehrAi route) so a pending recording or AI interview keeps getting
   // refetched no matter which tab the provider is on — the Ambient Scribe panel above reads
   // chartData.aiChat straight from the same query cache this refetch loop keeps warm.
@@ -74,9 +92,9 @@ export const InPersonLayout: React.FC = () => {
     appointment,
     encounter,
     oystehr,
-    chartDataHasResources: (chartData?.aiChat?.documents?.length ?? 0) > 0,
-    hasPendingRecording: Boolean(chartData?.aiChat?.hasPendingRecording),
-    onRefetch: refetchChartData,
+    chartDataHasResources: aiDocumentCount > 0,
+    hasPendingRecording,
+    onRefetch: refetchAiResources,
   });
   const { isAssignedProviderEligible, isAssignedProviderStale, assignedProviderName } = useAssignedProvider();
   // A finished visit is a record, not work in progress. The provider gate exists to stop new

--- a/apps/ehr/src/features/visits/in-person/layout/InPersonLayout.tsx
+++ b/apps/ehr/src/features/visits/in-person/layout/InPersonLayout.tsx
@@ -75,7 +75,7 @@ export const InPersonLayout: React.FC = () => {
   const aiDocumentCount = chartData?.aiChat?.documents?.length ?? 0;
   const hasPendingRecording = Boolean(chartData?.aiChat?.hasPendingRecording);
   // Each poll tick fetches only the AI chat documents; the unscoped chart, which the Ambient Scribe panel
-  // and the sidebar read aiChat from, is refetched once they change rather than on every tick.
+  // and the sidebar read aiChat from, is refetched once they change.
   const { refetch: refetchAiChat } = useChartFields({ requestedFields: AI_CHAT_REQUESTED_FIELDS, enabled: false });
   const refetchAiResources = useCallback(async (): Promise<void> => {
     const result = await refetchAiChat();

--- a/apps/ehr/src/features/visits/shared/components/review-tab/AddendumCard.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/AddendumCard.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 import { AccordionCard } from 'src/components/AccordionCard';
 import { PRIVATE_EXTENSION_BASE_URL } from 'utils/lib/fhir/constants';
 import { IN_PERSON_NOTE_ID, NOTE_TYPE } from 'utils/lib/types/api/chart-data/chart-data.types';
-import { useChartFields } from '../../hooks/useChartFields';
+import { useProgressNoteChartFields } from '../../hooks/useProgressNoteChartFields';
 import { BoxStyled } from '../generic-notes-list/components/ui/BoxStyled';
 import { defaultNoteLocales } from '../generic-notes-list/default-note-locales.helper';
 import { GenericNoteList } from '../generic-notes-list/GenericNoteList';
@@ -32,9 +32,7 @@ const addendumNotesConfig: GenericNotesConfig = {
 export const AddendumCard: FC = () => {
   // Surface the legacy single-string addendumNote (Encounter extension) so any pre-existing
   // content still appears after the migration to per-author NoteDTO entries.
-  const { data: legacyFields } = useChartFields({
-    requestedFields: { addendumNote: {} },
-  });
+  const { data: legacyFields } = useProgressNoteChartFields();
   const legacyAddendumText = legacyFields?.addendumNote?.text;
 
   return (

--- a/apps/ehr/src/features/visits/shared/components/review-tab/MissingCard.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/MissingCard.tsx
@@ -34,9 +34,9 @@ import {
 } from 'src/state/draft-data.store';
 import { safelyCaptureException } from 'utils/lib/frontend/sentry';
 import { AISuggestionNotes } from 'utils/lib/types/api/ai-suggestions-notes';
-import { useChartFields } from '../../hooks/useChartFields';
 import { useGetAppointmentAccessibility } from '../../hooks/useGetAppointmentAccessibility';
 import { useOystehrAPIClient } from '../../hooks/useOystehrAPIClient';
+import { useProgressNoteChartFields } from '../../hooks/useProgressNoteChartFields';
 import { useAiSuggestionNotes } from '../../stores/appointment/appointment.queries';
 import { useAppointmentData, useChartData } from '../../stores/appointment/appointment.store';
 import {
@@ -78,27 +78,7 @@ export const MissingCard: FC = () => {
   const { hasDraft: hasMedDraft } = useInHouseMedicationOrderStore();
   const { hasDraft: hasVitalsDraft } = useVitalsDraftStore();
 
-  const {
-    data: chartFields,
-    isFetching,
-    isFetched: isChartFieldsFetched,
-  } = useChartFields({
-    requestedFields: {
-      medicalDecision: {
-        _tag: 'medical-decision',
-      },
-      chiefComplaint: {
-        _tag: 'chief-complaint',
-      },
-      historyOfPresentIllness: {
-        _tag: 'history-of-present-illness',
-      },
-      patientInfoConfirmed: {},
-      accident: {
-        _tag: 'accident',
-      },
-    },
-  });
+  const { data: chartFields, isFetching, isFetched: isChartFieldsFetched } = useProgressNoteChartFields();
 
   const { mutateAsync: aiSuggestionNotes } = useAiSuggestionNotes();
   const { data: progressNoteConfig } = useProgressNoteConfig();

--- a/apps/ehr/src/features/visits/shared/components/review-tab/ReviewAndSignButton.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/ReviewAndSignButton.tsx
@@ -30,9 +30,9 @@ import { getInPersonVisitStatus, getSupervisorApprovalStatus } from 'utils/lib/u
 import { ConfirmationDialog } from '../../../../../components/ConfirmationDialog';
 import { RoundedButton } from '../../../../../components/RoundedButton';
 import { useAssignedProvider } from '../../hooks/useAssignedProvider';
-import { useChartFields } from '../../hooks/useChartFields';
 import { useGetAppointmentAccessibility } from '../../hooks/useGetAppointmentAccessibility';
 import { useOystehrAPIClient } from '../../hooks/useOystehrAPIClient';
+import { useProgressNoteChartFields } from '../../hooks/useProgressNoteChartFields';
 import { useAppointmentData, useChartData } from '../../stores/appointment/appointment.store';
 import { useSignAppointmentMutation } from '../../stores/tracking-board/tracking-board.queries';
 
@@ -54,24 +54,7 @@ export const ReviewAndSignButton: FC<ReviewAndSignButtonProps> = ({ onSigned }) 
   const { hasDraft: hasMedDraft } = useInHouseMedicationOrderStore();
   const { hasDraft: hasVitalsDraft } = useVitalsDraftStore();
 
-  const { data: chartFields } = useChartFields({
-    requestedFields: {
-      medicalDecision: {
-        _tag: 'medical-decision',
-      },
-      chiefComplaint: {
-        _tag: 'chief-complaint',
-      },
-      historyOfPresentIllness: {
-        _tag: 'history-of-present-illness',
-      },
-      accident: {
-        _tag: 'accident',
-      },
-      inHouseLabResults: {},
-      patientInfoConfirmed: {},
-    },
-  });
+  const { data: chartFields } = useProgressNoteChartFields();
 
   const apiClient = useOystehrAPIClient();
   const { isAssignedProviderEligible } = useAssignedProvider();

--- a/apps/ehr/src/features/visits/shared/components/review-tab/components/AssessmentGroupContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/components/AssessmentGroupContainer.tsx
@@ -8,7 +8,7 @@ import {
   useNoteSectionTitleInCardHeader,
 } from 'src/features/visits/shared/components/NoteSectionHeading';
 import { makeCptCodeDisplay } from 'utils/lib/fhir/helpers';
-import { useChartFields } from '../../../hooks/useChartFields';
+import { useProgressNoteChartFields } from '../../../hooks/useProgressNoteChartFields';
 import { useChartData } from '../../../stores/appointment/appointment.store';
 
 export const AssessmentGroupContainer: FC = () => {
@@ -16,13 +16,7 @@ export const AssessmentGroupContainer: FC = () => {
   const { chartData } = useChartData();
   const theme = useTheme();
 
-  const { data: chartFields } = useChartFields({
-    requestedFields: {
-      medicalDecision: {
-        _tag: 'medical-decision',
-      },
-    },
-  });
+  const { data: chartFields } = useProgressNoteChartFields();
 
   const diagnoses = chartData?.diagnosis;
   const primaryDiagnosis = diagnoses?.find((item) => item.isPrimary);

--- a/apps/ehr/src/features/visits/shared/components/review-tab/components/ChiefComplaintContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/components/ChiefComplaintContainer.tsx
@@ -8,7 +8,7 @@ import {
 } from 'src/features/visits/shared/components/NoteSectionHeading';
 import { getSpentTime } from 'utils/lib/fhir/encounter';
 import { isTelemedAppointment } from 'utils/lib/fhir/moduleIdentification';
-import { useChartFields } from '../../../hooks/useChartFields';
+import { useProgressNoteChartFields } from '../../../hooks/useProgressNoteChartFields';
 import { useAppointmentData, useChartData } from '../../../stores/appointment/appointment.store';
 
 // Chief complaint groups everything captured on the Chief Complaint screen: the reason for
@@ -19,14 +19,7 @@ export const ChiefComplaintContainer: FC = () => {
   const { chartData } = useChartData();
   const theme = useTheme();
 
-  const { data: chartFields } = useChartFields({
-    requestedFields: {
-      historyOfPresentIllness: {
-        _tag: 'history-of-present-illness',
-      },
-      reasonForVisit: {},
-    },
-  });
+  const { data: chartFields } = useProgressNoteChartFields();
 
   // Legacy tagging: the "additional information" free text is stored under the
   // history-of-present-illness tag.

--- a/apps/ehr/src/features/visits/shared/components/review-tab/components/HpiMoiContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/components/HpiMoiContainer.tsx
@@ -7,7 +7,7 @@ import {
   useNoteSectionTitleInCardHeader,
 } from 'src/features/visits/shared/components/NoteSectionHeading';
 import { formatISODateToLocaleDate } from 'src/helpers/formatDateTime';
-import { useChartFields } from '../../../hooks/useChartFields';
+import { useProgressNoteChartFields } from '../../../hooks/useProgressNoteChartFields';
 
 // Matches the checkbox labels on the HPI screen's "Patient's condition related to" card.
 const ACCIDENT_TYPE_LABELS: Record<string, string> = {
@@ -20,19 +20,7 @@ export const HpiMoiContainer: FC = () => {
   const titleInCardHeader = useNoteSectionTitleInCardHeader();
   const theme = useTheme();
 
-  const { data: chartFields } = useChartFields({
-    requestedFields: {
-      chiefComplaint: {
-        _tag: 'chief-complaint',
-      },
-      mechanismOfInjury: {
-        _tag: 'mechanism-of-injury',
-      },
-      accident: {
-        _tag: 'accident',
-      },
-    },
-  });
+  const { data: chartFields } = useProgressNoteChartFields();
 
   // Legacy tagging: the history of present illness text is stored under the
   // chief-complaint tag.

--- a/apps/ehr/src/features/visits/shared/components/review-tab/components/PatientInstructionsContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/components/PatientInstructionsContainer.tsx
@@ -20,15 +20,13 @@ import {
   REFUSAL_OF_EMS_TRANSPORT_FIELD,
   REFUSAL_OF_EMS_TRANSPORT_LABEL,
 } from 'utils/lib/types/api/chart-data/chart-data.types';
-import { useChartFields } from '../../../hooks/useChartFields';
 import { usePatientInstructionsVisibility } from '../../../hooks/usePatientInstructionsVisibility';
+import { useProgressNoteChartFields } from '../../../hooks/useProgressNoteChartFields';
 import { useChartData } from '../../../stores/appointment/appointment.store';
 
 export const PatientInstructionsContainer: FC = () => {
   const titleInCardHeader = useNoteSectionTitleInCardHeader();
-  const { data: chartFields } = useChartFields({
-    requestedFields: { disposition: {} },
-  });
+  const { data: chartFields } = useProgressNoteChartFields();
 
   const { chartData } = useChartData();
 

--- a/apps/ehr/src/features/visits/shared/components/review-tab/components/PrescribedMedicationsContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/components/PrescribedMedicationsContainer.tsx
@@ -7,15 +7,13 @@ import {
 } from 'src/features/visits/shared/components/NoteSectionHeading';
 import { useApiClients } from 'src/hooks/useAppClients';
 import { formatPhoneNumberDisplay, formatZipcodeForDisplay } from 'utils/lib/helpers/helpers';
-import { useChartFields } from '../../../hooks/useChartFields';
+import { useProgressNoteChartFields } from '../../../hooks/useProgressNoteChartFields';
 import { PrescribedMedicationReviewItem } from './PrescribedMedicationReviewItem';
 
 export const PrescribedMedicationsContainer: FC = () => {
   const titleInCardHeader = useNoteSectionTitleInCardHeader();
   const { oystehr } = useApiClients();
-  const { data: chartFields } = useChartFields({
-    requestedFields: { prescribedMedications: {} },
-  });
+  const { data: chartFields } = useProgressNoteChartFields();
 
   const prescriptions = chartFields?.prescribedMedications;
 

--- a/apps/ehr/src/features/visits/shared/components/review-tab/components/ReviewOfSystemsContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/components/ReviewOfSystemsContainer.tsx
@@ -5,14 +5,14 @@ import {
   SectionHeading,
   useNoteSectionTitleInCardHeader,
 } from 'src/features/visits/shared/components/NoteSectionHeading';
-import { useChartFields } from '../../../hooks/useChartFields';
+import { useProgressNoteChartFields } from '../../../hooks/useProgressNoteChartFields';
 
 /**
  * Legacy container for charts with ros data saved via the free text field.
  */
 export const ReviewOfSystemsContainer: FC = () => {
   const titleInCardHeader = useNoteSectionTitleInCardHeader();
-  const { data: chartFields } = useChartFields({ requestedFields: { ros: { _tag: 'ros' } } });
+  const { data: chartFields } = useProgressNoteChartFields();
   const ros = chartFields?.ros?.text;
 
   if (!ros) return null;

--- a/apps/ehr/src/features/visits/shared/components/review-tab/components/SurgicalHistoryContainer.tsx
+++ b/apps/ehr/src/features/visits/shared/components/review-tab/components/SurgicalHistoryContainer.tsx
@@ -7,18 +7,12 @@ import {
 } from 'src/features/visits/shared/components/NoteSectionHeading';
 import { NoteDTO } from 'utils/lib/types/api/chart-data/chart-data.types';
 import { AssessmentTitle } from '../../../../../../components/AssessmentTitle';
-import { useChartFields } from '../../../hooks/useChartFields';
+import { useProgressNoteChartFields } from '../../../hooks/useProgressNoteChartFields';
 import { useChartData } from '../../../stores/appointment/appointment.store';
 
 export const SurgicalHistoryContainer: FC<{ notes?: NoteDTO[] }> = ({ notes }) => {
   const titleInCardHeader = useNoteSectionTitleInCardHeader();
-  const { data: chartFields } = useChartFields({
-    requestedFields: {
-      surgicalHistoryNote: {
-        _tag: 'surgical-history-note',
-      },
-    },
-  });
+  const { data: chartFields } = useProgressNoteChartFields();
 
   const { chartData } = useChartData();
 

--- a/apps/ehr/src/features/visits/shared/hooks/aiChartRequests.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/aiChartRequests.ts
@@ -1,0 +1,16 @@
+import { PRIVATE_EXTENSION_BASE_URL } from 'utils/lib/fhir/constants';
+import { AI_OBSERVATION_META_SYSTEM } from 'utils/lib/types/api/chart-data/chart-data.types';
+import { ChartDataRequestedFields } from 'utils/lib/types/api/chart-data/get-chart-data.types';
+
+/**
+ * Narrow get-chart-data requests for the two AI polling loops. Both used to re-run the unscoped default
+ * set (thirteen FHIR searches) on every tick; these cost two searches each.
+ */
+
+/** The AI consult-note documents and the pending-recording marker. */
+export const AI_CHAT_REQUESTED_FIELDS: ChartDataRequestedFields = { aiChat: {} };
+
+/** The AI suggestion Observations only: the tag system alone matches every AI observation field. */
+export const AI_SUGGESTIONS_REQUESTED_FIELDS: ChartDataRequestedFields = {
+  observations: { _search_by: 'encounter', _tag: `${PRIVATE_EXTENSION_BASE_URL}/${AI_OBSERVATION_META_SYSTEM}|` },
+};

--- a/apps/ehr/src/features/visits/shared/hooks/aiChartRequests.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/aiChartRequests.ts
@@ -2,10 +2,7 @@ import { PRIVATE_EXTENSION_BASE_URL } from 'utils/lib/fhir/constants';
 import { AI_OBSERVATION_META_SYSTEM } from 'utils/lib/types/api/chart-data/chart-data.types';
 import { ChartDataRequestedFields } from 'utils/lib/types/api/chart-data/get-chart-data.types';
 
-/**
- * Narrow get-chart-data requests for the two AI polling loops. Both used to re-run the unscoped default
- * set (thirteen FHIR searches) on every tick; these cost two searches each.
- */
+/** Narrow get-chart-data requests for the two AI polling loops; each costs two FHIR searches. */
 
 /** The AI consult-note documents and the pending-recording marker. */
 export const AI_CHAT_REQUESTED_FIELDS: ChartDataRequestedFields = { aiChat: {} };

--- a/apps/ehr/src/features/visits/shared/hooks/useAiSuggestionsPolling.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useAiSuggestionsPolling.ts
@@ -44,22 +44,41 @@ export const useAiSuggestionsPolling = (): void => {
 
     const baseline = aiSuggestionCountRef.current;
     let attempts = 0;
+    let inFlight = false;
+    let stopped = false;
     const intervalId = setInterval(async () => {
+      // One request at a time: a slow response skips ticks instead of stacking requests.
+      if (inFlight) {
+        return;
+      }
       attempts += 1;
       if (attempts > MAX_POLL_ATTEMPTS) {
+        stopped = true;
         clearInterval(intervalId);
         return;
       }
-      const result = await refetchAiSuggestions();
-      const latest = countAiSuggestions(
-        (result.data as Pick<GetChartDataResponse, 'observations'> | undefined)?.observations
-      );
-      if (latest > baseline) {
-        clearInterval(intervalId);
-        void refetch();
+      inFlight = true;
+      try {
+        const result = await refetchAiSuggestions();
+        if (stopped) {
+          return;
+        }
+        const latest = countAiSuggestions(
+          (result.data as Pick<GetChartDataResponse, 'observations'> | undefined)?.observations
+        );
+        if (latest > baseline) {
+          stopped = true;
+          clearInterval(intervalId);
+          void refetch();
+        }
+      } finally {
+        inFlight = false;
       }
     }, POLL_INTERVAL_MS);
 
-    return () => clearInterval(intervalId);
+    return () => {
+      stopped = true;
+      clearInterval(intervalId);
+    };
   }, [endedCallCount, refetch, refetchAiSuggestions]);
 };

--- a/apps/ehr/src/features/visits/shared/hooks/useAiSuggestionsPolling.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useAiSuggestionsPolling.ts
@@ -1,26 +1,37 @@
 import { useEffect, useRef } from 'react';
 import { getSelectors } from 'utils/lib/store';
 import { AiObservationField } from 'utils/lib/types/api/chart-data/chart-data.constants';
+import { GetChartDataResponse } from 'utils/lib/types/api/chart-data/get-chart-data.types';
 import { useVideoCallStore } from '../../telemed/state/video-call/video-call.store';
 import { useChartData } from '../stores/appointment/appointment.store';
+import { AI_SUGGESTIONS_REQUESTED_FIELDS } from './aiChartRequests';
+import { useChartFields } from './useChartFields';
 
 const POLL_INTERVAL_MS = 30_000;
 const MAX_POLL_ATTEMPTS = 20; // ~10 minutes
 
 const AI_OBSERVATION_FIELDS = Object.values(AiObservationField) as string[];
 
+const countAiSuggestions = (observations: GetChartDataResponse['observations']): number =>
+  (observations ?? []).filter((observation) => AI_OBSERVATION_FIELDS.includes(observation.field)).length;
+
 // After the provider ends a telemed call (oystehr.telemed.endMeeting), the recording pipeline transcribes
-// the audio and creates AI suggestion Observations within a few minutes. Poll chart data until they appear
+// the audio and creates AI suggestion Observations within a few minutes. Poll for them until they appear
 // so suggestions show up without a manual page reload. A visit can have multiple calls, so we re-poll on
 // every call end (endedCallCount) and stop once this call's suggestions land (count grows past the baseline)
 // rather than keying on "any suggestions exist" — otherwise a later call would never be polled for.
+//
+// Each tick fetches only the AI suggestion Observations; the unscoped chart, which is where the UI reads
+// the suggestions from, is refetched once when they have arrived.
 export const useAiSuggestionsPolling = (): void => {
   const { endedCallCount } = getSelectors(useVideoCallStore, ['endedCallCount']);
   const { chartData, refetch } = useChartData();
+  const { refetch: refetchAiSuggestions } = useChartFields({
+    requestedFields: AI_SUGGESTIONS_REQUESTED_FIELDS,
+    enabled: false,
+  });
 
-  const aiSuggestionCount = (chartData?.observations ?? []).filter((observation) =>
-    AI_OBSERVATION_FIELDS.includes(observation.field)
-  ).length;
+  const aiSuggestionCount = countAiSuggestions(chartData?.observations);
   // Keep the latest count in a ref so the interval reads fresh values without re-running the effect
   // (which would reset the poll window on every chart refetch).
   const aiSuggestionCountRef = useRef(aiSuggestionCount);
@@ -33,15 +44,22 @@ export const useAiSuggestionsPolling = (): void => {
 
     const baseline = aiSuggestionCountRef.current;
     let attempts = 0;
-    const intervalId = setInterval(() => {
+    const intervalId = setInterval(async () => {
       attempts += 1;
-      if (aiSuggestionCountRef.current > baseline || attempts > MAX_POLL_ATTEMPTS) {
+      if (attempts > MAX_POLL_ATTEMPTS) {
         clearInterval(intervalId);
         return;
       }
-      void refetch();
+      const result = await refetchAiSuggestions();
+      const latest = countAiSuggestions(
+        (result.data as Pick<GetChartDataResponse, 'observations'> | undefined)?.observations
+      );
+      if (latest > baseline) {
+        clearInterval(intervalId);
+        void refetch();
+      }
     }, POLL_INTERVAL_MS);
 
     return () => clearInterval(intervalId);
-  }, [endedCallCount, refetch]);
+  }, [endedCallCount, refetch, refetchAiSuggestions]);
 };

--- a/apps/ehr/src/features/visits/shared/hooks/useChartDataArrayValue.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useChartDataArrayValue.ts
@@ -2,7 +2,12 @@ import { enqueueSnackbar } from 'notistack';
 import { SearchParams } from 'utils/lib/fhir/uri';
 import { SaveableDTO } from 'utils/lib/types/api/chart-data/chart-data.types';
 import { GetChartDataResponse } from 'utils/lib/types/api/chart-data/get-chart-data.types';
-import { useChartData, useDeleteChartData, useSaveChartData } from '../stores/appointment/appointment.store';
+import {
+  ChartDataResponse,
+  useChartData,
+  useDeleteChartData,
+  useSaveChartData,
+} from '../stores/appointment/appointment.store';
 import { useChartFields } from './useChartFields';
 
 type ChartDataArrayValueType = Pick<
@@ -36,7 +41,7 @@ export const useChartDataArrayValue = <
 } => {
   const { mutate: saveChartData, isPending: isSaveLoading } = useSaveChartData();
   const { mutate: deleteChartData, isPending: isDeleteLoading } = useDeleteChartData();
-  const { chartData, refetch } = useChartData();
+  const { chartData, setPartialChartData } = useChartData();
 
   const {
     isLoading: isChartDataLoading,
@@ -47,9 +52,15 @@ export const useChartDataArrayValue = <
     enabled: !!customParams,
   });
 
-  const values = (
-    customParams ? currentFieldData?.[name] || [] : (chartData as ChartDataArrayValueType)?.[name] || []
-  ) as K;
+  const unscopedValues = ((chartData as ChartDataArrayValueType)?.[name] || []) as K & SaveableDTO[];
+  const values = (customParams ? currentFieldData?.[name] || [] : unscopedValues) as K;
+
+  // Both caches are patched from the save/delete response instead of re-running the unscoped chart's
+  // thirteen FHIR searches after every change. The unscoped query is marked stale (not refetched) so the
+  // next screen that mounts it still starts from the server.
+  const patchUnscopedChart = (next: SaveableDTO[]): void => {
+    setPartialChartData({ [name]: next } as Partial<ChartDataResponse>, { invalidateQueries: false });
+  };
 
   const onSubmit = (data: ElementType<K>): Promise<boolean> => {
     return new Promise((resolve, reject) => {
@@ -58,14 +69,14 @@ export const useChartDataArrayValue = <
           [name]: [data],
         },
         {
-          onSuccess: async (data) => {
+          onSuccess: (data) => {
+            const saved = (data.chartData[name] ?? []) as unknown as SaveableDTO[];
             if (customParams) {
               setQueryCache({
-                [name]: [...(currentFieldData?.[name] || []), ...(data.chartData[name] as K)],
+                [name]: [...((currentFieldData?.[name] || []) as unknown as SaveableDTO[]), ...saved],
               });
             }
-
-            await refetch();
+            patchUnscopedChart([...unscopedValues, ...saved]);
             resolve(true);
           },
           onError: (error) => {
@@ -89,16 +100,15 @@ export const useChartDataArrayValue = <
         [name]: newState,
       },
       {
-        onSuccess: async (_data) => {
+        onSuccess: () => {
+          const withoutRemoved = (items: SaveableDTO[] | undefined): SaveableDTO[] =>
+            (items || []).filter((value) => value.resourceId !== resourceId);
           if (customParams) {
             setQueryCache({
-              [name]: ((currentFieldData?.[name] || []) as unknown as K & SaveableDTO[]).filter(
-                (value) => value.resourceId !== resourceId
-              ),
+              [name]: withoutRemoved(currentFieldData?.[name] as unknown as SaveableDTO[] | undefined),
             });
           }
-
-          await refetch();
+          patchUnscopedChart(withoutRemoved(unscopedValues));
           onRemoveCallback?.();
         },
         onError: () => {

--- a/apps/ehr/src/features/visits/shared/hooks/useChartDataArrayValue.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useChartDataArrayValue.ts
@@ -56,7 +56,7 @@ export const useChartDataArrayValue = <
   const values = (customParams ? currentFieldData?.[name] || [] : unscopedValues) as K;
 
   // Both caches are patched from the save/delete response instead of re-running the unscoped chart's
-  // thirteen FHIR searches after every change. The unscoped query is marked stale (not refetched) so the
+  // many FHIR searches after every change. The unscoped query is marked stale (not refetched) so the
   // next screen that mounts it still starts from the server.
   const patchUnscopedChart = (next: SaveableDTO[]): void => {
     setPartialChartData({ [name]: next } as Partial<ChartDataResponse>, { invalidateQueries: false });

--- a/apps/ehr/src/features/visits/shared/hooks/useChartDataArrayValue.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useChartDataArrayValue.ts
@@ -55,10 +55,9 @@ export const useChartDataArrayValue = <
   const unscopedValues = ((chartData as ChartDataArrayValueType)?.[name] || []) as K & SaveableDTO[];
   const values = (customParams ? currentFieldData?.[name] || [] : unscopedValues) as K;
 
-  // Both caches are patched from the save/delete response instead of re-running the unscoped chart's
-  // many FHIR searches after every change. Each patch reads the cache's current value, so two responses
-  // that land before a re-render both apply. The unscoped query is marked stale (not refetched) so the
-  // next screen that mounts it still starts from the server.
+  // Both caches are patched from the save/delete response. Each patch reads the cache's current value, so
+  // two responses that land before a re-render both apply. The unscoped query is marked stale (not
+  // refetched) so the next screen that mounts it starts from the server.
   const patchCaches = (update: (current: SaveableDTO[]) => SaveableDTO[]): void => {
     if (customParams) {
       setQueryCache(
@@ -87,7 +86,8 @@ export const useChartDataArrayValue = <
         {
           onSuccess: (data) => {
             const saved = (data.chartData[name] ?? []) as unknown as SaveableDTO[];
-            patchCaches((current) => [...current, ...saved]);
+            // Items without a resourceId are a caller's optimistic placeholders; the saved items take their place.
+            patchCaches((current) => [...current.filter((item) => item.resourceId !== undefined), ...saved]);
             resolve(true);
           },
           onError: (error) => {

--- a/apps/ehr/src/features/visits/shared/hooks/useChartDataArrayValue.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useChartDataArrayValue.ts
@@ -41,7 +41,7 @@ export const useChartDataArrayValue = <
 } => {
   const { mutate: saveChartData, isPending: isSaveLoading } = useSaveChartData();
   const { mutate: deleteChartData, isPending: isDeleteLoading } = useDeleteChartData();
-  const { chartData, setPartialChartData } = useChartData();
+  const { chartData, chartDataSetState } = useChartData();
 
   const {
     isLoading: isChartDataLoading,
@@ -56,10 +56,26 @@ export const useChartDataArrayValue = <
   const values = (customParams ? currentFieldData?.[name] || [] : unscopedValues) as K;
 
   // Both caches are patched from the save/delete response instead of re-running the unscoped chart's
-  // many FHIR searches after every change. The unscoped query is marked stale (not refetched) so the
+  // many FHIR searches after every change. Each patch reads the cache's current value, so two responses
+  // that land before a re-render both apply. The unscoped query is marked stale (not refetched) so the
   // next screen that mounts it still starts from the server.
-  const patchUnscopedChart = (next: SaveableDTO[]): void => {
-    setPartialChartData({ [name]: next } as Partial<ChartDataResponse>, { invalidateQueries: false });
+  const patchCaches = (update: (current: SaveableDTO[]) => SaveableDTO[]): void => {
+    if (customParams) {
+      setQueryCache(
+        (state) =>
+          ({ [name]: update(((state as Record<string, unknown>)?.[name] ?? []) as SaveableDTO[]) }) as Partial<
+            typeof state
+          >
+      );
+    }
+    chartDataSetState(
+      (state) => {
+        const current = ((state.chartData as ChartDataArrayValueType | undefined)?.[name] ?? []) as SaveableDTO[];
+        const next = { [name]: update(current) } as Partial<ChartDataResponse>;
+        return { chartData: { ...state.chartData, patientId: state.chartData?.patientId || '', ...next } };
+      },
+      { invalidateQueries: false }
+    );
   };
 
   const onSubmit = (data: ElementType<K>): Promise<boolean> => {
@@ -71,12 +87,7 @@ export const useChartDataArrayValue = <
         {
           onSuccess: (data) => {
             const saved = (data.chartData[name] ?? []) as unknown as SaveableDTO[];
-            if (customParams) {
-              setQueryCache({
-                [name]: [...((currentFieldData?.[name] || []) as unknown as SaveableDTO[]), ...saved],
-              });
-            }
-            patchUnscopedChart([...unscopedValues, ...saved]);
+            patchCaches((current) => [...current, ...saved]);
             resolve(true);
           },
           onError: (error) => {
@@ -101,14 +112,7 @@ export const useChartDataArrayValue = <
       },
       {
         onSuccess: () => {
-          const withoutRemoved = (items: SaveableDTO[] | undefined): SaveableDTO[] =>
-            (items || []).filter((value) => value.resourceId !== resourceId);
-          if (customParams) {
-            setQueryCache({
-              [name]: withoutRemoved(currentFieldData?.[name] as unknown as SaveableDTO[] | undefined),
-            });
-          }
-          patchUnscopedChart(withoutRemoved(unscopedValues));
+          patchCaches((current) => current.filter((value) => value.resourceId !== resourceId));
           onRemoveCallback?.();
         },
         onError: () => {

--- a/apps/ehr/src/features/visits/shared/hooks/useChartFields.test.tsx
+++ b/apps/ehr/src/features/visits/shared/hooks/useChartFields.test.tsx
@@ -4,13 +4,17 @@
 
 import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import { act, render, renderHook, waitFor } from '@testing-library/react';
-import { ReactNode } from 'react';
+import { FC, ReactNode } from 'react';
 import { VitalsObservationDTO } from 'utils/lib/types/api/chart-data/chart-data.types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChartFields } from './useChartFields';
+import { useInvalidateChartFieldsOnNavigate } from './useInvalidateChartFieldsOnNavigate';
+
+const route = vi.hoisted(() => ({ pathname: '/in-person/appointment-123/review-and-sign' }));
 
 vi.mock('react-router-dom', () => ({
   useParams: vi.fn().mockReturnValue({ id: 'appointment-123' }),
+  useLocation: () => ({ pathname: route.pathname }),
 }));
 
 vi.mock('src/hooks/useEvolveUser', () => ({
@@ -1100,5 +1104,48 @@ describe('useChartDataField - Advanced Cache Management', () => {
 
       expect(renderSpy).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('useInvalidateChartFieldsOnNavigate', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    route.pathname = '/in-person/appointment-123/review-and-sign';
+    const { useOystehrAPIClient } = await import('./useOystehrAPIClient');
+    vi.mocked(useOystehrAPIClient).mockReturnValue(mockApiClient);
+    mockApiClient.getChartData.mockResolvedValue(mockChartData);
+  });
+
+  it('marks the chart fields stale before the next screen subscribes, so that screen re-reads them', async () => {
+    const requestedFields = { episodeOfCare: {} };
+    /** A screen reading a field set; the next screen reads the same set through a fresh mount. */
+    const Screen: FC = () => {
+      useChartFields({ requestedFields });
+      return null;
+    };
+    /** The layout around every screen, as InPersonLayout mounts the hook. */
+    const Layout: FC<{ screen: string }> = ({ screen }) => {
+      useInvalidateChartFieldsOnNavigate();
+      return <Screen key={screen} />;
+    };
+    const Wrapper = createWrapper();
+
+    const { rerender } = render(
+      <Wrapper>
+        <Layout screen="review-and-sign" />
+      </Wrapper>
+    );
+    await waitFor(() => expect(mockApiClient.getChartData).toHaveBeenCalledTimes(1));
+
+    // The data is fresh within staleTime; only the screen change makes the next screen read it again. The
+    // new screen's query subscribes in a passive effect that runs before the layout's, so the stale mark
+    // has to land in a layout effect to be seen.
+    route.pathname = '/in-person/appointment-123/hospitalization';
+    rerender(
+      <Wrapper>
+        <Layout screen="hospitalization" />
+      </Wrapper>
+    );
+    await waitFor(() => expect(mockApiClient.getChartData).toHaveBeenCalledTimes(2));
   });
 });

--- a/apps/ehr/src/features/visits/shared/hooks/useChartFields.test.tsx
+++ b/apps/ehr/src/features/visits/shared/hooks/useChartFields.test.tsx
@@ -10,7 +10,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChartFields } from './useChartFields';
 import { useInvalidateChartFieldsOnNavigate } from './useInvalidateChartFieldsOnNavigate';
 
-const route = vi.hoisted(() => ({ pathname: '/in-person/appointment-123/review-and-sign' }));
+const route = vi.hoisted(() => ({
+  pathname: '/in-person/appointment-123/review-and-sign',
+  encounterId: 'encounter-123',
+}));
 
 vi.mock('react-router-dom', () => ({
   useParams: vi.fn().mockReturnValue({ id: 'appointment-123' }),
@@ -30,9 +33,7 @@ vi.mock('./useGetAppointmentAccessibility', () => ({
 }));
 
 vi.mock('../stores/appointment/appointment.store', () => ({
-  useAppointmentData: vi.fn().mockReturnValue({
-    encounter: { id: 'encounter-123' },
-  }),
+  useAppointmentData: vi.fn(() => ({ encounter: { id: route.encounterId } })),
 }));
 
 vi.mock('utils/lib/frontend', async (importOriginal) => {
@@ -1111,23 +1112,28 @@ describe('useInvalidateChartFieldsOnNavigate', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     route.pathname = '/in-person/appointment-123/review-and-sign';
+    route.encounterId = 'encounter-123';
     const { useOystehrAPIClient } = await import('./useOystehrAPIClient');
     vi.mocked(useOystehrAPIClient).mockReturnValue(mockApiClient);
     mockApiClient.getChartData.mockResolvedValue(mockChartData);
+    // Earlier tests pin the encounter with mockReturnValue, which clearAllMocks keeps; read the route again.
+    const { useAppointmentData } = await import('../stores/appointment/appointment.store');
+    vi.mocked(useAppointmentData).mockReset();
+    vi.mocked(useAppointmentData).mockImplementation((() => ({ encounter: { id: route.encounterId } })) as any);
   });
 
+  /** A screen reading a field set; the next screen reads the same set through a fresh mount. */
+  const Screen: FC = () => {
+    useChartFields({ requestedFields: { episodeOfCare: {} } });
+    return null;
+  };
+  /** The layout around every screen, as InPersonLayout mounts the hook. */
+  const Layout: FC<{ screen: string }> = ({ screen }) => {
+    useInvalidateChartFieldsOnNavigate();
+    return <Screen key={screen} />;
+  };
+
   it('marks the chart fields stale before the next screen subscribes, so that screen re-reads them', async () => {
-    const requestedFields = { episodeOfCare: {} };
-    /** A screen reading a field set; the next screen reads the same set through a fresh mount. */
-    const Screen: FC = () => {
-      useChartFields({ requestedFields });
-      return null;
-    };
-    /** The layout around every screen, as InPersonLayout mounts the hook. */
-    const Layout: FC<{ screen: string }> = ({ screen }) => {
-      useInvalidateChartFieldsOnNavigate();
-      return <Screen key={screen} />;
-    };
     const Wrapper = createWrapper();
 
     const { rerender } = render(
@@ -1137,9 +1143,7 @@ describe('useInvalidateChartFieldsOnNavigate', () => {
     );
     await waitFor(() => expect(mockApiClient.getChartData).toHaveBeenCalledTimes(1));
 
-    // The data is fresh within staleTime; only the screen change makes the next screen read it again. The
-    // new screen's query subscribes in a passive effect that runs before the layout's, so the stale mark
-    // has to land in a layout effect to be seen.
+    // The data is fresh within staleTime; only the screen change makes the next screen read it again.
     route.pathname = '/in-person/appointment-123/hospitalization';
     rerender(
       <Wrapper>
@@ -1147,5 +1151,32 @@ describe('useInvalidateChartFieldsOnNavigate', () => {
       </Wrapper>
     );
     await waitFor(() => expect(mockApiClient.getChartData).toHaveBeenCalledTimes(2));
+  });
+
+  it("re-reads a returning encounter's chart fields when the encounter changes without a route change", async () => {
+    const Wrapper = createWrapper();
+    const { rerender } = render(
+      <Wrapper>
+        <Layout screen="a" />
+      </Wrapper>
+    );
+    await waitFor(() => expect(mockApiClient.getChartData).toHaveBeenCalledTimes(1));
+
+    route.encounterId = 'encounter-456';
+    rerender(
+      <Wrapper>
+        <Layout screen="b" />
+      </Wrapper>
+    );
+    await waitFor(() => expect(mockApiClient.getChartData).toHaveBeenCalledTimes(2));
+
+    // Back within staleTime: the first encounter's entry is still fresh, so only the switch makes it re-read.
+    route.encounterId = 'encounter-123';
+    rerender(
+      <Wrapper>
+        <Layout screen="c" />
+      </Wrapper>
+    );
+    await waitFor(() => expect(mockApiClient.getChartData).toHaveBeenCalledTimes(3));
   });
 });

--- a/apps/ehr/src/features/visits/shared/hooks/useChartFields.test.tsx
+++ b/apps/ehr/src/features/visits/shared/hooks/useChartFields.test.tsx
@@ -617,11 +617,13 @@ describe('useChartDataField', () => {
         expect(result1.current.isLoading).toBe(false);
       });
 
-      renderHook(() => useChartFields({ requestedFields: params2 }), { wrapper });
+      const { result: result2 } = renderHook(() => useChartFields({ requestedFields: params2 }), { wrapper });
 
+      // Equivalent params produce the same key, and fresh data is shared within staleTime: one call in total.
       await waitFor(() => {
-        expect(mockApiClient.getChartData).toHaveBeenCalledTimes(2); // staleTime is 0, so two calls are expected now
+        expect(result2.current.data).toBeDefined();
       });
+      expect(mockApiClient.getChartData).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/ehr/src/features/visits/shared/hooks/useChartFields.test.tsx
+++ b/apps/ehr/src/features/visits/shared/hooks/useChartFields.test.tsx
@@ -1153,6 +1153,25 @@ describe('useInvalidateChartFieldsOnNavigate', () => {
     await waitFor(() => expect(mockApiClient.getChartData).toHaveBeenCalledTimes(2));
   });
 
+  it('re-reads the chart fields when the visit is entered again within staleTime', async () => {
+    const Wrapper = createWrapper();
+    const first = render(
+      <Wrapper>
+        <Layout screen="review-and-sign" />
+      </Wrapper>
+    );
+    await waitFor(() => expect(mockApiClient.getChartData).toHaveBeenCalledTimes(1));
+    first.unmount();
+
+    // Leaving the visit unmounts the layout; coming back to the same screen re-reads its fields.
+    render(
+      <Wrapper>
+        <Layout screen="review-and-sign" />
+      </Wrapper>
+    );
+    await waitFor(() => expect(mockApiClient.getChartData).toHaveBeenCalledTimes(2));
+  });
+
   it("re-reads a returning encounter's chart fields when the encounter changes without a route change", async () => {
     const Wrapper = createWrapper();
     const { rerender } = render(

--- a/apps/ehr/src/features/visits/shared/hooks/useChartFields.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useChartFields.ts
@@ -1,7 +1,7 @@
 import { QueryObserverResult, RefetchOptions, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
-import { CHART_FIELDS_QUERY_KEY } from 'src/constants';
+import { CHART_FIELDS_QUERY_KEY, QUERY_STALE_TIME } from 'src/constants';
 import useEvolveUser from 'src/hooks/useEvolveUser';
 import { SearchParams } from 'utils/lib/fhir/uri';
 import { useErrorQuery, useSuccessQuery } from 'utils/lib/frontend';
@@ -167,7 +167,11 @@ export function useChartFields<T extends ChartDataRequestedFields>({
       return result as Pick<GetChartDataResponse, keyof ChartDataRequestedFields>;
     },
     enabled: !!apiClient && !!encounterId && !!user && enabled,
-    staleTime: 0, // TODO: add QUERY_STALE_TIME; set to 0 for now since not all api calls update cache (e.g., in-house order status changes to "collected")
+    // Fresh data within a screen is shared by every component that mounts the same field set. Moving to
+    // another visit screen marks every chart-fields query stale (useInvalidateChartFieldsOnNavigate), so
+    // flows that change chart data through other endpoints, such as an in-house lab order being
+    // collected, are picked up on the next screen; flows that stay on one screen invalidate explicitly.
+    staleTime: QUERY_STALE_TIME,
     refetchInterval: refetchInterval || false,
   });
 

--- a/apps/ehr/src/features/visits/shared/hooks/useInvalidateChartFieldsOnNavigate.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useInvalidateChartFieldsOnNavigate.ts
@@ -5,10 +5,11 @@ import { CHART_FIELDS_QUERY_KEY } from 'src/constants';
 import { useAppointmentData } from '../stores/appointment/appointment.store';
 
 /**
- * Marks every chart-fields query for the current encounter stale when the provider moves to another visit
- * screen or switches to another encounter of the visit. Nothing is refetched here: a stale query is
- * refetched when a component on the new screen mounts it, so each distinct field set costs one request per
- * screen visit.
+ * Marks every chart-fields query for the current encounter stale when the provider enters the visit, moves
+ * to another visit screen or switches to another encounter of the visit. Nothing is refetched here: a stale
+ * query is refetched when a component on the new screen mounts it or when the window regains focus, so each
+ * distinct field set costs one request per screen visit. Refetching the active queries instead would re-read
+ * the layout-level queries, which never remount, on every screen change.
  *
  * A layout effect on purpose: react-query decides whether to fetch on mount when a query subscribes, in a
  * passive effect, and the new screen's components (children of this layout) run their passive effects
@@ -20,7 +21,8 @@ export const useInvalidateChartFieldsOnNavigate = (): void => {
   const queryClient = useQueryClient();
   const { encounter } = useAppointmentData();
   const encounterId = encounter?.id;
-  const previous = useRef({ pathname, encounterId });
+  // Starts empty so that entering the visit counts as a transition too.
+  const previous = useRef<{ pathname?: string; encounterId?: string }>({});
 
   useLayoutEffect(() => {
     if (previous.current.pathname === pathname && previous.current.encounterId === encounterId) return;

--- a/apps/ehr/src/features/visits/shared/hooks/useInvalidateChartFieldsOnNavigate.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useInvalidateChartFieldsOnNavigate.ts
@@ -6,8 +6,9 @@ import { useAppointmentData } from '../stores/appointment/appointment.store';
 
 /**
  * Marks every chart-fields query for the current encounter stale when the provider moves to another visit
- * screen. Nothing is refetched here: a stale query is refetched when a component on the new screen mounts
- * it, so each distinct field set costs one request per screen visit rather than one per component mount.
+ * screen or switches to another encounter of the visit. Nothing is refetched here: a stale query is
+ * refetched when a component on the new screen mounts it, so each distinct field set costs one request per
+ * screen visit.
  *
  * A layout effect on purpose: react-query decides whether to fetch on mount when a query subscribes, in a
  * passive effect, and the new screen's components (children of this layout) run their passive effects
@@ -19,11 +20,11 @@ export const useInvalidateChartFieldsOnNavigate = (): void => {
   const queryClient = useQueryClient();
   const { encounter } = useAppointmentData();
   const encounterId = encounter?.id;
-  const previousPathname = useRef(pathname);
+  const previous = useRef({ pathname, encounterId });
 
   useLayoutEffect(() => {
-    if (previousPathname.current === pathname) return;
-    previousPathname.current = pathname;
+    if (previous.current.pathname === pathname && previous.current.encounterId === encounterId) return;
+    previous.current = { pathname, encounterId };
     if (!encounterId) return;
     void queryClient.invalidateQueries({ queryKey: [CHART_FIELDS_QUERY_KEY, encounterId], refetchType: 'none' });
   }, [pathname, encounterId, queryClient]);

--- a/apps/ehr/src/features/visits/shared/hooks/useInvalidateChartFieldsOnNavigate.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useInvalidateChartFieldsOnNavigate.ts
@@ -1,0 +1,28 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { CHART_FIELDS_QUERY_KEY } from 'src/constants';
+import { useAppointmentData } from '../stores/appointment/appointment.store';
+
+/**
+ * Marks every chart-fields query for the current encounter stale when the provider moves to another visit
+ * screen. Nothing is refetched here: a stale query is refetched when a component on the new screen mounts
+ * it, so each distinct field set costs one request per screen visit rather than one per component mount.
+ *
+ * This replaces the `staleTime: 0` the chart-fields cache used to run with, which kept every screen fresh
+ * by refetching on every mount, including the many mounts of the same field set within one screen.
+ */
+export const useInvalidateChartFieldsOnNavigate = (): void => {
+  const { pathname } = useLocation();
+  const queryClient = useQueryClient();
+  const { encounter } = useAppointmentData();
+  const encounterId = encounter?.id;
+  const previousPathname = useRef(pathname);
+
+  useEffect(() => {
+    if (previousPathname.current === pathname) return;
+    previousPathname.current = pathname;
+    if (!encounterId) return;
+    void queryClient.invalidateQueries({ queryKey: [CHART_FIELDS_QUERY_KEY, encounterId], refetchType: 'none' });
+  }, [pathname, encounterId, queryClient]);
+};

--- a/apps/ehr/src/features/visits/shared/hooks/useInvalidateChartFieldsOnNavigate.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useInvalidateChartFieldsOnNavigate.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { CHART_FIELDS_QUERY_KEY } from 'src/constants';
 import { useAppointmentData } from '../stores/appointment/appointment.store';
@@ -9,8 +9,10 @@ import { useAppointmentData } from '../stores/appointment/appointment.store';
  * screen. Nothing is refetched here: a stale query is refetched when a component on the new screen mounts
  * it, so each distinct field set costs one request per screen visit rather than one per component mount.
  *
- * This replaces the `staleTime: 0` the chart-fields cache used to run with, which kept every screen fresh
- * by refetching on every mount, including the many mounts of the same field set within one screen.
+ * A layout effect on purpose: react-query decides whether to fetch on mount when a query subscribes, in a
+ * passive effect, and the new screen's components (children of this layout) run their passive effects
+ * before the layout's. Marking stale in a layout effect puts it ahead of every subscription of the new
+ * screen; in a passive effect it would land after them and the new screen would show the old chart.
  */
 export const useInvalidateChartFieldsOnNavigate = (): void => {
   const { pathname } = useLocation();
@@ -19,7 +21,7 @@ export const useInvalidateChartFieldsOnNavigate = (): void => {
   const encounterId = encounter?.id;
   const previousPathname = useRef(pathname);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (previousPathname.current === pathname) return;
     previousPathname.current = pathname;
     if (!encounterId) return;

--- a/apps/ehr/src/features/visits/shared/hooks/usePatientInstructionsVisibility.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/usePatientInstructionsVisibility.ts
@@ -1,7 +1,7 @@
 import { useExcusePresignedFiles } from 'src/shared/hooks/useExcusePresignedFiles';
 import { NOTHING_TO_EAT_OR_DRINK_FIELD } from 'utils/lib/types/api/chart-data/chart-data.types';
 import { useChartData } from '../stores/appointment/appointment.store';
-import { useChartFields } from './useChartFields';
+import { useProgressNoteChartFields } from './useProgressNoteChartFields';
 
 export const usePatientInstructionsVisibility = (): {
   showInstructions: boolean;
@@ -11,9 +11,7 @@ export const usePatientInstructionsVisibility = (): {
   showPatientInstructions: boolean;
 } => {
   const { chartData } = useChartData();
-  const { data: chartFields } = useChartFields({
-    requestedFields: { disposition: {} },
-  });
+  const { data: chartFields } = useProgressNoteChartFields();
   const instructions = chartData?.instructions;
   const disposition = chartFields?.disposition;
   const schoolWorkExcuses = useExcusePresignedFiles(chartData?.schoolWorkNotes);

--- a/apps/ehr/src/features/visits/shared/hooks/useProgressNoteChartFields.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useProgressNoteChartFields.ts
@@ -4,9 +4,7 @@ import { useChartFields } from './useChartFields';
 /**
  * The one chart-fields query behind the Review & Sign and follow-up note pages.
  *
- * Every section summary on those pages reads from this query instead of requesting its own fields, so the
- * page costs one get-chart-data call however many sections it renders. Before this, each summary asked for
- * its own combination of fields and the page issued a dozen requests for data the note had already fetched.
+ * Every section summary on those pages reads from this query instead of requesting its own fields.
  *
  * Keep `progressNoteChartDataRequestedFields` a superset of what the summaries need.
  */

--- a/apps/ehr/src/features/visits/shared/hooks/useProgressNoteChartFields.ts
+++ b/apps/ehr/src/features/visits/shared/hooks/useProgressNoteChartFields.ts
@@ -1,0 +1,15 @@
+import { progressNoteChartDataRequestedFields } from 'utils/lib/helpers/visit-note/progress-note-chart-data-requested-fields.helper';
+import { useChartFields } from './useChartFields';
+
+/**
+ * The one chart-fields query behind the Review & Sign and follow-up note pages.
+ *
+ * Every section summary on those pages reads from this query instead of requesting its own fields, so the
+ * page costs one get-chart-data call however many sections it renders. Before this, each summary asked for
+ * its own combination of fields and the page issued a dozen requests for data the note had already fetched.
+ *
+ * Keep `progressNoteChartDataRequestedFields` a superset of what the summaries need.
+ */
+export const useProgressNoteChartFields = (): ReturnType<
+  typeof useChartFields<typeof progressNoteChartDataRequestedFields>
+> => useChartFields({ requestedFields: progressNoteChartDataRequestedFields });

--- a/apps/ehr/src/features/visits/shared/stores/appointment/appointment.store.tsx
+++ b/apps/ehr/src/features/visits/shared/stores/appointment/appointment.store.tsx
@@ -117,7 +117,7 @@ export type ChartDataResponse = Omit<
   GetChartDataResponse,
   Exclude<
     RequestedFields,
-    'medications' | 'inhouseMedications' | 'observations' | 'procedures' | 'patientHasPreviousVisits'
+    'medications' | 'inhouseMedications' | 'observations' | 'procedures' | 'patientHasPreviousVisits' | 'aiChat'
   >
 >;
 

--- a/apps/ehr/tests/component/AccidentField.test.tsx
+++ b/apps/ehr/tests/component/AccidentField.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { FC, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AccidentField } from '../../src/features/visits/AccidentField';
+import { useProgressNoteChartFields } from '../../src/features/visits/shared/hooks/useProgressNoteChartFields';
+
+vi.mock('react-router-dom', () => ({
+  useParams: vi.fn().mockReturnValue({ id: 'appointment-123' }),
+  useLocation: () => ({ pathname: '/in-person/appointment-123/review-and-sign' }),
+}));
+
+vi.mock('../../src/hooks/useEvolveUser', () => ({
+  default: vi.fn().mockReturnValue({ id: 'user-123' }),
+}));
+
+vi.mock('../../src/features/visits/shared/hooks/useOystehrAPIClient', () => ({
+  useOystehrAPIClient: vi.fn(),
+}));
+
+vi.mock('../../src/features/visits/shared/hooks/useGetAppointmentAccessibility', () => ({
+  useGetAppointmentAccessibility: vi.fn().mockReturnValue({ isAppointmentReadOnly: false }),
+}));
+
+vi.mock('../../src/features/visits/shared/stores/appointment/appointment.store', () => ({
+  useAppointmentData: vi.fn(() => ({ encounter: { id: 'encounter-123' } })),
+  useSaveChartData: vi.fn(),
+  useDeleteChartData: vi.fn(),
+}));
+
+vi.mock('utils/lib/frontend', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useSuccessQuery: vi.fn(), useErrorQuery: vi.fn() };
+});
+
+import { useOystehrAPIClient } from '../../src/features/visits/shared/hooks/useOystehrAPIClient';
+import {
+  useDeleteChartData,
+  useSaveChartData,
+} from '../../src/features/visits/shared/stores/appointment/appointment.store';
+
+type Accident = { resourceId?: string; type: string[]; date?: string; state?: string };
+
+const getChartData = vi.fn();
+// The save response echoes the accident that was sent, with a resource id like the server would add.
+const saveMutate = vi.fn((variables: { accident: Accident }, options?: { onSuccess?: (data: unknown) => void }) => {
+  options?.onSuccess?.({
+    chartData: { accident: { ...variables.accident, resourceId: variables.accident.resourceId ?? 'accident-1' } },
+  });
+});
+const deleteMutate = vi.fn((_variables: unknown, options?: { onSuccess?: () => void }) => {
+  options?.onSuccess?.();
+});
+
+/** The checkbox rendered next to a label; CheckboxInput does not associate the two. */
+const checkboxFor = (label: string): HTMLInputElement => {
+  const input = screen.getByText(label).parentElement?.querySelector<HTMLInputElement>('input[type="checkbox"]');
+  if (!input) throw new Error(`no checkbox next to "${label}"`);
+  return input;
+};
+
+/** Stands in for the Review & Sign summaries, which read the accident from the progress-note query. */
+const ProgressNoteAccident: FC = () => {
+  const { data, isLoading } = useProgressNoteChartFields();
+  if (isLoading) return <span>summary loading</span>;
+  return <span>summary accident: {(data?.accident?.type ?? []).join(',') || 'none'}</span>;
+};
+
+const renderWithClient = (ui: ReactNode): ReturnType<typeof render> => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+describe('AccidentField', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useOystehrAPIClient).mockReturnValue({ getChartData } as never);
+    vi.mocked(useSaveChartData).mockReturnValue({ mutate: saveMutate, isPending: false } as never);
+    vi.mocked(useDeleteChartData).mockReturnValue({ mutate: deleteMutate, isPending: false } as never);
+  });
+
+  it('a saved accident shows in the progress-note summary without another chart read', async () => {
+    getChartData.mockResolvedValue({ patientId: 'patient-123' });
+
+    renderWithClient(
+      <>
+        <ProgressNoteAccident />
+        <AccidentField readOnly={false} />
+      </>
+    );
+
+    await screen.findByText('summary accident: none');
+    const autoAccident = checkboxFor('Auto Accident');
+    await waitFor(() => expect(autoAccident).toBeEnabled());
+    const readsBeforeSave = getChartData.mock.calls.length;
+
+    fireEvent.click(autoAccident);
+
+    await screen.findByText('summary accident: AA');
+    expect(saveMutate).toHaveBeenCalledWith(
+      { accident: expect.objectContaining({ type: ['AA'] }) },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+    expect(getChartData).toHaveBeenCalledTimes(readsBeforeSave);
+  });
+
+  it('a cleared accident disappears from the progress-note summary without another chart read', async () => {
+    getChartData.mockResolvedValue({
+      patientId: 'patient-123',
+      accident: { resourceId: 'accident-1', type: ['OA'], date: '2026-01-02' },
+    });
+
+    renderWithClient(
+      <>
+        <ProgressNoteAccident />
+        <AccidentField readOnly={false} />
+      </>
+    );
+
+    await screen.findByText('summary accident: OA');
+    const otherAccident = checkboxFor('Other Accident');
+    await waitFor(() => expect(otherAccident).toBeChecked());
+    const readsBeforeDelete = getChartData.mock.calls.length;
+
+    fireEvent.click(otherAccident);
+
+    await screen.findByText('summary accident: none');
+    expect(deleteMutate).toHaveBeenCalledWith(
+      { accident: expect.objectContaining({ resourceId: 'accident-1' }) },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+    expect(getChartData).toHaveBeenCalledTimes(readsBeforeDelete);
+  });
+});

--- a/packages/utils/lib/helpers/visit-note/progress-note-chart-data-requested-fields.helper.ts
+++ b/packages/utils/lib/helpers/visit-note/progress-note-chart-data-requested-fields.helper.ts
@@ -15,12 +15,21 @@ export const vitalsObservationsRequest: SearchParams = {
     .join(','),
 };
 
+/**
+ * The one chart-fields request behind the Review & Sign and follow-up note pages. Every section summary on
+ * those pages reads from this query (see useProgressNoteChartFields), so it has to stay a superset of what
+ * they need; a section that requests its own fields costs the page an extra get-chart-data call.
+ */
 export const progressNoteChartDataRequestedFields: ChartDataRequestedFields = {
   chiefComplaint: { _tag: 'chief-complaint' },
   reasonForVisit: {},
   mechanismOfInjury: { _tag: 'mechanism-of-injury' },
   historyOfPresentIllness: { _tag: 'history-of-present-illness' },
   ros: { _tag: 'ros' },
+  accident: { _tag: 'accident' },
+  surgicalHistoryNote: { _tag: 'surgical-history-note' },
+  patientInfoConfirmed: {},
+  addendumNote: {},
   episodeOfCare: {},
   prescribedMedications: {},
   disposition: { _tag: 'disposition-follow-up,sub-follow-up' },

--- a/packages/utils/lib/types/api/chart-data/chart-data.types.ts
+++ b/packages/utils/lib/types/api/chart-data/chart-data.types.ts
@@ -102,7 +102,8 @@ export type RequestedFields =
   | 'reasonForVisit'
   | 'accident'
   | 'patientHasPreviousVisits'
-  | 'radiologyOrders';
+  | 'radiologyOrders'
+  | 'aiChat';
 
 export type AllChartValuesKeys = keyof AllChartValues;
 

--- a/packages/zambdas/src/ehr/get-chart-data/helpers.ts
+++ b/packages/zambdas/src/ehr/get-chart-data/helpers.ts
@@ -217,7 +217,9 @@ export async function convertSearchResultsToResponse(
     patientId,
     ...(fields
       ? {
-          ...Object.fromEntries(fields.map((field) => [field, []])),
+          ...Object.fromEntries(
+            fields.map((field) => [field, field === 'aiChat' ? { documents: [], providers: [] } : []])
+          ),
           practitioners: [],
         }
       : {

--- a/packages/zambdas/src/ehr/get-chart-data/index.ts
+++ b/packages/zambdas/src/ehr/get-chart-data/index.ts
@@ -23,9 +23,7 @@ import {
 import { validateRequestParameters } from './validateRequestParameters';
 
 // A FHIR batch runs its entries one after another on the server, so one batch of N searches costs roughly
-// the sum of all N. Splitting the chart searches into several concurrent batches turns that sum into a max:
-// measured against this backend, the progress note's ~18 searches took 455ms as one batch and 173ms as six
-// concurrent batches of three, while three batches of six were indistinguishable from six of three.
+// the sum of all N. Splitting the chart searches into several concurrent batches turns that sum into a max.
 const CHART_DATA_BATCH_TARGET_CONCURRENCY = 6;
 const CHART_DATA_MIN_BATCH_SIZE = 3;
 

--- a/packages/zambdas/src/ehr/get-chart-data/index.ts
+++ b/packages/zambdas/src/ehr/get-chart-data/index.ts
@@ -24,8 +24,8 @@ import { validateRequestParameters } from './validateRequestParameters';
 
 // A FHIR batch runs its entries one after another on the server, so one batch of N searches costs roughly
 // the sum of all N. Splitting the chart searches into several concurrent batches turns that sum into a max.
-const CHART_DATA_BATCH_TARGET_CONCURRENCY = 6;
-const CHART_DATA_MIN_BATCH_SIZE = 3;
+export const CHART_DATA_BATCH_TARGET_CONCURRENCY = 6;
+export const CHART_DATA_MIN_BATCH_SIZE = 3;
 
 // Lifting up value to outside of the handler allows it to stay in memory across warm lambda invocations
 let m2mToken: string;

--- a/packages/zambdas/src/ehr/get-chart-data/index.ts
+++ b/packages/zambdas/src/ehr/get-chart-data/index.ts
@@ -306,8 +306,11 @@ export async function getChartData(
     ? encounter.subject.reference.replace('Patient/', '')
     : undefined;
   if (patientId === undefined) throw new Error(`Encounter  ${encounterId} must be associated with a patient... `);
-  // Present only when preferredPharmacies was requested.
+  // Searched only when preferredPharmacies was requested; then it has to be there.
   const patient = resources.find((resource): resource is Patient => resource.resourceType === 'Patient');
+  if (requestedFields?.preferredPharmacies && patient === undefined) {
+    throw new Error(`Patient ${patientId} of encounter ${encounterId} must exist... `);
+  }
   console.log(`Got encounter with id ${encounter.id} and patient with id ${patientId}`);
   // console.debug('result JSON\n\n==============\n\n', JSON.stringify(result));
 

--- a/packages/zambdas/src/ehr/get-chart-data/index.ts
+++ b/packages/zambdas/src/ehr/get-chart-data/index.ts
@@ -5,7 +5,7 @@ import { chunkThings } from 'utils/lib/fhir/chat';
 import { PUBLIC_EXTENSION_BASE_URL } from 'utils/lib/fhir/constants';
 import { ChartDataRequestedFields, GetChartDataResponse } from 'utils/lib/types/api/chart-data/get-chart-data.types';
 import { checkOrCreateM2MClientToken } from '../../shared/auth';
-import { createClinicalOystehrClient } from '../../shared/helpers';
+import { createClinicalOystehrClient, patientIdFromReference } from '../../shared/helpers';
 import { wrapHandler } from '../../shared/sentry';
 import { ZambdaInput } from '../../shared/types/common';
 import { configLabRequestsForGetChartData } from '../lab/shared/labs';
@@ -302,9 +302,7 @@ export async function getChartData(
   const resources = parseChartDataBundle(result);
   const encounter = resources.find((resource): resource is Encounter => resource.resourceType === 'Encounter');
   if (encounter === undefined) throw new Error(`Encounter with ID ${encounterId} must exist... `);
-  const patientId = encounter.subject?.reference?.startsWith('Patient/')
-    ? encounter.subject.reference.replace('Patient/', '')
-    : undefined;
+  const patientId = patientIdFromReference(encounter.subject?.reference);
   if (patientId === undefined) throw new Error(`Encounter  ${encounterId} must be associated with a patient... `);
   // Searched only when preferredPharmacies was requested; then it has to be there.
   const patient = resources.find((resource): resource is Patient => resource.resourceType === 'Patient');

--- a/packages/zambdas/src/ehr/get-chart-data/index.ts
+++ b/packages/zambdas/src/ehr/get-chart-data/index.ts
@@ -1,6 +1,7 @@
 import Oystehr, { BatchInputGetRequest } from '@oystehr/sdk';
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { Bundle, FhirResource, Patient, Practitioner, Resource } from 'fhir/r4b';
+import { Bundle, Encounter, FhirResource, Patient, Practitioner, Resource } from 'fhir/r4b';
+import { chunkThings } from 'utils/lib/fhir/chat';
 import { PUBLIC_EXTENSION_BASE_URL } from 'utils/lib/fhir/constants';
 import { ChartDataRequestedFields, GetChartDataResponse } from 'utils/lib/types/api/chart-data/get-chart-data.types';
 import { checkOrCreateM2MClientToken } from '../../shared/auth';
@@ -20,6 +21,13 @@ import {
   SupportedResourceType,
 } from './helpers';
 import { validateRequestParameters } from './validateRequestParameters';
+
+// A FHIR batch runs its entries one after another on the server, so one batch of N searches costs roughly
+// the sum of all N. Splitting the chart searches into several concurrent batches turns that sum into a max:
+// measured against this backend, the progress note's ~18 searches took 455ms as one batch and 173ms as six
+// concurrent batches of three, while three batches of six were indistinguishable from six of three.
+const CHART_DATA_BATCH_TARGET_CONCURRENCY = 6;
+const CHART_DATA_MIN_BATCH_SIZE = 3;
 
 // Lifting up value to outside of the handler allows it to stay in memory across warm lambda invocations
 let m2mToken: string;
@@ -203,22 +211,10 @@ export async function getChartData(
     addRequestIfNeeded({ field: 'accident', resourceType: 'Condition', defaultSearchBy: 'encounter' });
   }
 
-  if (requestedFields == null) {
-    // AI chat
-    chartDataRequests.push(
-      createFindResourceRequest(
-        encounterId,
-        'DocumentReference',
-        // {
-        //   type: {
-        //     type: 'string',
-        //     value: '#aiInterviewQuestionnaire',
-        //   },
-        // },
-        {},
-        'encounter'
-      )
-    );
+  // AI chat documents (consult notes and pending-recording markers): part of the default set, and
+  // requestable on their own so the AI polling loops don't have to re-run the whole default set.
+  if (requestedFields == null || requestedFields.aiChat) {
+    chartDataRequests.push(createFindResourceRequest(encounterId, 'DocumentReference', {}, 'encounter'));
   }
 
   // Practitioners
@@ -251,6 +247,9 @@ export async function getChartData(
     chartDataRequests.push(
       createFindResourceRequest(encounterId, 'QuestionnaireResponse', { _search_by: 'encounter' })
     );
+    // The Patient is only read for its contained pharmacy Organizations, so it is fetched only here, and in
+    // the same batch as everything else. Every other use of the patient goes through encounter.subject.
+    chartDataRequests.push({ method: 'GET', url: encounterSubjectScopedSearchUrl('Patient', null, encounterId) });
   }
 
   // Determine if we need to check whether the patient is new
@@ -259,28 +258,23 @@ export async function getChartData(
   console.timeLog('check', 'before resources fetch');
   console.log('Starting a transaction to retrieve chart data...');
 
-  // Fetched concurrently with the chart batch and kept out of the merged bundle, so only the chart
-  // requests' resources feed the response.
-  const patientPromise = oystehr.fhir
-    .batch<Patient>({
-      requests: [{ method: 'GET', url: encounterSubjectScopedSearchUrl('Patient', null, encounterId) }],
-    })
-    .then((result) => {
-      const nested = result.entry?.[0]?.resource as Bundle<Patient> | undefined;
-      return nested?.entry?.map((entry) => entry.resource).find((resource) => resource?.resourceType === 'Patient');
-    });
+  // The searches are independent and the response is assembled by resource type rather than by request
+  // index, so they can be spread over concurrent batches and the entries concatenated back afterwards.
+  const batchGroups = chunkThings(
+    chartDataRequests,
+    Math.max(CHART_DATA_MIN_BATCH_SIZE, Math.ceil(chartDataRequests.length / CHART_DATA_BATCH_TARGET_CONCURRENCY))
+  );
 
-  // Run the chart-data batch, the patient lookup and the patientHasPreviousVisits query in parallel
-  const [batchResult, patient, appointmentCountResult] = await Promise.all([
-    oystehr.fhir
-      .batch<FhirResource>({
-        requests: chartDataRequests,
-      })
-      .catch((error) => {
-        console.log('Error fetching chart data...', error, JSON.stringify(error));
-        throw new Error(`Unable to retrieve chart data for encounter with ID ${encounterId}`);
-      }),
-    patientPromise,
+  // Run the chart-data batches and the patientHasPreviousVisits query in parallel
+  const [batchResults, appointmentCountResult] = await Promise.all([
+    Promise.all(
+      batchGroups.map((requests) =>
+        oystehr.fhir.batch<FhirResource>({ requests }).catch((error) => {
+          console.log('Error fetching chart data...', error, JSON.stringify(error));
+          throw new Error(`Unable to retrieve chart data for encounter with ID ${encounterId}`);
+        })
+      )
+    ),
     shouldFetchPatientHasPreviousVisits
       ? oystehr.fhir
           .batch<FhirResource>({
@@ -299,21 +293,31 @@ export async function getChartData(
       : Promise.resolve(undefined),
   ]);
 
-  const result = batchResult;
+  const result: Bundle<FhirResource> = {
+    resourceType: 'Bundle',
+    type: 'batch-response',
+    entry: batchResults.flatMap((batchResult) => batchResult.entry ?? []),
+  };
   console.log('Retrieved chart data...');
 
   // The encounter must exist and must have a patient as its subject.
-  const encounter = parseChartDataBundle(result).find((resource) => resource.resourceType === 'Encounter');
+  const resources = parseChartDataBundle(result);
+  const encounter = resources.find((resource): resource is Encounter => resource.resourceType === 'Encounter');
   if (encounter === undefined) throw new Error(`Encounter with ID ${encounterId} must exist... `);
-  if (patient === undefined) throw new Error(`Encounter  ${encounterId} must be associated with a patient... `);
-  console.log(`Got encounter with id ${encounter.id} and patient with id ${patient.id}`);
+  const patientId = encounter.subject?.reference?.startsWith('Patient/')
+    ? encounter.subject.reference.replace('Patient/', '')
+    : undefined;
+  if (patientId === undefined) throw new Error(`Encounter  ${encounterId} must be associated with a patient... `);
+  // Present only when preferredPharmacies was requested.
+  const patient = resources.find((resource): resource is Patient => resource.resourceType === 'Patient');
+  console.log(`Got encounter with id ${encounter.id} and patient with id ${patientId}`);
   // console.debug('result JSON\n\n==============\n\n', JSON.stringify(result));
 
   console.timeLog('check', 'after fetch, before converting chart data to response');
   const chartDataResult = await convertSearchResultsToResponse(
     result,
     m2mToken,
-    patient.id!,
+    patientId,
     encounterId,
     requestedFields ? (Object.keys(requestedFields) as (keyof ChartDataRequestedFields)[]) : undefined,
     patient,

--- a/packages/zambdas/src/shared/helpers.ts
+++ b/packages/zambdas/src/shared/helpers.ts
@@ -222,6 +222,14 @@ export function validateJsonBody(input: ZambdaInput): any {
   }
 }
 
+/**
+ * The id of the Patient a FHIR reference points at, whether the reference is relative
+ * (`Patient/<id>`) or absolute (`https://fhir-api.zapehr.com/r4/Patient/<id>`). Undefined when the
+ * reference is missing or points at another resource type.
+ */
+export const patientIdFromReference = (reference: string | undefined): string | undefined =>
+  reference?.match(/(?:^|\/)Patient\/([^/]+)$/)?.[1];
+
 export function getParticipantFromAppointment(appointment: Appointment, participant: string): string {
   const participantTemp = appointment.participant
     .find((currentParticipant: any) => currentParticipant.actor?.reference?.startsWith(participant))

--- a/packages/zambdas/test/unit/__snapshots__/chart-data-golden-mapping.test.ts.snap
+++ b/packages/zambdas/test/unit/__snapshots__/chart-data-golden-mapping.test.ts.snap
@@ -16,6 +16,53 @@ exports[`get-chart-data mapping layer — golden fixture > every requestable fie
   "addendumNote": {
     "text": "Legacy single-string addendum",
   },
+  "aiChat": {
+    "documents": [
+      {
+        "content": [
+          {
+            "attachment": {
+              "title": "AI consult note",
+              "url": "https://z3.example/ai/consult-note.json",
+            },
+          },
+        ],
+        "context": {
+          "encounter": [
+            {
+              "reference": "Encounter/11111111-1111-4111-8111-111111111111",
+            },
+          ],
+        },
+        "date": "2026-01-15T12:00:00.000Z",
+        "extension": [
+          {
+            "url": "https://extensions.fhir.zapehr.com/provider",
+            "valueReference": {
+              "reference": "Practitioner/33333333-3333-4333-8333-333333333333",
+            },
+          },
+        ],
+        "id": "dr-ai-consult-note",
+        "resourceType": "DocumentReference",
+        "status": "current",
+        "subject": {
+          "reference": "Patient/22222222-2222-4222-8222-222222222222",
+        },
+        "type": {
+          "coding": [
+            {
+              "code": "11488-4",
+              "display": "Consult note",
+              "system": "http://loinc.org",
+            },
+          ],
+        },
+      },
+    ],
+    "hasPendingRecording": true,
+    "providers": [],
+  },
   "birthHistory": [
     {
       "field": "weight",

--- a/packages/zambdas/test/unit/__snapshots__/chart-data-golden-mapping.test.ts.snap
+++ b/packages/zambdas/test/unit/__snapshots__/chart-data-golden-mapping.test.ts.snap
@@ -420,7 +420,14 @@ exports[`get-chart-data mapping layer — golden fixture > every requestable fie
 
 exports[`get-chart-data mapping layer — golden fixture > progress-note mode (useChartFields with progressNoteChartDataRequestedFields) > matches the golden snapshot 1`] = `
 {
-  "accident": undefined,
+  "accident": {
+    "date": "2026-01-10",
+    "resourceId": "cond-accident",
+    "state": "IL",
+    "type": [
+      "AA",
+    ],
+  },
   "addToVisitNote": {
     "value": true,
   },
@@ -666,6 +673,10 @@ exports[`get-chart-data mapping layer — golden fixture > progress-note mode (u
   "ros": {
     "resourceId": "cond-ros",
     "text": "Negative except as noted",
+  },
+  "surgicalHistoryNote": {
+    "resourceId": "proc-surgical-history-note",
+    "text": "Uncomplicated recovery",
   },
   "vitalsObservations": [
     {

--- a/packages/zambdas/test/unit/__snapshots__/get-chart-data-request-budget.test.ts.snap
+++ b/packages/zambdas/test/unit/__snapshots__/get-chart-data-request-budget.test.ts.snap
@@ -5,7 +5,6 @@ exports[`get-chart-data FHIR request budget > pins the FHIR searches issued for 
   {
     "name": "01 unscoped (InPersonLayout, Header, Sidebar, ProgressNote)",
     "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
       "/Encounter?_id=11111111-1111-4111-8111-111111111111",
       "/AllergyIntolerance?patient:Patient._has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
       "/Condition?subject:Patient._has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
@@ -23,39 +22,13 @@ exports[`get-chart-data FHIR request budget > pins the FHIR searches issued for 
   {
     "name": "02 InPersonNavigationContext",
     "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
       "/Encounter?_id=11111111-1111-4111-8111-111111111111",
       "/EpisodeOfCare?patient:Patient._has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
     ],
   },
   {
-    "name": "03 MissingCard",
+    "name": "03 useProgressNoteChartFields (ProgressNoteDetails, MissingCard, ReviewAndSignButton, section summaries)",
     "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
-      "/Encounter?_id=11111111-1111-4111-8111-111111111111",
-      "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=chief-complaint",
-      "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=history-of-present-illness",
-      "/ClinicalImpression?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=medical-decision",
-      "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=accident",
-    ],
-  },
-  {
-    "name": "04 ReviewAndSignButton",
-    "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
-      "/Encounter?_id=11111111-1111-4111-8111-111111111111",
-      "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=chief-complaint",
-      "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=history-of-present-illness",
-      "/ClinicalImpression?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=medical-decision",
-      "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=accident",
-      "/DocumentReference?status=current&type=11502-2&encounter=11111111-1111-4111-8111-111111111111&_include:iterate=DocumentReference:related&_include:iterate=DiagnosticReport:based-on&_include:iterate=DiagnosticReport:result",
-      "/ServiceRequest?encounter=Encounter/11111111-1111-4111-8111-111111111111&status=active&code=https://terminology.fhir.oystehr.com/CodeSystem/oystehr-lab-local-codes|,http://ottehr.org/fhir/StructureDefinition/in-house-lab-test-code|",
-    ],
-  },
-  {
-    "name": "05 ProgressNoteDetails (progressNoteChartDataRequestedFields)",
-    "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
       "/Encounter?_id=11111111-1111-4111-8111-111111111111",
       "/ServiceRequest?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=disposition-follow-up,sub-follow-up",
       "/MedicationRequest?encounter=Encounter/11111111-1111-4111-8111-111111111111",
@@ -64,9 +37,11 @@ exports[`get-chart-data FHIR request budget > pins the FHIR searches issued for 
       "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=history-of-present-illness",
       "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=mechanism-of-injury",
       "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=ros",
+      "/Procedure?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=surgical-history-note",
       "/ClinicalImpression?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=medical-decision",
       "/Observation?encounter=Encounter/11111111-1111-4111-8111-111111111111&_count=100&_sort=-_lastUpdated&_tag=vital-temperature,vital-heartbeat,vital-blood-pressure,vital-oxygen-sat,vital-respiration-rate,vital-weight,vital-height,vital-bmi,vital-vision,vital-last-menstrual-period",
       "/EpisodeOfCare?patient:Patient._has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
+      "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=accident",
       "/Practitioner?_has:Encounter:participant:_id=11111111-1111-4111-8111-111111111111",
       "/DocumentReference?status=current&type=11502-2&encounter=11111111-1111-4111-8111-111111111111&_include:iterate=DocumentReference:related&_include:iterate=DiagnosticReport:based-on&_include:iterate=DiagnosticReport:result",
       "/ServiceRequest?encounter=Encounter/11111111-1111-4111-8111-111111111111&status=active&code=https://terminology.fhir.oystehr.com/CodeSystem/oystehr-lab-local-codes|,http://ottehr.org/fhir/StructureDefinition/in-house-lab-test-code|",
@@ -74,84 +49,20 @@ exports[`get-chart-data FHIR request budget > pins the FHIR searches issued for 
     ],
   },
   {
-    "name": "06 usePatientInstructionsVisibility + PatientInstructionsContainer",
+    "name": "04 AddendumCard GenericNoteList",
     "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
-      "/Encounter?_id=11111111-1111-4111-8111-111111111111",
-      "/ServiceRequest?encounter=Encounter/11111111-1111-4111-8111-111111111111",
-    ],
-  },
-  {
-    "name": "07 ChiefComplaintContainer",
-    "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
-      "/Encounter?_id=11111111-1111-4111-8111-111111111111",
-      "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=history-of-present-illness",
-    ],
-  },
-  {
-    "name": "08 HpiMoiContainer",
-    "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
-      "/Encounter?_id=11111111-1111-4111-8111-111111111111",
-      "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=chief-complaint",
-      "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=mechanism-of-injury",
-      "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=accident",
-    ],
-  },
-  {
-    "name": "09 SurgicalHistoryContainer",
-    "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
-      "/Encounter?_id=11111111-1111-4111-8111-111111111111",
-      "/Procedure?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=surgical-history-note",
-    ],
-  },
-  {
-    "name": "10 AssessmentGroupContainer",
-    "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
-      "/Encounter?_id=11111111-1111-4111-8111-111111111111",
-      "/ClinicalImpression?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=medical-decision",
-    ],
-  },
-  {
-    "name": "11 AddendumCard (legacy addendumNote)",
-    "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
-      "/Encounter?_id=11111111-1111-4111-8111-111111111111",
-    ],
-  },
-  {
-    "name": "12 AddendumCard GenericNoteList",
-    "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
       "/Encounter?_id=11111111-1111-4111-8111-111111111111",
       "/Communication?encounter=Encounter/11111111-1111-4111-8111-111111111111&_count=1000&_sort=-_lastUpdated&_tag=https://fhir.zapehr.com/r4/StructureDefinitions/addendum|css-note",
     ],
   },
   {
-    "name": "13 HospitalizationContainer (episodeOfCare refetch, staleTime 0)",
+    "name": "ERxContainer",
     "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
       "/Encounter?_id=11111111-1111-4111-8111-111111111111",
-      "/EpisodeOfCare?patient:Patient._has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
-    ],
-  },
-  {
-    "name": "c1 PrescribedMedicationsContainer",
-    "urls": [
+      "/MedicationRequest?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=erx-medication",
+      "/Practitioner?_has:Encounter:participant:_id=11111111-1111-4111-8111-111111111111",
+      "/QuestionnaireResponse?encounter=Encounter/11111111-1111-4111-8111-111111111111",
       "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
-      "/Encounter?_id=11111111-1111-4111-8111-111111111111",
-      "/MedicationRequest?encounter=Encounter/11111111-1111-4111-8111-111111111111",
-    ],
-  },
-  {
-    "name": "c2 ReviewOfSystemsContainer (legacy ros text)",
-    "urls": [
-      "/Patient?_has:Encounter:subject:_id=11111111-1111-4111-8111-111111111111",
-      "/Encounter?_id=11111111-1111-4111-8111-111111111111",
-      "/Condition?encounter=Encounter/11111111-1111-4111-8111-111111111111&_tag=ros",
     ],
   },
 ]

--- a/packages/zambdas/test/unit/chart-data-golden-mapping.test.ts
+++ b/packages/zambdas/test/unit/chart-data-golden-mapping.test.ts
@@ -178,7 +178,7 @@ describe('get-chart-data mapping layer — golden fixture', () => {
       expect(additionalChartData.diagnosis).toBeUndefined();
       expect(additionalChartData.observations).toBeUndefined();
 
-      // The fields the Review & Sign summaries used to request on their own now ride along.
+      // The progress-note field set carries the accident and the surgical-history note.
       expect(additionalChartData.accident).toMatchObject({ type: ['AA'], date: '2026-01-10', state: 'IL' });
       expect(additionalChartData.surgicalHistoryNote?.text).toBe('Uncomplicated recovery');
 

--- a/packages/zambdas/test/unit/chart-data-golden-mapping.test.ts
+++ b/packages/zambdas/test/unit/chart-data-golden-mapping.test.ts
@@ -178,13 +178,16 @@ describe('get-chart-data mapping layer — golden fixture', () => {
       expect(additionalChartData.diagnosis).toBeUndefined();
       expect(additionalChartData.observations).toBeUndefined();
 
+      // The fields the Review & Sign summaries used to request on their own now ride along.
+      expect(additionalChartData.accident).toMatchObject({ type: ['AA'], date: '2026-01-10', state: 'IL' });
+      expect(additionalChartData.surgicalHistoryNote?.text).toBe('Uncomplicated recovery');
+
       // Computed on every call regardless of the request, from whatever the searches happened to return:
-      // the Encounter extension is always there, while the accident Condition and the completed procedure
-      // ServiceRequest are not part of this request's searches, so both come back undefined.
+      // the Encounter extensions are always there, while the completed procedure ServiceRequest is not part
+      // of this request's searches, so procedures comes back undefined.
       expect(additionalChartData.patientInfoConfirmed).toEqual({ value: true });
       expect(additionalChartData.addToVisitNote).toEqual({ value: true });
       expect(additionalChartData.addendumNote).toEqual({ text: 'Legacy single-string addendum' });
-      expect(additionalChartData.accident).toBeUndefined();
       expect(additionalChartData.procedures).toBeUndefined();
     });
   });

--- a/packages/zambdas/test/unit/fixtures/chart-data-golden.fixture.ts
+++ b/packages/zambdas/test/unit/fixtures/chart-data-golden.fixture.ts
@@ -641,9 +641,11 @@ export function resourcesReturnedByProgressNoteSearches(resources: FhirResource[
       case 'DiagnosticReport':
         return true;
       case 'Condition':
-        return ['chief-complaint', 'history-of-present-illness', 'mechanism-of-injury', 'ros'].includes(
+        return ['chief-complaint', 'history-of-present-illness', 'mechanism-of-injury', 'ros', 'accident'].includes(
           tagCode(resource) ?? ''
         );
+      case 'Procedure':
+        return tagCode(resource) === 'surgical-history-note';
       case 'ServiceRequest':
         return ['disposition-follow-up', 'sub-follow-up', 'radiology'].includes(tagCode(resource) ?? '');
       case 'Communication':

--- a/packages/zambdas/test/unit/fixtures/chart-data-golden.fixture.ts
+++ b/packages/zambdas/test/unit/fixtures/chart-data-golden.fixture.ts
@@ -118,6 +118,7 @@ export const ALL_REQUESTED_FIELDS: RequestedFields[] = [
   'accident',
   'patientHasPreviousVisits',
   'radiologyOrders',
+  'aiChat',
 ];
 
 export const PROGRESS_NOTE_FIELDS = Object.keys(progressNoteChartDataRequestedFields) as RequestedFields[];

--- a/packages/zambdas/test/unit/get-chart-data-request-budget.test.ts
+++ b/packages/zambdas/test/unit/get-chart-data-request-budget.test.ts
@@ -1,9 +1,9 @@
 /**
  * Characterization of the FHIR requests get-chart-data issues.
  *
- * The zambda builds its FHIR batch deterministically from `requestedFields`, so the URLs below are exact
+ * The zambda builds its FHIR batches deterministically from `requestedFields`, so the URLs below are exact
  * for a page load. The scenarios replay every distinct react-query key mounted when the in-person
- * Review & Sign page opens, plus the two conditional ones, and pin:
+ * Review & Sign page opens and pin:
  *   - the URL set each call issues (snapshot),
  *   - the totals for the page load (explicit, so a change is a deliberate diff in this file),
  *   - the two ways a caller can steer a search off the requested encounter (documented as `it.fails`,
@@ -80,64 +80,32 @@ interface Scenario {
   fields?: ChartDataRequestedFields;
 }
 
-/** One entry per distinct react-query key mounted on /in-person/:id/review-and-sign, in mount order. */
+/**
+ * One entry per distinct react-query key mounted on /in-person/:id/review-and-sign, in mount order.
+ * Every section summary on the page reads the shared progress-note query (useProgressNoteChartFields),
+ * so the page costs the layout's unscoped call, the navigation context's hospitalizations, the note itself
+ * and the addendum list.
+ */
 export const REVIEW_AND_SIGN_SCENARIOS: Scenario[] = [
   { name: '01 unscoped (InPersonLayout, Header, Sidebar, ProgressNote)', fields: undefined },
   { name: '02 InPersonNavigationContext', fields: { episodeOfCare: {} } },
   {
-    name: '03 MissingCard',
-    fields: {
-      medicalDecision: { _tag: 'medical-decision' },
-      chiefComplaint: { _tag: 'chief-complaint' },
-      historyOfPresentIllness: { _tag: 'history-of-present-illness' },
-      patientInfoConfirmed: {},
-      accident: { _tag: 'accident' },
-    },
-  },
-  {
-    name: '04 ReviewAndSignButton',
-    fields: {
-      medicalDecision: { _tag: 'medical-decision' },
-      chiefComplaint: { _tag: 'chief-complaint' },
-      historyOfPresentIllness: { _tag: 'history-of-present-illness' },
-      accident: { _tag: 'accident' },
-      inHouseLabResults: {},
-      patientInfoConfirmed: {},
-    },
-  },
-  {
-    name: '05 ProgressNoteDetails (progressNoteChartDataRequestedFields)',
+    name: '03 useProgressNoteChartFields (ProgressNoteDetails, MissingCard, ReviewAndSignButton, section summaries)',
     fields: progressNoteChartDataRequestedFields,
   },
-  { name: '06 usePatientInstructionsVisibility + PatientInstructionsContainer', fields: { disposition: {} } },
   {
-    name: '07 ChiefComplaintContainer',
-    fields: { historyOfPresentIllness: { _tag: 'history-of-present-illness' }, reasonForVisit: {} },
-  },
-  {
-    name: '08 HpiMoiContainer',
-    fields: {
-      chiefComplaint: { _tag: 'chief-complaint' },
-      mechanismOfInjury: { _tag: 'mechanism-of-injury' },
-      accident: { _tag: 'accident' },
-    },
-  },
-  { name: '09 SurgicalHistoryContainer', fields: { surgicalHistoryNote: { _tag: 'surgical-history-note' } } },
-  { name: '10 AssessmentGroupContainer', fields: { medicalDecision: { _tag: 'medical-decision' } } },
-  { name: '11 AddendumCard (legacy addendumNote)', fields: { addendumNote: {} } },
-  {
-    name: '12 AddendumCard GenericNoteList',
+    name: '04 AddendumCard GenericNoteList',
     fields: {
       notes: { _search_by: 'encounter', _sort: '-_lastUpdated', _count: 1000, _tag: noteTag([NOTE_TYPE.ADDENDUM]) },
     },
   },
-  { name: '13 HospitalizationContainer (episodeOfCare refetch, staleTime 0)', fields: { episodeOfCare: {} } },
 ];
 
-export const CONDITIONAL_SCENARIOS: Scenario[] = [
-  { name: 'c1 PrescribedMedicationsContainer', fields: { prescribedMedications: {} } },
-  { name: 'c2 ReviewOfSystemsContainer (legacy ros text)', fields: { ros: { _tag: 'ros' } } },
-];
+/** The eRX screen is the only reader of preferredPharmacies, and so the only request that needs the Patient. */
+const PREFERRED_PHARMACIES_SCENARIO: Scenario = {
+  name: 'ERxContainer',
+  fields: { practitioners: {}, prescribedMedications: { _tag: 'erx-medication' }, preferredPharmacies: {} },
+};
 
 interface ScenarioResult {
   name: string;
@@ -156,6 +124,14 @@ async function runScenario(scenario: Scenario): Promise<ScenarioResult> {
     fhirSearches: mine.reduce((n, call) => n + call.urls.length, 0),
     urls: mine.flatMap((call) => call.urls),
   };
+}
+
+async function runAll(scenarios: Scenario[]): Promise<ScenarioResult[]> {
+  const results: ScenarioResult[] = [];
+  for (const scenario of scenarios) {
+    results.push(await runScenario(scenario));
+  }
+  return results;
 }
 
 const summarize = (
@@ -177,47 +153,66 @@ describe('get-chart-data FHIR request budget', () => {
   });
 
   it('pins the FHIR searches issued for every distinct request on the Review & Sign page', async () => {
-    const results: ScenarioResult[] = [];
-    for (const scenario of [...REVIEW_AND_SIGN_SCENARIOS, ...CONDITIONAL_SCENARIOS]) {
-      results.push(await runScenario(scenario));
-    }
+    const results = await runAll([...REVIEW_AND_SIGN_SCENARIOS, PREFERRED_PHARMACIES_SCENARIO]);
     // Snapshot the URL set of every scenario so that any change in what the endpoint searches is visible in
     // review rather than measured after the fact.
     expect(results.map(({ name, urls }) => ({ name, urls }))).toMatchSnapshot();
   });
 
-  it('opening Review & Sign costs 13 calls, 27 FHIR round trips and 71 searches, 40 of them redundant', async () => {
-    const results: ScenarioResult[] = [];
-    for (const scenario of REVIEW_AND_SIGN_SCENARIOS) {
-      results.push(await runScenario(scenario));
-    }
-    expect(results).toHaveLength(13);
+  it('opening Review & Sign costs 4 calls, 33 FHIR searches (29 distinct) over 13 concurrent batches', async () => {
+    // Down from 13 calls, 71 searches (31 distinct, 40 redundant) and 27 round trips before the section
+    // summaries shared one query and the Patient stopped being fetched on every call. The remaining
+    // redundancy is the Encounter read each call still makes plus the hospitalizations the navigation
+    // context and the note both ask for. Round trips are now a latency choice rather than a cost: each
+    // call spreads its searches over concurrent batches (see CHART_DATA_BATCH_TARGET_CONCURRENCY).
+    const results = await runAll(REVIEW_AND_SIGN_SCENARIOS);
+    expect(results).toHaveLength(4);
     expect(summarize(results)).toEqual({
-      fhirHttpRequests: 27,
-      fhirSearches: 71,
-      distinctSearches: 31,
-      redundantSearches: 40,
+      fhirHttpRequests: 13,
+      fhirSearches: 33,
+      distinctSearches: 29,
+      redundantSearches: 4,
     });
   });
 
-  it('every call re-fetches the Patient in its own round trip and the Encounter inside the chart batch', async () => {
-    const results: ScenarioResult[] = [];
-    for (const scenario of REVIEW_AND_SIGN_SCENARIOS) {
-      results.push(await runScenario(scenario));
-    }
-    const patientSearches = results.flatMap((r) => r.urls).filter((url) => url.startsWith('/Patient?'));
-    const encounterSearches = results.flatMap((r) => r.urls).filter((url) => url.startsWith('/Encounter?_id='));
-    expect(patientSearches).toHaveLength(13);
-    expect(encounterSearches).toHaveLength(13);
-    // Only the unscoped call adds a third round trip, for the appointment count behind patientHasPreviousVisits.
-    expect(results.map((r) => r.fhirHttpRequests)).toEqual([3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]);
+  it('fetches the Patient only when preferredPharmacies is requested, inside a chart batch', async () => {
+    const reviewAndSign = await runAll(REVIEW_AND_SIGN_SCENARIOS);
+    expect(reviewAndSign.flatMap((r) => r.urls).filter((url) => url.startsWith('/Patient?'))).toEqual([]);
+
+    recorded.length = 0;
+    const pharmacies = await runScenario(PREFERRED_PHARMACIES_SCENARIO);
+    expect(pharmacies.urls.filter((url) => url.startsWith('/Patient?'))).toHaveLength(1);
+    // No dedicated round trip for it: the Patient search shares a batch with other chart searches.
+    const patientBatch = recorded.find((call) => call.urls.some((url) => url.startsWith('/Patient?')));
+    expect(patientBatch?.kind).toBe('batch');
+    expect(patientBatch?.urls.length).toBeGreaterThan(1);
   });
 
-  it('nine of the distinct searches carry only their anchor, seven of which return mixed content', async () => {
-    const results: ScenarioResult[] = [];
-    for (const scenario of REVIEW_AND_SIGN_SCENARIOS) {
-      results.push(await runScenario(scenario));
-    }
+  it('the progress-note request carries the fields the Review & Sign summaries used to fetch on their own', async () => {
+    const [progressNote] = await runAll(REVIEW_AND_SIGN_SCENARIOS.filter((s) => s.name.startsWith('03')));
+    expect(progressNote.urls).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^\/Condition\?encounter=.*&_tag=accident$/),
+        expect.stringMatching(/^\/Procedure\?encounter=.*&_tag=surgical-history-note$/),
+      ])
+    );
+  });
+
+  it('spreads a call over concurrent batches of at least three searches', async () => {
+    const [unscoped, navigation, progressNote] = await runAll(REVIEW_AND_SIGN_SCENARIOS);
+    const batches = (result: ScenarioResult): number[] =>
+      recorded
+        .slice(recorded.length - result.fhirHttpRequests)
+        .filter((call) => call.kind === 'batch')
+        .map((call) => call.urls.length);
+    expect(navigation.fhirHttpRequests).toBe(1);
+    expect(unscoped.fhirHttpRequests).toBeGreaterThan(1);
+    expect(progressNote.fhirHttpRequests).toBeGreaterThan(1);
+    batches(progressNote).forEach((size) => expect(size).toBeGreaterThanOrEqual(1));
+  });
+
+  it('eight of the distinct searches carry only their anchor, six of which return mixed content', async () => {
+    const results = await runAll(REVIEW_AND_SIGN_SCENARIOS);
     const distinct = [...new Set(results.flatMap((r) => r.urls))];
     const anchorOnly = distinct.filter((url) => {
       const query = url.split('?')[1] ?? '';
@@ -234,9 +229,10 @@ describe('get-chart-data FHIR request budget', () => {
     });
     // For these two the resource type is the intended filter: every allergy and hospitalization is wanted.
     const singlePurpose = ['/AllergyIntolerance', '/EpisodeOfCare'];
-    // These seven return every resource of the type and leave the mapper to discard by tag: all
+    // These six return every resource of the type and leave the mapper to discard by tag: all
     // communications, every condition and procedure the patient ever had, all observations on the
-    // encounter, all document references, all medication requests, all service requests.
+    // encounter, all document references, all medication requests. (The untagged ServiceRequest search
+    // went away with the separate disposition request.)
     const mixedContent = [
       '/Communication',
       '/Condition',
@@ -244,7 +240,6 @@ describe('get-chart-data FHIR request budget', () => {
       '/MedicationRequest',
       '/Observation',
       '/Procedure',
-      '/ServiceRequest',
     ];
     expect(anchorOnly.map((url) => url.split('?')[0]).sort()).toEqual([...singlePurpose, ...mixedContent].sort());
   });

--- a/packages/zambdas/test/unit/get-chart-data-request-budget.test.ts
+++ b/packages/zambdas/test/unit/get-chart-data-request-budget.test.ts
@@ -16,7 +16,7 @@ import { progressNoteChartDataRequestedFields } from 'utils/lib/helpers/visit-no
 import { IN_PERSON_NOTE_ID, NOTE_TYPE } from 'utils/lib/types/api/chart-data/chart-data.types';
 import { ChartDataRequestedFields } from 'utils/lib/types/api/chart-data/get-chart-data.types';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { getChartData } from '../../src/ehr/get-chart-data';
+import { CHART_DATA_MIN_BATCH_SIZE, getChartData } from '../../src/ehr/get-chart-data';
 
 const ENCOUNTER_ID = '11111111-1111-4111-8111-111111111111';
 const PATIENT_ID = '22222222-2222-4222-8222-222222222222';
@@ -112,6 +112,8 @@ interface ScenarioResult {
   fhirHttpRequests: number;
   fhirSearches: number;
   urls: string[];
+  /** The FHIR round trips this scenario made, in the order they were issued. */
+  calls: RecordedCall[];
 }
 
 async function runScenario(scenario: Scenario): Promise<ScenarioResult> {
@@ -123,6 +125,7 @@ async function runScenario(scenario: Scenario): Promise<ScenarioResult> {
     fhirHttpRequests: mine.length,
     fhirSearches: mine.reduce((n, call) => n + call.urls.length, 0),
     urls: mine.flatMap((call) => call.urls),
+    calls: mine,
   };
 }
 
@@ -198,17 +201,22 @@ describe('get-chart-data FHIR request budget', () => {
     );
   });
 
-  it('spreads a call over concurrent batches of at least three searches', async () => {
+  it('spreads a call over concurrent chart batches of at least three searches, the remainder aside', async () => {
     const [unscoped, navigation, progressNote] = await runAll(REVIEW_AND_SIGN_SCENARIOS);
-    const batches = (result: ScenarioResult): number[] =>
-      recorded
-        .slice(recorded.length - result.fhirHttpRequests)
-        .filter((call) => call.kind === 'batch')
+    // The appointment count is a single-search batch on purpose (it stays out of the merged chart bundle);
+    // the chart searches are chunked into batches of at least CHART_DATA_MIN_BATCH_SIZE, the last one taking
+    // whatever is left.
+    const chartBatchSizes = (result: ScenarioResult): number[] =>
+      result.calls
+        .filter((call) => call.kind === 'batch' && !call.urls.some((url) => url.includes('_summary=count')))
         .map((call) => call.urls.length);
     expect(navigation.fhirHttpRequests).toBe(1);
-    expect(unscoped.fhirHttpRequests).toBeGreaterThan(1);
-    expect(progressNote.fhirHttpRequests).toBeGreaterThan(1);
-    batches(progressNote).forEach((size) => expect(size).toBeGreaterThanOrEqual(1));
+    [unscoped, progressNote].forEach((result) => {
+      const sizes = chartBatchSizes(result);
+      expect(sizes.length).toBeGreaterThan(1);
+      sizes.slice(0, -1).forEach((size) => expect(size).toBeGreaterThanOrEqual(CHART_DATA_MIN_BATCH_SIZE));
+      expect(sizes[sizes.length - 1]).toBeGreaterThanOrEqual(1);
+    });
   });
 
   it('eight of the distinct searches carry only their anchor, six of which return mixed content', async () => {
@@ -231,8 +239,8 @@ describe('get-chart-data FHIR request budget', () => {
     const singlePurpose = ['/AllergyIntolerance', '/EpisodeOfCare'];
     // These six return every resource of the type and leave the mapper to discard by tag: all
     // communications, every condition and procedure the patient ever had, all observations on the
-    // encounter, all document references, all medication requests. (The untagged ServiceRequest search
-    // went away with the separate disposition request.)
+    // encounter, all document references, all medication requests. (Every ServiceRequest search carries a
+    // status or tag filter, so none of them is anchor-only.)
     const mixedContent = [
       '/Communication',
       '/Condition',

--- a/packages/zambdas/test/unit/get-chart-data-request-budget.test.ts
+++ b/packages/zambdas/test/unit/get-chart-data-request-budget.test.ts
@@ -163,11 +163,9 @@ describe('get-chart-data FHIR request budget', () => {
   });
 
   it('opening Review & Sign costs 4 calls, 33 FHIR searches (29 distinct) over 13 concurrent batches', async () => {
-    // Down from 13 calls, 71 searches (31 distinct, 40 redundant) and 27 round trips before the section
-    // summaries shared one query and the Patient stopped being fetched on every call. The remaining
-    // redundancy is the Encounter read each call still makes plus the hospitalizations the navigation
-    // context and the note both ask for. Round trips are now a latency choice rather than a cost: each
-    // call spreads its searches over concurrent batches (see CHART_DATA_BATCH_TARGET_CONCURRENCY).
+    // The redundancy is the Encounter read each call makes plus the hospitalizations the navigation context
+    // and the note both ask for. Round trips are a latency choice rather than a cost: each call spreads its
+    // searches over concurrent batches (see CHART_DATA_BATCH_TARGET_CONCURRENCY).
     const results = await runAll(REVIEW_AND_SIGN_SCENARIOS);
     expect(results).toHaveLength(4);
     expect(summarize(results)).toEqual({
@@ -191,7 +189,7 @@ describe('get-chart-data FHIR request budget', () => {
     expect(patientBatch?.urls.length).toBeGreaterThan(1);
   });
 
-  it('the progress-note request carries the fields the Review & Sign summaries used to fetch on their own', async () => {
+  it('the progress-note request carries the accident and the surgical-history note', async () => {
     const [progressNote] = await runAll(REVIEW_AND_SIGN_SCENARIOS.filter((s) => s.name.startsWith('03')));
     expect(progressNote.urls).toEqual(
       expect.arrayContaining([

--- a/packages/zambdas/test/unit/patient-id-from-reference.test.ts
+++ b/packages/zambdas/test/unit/patient-id-from-reference.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { patientIdFromReference } from '../../src/shared/helpers';
+
+describe('patientIdFromReference', () => {
+  it('reads a relative reference', () => {
+    expect(patientIdFromReference('Patient/abc-123')).toBe('abc-123');
+  });
+
+  it('reads an absolute reference', () => {
+    expect(patientIdFromReference('https://fhir-api.zapehr.com/r4/Patient/abc-123')).toBe('abc-123');
+  });
+
+  it('is undefined for a missing reference', () => {
+    expect(patientIdFromReference(undefined)).toBeUndefined();
+  });
+
+  it('is undefined for a reference to another resource type', () => {
+    expect(patientIdFromReference('Group/abc-123')).toBeUndefined();
+    expect(patientIdFromReference('https://fhir-api.zapehr.com/r4/RelatedPerson/abc-123')).toBeUndefined();
+  });
+
+  it('is undefined for a bare id or a trailing slash', () => {
+    expect(patientIdFromReference('abc-123')).toBeUndefined();
+    expect(patientIdFromReference('Patient/')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Alex: This PR mostly just reworks react-query caching and eliminates an unnecessary FHIR call on most get-chart-data invocations. it is a precursor to a plan that replaces the get-chart-data with something better.

🤖 :

Second of six stacked PRs. #9543 (the characterization tests) is merged, so this one now targets `develop` directly. Quick wins on the current `get-chart-data` endpoint and its callers, ahead of the section rewrite. No API shape changes; `aiChat` becomes requestable as a field.

## Result on Review & Sign (measured by the request-budget test)

| | Before | After |
|---|---|---|
| get-chart-data calls | 13 | 4 |
| FHIR searches | 71 | 33 |
| Distinct searches | 31 | 29 |
| Redundant searches | 40 | 4 |
| Patient searches | 13 | 0 |

Round trips go from 27 to 13, but they now mean something different: each call spreads its searches over concurrent batches of at least three (see below), so the count is a latency choice rather than a cost. The remaining redundancy is the Encounter read each call still makes plus the hospitalizations both the navigation context and the note request.

## Backend

- **No Patient round trip.** `patientId` comes from `encounter.subject`. The Patient is only searched when `preferredPharmacies` is requested (its contained pharmacy Organizations are the only thing read from it), and then inside the chart batch.
- **Concurrent batches** (adopted from `alex/perf/get-chart-data-batch-split`, which this supersedes). FHIR executes batch entries serially, so one batch of 18 searches costs the sum of all 18; six batches of three cost roughly the slowest one. The searches are independent and the response is assembled by resource type, so the split is invisible to callers.
- **`aiChat` requestable** on its own, so the AI polling loops can stop re-running the unscoped default set every tick.

## Frontend

- **`useProgressNoteChartFields`**: the one query behind Review & Sign and the follow-up note. `MissingCard`, `ReviewAndSignButton`, `AddendumCard`, `HospitalizationContainer` and every section summary read it instead of requesting their own field combinations. `accident`, `patientInfoConfirmed`, `addendumNote` and `surgicalHistoryNote` join `progressNoteChartDataRequestedFields` so the set covers them (two extra searches on that call; nine calls gone).
- **`useChartFields` staleTime** goes from 0 to `QUERY_STALE_TIME`. Moving between visit screens marks every chart-fields query stale (`useInvalidateChartFieldsOnNavigate`, refetch on next mount) so cross-screen freshness is kept, while repeated mounts of the same field set within one screen share the data. This is what turned the `HospitalizationContainer` remount into a 13th call.
- **AI polling** fetches only AI observations (`useAiSuggestionsPolling`) or AI chat documents (`useAiResourcesPolling` via the layout) per tick, and refetches the unscoped chart once when something changed.
- **`useChartDataArrayValue`** patches both caches from the save/delete response instead of refetching the whole chart after every add or remove.

## Tests

- Request budget test mirrors the four-call page and pins the new totals; the Patient assertion flips to "only for preferredPharmacies, inside a batch"; the two `it.fails` escape-hatch cases still fail as documented.
- Golden fixture and mapping snapshot follow the wider progress-note field set (accident and surgical-history note now present). The PDF composer snapshot is unchanged.
- `useChartFields.test.tsx`: the equivalent-key test now expects one request, since fresh data is shared within staleTime.

## Verification

- `tsc --noEmit` clean for `packages/utils`, `packages/zambdas`, `apps/ehr`; eslint clean on every touched file.
- Zambda unit tests: the three golden/budget files plus addendum-roundtrip, apply-procedures, apply-template, plan-section and the validation tests (108 passed, 2 expected failures).
- EHR: `useChartFields.test.tsx` (32 passed) and the component tests for MissingCard, ReviewAndSignPermission, ProgressNoteCancelledItems, RadiologyOrdersContainer, MedicalDecisionField, InlineEditSection and ScheduledFollowupParentSelector all pass. `ProgressNoteCancelledItems` needs `VITE_APP_IS_LOCAL` set to build, on this branch and on `develop` alike.
- Not run locally: integration tests and E2E.

## Stack

1. #9543 (merged): characterization tests.
2. **This PR**: Phase 0.
3. Phase 1 (#9545), 4. Phase 2 (#9546), 5. Phase 3 (#9547), 6. Phase 4 (#9551). Merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgLd9gsGP3P3GRVrncBZ5x