### PR TITLE
EHR. Telemed. 'Arrived' status should be present in status history for on-demand visits

### DIFF
--- a/apps/ehr/src/features/visits/in-person/components/VirtualAppointmentFooter.tsx
+++ b/apps/ehr/src/features/visits/in-person/components/VirtualAppointmentFooter.tsx
@@ -58,7 +58,7 @@ export const VirtualAppointmentFooter: FC = () => {
   const isActiveVisitStatus = ['arrived', 'ready', 'intake', 'ready for provider', 'provider'].includes(
     appointmentStatus
   );
-  const statusHistory = getVisitStatusHistory(encounter);
+  const statusHistory = getVisitStatusHistory(encounter, appointment ?? undefined);
   const arrivedStart = statusHistory.find((status) => status.status === 'arrived')?.period?.start;
   const waitingTime = arrivedStart ? diffInMinutes(DateTime.now(), DateTime.fromISO(arrivedStart)) : 0;
 

--- a/packages/utils/lib/utils/visitUtils.ts
+++ b/packages/utils/lib/utils/visitUtils.ts
@@ -1,6 +1,8 @@
 import { Appointment, Encounter, EncounterParticipant, EncounterStatusHistory } from 'fhir/r4b';
 import { DateTime } from 'luxon';
+import { appointmentTypeForAppointment } from '../fhir/appointments';
 import { FHIR_EXTENSION } from '../fhir/constants';
+import { isTelemedAppointment } from '../fhir/moduleIdentification';
 import {
   SupervisorApprovalStatus,
   VisitStatusHistoryEntry,
@@ -137,7 +139,11 @@ export const isVisitFinished = (appointment?: Appointment, encounter?: Encounter
   return FINISHED_VISIT_STATUSES.includes(getInPersonVisitStatus(appointment, encounter, true));
 };
 
-export const getVisitStatusHistory = (encounter: Encounter): VisitStatusHistoryEntry[] => {
+export const getVisitStatusHistory = (encounter: Encounter, appointment?: Appointment): VisitStatusHistoryEntry[] => {
+  const isOnDemandVirtual =
+    appointment != null &&
+    isTelemedAppointment(appointment) &&
+    appointmentTypeForAppointment(appointment) === 'walk-in';
   const visitHistory: VisitStatusHistoryEntry[] = [];
 
   encounter?.statusHistory?.forEach((statusHist: EncounterStatusHistory) => {
@@ -161,7 +167,17 @@ export const getVisitStatusHistory = (encounter: Encounter): VisitStatusHistoryE
       // fallback to old logic
       const curVisitHistory: any = {};
       if (statusHist.status === 'planned') {
-        curVisitHistory.status = 'pending';
+        if (isOnDemandVirtual) {
+          // On-demand virtual visits start as FHIR 'planned' for notification purposes,
+          // but clinically represent 'arrived'. Only show the entry while it is the open
+          // (current) state; once it has been closed by create-waiting-room-notification-task
+          // a proper 'arrived' entry with the ottehr extension is present, so skip this one.
+          if (!statusHist.period.end) {
+            curVisitHistory.status = 'arrived';
+          }
+        } else {
+          curVisitHistory.status = 'pending';
+        }
       } else if (statusHist.status === 'arrived') {
         curVisitHistory.status = 'arrived';
       } else if (statusHist.status === 'cancelled') {

--- a/packages/zambdas/src/ehr/get-appointments/index.ts
+++ b/packages/zambdas/src/ehr/get-appointments/index.ts
@@ -893,7 +893,7 @@ const makeAppointmentInformation = (
     },
     participants,
     next,
-    visitStatusHistory: getVisitStatusHistory(encounter),
+    visitStatusHistory: getVisitStatusHistory(encounter, appointment),
     waitingMinutes,
     // Prefer the human-readable display, but fall back to the code: FHIR-backed
     // (non-system) categories are stamped on the slot with only system+code and


### PR DESCRIPTION
https://linear.app/zapehr/issue/OTR-2930/ehr-telemed-arrived-status-should-be-present-in-status-history-for-on